### PR TITLE
Add personal access token (PAT) management UI and API

### DIFF
--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -71,7 +71,7 @@ User-created tokens for authenticating with the API from external clients (e.g.,
 |---|---|---|---|
 | `id` | `uuid` | PK, DEFAULT `gen_random_uuid()` | |
 | `user_id` | `text` | FK → `users.id`, NOT NULL | The user who created this token. |
-| `name` | `text` | NOT NULL | User-provided label (e.g., "Lab PC watcher", "Lambda production"). |
+| `name` | `text` | NOT NULL | User-provided label (e.g., "Plate Reader PC", "Lambda production"). |
 | `token_hash` | `text` | NOT NULL, UNIQUE | SHA-256 hash of the token. The plaintext token is shown once at creation and never stored. |
 | `token_prefix` | `text` | NOT NULL | First 8 characters of the token, stored for display purposes (e.g., `dhub_a1b2...`). |
 | `last_used_at` | `timestamptz` | | Updated on each API call authenticated with this token. |

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -73,7 +73,7 @@ User-created tokens for authenticating with the API from external clients (e.g.,
 | `user_id` | `text` | FK → `users.id`, NOT NULL | The user who created this token. |
 | `name` | `text` | NOT NULL | User-provided label (e.g., "Plate Reader PC", "Lambda production"). |
 | `token_hash` | `text` | NOT NULL, UNIQUE | SHA-256 hash of the token. The plaintext token is shown once at creation and never stored. |
-| `token_prefix` | `text` | NOT NULL | First 8 characters of the token, stored for display purposes (e.g., `dhub_a1b2...`). |
+| `token_prefix` | `text` | NOT NULL | First 9 characters of the token, stored for display purposes (e.g., `dhub_a1b2...`). |
 | `last_used_at` | `timestamptz` | | Updated on each API call authenticated with this token. |
 | `expires_at` | `timestamptz` | | Optional expiry. `NULL` means no expiry. |
 | `created_at` | `timestamptz` | NOT NULL, DEFAULT `now()` | |

--- a/docs/api/AUTHENTICATION.md
+++ b/docs/api/AUTHENTICATION.md
@@ -50,7 +50,7 @@ Lists the current user's personal access tokens.
 [
   {
     "id": "a1b2c3d4-...",
-    "name": "Lab PC watcher",
+    "name": "Plate Reader PC",
     "token_prefix": "dhub_a1b2",
     "last_used_at": "2026-03-26T20:15:00Z",
     "expires_at": null,
@@ -69,7 +69,7 @@ Creates a new personal access token. The plaintext token is returned **once** in
 
 ```json
 {
-  "name": "Lab PC watcher",
+  "name": "Plate Reader PC",
   "expires_at": "2027-03-26T00:00:00Z"
 }
 ```
@@ -81,7 +81,7 @@ Creates a new personal access token. The plaintext token is returned **once** in
 ```json
 {
   "id": "a1b2c3d4-...",
-  "name": "Lab PC watcher",
+  "name": "Plate Reader PC",
   "token": "dhub_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0",
   "token_prefix": "dhub_a1b2",
   "expires_at": "2027-03-26T00:00:00Z",

--- a/web-app/app/api/v1/tokens/[id]/route.ts
+++ b/web-app/app/api/v1/tokens/[id]/route.ts
@@ -20,6 +20,8 @@ export async function DELETE(
     return Response.json({ error: "Invalid token ID" }, { status: 400 });
   }
 
+  // Scope the delete to the authenticated user so one user can never
+  // delete another user's token — a non-match returns 0 rows → 404.
   const deleted = await db
     .delete(personalAccessTokens)
     .where(

--- a/web-app/app/api/v1/tokens/[id]/route.ts
+++ b/web-app/app/api/v1/tokens/[id]/route.ts
@@ -1,0 +1,32 @@
+import { requireSession } from "@/lib/api/auth";
+import { db } from "@/lib/db";
+import { personalAccessTokens } from "@/lib/db/schema";
+import { and, eq } from "drizzle-orm";
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const authResult = await requireSession();
+  if (!authResult) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const deleted = await db
+    .delete(personalAccessTokens)
+    .where(
+      and(
+        eq(personalAccessTokens.id, id),
+        eq(personalAccessTokens.userId, authResult.userId)
+      )
+    )
+    .returning({ id: personalAccessTokens.id });
+
+  if (deleted.length === 0) {
+    return Response.json({ error: "Token not found" }, { status: 404 });
+  }
+
+  return new Response(null, { status: 204 });
+}

--- a/web-app/app/api/v1/tokens/[id]/route.ts
+++ b/web-app/app/api/v1/tokens/[id]/route.ts
@@ -14,6 +14,12 @@ export async function DELETE(
 
   const { id } = await params;
 
+  const UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!UUID_RE.test(id)) {
+    return Response.json({ error: "Invalid token ID" }, { status: 400 });
+  }
+
   const deleted = await db
     .delete(personalAccessTokens)
     .where(

--- a/web-app/app/api/v1/tokens/route.ts
+++ b/web-app/app/api/v1/tokens/route.ts
@@ -57,6 +57,12 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+    if (expiresAt <= new Date()) {
+      return Response.json(
+        { error: "expires_at must be in the future" },
+        { status: 400 }
+      );
+    }
   }
 
   const plaintext = generateToken();

--- a/web-app/app/api/v1/tokens/route.ts
+++ b/web-app/app/api/v1/tokens/route.ts
@@ -65,6 +65,8 @@ export async function POST(request: NextRequest) {
     }
   }
 
+  // Only the hash is persisted — the plaintext is returned in this response
+  // and can never be retrieved again.
   const plaintext = generateToken();
   const tokenHash = hashToken(plaintext);
   const tokenPrefix = getTokenPrefix(plaintext);

--- a/web-app/app/api/v1/tokens/route.ts
+++ b/web-app/app/api/v1/tokens/route.ts
@@ -1,0 +1,84 @@
+import { requireSession } from "@/lib/api/auth";
+import { db } from "@/lib/db";
+import { personalAccessTokens } from "@/lib/db/schema";
+import { generateToken, getTokenPrefix, hashToken } from "@/lib/tokens";
+import { desc, eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+export async function GET() {
+  const authResult = await requireSession();
+  if (!authResult) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const tokens = await db
+    .select({
+      id: personalAccessTokens.id,
+      name: personalAccessTokens.name,
+      token_prefix: personalAccessTokens.tokenPrefix,
+      last_used_at: personalAccessTokens.lastUsedAt,
+      expires_at: personalAccessTokens.expiresAt,
+      created_at: personalAccessTokens.createdAt,
+    })
+    .from(personalAccessTokens)
+    .where(eq(personalAccessTokens.userId, authResult.userId))
+    .orderBy(desc(personalAccessTokens.createdAt));
+
+  return Response.json(tokens);
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await requireSession();
+  if (!authResult) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: { name?: string; expires_at?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  if (!name || name.length > 100) {
+    return Response.json(
+      { error: "name is required and must be at most 100 characters" },
+      { status: 400 }
+    );
+  }
+
+  let expiresAt: Date | null = null;
+  if (body.expires_at) {
+    expiresAt = new Date(body.expires_at);
+    if (isNaN(expiresAt.getTime())) {
+      return Response.json(
+        { error: "expires_at must be a valid ISO 8601 date" },
+        { status: 400 }
+      );
+    }
+  }
+
+  const plaintext = generateToken();
+  const tokenHash = hashToken(plaintext);
+  const tokenPrefix = getTokenPrefix(plaintext);
+
+  const [inserted] = await db
+    .insert(personalAccessTokens)
+    .values({
+      userId: authResult.userId,
+      name,
+      tokenHash,
+      tokenPrefix,
+      expiresAt,
+    })
+    .returning({
+      id: personalAccessTokens.id,
+      name: personalAccessTokens.name,
+      token_prefix: personalAccessTokens.tokenPrefix,
+      expires_at: personalAccessTokens.expiresAt,
+      created_at: personalAccessTokens.createdAt,
+    });
+
+  return Response.json({ ...inserted, token: plaintext }, { status: 201 });
+}

--- a/web-app/app/layout.tsx
+++ b/web-app/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Geist_Mono, Inter } from "next/font/google";
 
 import { ThemeProvider } from "@/components/theme-provider";
+import { Toaster } from "@/components/ui/sonner";
 import { cn } from "@/lib/utils";
 import { SessionProvider } from "next-auth/react";
 import "./globals.css";
@@ -30,7 +31,10 @@ export default function RootLayout({
     >
       <body>
         <SessionProvider>
-          <ThemeProvider>{children}</ThemeProvider>
+          <ThemeProvider>
+            {children}
+            <Toaster />
+          </ThemeProvider>
         </SessionProvider>
       </body>
     </html>

--- a/web-app/app/settings/layout.tsx
+++ b/web-app/app/settings/layout.tsx
@@ -1,6 +1,5 @@
+import { SettingsNav } from "@/components/settings/settings-nav";
 import { auth } from "@/lib/auth";
-import { KeyRound } from "lucide-react";
-import Link from "next/link";
 import { redirect } from "next/navigation";
 
 export default async function SettingsLayout({
@@ -17,19 +16,7 @@ export default async function SettingsLayout({
     <div className="mx-auto max-w-4xl px-4 py-10 sm:px-6 lg:px-8">
       <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
       <div className="mt-6 flex gap-8">
-        <nav className="hidden w-48 shrink-0 sm:block">
-          <ul className="space-y-1">
-            <li>
-              <Link
-                href="/settings/tokens"
-                className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              >
-                <KeyRound className="size-4" />
-                Access Tokens
-              </Link>
-            </li>
-          </ul>
-        </nav>
+        <SettingsNav />
         <main className="min-w-0 flex-1">{children}</main>
       </div>
     </div>

--- a/web-app/app/settings/layout.tsx
+++ b/web-app/app/settings/layout.tsx
@@ -1,0 +1,37 @@
+import { auth } from "@/lib/auth";
+import { KeyRound } from "lucide-react";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+export default async function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10 sm:px-6 lg:px-8">
+      <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
+      <div className="mt-6 flex gap-8">
+        <nav className="hidden w-48 shrink-0 sm:block">
+          <ul className="space-y-1">
+            <li>
+              <Link
+                href="/settings/tokens"
+                className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <KeyRound className="size-4" />
+                Access Tokens
+              </Link>
+            </li>
+          </ul>
+        </nav>
+        <main className="min-w-0 flex-1">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/web-app/app/settings/page.tsx
+++ b/web-app/app/settings/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function SettingsPage() {
+  redirect("/settings/tokens");
+}

--- a/web-app/app/settings/tokens/page.tsx
+++ b/web-app/app/settings/tokens/page.tsx
@@ -1,0 +1,135 @@
+import { CreateTokenDialog } from "@/components/tokens/create-token-dialog";
+import { DeleteTokenDialog } from "@/components/tokens/delete-token-dialog";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { personalAccessTokens } from "@/lib/db/schema";
+import { formatRelativeTime } from "@/lib/utils";
+import { desc, eq } from "drizzle-orm";
+import { KeyRound } from "lucide-react";
+import { redirect } from "next/navigation";
+
+export default async function TokensPage() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  const tokens = await db
+    .select({
+      id: personalAccessTokens.id,
+      name: personalAccessTokens.name,
+      tokenPrefix: personalAccessTokens.tokenPrefix,
+      lastUsedAt: personalAccessTokens.lastUsedAt,
+      expiresAt: personalAccessTokens.expiresAt,
+      createdAt: personalAccessTokens.createdAt,
+    })
+    .from(personalAccessTokens)
+    .where(eq(personalAccessTokens.userId, session.user.id))
+    .orderBy(desc(personalAccessTokens.createdAt));
+
+  const isExpired = (expiresAt: Date | null) =>
+    expiresAt ? expiresAt < new Date() : false;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold tracking-tight">
+            Access Tokens
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Manage personal access tokens for API authentication.
+          </p>
+        </div>
+        <CreateTokenDialog />
+      </div>
+
+      <div className="mt-6">
+        {tokens.length === 0 ? (
+          <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-12">
+            <KeyRound className="size-10 text-muted-foreground/50" />
+            <p className="mt-3 text-sm font-medium text-muted-foreground">
+              No access tokens yet
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground/70">
+              Create a token to authenticate with the API.
+            </p>
+          </div>
+        ) : (
+          <div className="rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Token</TableHead>
+                  <TableHead>Last used</TableHead>
+                  <TableHead>Expires</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead className="w-12" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tokens.map((token) => (
+                  <TableRow key={token.id}>
+                    <TableCell className="font-medium">{token.name}</TableCell>
+                    <TableCell>
+                      <Badge variant="secondary" className="font-mono text-xs">
+                        {token.tokenPrefix}...
+                      </Badge>
+                    </TableCell>
+                    <TableCell
+                      className="text-muted-foreground"
+                      suppressHydrationWarning
+                    >
+                      {token.lastUsedAt
+                        ? formatRelativeTime(token.lastUsedAt)
+                        : "Never"}
+                    </TableCell>
+                    <TableCell suppressHydrationWarning>
+                      {token.expiresAt ? (
+                        <span
+                          className={
+                            isExpired(token.expiresAt)
+                              ? "text-destructive"
+                              : "text-muted-foreground"
+                          }
+                        >
+                          {isExpired(token.expiresAt)
+                            ? "Expired"
+                            : formatRelativeTime(token.expiresAt)}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">Never</span>
+                      )}
+                    </TableCell>
+                    <TableCell
+                      className="text-muted-foreground"
+                      suppressHydrationWarning
+                    >
+                      {formatRelativeTime(token.createdAt)}
+                    </TableCell>
+                    <TableCell>
+                      <DeleteTokenDialog
+                        tokenId={token.id}
+                        tokenName={token.name}
+                      />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-app/app/settings/tokens/page.tsx
+++ b/web-app/app/settings/tokens/page.tsx
@@ -15,13 +15,9 @@ import { personalAccessTokens } from "@/lib/db/schema";
 import { formatRelativeTime } from "@/lib/utils";
 import { desc, eq } from "drizzle-orm";
 import { KeyRound } from "lucide-react";
-import { redirect } from "next/navigation";
 
 export default async function TokensPage() {
   const session = await auth();
-  if (!session?.user?.id) {
-    redirect("/login");
-  }
 
   const tokens = await db
     .select({
@@ -33,7 +29,7 @@ export default async function TokensPage() {
       createdAt: personalAccessTokens.createdAt,
     })
     .from(personalAccessTokens)
-    .where(eq(personalAccessTokens.userId, session.user.id))
+    .where(eq(personalAccessTokens.userId, session!.user!.id!))
     .orderBy(desc(personalAccessTokens.createdAt));
 
   const isExpired = (expiresAt: Date | null) =>

--- a/web-app/components/settings/settings-nav.tsx
+++ b/web-app/components/settings/settings-nav.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { KeyRound } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const NAV_ITEMS = [
+  { href: "/settings/tokens", label: "Access Tokens", icon: KeyRound },
+] as const;
+
+export function SettingsNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="hidden w-48 shrink-0 sm:block">
+      <ul className="space-y-1">
+        {NAV_ITEMS.map((item) => {
+          const active = pathname.startsWith(item.href);
+          return (
+            <li key={item.href}>
+              <Link
+                href={item.href}
+                className={cn(
+                  "flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                  active
+                    ? "bg-muted text-foreground"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                )}
+              >
+                <item.icon className="size-4" />
+                {item.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/web-app/components/tokens/create-token-dialog.tsx
+++ b/web-app/components/tokens/create-token-dialog.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Check, Copy, Loader2, Plus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useCallback, useState, useTransition } from "react";
+
+type Step = "form" | "display";
+
+const EXPIRY_PRESETS = [
+  { label: "30 days", value: "30" },
+  { label: "90 days", value: "90" },
+  { label: "1 year", value: "365" },
+  { label: "No expiry", value: "none" },
+] as const;
+
+function computeExpiresAt(days: string): string | undefined {
+  if (days === "none") return undefined;
+  const d = new Date();
+  d.setDate(d.getDate() + parseInt(days, 10));
+  return d.toISOString();
+}
+
+export function CreateTokenDialog() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState<Step>("form");
+  const [name, setName] = useState("");
+  const [expiry, setExpiry] = useState("90");
+  const [isPending, startTransition] = useTransition();
+  const [plaintext, setPlaintext] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  const reset = useCallback(() => {
+    setStep("form");
+    setName("");
+    setExpiry("90");
+    setPlaintext("");
+    setCopied(false);
+  }, []);
+
+  const handleCreate = () => {
+    startTransition(async () => {
+      const expiresAt = computeExpiresAt(expiry);
+      const res = await fetch("/api/v1/tokens", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          expires_at: expiresAt,
+        }),
+      });
+
+      if (!res.ok) {
+        return;
+      }
+
+      const data = await res.json();
+      setPlaintext(data.token);
+      setStep("display");
+    });
+  };
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(plaintext);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleDone = () => {
+    setOpen(false);
+    reset();
+    router.refresh();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => {
+        if (!value && step === "display") return;
+        setOpen(value);
+        if (!value) reset();
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button size="sm">
+          <Plus data-icon="inline-start" />
+          Create token
+        </Button>
+      </DialogTrigger>
+      <DialogContent
+        onPointerDownOutside={(e) => {
+          if (step === "display") e.preventDefault();
+        }}
+        onEscapeKeyDown={(e) => {
+          if (step === "display") e.preventDefault();
+        }}
+      >
+        {step === "form" ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Create access token</DialogTitle>
+              <DialogDescription>
+                Tokens are used to authenticate API requests from external
+                tools.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-4 py-2">
+              <div className="grid gap-2">
+                <Label htmlFor="token-name">Name</Label>
+                <Input
+                  id="token-name"
+                  placeholder="e.g. Plate Reader PC"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  maxLength={100}
+                  autoFocus
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="token-expiry">Expiration</Label>
+                <Select value={expiry} onValueChange={setExpiry}>
+                  <SelectTrigger id="token-expiry">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {EXPIRY_PRESETS.map((preset) => (
+                      <SelectItem key={preset.value} value={preset.value}>
+                        {preset.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <DialogFooter>
+              <Button
+                onClick={handleCreate}
+                disabled={!name.trim() || isPending}
+              >
+                {isPending ? (
+                  <Loader2 className="animate-spin" data-icon="inline-start" />
+                ) : null}
+                Create token
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Token created</DialogTitle>
+              <DialogDescription>
+                Make sure to copy your token now. You won&apos;t be able to see
+                it again.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="min-w-0 py-2">
+              <div className="flex items-center gap-2">
+                <code className="overflow-x-hidden min-w-0 flex-1 rounded-md border bg-muted px-3 py-2 font-mono text-sm">
+                  {plaintext}
+                </code>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={handleCopy}
+                  aria-label="Copy token"
+                >
+                  {copied ? (
+                    <Check className="size-4" />
+                  ) : (
+                    <Copy className="size-4" />
+                  )}
+                </Button>
+              </div>
+            </div>
+            <DialogFooter>
+              <Button onClick={handleDone}>Done</Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web-app/components/tokens/create-token-dialog.tsx
+++ b/web-app/components/tokens/create-token-dialog.tsx
@@ -22,6 +22,7 @@ import {
 import { Check, Copy, Loader2, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useState, useTransition } from "react";
+import { toast } from "sonner";
 
 type Step = "form" | "display";
 
@@ -70,6 +71,8 @@ export function CreateTokenDialog() {
       });
 
       if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        toast.error(body?.error ?? "Failed to create token");
         return;
       }
 
@@ -174,7 +177,7 @@ export function CreateTokenDialog() {
             </DialogHeader>
             <div className="min-w-0 py-2">
               <div className="flex items-center gap-2">
-                <code className="overflow-x-hidden min-w-0 flex-1 rounded-md border bg-muted px-3 py-2 font-mono text-sm">
+                <code className="min-w-0 flex-1 overflow-x-hidden rounded-md border bg-muted px-3 py-2 font-mono text-sm">
                   {plaintext}
                 </code>
                 <Button

--- a/web-app/components/tokens/create-token-dialog.tsx
+++ b/web-app/components/tokens/create-token-dialog.tsx
@@ -98,6 +98,8 @@ export function CreateTokenDialog() {
     <Dialog
       open={open}
       onOpenChange={(value) => {
+        // Block dismissal while the plaintext is shown — the token can never
+        // be retrieved again, so the user must explicitly click "Done".
         if (!value && step === "display") return;
         setOpen(value);
         if (!value) reset();

--- a/web-app/components/tokens/delete-token-dialog.tsx
+++ b/web-app/components/tokens/delete-token-dialog.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Loader2, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import { toast } from "sonner";
+
+export function DeleteTokenDialog({
+  tokenId,
+  tokenName,
+}: {
+  tokenId: string;
+  tokenName: string;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const handleDelete = () => {
+    startTransition(async () => {
+      const res = await fetch(`/api/v1/tokens/${tokenId}`, {
+        method: "DELETE",
+      });
+
+      if (res.ok || res.status === 204) {
+        toast.success(`Token "${tokenName}" deleted`);
+        router.refresh();
+      } else {
+        toast.error("Failed to delete token");
+      }
+    });
+  };
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="ghost" size="icon-sm" aria-label="Delete token">
+          <Trash2 className="size-4 text-muted-foreground" />
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete access token</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to delete{" "}
+            <span className="font-medium text-foreground">{tokenName}</span>?
+            Any tools using this token will lose access immediately.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleDelete}
+            disabled={isPending}
+            className="bg-destructive/10 text-destructive hover:bg-destructive/20"
+          >
+            {isPending ? (
+              <Loader2 className="animate-spin" data-icon="inline-start" />
+            ) : null}
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/web-app/components/ui/alert-dialog.tsx
+++ b/web-app/components/ui/alert-dialog.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui";
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  );
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  );
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  size?: "default" | "sm";
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl bg-popover p-6 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-16 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "font-heading text-lg font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Action
+        data-slot="alert-dialog-action"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  );
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Cancel
+        data-slot="alert-dialog-cancel"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/web-app/components/ui/badge.tsx
+++ b/web-app/components/ui/badge.tsx
@@ -1,0 +1,49 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span";
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/web-app/components/ui/button.tsx
+++ b/web-app/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 cursor-pointer items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/web-app/components/ui/dialog.tsx
+++ b/web-app/components/ui/dialog.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { Dialog as DialogPrimitive } from "radix-ui";
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { XIcon } from "lucide-react";
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl bg-popover p-6 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-md data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close data-slot="dialog-close" asChild>
+            <Button
+              variant="ghost"
+              className="absolute top-4 right-4"
+              size="icon-sm"
+            >
+              <XIcon />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("font-heading leading-none font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/web-app/components/ui/dropdown-menu.tsx
+++ b/web-app/components/ui/dropdown-menu.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { CheckIcon, ChevronRightIcon } from "lucide-react";
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  );
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuContent({
+  className,
+  align = "start",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        align={align}
+        className={cn(
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-8 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-8 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-xs font-medium text-muted-foreground data-inset:pl-8",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-8 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "z-50 min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+};

--- a/web-app/components/ui/input.tsx
+++ b/web-app/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/web-app/components/ui/label.tsx
+++ b/web-app/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Label as LabelPrimitive } from "radix-ui";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };

--- a/web-app/components/ui/select.tsx
+++ b/web-app/components/ui/select.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { Select as SelectPrimitive } from "radix-ui";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-md border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        data-align-trigger={position === "item-aligned"}
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          data-position={position}
+          className={cn(
+            "data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)",
+            position === "popper" && ""
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="pointer-events-none" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/web-app/components/ui/sonner.tsx
+++ b/web-app/components/ui/sonner.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react";
+import { useTheme } from "next-themes";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme();
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/web-app/components/ui/table.tsx
+++ b/web-app/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+};

--- a/web-app/drizzle/0000_parched_the_santerians.sql
+++ b/web-app/drizzle/0000_parched_the_santerians.sql
@@ -1,0 +1,177 @@
+CREATE TYPE "public"."file_category" AS ENUM('raw', 'processed');--> statement-breakpoint
+CREATE TYPE "public"."file_status" AS ENUM('detected', 'upload_requested', 'uploaded', 'processing', 'completed', 'failed');--> statement-breakpoint
+CREATE TYPE "public"."instrument_run_source" AS ENUM('lambda', 'watcher');--> statement-breakpoint
+CREATE TYPE "public"."instrument_status" AS ENUM('pending', 'active', 'inactive');--> statement-breakpoint
+CREATE TYPE "public"."upload_mode" AS ENUM('auto', 'manual');--> statement-breakpoint
+CREATE TYPE "public"."watcher_event_type" AS ENUM('watcher_started', 'watcher_stopped', 'file_uploaded', 'upload_failed', 'run_reported', 'config_synced', 'error');--> statement-breakpoint
+CREATE TYPE "public"."watcher_status" AS ENUM('registered', 'watching', 'stopped');--> statement-breakpoint
+CREATE TABLE "account" (
+	"userId" text NOT NULL,
+	"type" text NOT NULL,
+	"provider" text NOT NULL,
+	"providerAccountId" text NOT NULL,
+	"refresh_token" text,
+	"access_token" text,
+	"expires_at" integer,
+	"token_type" text,
+	"scope" text,
+	"id_token" text,
+	"session_state" text,
+	CONSTRAINT "account_provider_providerAccountId_pk" PRIMARY KEY("provider","providerAccountId")
+);
+--> statement-breakpoint
+CREATE TABLE "files" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"instrument_run_id" uuid NOT NULL,
+	"relative_path" text,
+	"s3_bucket" text,
+	"s3_key" text,
+	"filename" text NOT NULL,
+	"content_type" text,
+	"size_bytes" bigint,
+	"category" "file_category" DEFAULT 'raw' NOT NULL,
+	"status" "file_status" DEFAULT 'detected' NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"error_message" text,
+	"detected_at" timestamp with time zone,
+	"upload_requested_at" timestamp with time zone,
+	"uploaded_at" timestamp with time zone,
+	"processed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "instrument_runs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"instrument_id" text NOT NULL,
+	"run_id" text NOT NULL,
+	"source" "instrument_run_source" DEFAULT 'lambda' NOT NULL,
+	"watcher_id" uuid,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone,
+	"files_purged_at" timestamp with time zone,
+	CONSTRAINT "uq_instrument_runs_instrument_id_run_id" UNIQUE("instrument_id","run_id")
+);
+--> statement-breakpoint
+CREATE TABLE "instruments" (
+	"id" text PRIMARY KEY NOT NULL,
+	"display_name" text NOT NULL,
+	"status" "instrument_status" DEFAULT 'active' NOT NULL,
+	"file_patterns" text[],
+	"s3_trigger_suffix" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "personal_access_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"name" text NOT NULL,
+	"token_hash" text NOT NULL,
+	"token_prefix" text NOT NULL,
+	"last_used_at" timestamp with time zone,
+	"expires_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "personal_access_tokens_token_hash_unique" UNIQUE("token_hash")
+);
+--> statement-breakpoint
+CREATE TABLE "run_report_data" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"instrument_run_id" uuid NOT NULL,
+	"file_id" bigint,
+	"data_type" text NOT NULL,
+	"data" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "session" (
+	"sessionToken" text PRIMARY KEY NOT NULL,
+	"userId" text NOT NULL,
+	"expires" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text,
+	"email" text,
+	"emailVerified" timestamp,
+	"image" text,
+	CONSTRAINT "user_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "verificationToken" (
+	"identifier" text NOT NULL,
+	"token" text NOT NULL,
+	"expires" timestamp NOT NULL,
+	CONSTRAINT "verificationToken_identifier_token_pk" PRIMARY KEY("identifier","token")
+);
+--> statement-breakpoint
+CREATE TABLE "watcher_events" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"watcher_id" uuid NOT NULL,
+	"event_type" "watcher_event_type" NOT NULL,
+	"message" text NOT NULL,
+	"details" jsonb,
+	"timestamp" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "watcher_heartbeats" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"watcher_id" uuid NOT NULL,
+	"timestamp" timestamp with time zone NOT NULL,
+	"status" text NOT NULL,
+	"upload_mode" "upload_mode",
+	"files_uploaded_since_last" integer DEFAULT 0,
+	"runs_reported_since_last" integer DEFAULT 0,
+	"errors_since_last" integer DEFAULT 0,
+	"uptime_seconds" integer,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "watchers" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"instrument_id" text NOT NULL,
+	"hostname" text,
+	"os_info" text,
+	"config_checksum" text,
+	"config_yaml" text,
+	"last_heartbeat_at" timestamp with time zone,
+	"status" "watcher_status" DEFAULT 'registered' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "account" ADD CONSTRAINT "account_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "files" ADD CONSTRAINT "files_instrument_run_id_instrument_runs_id_fk" FOREIGN KEY ("instrument_run_id") REFERENCES "public"."instrument_runs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "instrument_runs" ADD CONSTRAINT "instrument_runs_instrument_id_instruments_id_fk" FOREIGN KEY ("instrument_id") REFERENCES "public"."instruments"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "instrument_runs" ADD CONSTRAINT "instrument_runs_watcher_id_watchers_id_fk" FOREIGN KEY ("watcher_id") REFERENCES "public"."watchers"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "personal_access_tokens" ADD CONSTRAINT "personal_access_tokens_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "run_report_data" ADD CONSTRAINT "run_report_data_instrument_run_id_instrument_runs_id_fk" FOREIGN KEY ("instrument_run_id") REFERENCES "public"."instrument_runs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "run_report_data" ADD CONSTRAINT "run_report_data_file_id_files_id_fk" FOREIGN KEY ("file_id") REFERENCES "public"."files"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "session" ADD CONSTRAINT "session_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "watcher_events" ADD CONSTRAINT "watcher_events_watcher_id_watchers_id_fk" FOREIGN KEY ("watcher_id") REFERENCES "public"."watchers"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "watcher_heartbeats" ADD CONSTRAINT "watcher_heartbeats_watcher_id_watchers_id_fk" FOREIGN KEY ("watcher_id") REFERENCES "public"."watchers"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "watchers" ADD CONSTRAINT "watchers_instrument_id_instruments_id_fk" FOREIGN KEY ("instrument_id") REFERENCES "public"."instruments"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_accounts_user_id" ON "account" USING btree ("userId");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_files_instrument_run_id_relative_path" ON "files" USING btree ("instrument_run_id","relative_path") WHERE "files"."relative_path" is not null;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_files_s3_key" ON "files" USING btree ("s3_key") WHERE "files"."s3_key" is not null;--> statement-breakpoint
+CREATE INDEX "idx_files_instrument_run_id" ON "files" USING btree ("instrument_run_id");--> statement-breakpoint
+CREATE INDEX "idx_files_status_instrument_run_id" ON "files" USING btree ("status","instrument_run_id");--> statement-breakpoint
+CREATE INDEX "idx_files_active" ON "files" USING btree ("instrument_run_id") WHERE "files"."deleted_at" is null;--> statement-breakpoint
+CREATE INDEX "idx_files_upload_queue" ON "files" USING btree ("upload_requested_at") WHERE "files"."upload_requested_at" is not null and "files"."uploaded_at" is null and "files"."deleted_at" is null;--> statement-breakpoint
+CREATE INDEX "idx_files_metadata_gin" ON "files" USING gin ("metadata");--> statement-breakpoint
+CREATE INDEX "idx_instrument_runs_instrument_id_created_at" ON "instrument_runs" USING btree ("instrument_id","created_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "idx_instrument_runs_active" ON "instrument_runs" USING btree ("instrument_id","created_at" DESC NULLS LAST) WHERE "instrument_runs"."deleted_at" is null;--> statement-breakpoint
+CREATE INDEX "idx_instrument_runs_metadata_gin" ON "instrument_runs" USING gin ("metadata");--> statement-breakpoint
+CREATE INDEX "idx_personal_access_tokens_user_id" ON "personal_access_tokens" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_run_report_data_instrument_run_id" ON "run_report_data" USING btree ("instrument_run_id");--> statement-breakpoint
+CREATE INDEX "idx_run_report_data_file_id" ON "run_report_data" USING btree ("file_id");--> statement-breakpoint
+CREATE INDEX "idx_sessions_user_id" ON "session" USING btree ("userId");--> statement-breakpoint
+CREATE INDEX "idx_watcher_events_watcher_id_timestamp" ON "watcher_events" USING btree ("watcher_id","timestamp" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "idx_watcher_events_watcher_id_event_type" ON "watcher_events" USING btree ("watcher_id","event_type");--> statement-breakpoint
+CREATE INDEX "idx_watcher_heartbeats_watcher_id_timestamp" ON "watcher_heartbeats" USING btree ("watcher_id","timestamp" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "idx_watchers_instrument_id" ON "watchers" USING btree ("instrument_id") WHERE "watchers"."deleted_at" is null;

--- a/web-app/drizzle/meta/0000_snapshot.json
+++ b/web-app/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,1403 @@
+{
+  "id": "0783aba4-5df2-4b09-aacd-a56feee3272d",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "file_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raw'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_requested_at": {
+          "name": "upload_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_files_instrument_run_id_relative_path": {
+          "name": "uq_files_instrument_run_id_relative_path",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"relative_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_s3_key": {
+          "name": "uq_files_s3_key",
+          "columns": [
+            {
+              "expression": "s3_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"s3_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_instrument_run_id": {
+          "name": "idx_files_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_status_instrument_run_id": {
+          "name": "idx_files_status_instrument_run_id",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_active": {
+          "name": "idx_files_active",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_upload_queue": {
+          "name": "idx_files_upload_queue",
+          "columns": [
+            {
+              "expression": "upload_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"upload_requested_at\" is not null and \"files\".\"uploaded_at\" is null and \"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_metadata_gin": {
+          "name": "idx_files_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_instrument_run_id_instrument_runs_id_fk": {
+          "name": "files_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_runs": {
+      "name": "instrument_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "instrument_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lambda'"
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_purged_at": {
+          "name": "files_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instrument_runs_instrument_id_created_at": {
+          "name": "idx_instrument_runs_instrument_id_created_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active": {
+          "name": "idx_instrument_runs_active",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_metadata_gin": {
+          "name": "idx_instrument_runs_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_runs_instrument_id_instruments_id_fk": {
+          "name": "instrument_runs_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_watcher_id_watchers_id_fk": {
+          "name": "instrument_runs_watcher_id_watchers_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_instrument_runs_instrument_id_run_id": {
+          "name": "uq_instrument_runs_instrument_id_run_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instrument_id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instruments": {
+      "name": "instruments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instrument_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "file_patterns": {
+          "name": "file_patterns",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_trigger_suffix": {
+          "name": "s3_trigger_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_personal_access_tokens_user_id": {
+          "name": "idx_personal_access_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_user_id_fk": {
+          "name": "personal_access_tokens_user_id_user_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_report_data": {
+      "name": "run_report_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_report_data_instrument_run_id": {
+          "name": "idx_run_report_data_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_report_data_file_id": {
+          "name": "idx_run_report_data_file_id",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_report_data_instrument_run_id_instrument_runs_id_fk": {
+          "name": "run_report_data_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_report_data",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "run_report_data_file_id_files_id_fk": {
+          "name": "run_report_data_file_id_files_id_fk",
+          "tableFrom": "run_report_data",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "name": "verificationToken_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_events": {
+      "name": "watcher_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "watcher_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_events_watcher_id_timestamp": {
+          "name": "idx_watcher_events_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_watcher_events_watcher_id_event_type": {
+          "name": "idx_watcher_events_watcher_id_event_type",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_events_watcher_id_watchers_id_fk": {
+          "name": "watcher_events_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_events",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_heartbeats": {
+      "name": "watcher_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_mode": {
+          "name": "upload_mode",
+          "type": "upload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_uploaded_since_last": {
+          "name": "files_uploaded_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "runs_reported_since_last": {
+          "name": "runs_reported_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_since_last": {
+          "name": "errors_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_heartbeats_watcher_id_timestamp": {
+          "name": "idx_watcher_heartbeats_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_heartbeats_watcher_id_watchers_id_fk": {
+          "name": "watcher_heartbeats_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_heartbeats",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watchers": {
+      "name": "watchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_info": {
+          "name": "os_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_checksum": {
+          "name": "config_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_yaml": {
+          "name": "config_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "watcher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_watchers_instrument_id": {
+          "name": "idx_watchers_instrument_id",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"watchers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchers_instrument_id_instruments_id_fk": {
+          "name": "watchers_instrument_id_instruments_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.file_category": {
+      "name": "file_category",
+      "schema": "public",
+      "values": [
+        "raw",
+        "processed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "detected",
+        "upload_requested",
+        "uploaded",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.instrument_run_source": {
+      "name": "instrument_run_source",
+      "schema": "public",
+      "values": [
+        "lambda",
+        "watcher"
+      ]
+    },
+    "public.instrument_status": {
+      "name": "instrument_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "inactive"
+      ]
+    },
+    "public.upload_mode": {
+      "name": "upload_mode",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual"
+      ]
+    },
+    "public.watcher_event_type": {
+      "name": "watcher_event_type",
+      "schema": "public",
+      "values": [
+        "watcher_started",
+        "watcher_stopped",
+        "file_uploaded",
+        "upload_failed",
+        "run_reported",
+        "config_synced",
+        "error"
+      ]
+    },
+    "public.watcher_status": {
+      "name": "watcher_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "watching",
+        "stopped"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web-app/drizzle/meta/_journal.json
+++ b/web-app/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1774914937148,
+      "tag": "0000_parched_the_santerians",
+      "breakpoints": true
+    }
+  ]
+}

--- a/web-app/lib/api/auth.ts
+++ b/web-app/lib/api/auth.ts
@@ -25,6 +25,8 @@ export async function authenticateRequest(
   }
 
   const plaintext = authHeader.slice(7);
+  // Reject tokens without our prefix early to avoid a needless DB lookup
+  // when the bearer value is a JWT or other non-PAT credential.
   if (!plaintext.startsWith("dhub_")) {
     return null;
   }
@@ -48,6 +50,8 @@ export async function authenticateRequest(
     return null;
   }
 
+  // Defer the last-used timestamp update so it doesn't add latency to the
+  // API response. next/server `after()` runs after the response is sent.
   after(async () => {
     await db
       .update(personalAccessTokens)

--- a/web-app/lib/api/auth.ts
+++ b/web-app/lib/api/auth.ts
@@ -1,0 +1,68 @@
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { personalAccessTokens } from "@/lib/db/schema";
+import { hashToken } from "@/lib/tokens";
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+type AuthResult = {
+  userId: string;
+  authMethod: "session" | "token";
+};
+
+export async function authenticateRequest(
+  _request: NextRequest
+): Promise<AuthResult | null> {
+  const session = await auth();
+  if (session?.user?.id) {
+    return { userId: session.user.id, authMethod: "session" };
+  }
+
+  const authHeader = _request.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return null;
+  }
+
+  const plaintext = authHeader.slice(7);
+  if (!plaintext.startsWith("dhub_")) {
+    return null;
+  }
+
+  const hash = hashToken(plaintext);
+  const [pat] = await db
+    .select({
+      id: personalAccessTokens.id,
+      userId: personalAccessTokens.userId,
+      expiresAt: personalAccessTokens.expiresAt,
+    })
+    .from(personalAccessTokens)
+    .where(eq(personalAccessTokens.tokenHash, hash))
+    .limit(1);
+
+  if (!pat) {
+    return null;
+  }
+
+  if (pat.expiresAt && pat.expiresAt < new Date()) {
+    return null;
+  }
+
+  // Non-blocking last-used update (best-effort)
+  db.update(personalAccessTokens)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(personalAccessTokens.id, pat.id))
+    .then(
+      () => {},
+      () => {}
+    );
+
+  return { userId: pat.userId, authMethod: "token" };
+}
+
+export async function requireSession(): Promise<AuthResult | null> {
+  const session = await auth();
+  if (session?.user?.id) {
+    return { userId: session.user.id, authMethod: "session" };
+  }
+  return null;
+}

--- a/web-app/lib/api/auth.ts
+++ b/web-app/lib/api/auth.ts
@@ -4,6 +4,7 @@ import { personalAccessTokens } from "@/lib/db/schema";
 import { hashToken } from "@/lib/tokens";
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
+import { after } from "next/server";
 
 type AuthResult = {
   userId: string;
@@ -47,14 +48,12 @@ export async function authenticateRequest(
     return null;
   }
 
-  // Non-blocking last-used update (best-effort)
-  db.update(personalAccessTokens)
-    .set({ lastUsedAt: new Date() })
-    .where(eq(personalAccessTokens.id, pat.id))
-    .then(
-      () => {},
-      () => {}
-    );
+  after(async () => {
+    await db
+      .update(personalAccessTokens)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(personalAccessTokens.id, pat.id));
+  });
 
   return { userId: pat.userId, authMethod: "token" };
 }

--- a/web-app/lib/db/schema.ts
+++ b/web-app/lib/db/schema.ts
@@ -1,19 +1,73 @@
 import type { AdapterAccountType } from "@auth/core/adapters";
+import { sql } from "drizzle-orm";
 import {
+  bigint,
+  bigserial,
+  index,
   integer,
+  jsonb,
+  pgEnum,
   pgTable,
   primaryKey,
   text,
   timestamp,
+  unique,
+  uniqueIndex,
+  uuid,
 } from "drizzle-orm/pg-core";
 
+export const instrumentStatusEnum = pgEnum("instrument_status", [
+  "pending",
+  "active",
+  "inactive",
+]);
+
+export const watcherStatusEnum = pgEnum("watcher_status", [
+  "registered",
+  "watching",
+  "stopped",
+]);
+
+export const watcherEventTypeEnum = pgEnum("watcher_event_type", [
+  "watcher_started",
+  "watcher_stopped",
+  "file_uploaded",
+  "upload_failed",
+  "run_reported",
+  "config_synced",
+  "error",
+]);
+
+export const uploadModeEnum = pgEnum("upload_mode", ["auto", "manual"]);
+
+export const instrumentRunSourceEnum = pgEnum("instrument_run_source", [
+  "lambda",
+  "watcher",
+]);
+
+export const fileCategoryEnum = pgEnum("file_category", ["raw", "processed"]);
+
+export const fileStatusEnum = pgEnum("file_status", [
+  "detected",
+  "upload_requested",
+  "uploaded",
+  "processing",
+  "completed",
+  "failed",
+]);
+
 export const users = pgTable("user", {
+  // Auth.js-generated user ID.
   id: text("id")
     .primaryKey()
     .$defaultFn(() => crypto.randomUUID()),
+  // Display name from Google profile.
   name: text("name"),
+  // Google email address.
   email: text("email").unique(),
+  // When the email was verified.
   emailVerified: timestamp("emailVerified", { mode: "date" }),
+  // Profile image URL from Google.
   image: text("image"),
 });
 
@@ -23,11 +77,17 @@ export const accounts = pgTable(
     userId: text("userId")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
+    // Account type (e.g., `oauth`).
     type: text("type").$type<AdapterAccountType>().notNull(),
+    // OAuth provider (e.g., `google`).
     provider: text("provider").notNull(),
+    // Provider's user ID.
     providerAccountId: text("providerAccountId").notNull(),
+    // OAuth refresh token.
     refresh_token: text("refresh_token"),
+    // OAuth access token.
     access_token: text("access_token"),
+    // Token expiry (Unix timestamp).
     expires_at: integer("expires_at"),
     token_type: text("token_type"),
     scope: text("scope"),
@@ -35,21 +95,26 @@ export const accounts = pgTable(
     session_state: text("session_state"),
   },
   (account) => [
-    {
-      compoundKey: primaryKey({
-        columns: [account.provider, account.providerAccountId],
-      }),
-    },
+    primaryKey({
+      columns: [account.provider, account.providerAccountId],
+    }),
+    index("idx_accounts_user_id").on(account.userId),
   ]
 );
 
-export const sessions = pgTable("session", {
-  sessionToken: text("sessionToken").primaryKey(),
-  userId: text("userId")
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
-  expires: timestamp("expires", { mode: "date" }).notNull(),
-});
+export const sessions = pgTable(
+  "session",
+  {
+    // Opaque session token.
+    sessionToken: text("sessionToken").primaryKey(),
+    userId: text("userId")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    // Session expiry.
+    expires: timestamp("expires", { mode: "date" }).notNull(),
+  },
+  (session) => [index("idx_sessions_user_id").on(session.userId)]
+);
 
 export const verificationTokens = pgTable(
   "verificationToken",
@@ -59,10 +124,385 @@ export const verificationTokens = pgTable(
     expires: timestamp("expires", { mode: "date" }).notNull(),
   },
   (verificationToken) => [
-    {
-      compositePk: primaryKey({
-        columns: [verificationToken.identifier, verificationToken.token],
-      }),
-    },
+    primaryKey({
+      columns: [verificationToken.identifier, verificationToken.token],
+    }),
+  ]
+);
+
+export const personalAccessTokens = pgTable(
+  "personal_access_tokens",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    // The user who created this token.
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    // User-provided label (e.g., "Lab PC watcher", "Lambda production").
+    name: text("name").notNull(),
+    // SHA-256 hash of the token. The plaintext token is shown once at creation
+    // and never stored.
+    tokenHash: text("token_hash").notNull().unique(),
+    // First 8 characters of the token, stored for display purposes
+    // (e.g., `dhub_a1b2...`).
+    tokenPrefix: text("token_prefix").notNull(),
+    // Updated on each API call authenticated with this token.
+    lastUsedAt: timestamp("last_used_at", {
+      withTimezone: true,
+      mode: "date",
+    }),
+    // Optional expiry. NULL means no expiry.
+    expiresAt: timestamp("expires_at", {
+      withTimezone: true,
+      mode: "date",
+    }),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "date",
+    })
+      .notNull()
+      .defaultNow(),
+  },
+  (token) => [index("idx_personal_access_tokens_user_id").on(token.userId)]
+);
+
+export const instruments = pgTable("instruments", {
+  // Kebab-case identifier (e.g., `spectramax-id3-plate-reader`). Also used as
+  // the first segment of the S3 key (`{instrument_id}/{run_id}/{filename}`).
+  id: text("id").primaryKey(),
+  // Human-readable name (e.g., "SpectraMax iD3 Plate Reader").
+  displayName: text("display_name").notNull(),
+  // New instruments registered via the watcher CLI start as `pending` until
+  // confirmed by an admin.
+  status: instrumentStatusEnum("status").notNull().default("active"),
+  // Suggested glob patterns for the file upload service (e.g., `["*.xls"]`).
+  filePatterns: text("file_patterns").array(),
+  // The file extension suffix configured on the S3→Lambda trigger (e.g.,
+  // `.xls`). Used for validation warnings in the watcher.
+  s3TriggerSuffix: text("s3_trigger_suffix"),
+  createdAt: timestamp("created_at", {
+    withTimezone: true,
+    mode: "date",
+  })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp("updated_at", {
+    withTimezone: true,
+    mode: "date",
+  })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+});
+
+export const watchers = pgTable(
+  "watchers",
+  {
+    // The watcher_id returned to the CLI on registration.
+    id: uuid("id").primaryKey().defaultRandom(),
+    instrumentId: text("instrument_id")
+      .notNull()
+      .references(() => instruments.id),
+    // The hostname of the machine running the watcher.
+    hostname: text("hostname"),
+    // OS description (e.g., "Windows 11 23H2").
+    osInfo: text("os_info"),
+    // SHA-256 of the last-pushed config YAML.
+    configChecksum: text("config_checksum"),
+    // The raw YAML text of the watcher's config file, stored verbatim as
+    // pushed by the watcher.
+    configYaml: text("config_yaml"),
+    // Updated on each heartbeat.
+    lastHeartbeatAt: timestamp("last_heartbeat_at", {
+      withTimezone: true,
+      mode: "date",
+    }),
+    // `stale` is computed at query time when
+    // last_heartbeat_at < now() - interval '5 minutes'.
+    status: watcherStatusEnum("status").notNull().default("registered"),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "date",
+    })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", {
+      withTimezone: true,
+      mode: "date",
+    })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+    // Soft-delete marker. NULL means active; non-NULL means deregistered.
+    deletedAt: timestamp("deleted_at", {
+      withTimezone: true,
+      mode: "date",
+    }),
+  },
+  (watcher) => [
+    index("idx_watchers_instrument_id")
+      .on(watcher.instrumentId)
+      .where(sql`${watcher.deletedAt} is null`),
+  ]
+);
+
+export const watcherHeartbeats = pgTable(
+  "watcher_heartbeats",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    watcherId: uuid("watcher_id")
+      .notNull()
+      .references(() => watchers.id),
+    // Client-reported timestamp.
+    timestamp: timestamp("timestamp", {
+      withTimezone: true,
+      mode: "date",
+    }).notNull(),
+    // Status string from the heartbeat payload (e.g., `watching`, `stopping`).
+    status: text("status").notNull(),
+    // Included so heartbeat history is interpretable without joining the
+    // watcher config.
+    uploadMode: uploadModeEnum("upload_mode"),
+    filesUploadedSinceLast: integer("files_uploaded_since_last").default(0),
+    // Manual mode only.
+    runsReportedSinceLast: integer("runs_reported_since_last").default(0),
+    errorsSinceLast: integer("errors_since_last").default(0),
+    uptimeSeconds: integer("uptime_seconds"),
+    // Server-side receive time.
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "date",
+    })
+      .notNull()
+      .defaultNow(),
+  },
+  (heartbeat) => [
+    index("idx_watcher_heartbeats_watcher_id_timestamp").on(
+      heartbeat.watcherId,
+      heartbeat.timestamp.desc()
+    ),
+  ]
+);
+
+export const watcherEvents = pgTable(
+  "watcher_events",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    watcherId: uuid("watcher_id")
+      .notNull()
+      .references(() => watchers.id),
+    eventType: watcherEventTypeEnum("event_type").notNull(),
+    // Human-readable summary (e.g., "Uploaded 2026-03-26_experiment.xls to S3").
+    message: text("message").notNull(),
+    // Structured event data. Shape varies by event_type.
+    details: jsonb("details"),
+    // Client-reported event time.
+    timestamp: timestamp("timestamp", {
+      withTimezone: true,
+      mode: "date",
+    }).notNull(),
+    // Server-side receive time.
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "date",
+    })
+      .notNull()
+      .defaultNow(),
+  },
+  (event) => [
+    index("idx_watcher_events_watcher_id_timestamp").on(
+      event.watcherId,
+      event.timestamp.desc()
+    ),
+    index("idx_watcher_events_watcher_id_event_type").on(
+      event.watcherId,
+      event.eventType
+    ),
+  ]
+);
+
+export const instrumentRuns = pgTable(
+  "instrument_runs",
+  {
+    // Surrogate primary key. The natural key is (instrument_id, run_id).
+    id: uuid("id").primaryKey().defaultRandom(),
+    instrumentId: text("instrument_id")
+      .notNull()
+      .references(() => instruments.id),
+    // The run identifier — derived by the Lambda function for auto-mode runs
+    // (e.g., filename without extension), or by the watcher's run detection
+    // logic for manual-mode runs (e.g., shared prefix, directory name).
+    runId: text("run_id").notNull(),
+    // How the run was created: `lambda` (auto-created when a file arrives in
+    // S3 without a pre-existing run) or `watcher` (reported by the watcher).
+    source: instrumentRunSourceEnum("source").notNull().default("lambda"),
+    // Set when the run was reported by a watcher. NULL for Lambda-created runs.
+    watcherId: uuid("watcher_id").references(() => watchers.id),
+    // Run-level metadata, written via
+    // PATCH /api/v1/instruments/:instrumentId/runs/:runId. Typically set by
+    // the Lambda function after processing all files in a run. Stored as a
+    // flat object; multi-valued properties use JSON arrays.
+    metadata: jsonb("metadata").notNull().default({}),
+    // When the run was first created (reported by watcher or auto-created by
+    // Lambda).
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "date",
+    })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", {
+      withTimezone: true,
+      mode: "date",
+    })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+    // Soft-delete marker. NULL means active; non-NULL means deleted. Queries
+    // should filter on this column to exclude deleted runs.
+    deletedAt: timestamp("deleted_at", {
+      withTimezone: true,
+      mode: "date",
+    }),
+    // Set by the S3 lifecycle cleanup job when S3 objects for this run have
+    // been permanently deleted. NULL means S3 objects are still available. A
+    // run with deleted_at set but files_purged_at NULL can still be restored
+    // with full data.
+    filesPurgedAt: timestamp("files_purged_at", {
+      withTimezone: true,
+      mode: "date",
+    }),
+  },
+  (run) => [
+    unique("uq_instrument_runs_instrument_id_run_id").on(
+      run.instrumentId,
+      run.runId
+    ),
+    index("idx_instrument_runs_instrument_id_created_at").on(
+      run.instrumentId,
+      run.createdAt.desc()
+    ),
+    index("idx_instrument_runs_active")
+      .on(run.instrumentId, run.createdAt.desc())
+      .where(sql`${run.deletedAt} is null`),
+    index("idx_instrument_runs_metadata_gin").using("gin", run.metadata),
+  ]
+);
+
+export const files = pgTable(
+  "files",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    instrumentRunId: uuid("instrument_run_id")
+      .notNull()
+      .references(() => instrumentRuns.id),
+    // Path relative to the watcher's watch directory (e.g.,
+    // `20260325_data_file_1.csv` or `20260325_testing/data_file_1.csv`). NULL
+    // for Lambda-created files (they skip the detection phase).
+    relativePath: text("relative_path"),
+    // NULL until the file is uploaded to S3.
+    s3Bucket: text("s3_bucket"),
+    // NULL until the file is uploaded to S3.
+    s3Key: text("s3_key"),
+    // Original filename.
+    filename: text("filename").notNull(),
+    // MIME type.
+    contentType: text("content_type"),
+    sizeBytes: bigint("size_bytes", { mode: "number" }),
+    // Distinguishes raw uploads from Lambda-generated artifacts.
+    category: fileCategoryEnum("category").notNull().default("raw"),
+    // detected → upload_requested → uploaded → processing → completed | failed
+    status: fileStatusEnum("status").notNull().default("detected"),
+    // Instrument-specific key-value metadata extracted by the Lambda function
+    // from this file. Stored as a flat object; multi-valued properties use
+    // JSON arrays.
+    metadata: jsonb("metadata").notNull().default({}),
+    // Human-readable error description if status = 'failed'. NULL otherwise.
+    errorMessage: text("error_message"),
+    // When the watcher first detected this file on the local filesystem. NULL
+    // for Lambda-created files.
+    detectedAt: timestamp("detected_at", {
+      withTimezone: true,
+      mode: "date",
+    }),
+    // When a user requested upload of this file via the web UI. NULL for
+    // auto-mode and Lambda-created files.
+    uploadRequestedAt: timestamp("upload_requested_at", {
+      withTimezone: true,
+      mode: "date",
+    }),
+    // When the file was confirmed uploaded to S3. For Lambda-created files,
+    // equals created_at.
+    uploadedAt: timestamp("uploaded_at", {
+      withTimezone: true,
+      mode: "date",
+    }),
+    // When the Lambda function finished processing this file (regardless of
+    // success or failure).
+    processedAt: timestamp("processed_at", {
+      withTimezone: true,
+      mode: "date",
+    }),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "date",
+    })
+      .notNull()
+      .defaultNow(),
+    // Per-file soft-delete for dismissing individual files. NULL means active.
+    deletedAt: timestamp("deleted_at", {
+      withTimezone: true,
+      mode: "date",
+    }),
+  },
+  (file) => [
+    uniqueIndex("uq_files_instrument_run_id_relative_path")
+      .on(file.instrumentRunId, file.relativePath)
+      .where(sql`${file.relativePath} is not null`),
+    uniqueIndex("uq_files_s3_key")
+      .on(file.s3Key)
+      .where(sql`${file.s3Key} is not null`),
+    index("idx_files_instrument_run_id").on(file.instrumentRunId),
+    index("idx_files_status_instrument_run_id").on(
+      file.status,
+      file.instrumentRunId
+    ),
+    index("idx_files_active")
+      .on(file.instrumentRunId)
+      .where(sql`${file.deletedAt} is null`),
+    index("idx_files_upload_queue")
+      .on(file.uploadRequestedAt)
+      .where(
+        sql`${file.uploadRequestedAt} is not null and ${file.uploadedAt} is null and ${file.deletedAt} is null`
+      ),
+    index("idx_files_metadata_gin").using("gin", file.metadata),
+  ]
+);
+
+export const runReportData = pgTable(
+  "run_report_data",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    instrumentRunId: uuid("instrument_run_id")
+      .notNull()
+      .references(() => instrumentRuns.id),
+    // The source file this data was extracted from. NULL for data produced by
+    // run-level analyses (which may aggregate across multiple files).
+    fileId: bigint("file_id", { mode: "number" }).references(() => files.id),
+    // Identifies the dataset (e.g., `raw_well_data`, `plate_map`,
+    // `kinetic_data`, `spectrum_data`, `sample_table`).
+    dataType: text("data_type").notNull(),
+    // The structured data as a JSON array of row objects.
+    data: jsonb("data").notNull(),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "date",
+    })
+      .notNull()
+      .defaultNow(),
+  },
+  (report) => [
+    index("idx_run_report_data_instrument_run_id").on(report.instrumentRunId),
+    index("idx_run_report_data_file_id").on(report.fileId),
   ]
 );

--- a/web-app/lib/db/schema.ts
+++ b/web-app/lib/db/schema.ts
@@ -138,7 +138,7 @@ export const personalAccessTokens = pgTable(
     userId: text("user_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
-    // User-provided label (e.g., "Lab PC watcher", "Lambda production").
+    // User-provided label (e.g., "Plate Reader PC", "Lambda production").
     name: text("name").notNull(),
     // SHA-256 hash of the token. The plaintext token is shown once at creation
     // and never stored.

--- a/web-app/lib/tokens.ts
+++ b/web-app/lib/tokens.ts
@@ -11,5 +11,7 @@ export function hashToken(plaintext: string): string {
 }
 
 export function getTokenPrefix(plaintext: string): string {
-  return plaintext.slice(0, 9);
+  // "dhub_" (5) + first 4 hex chars — enough to identify a token in the UI
+  // without leaking meaningful entropy.
+  return plaintext.slice(0, TOKEN_PREFIX.length + 4);
 }

--- a/web-app/lib/tokens.ts
+++ b/web-app/lib/tokens.ts
@@ -1,0 +1,15 @@
+import { createHash, randomBytes } from "node:crypto";
+
+const TOKEN_PREFIX = "dhub_";
+
+export function generateToken(): string {
+  return TOKEN_PREFIX + randomBytes(32).toString("hex");
+}
+
+export function hashToken(plaintext: string): string {
+  return createHash("sha256").update(plaintext).digest("hex");
+}
+
+export function getTokenPrefix(plaintext: string): string {
+  return plaintext.slice(0, 9);
+}

--- a/web-app/lib/utils.ts
+++ b/web-app/lib/utils.ts
@@ -4,3 +4,29 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+const DIVISIONS: { amount: number; name: Intl.RelativeTimeFormatUnit }[] = [
+  { amount: 60, name: "seconds" },
+  { amount: 60, name: "minutes" },
+  { amount: 24, name: "hours" },
+  { amount: 7, name: "days" },
+  { amount: 4.34524, name: "weeks" },
+  { amount: 12, name: "months" },
+  { amount: Number.POSITIVE_INFINITY, name: "years" },
+];
+
+export function formatRelativeTime(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  let duration = (d.getTime() - Date.now()) / 1000;
+
+  for (const division of DIVISIONS) {
+    if (Math.abs(duration) < division.amount) {
+      return rtf.format(Math.round(duration), division.name);
+    }
+    duration /= division.amount;
+  }
+
+  return d.toLocaleDateString();
+}

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "shadcn": "^4.1.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -11527,6 +11528,16 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -32,6 +32,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "shadcn": "^4.1.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/web-app/proxy.ts
+++ b/web-app/proxy.ts
@@ -1,7 +1,7 @@
 import { auth } from "@/lib/auth";
 import { NextResponse } from "next/server";
 
-const publicRoutes = ["/login", "/api/auth"];
+const publicRoutes = ["/login", "/api/auth", "/api/v1"];
 
 export const proxy = auth((req) => {
   const { pathname } = req.nextUrl;


### PR DESCRIPTION
## Summary

- Adds a full PAT management system: API routes for creating/listing/deleting tokens, a settings UI for managing them, and the supporting auth infrastructure for Bearer token authentication.
- Tokens use a `dhub_` prefix, are hashed with SHA-256 before storage, and the plaintext is shown exactly once at creation. Expiry and last-used tracking are supported.
- Includes a new `/settings` section with sidebar navigation, seeded with the "Access Tokens" page.

## Changes

- **API routes:**
  - `POST /api/v1/tokens` — creates a new PAT (validates name/expiry, returns plaintext once)
  - `GET /api/v1/tokens` — lists the current user's tokens (session-authenticated)
  - `DELETE /api/v1/tokens/[id]` — revokes a token by ID (ownership-scoped, UUID-validated)
- **Auth helpers** (`lib/api/auth.ts`):
  - `authenticateRequest()` — supports both session and Bearer token auth; looks up token by SHA-256 hash, checks expiry, updates `last_used_at` via `after()`
  - `requireSession()` — session-only auth for management endpoints
- **Token utilities** (`lib/tokens.ts`): `generateToken()`, `hashToken()`, `getTokenPrefix()` (first 9 chars)
- **Drizzle schema**: `personal_access_tokens` table with user FK, hash, prefix, expiry, last-used, and created timestamps
- **Settings UI:**
  - `/settings` layout with authenticated guard and sidebar nav (`SettingsNav`)
  - `/settings/tokens` page — server component that lists tokens in a table with name, prefix badge, last-used/expiry/created relative times, and a delete action
  - `CreateTokenDialog` — two-step dialog (form → display plaintext with copy button); prevents dismissal before copying
  - `DeleteTokenDialog` — destructive confirmation via `AlertDialog`
- **New shadcn/ui components:** `AlertDialog`, `Badge`, `Dialog`, `DropdownMenu`, `Select`, `Sonner` (toast), `Table`, `Label`
- **Root layout:** added global `<Toaster />` for toast notifications
- **Docs:** updated `DATABASE_SCHEMA.md` and `AUTHENTICATION.md` to reflect the `dhub_` prefix (9 chars), corrected example token names

## Breaking changes

None.

## Driveby changes

- Added `cursor-pointer` to the base `Button` component variant (`button.tsx`)

## Testing

- [x] Create a new token via the dialog — verify plaintext is displayed and copyable
- [x] Verify the plaintext token is **not** visible after closing the dialog
- [x] Confirm the new token appears in the table with correct prefix badge
- [x] Delete a token and verify it is removed from the list with a success toast
- [x] Authenticate an API request using `Authorization: Bearer dhub_...` and confirm it succeeds
- [x] Confirm expired tokens are rejected by the API
- [x] Verify `last_used_at` is updated after an API call with a valid token
- [x] Try to delete another user's token — should return 404
- [x] Verify `/settings` redirects to `/settings/tokens`
- [x] Verify unauthenticated users are redirected to `/login` from `/settings`