### PR TITLE
Add v1 API endpoints for watchers, instruments, runs, and files

### DIFF
--- a/web-app/app/api/v1/files/[fileId]/download/route.ts
+++ b/web-app/app/api/v1/files/[fileId]/download/route.ts
@@ -1,7 +1,12 @@
 import { authenticateRequest } from "@/lib/api/auth";
-import { apiError, NOT_FOUND, UNAUTHORIZED } from "@/lib/api/errors";
+import {
+  apiError,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
 import { db } from "@/lib/db";
-import { files } from "@/lib/db/schema";
+import { files, instrumentRuns } from "@/lib/db/schema";
 import { getPresignedDownloadUrl } from "@/lib/s3";
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
@@ -27,19 +32,35 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
   const { fileId } = await params;
   const numericId = parseInt(fileId, 10);
   if (isNaN(numericId)) {
-    return apiError(404, NOT_FOUND, "Invalid file ID");
+    return apiError(400, VALIDATION_ERROR, "Invalid file ID");
   }
 
   const [file] = await db
     .select({
       s3Bucket: files.s3Bucket,
       s3Key: files.s3Key,
+      deletedAt: files.deletedAt,
+      instrumentRunId: files.instrumentRunId,
     })
     .from(files)
     .where(eq(files.id, numericId))
     .limit(1);
 
   if (!file) {
+    return apiError(404, NOT_FOUND, `File '${fileId}' not found`);
+  }
+
+  if (file.deletedAt) {
+    return apiError(404, NOT_FOUND, `File '${fileId}' not found`);
+  }
+
+  const [parentRun] = await db
+    .select({ deletedAt: instrumentRuns.deletedAt })
+    .from(instrumentRuns)
+    .where(eq(instrumentRuns.id, file.instrumentRunId))
+    .limit(1);
+
+  if (parentRun?.deletedAt) {
     return apiError(404, NOT_FOUND, `File '${fileId}' not found`);
   }
 

--- a/web-app/app/api/v1/files/[fileId]/download/route.ts
+++ b/web-app/app/api/v1/files/[fileId]/download/route.ts
@@ -1,0 +1,56 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import { apiError, NOT_FOUND, UNAUTHORIZED } from "@/lib/api/errors";
+import { db } from "@/lib/db";
+import { files } from "@/lib/db/schema";
+import { getPresignedDownloadUrl } from "@/lib/s3";
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+type RouteContext = {
+  params: Promise<{ fileId: string }>;
+};
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/files/:fileId/download
+//
+// Generates a short-lived pre-signed S3 URL and issues a 302 redirect.
+// This avoids exposing raw S3 URLs in the web UI's HTML while still
+// allowing direct browser downloads.
+// ---------------------------------------------------------------------------
+
+export async function GET(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { fileId } = await params;
+  const numericId = parseInt(fileId, 10);
+  if (isNaN(numericId)) {
+    return apiError(404, NOT_FOUND, "Invalid file ID");
+  }
+
+  const [file] = await db
+    .select({
+      s3Bucket: files.s3Bucket,
+      s3Key: files.s3Key,
+    })
+    .from(files)
+    .where(eq(files.id, numericId))
+    .limit(1);
+
+  if (!file) {
+    return apiError(404, NOT_FOUND, `File '${fileId}' not found`);
+  }
+
+  if (!file.s3Bucket || !file.s3Key) {
+    return apiError(404, NOT_FOUND, "File has not been uploaded to S3 yet");
+  }
+
+  const url = await getPresignedDownloadUrl(file.s3Bucket, file.s3Key);
+
+  return new Response(null, {
+    status: 302,
+    headers: { Location: url },
+  });
+}

--- a/web-app/app/api/v1/files/[fileId]/route.ts
+++ b/web-app/app/api/v1/files/[fileId]/route.ts
@@ -1,0 +1,246 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import {
+  apiError,
+  CONFLICT,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
+import { db } from "@/lib/db";
+import { files, instrumentRuns, runReportData } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+type RouteContext = {
+  params: Promise<{ fileId: string }>;
+};
+
+// Enforced state machine for file status transitions. The two paths through
+// the lifecycle are:
+//   Watcher flow:  detected → [upload_requested →] uploaded → processing → completed|failed
+//   Lambda flow:   (created as "uploaded" via POST .../files) → processing → completed|failed
+// "completed" and "failed" are terminal states — no further transitions allowed.
+const VALID_TRANSITIONS: Record<string, string[]> = {
+  detected: ["uploaded"],
+  upload_requested: ["uploaded"],
+  uploaded: ["processing"],
+  processing: ["completed", "failed"],
+};
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/files/:fileId
+//
+// Serves multiple callers:
+//   - Watcher: detected/upload_requested → uploaded (with S3 info)
+//   - Lambda: uploaded → processing → completed/failed (with metadata +
+//     report_data)
+//
+// Enforces the file status state machine and rejects mutations on
+// soft-deleted files or files whose parent run is soft-deleted.
+// ---------------------------------------------------------------------------
+
+export async function PATCH(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { fileId } = await params;
+  const numericId = parseInt(fileId, 10);
+  if (isNaN(numericId)) {
+    return apiError(400, VALIDATION_ERROR, "Invalid file ID");
+  }
+
+  const [file] = await db
+    .select()
+    .from(files)
+    .where(eq(files.id, numericId))
+    .limit(1);
+
+  if (!file) {
+    return apiError(404, NOT_FOUND, `File '${fileId}' not found`);
+  }
+
+  if (file.deletedAt) {
+    return apiError(409, CONFLICT, "Cannot update a soft-deleted file");
+  }
+
+  // Verify the parent run is not soft-deleted.
+  const [parentRun] = await db
+    .select({ deletedAt: instrumentRuns.deletedAt })
+    .from(instrumentRuns)
+    .where(eq(instrumentRuns.id, file.instrumentRunId))
+    .limit(1);
+
+  if (parentRun?.deletedAt) {
+    return apiError(
+      409,
+      CONFLICT,
+      "Cannot update a file whose parent run is soft-deleted"
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
+  }
+
+  const updates: Record<string, unknown> = {};
+  const now = new Date();
+
+  // Status transition validation.
+  if ("status" in body && typeof body.status === "string") {
+    const allowed = VALID_TRANSITIONS[file.status];
+    if (!allowed || !allowed.includes(body.status)) {
+      return apiError(
+        409,
+        CONFLICT,
+        `Cannot transition from '${file.status}' to '${body.status}'`,
+        { allowed_transitions: allowed ?? [] }
+      );
+    }
+
+    updates.status = body.status;
+
+    if (body.status === "uploaded") {
+      updates.uploadedAt = now;
+    }
+    if (body.status === "completed" || body.status === "failed") {
+      updates.processedAt = now;
+    }
+  }
+
+  // S3 info — set when transitioning to "uploaded" (watcher path).
+  if (typeof body.s3_bucket === "string") updates.s3Bucket = body.s3_bucket;
+  if (typeof body.s3_key === "string") updates.s3Key = body.s3_key;
+  if (typeof body.content_type === "string")
+    updates.contentType = body.content_type;
+  if (typeof body.size_bytes === "number") updates.sizeBytes = body.size_bytes;
+
+  // Metadata — flat JSON object set by the Lambda after processing.
+  if (
+    "metadata" in body &&
+    typeof body.metadata === "object" &&
+    body.metadata !== null &&
+    !Array.isArray(body.metadata)
+  ) {
+    updates.metadata = body.metadata;
+  }
+
+  // Error message — set when status transitions to "failed".
+  if (typeof body.error_message === "string") {
+    updates.errorMessage = body.error_message;
+  }
+
+  if (Object.keys(updates).length > 0) {
+    await db.update(files).set(updates).where(eq(files.id, numericId));
+  }
+
+  // Report data — array of { data_type, data } objects inserted into
+  // run_report_data, linked to both the file and its parent run. Dual linkage
+  // allows querying report data both per-file and per-run. The data_type field
+  // (e.g., "raw_well_data", "plate_map") identifies the dataset shape so the
+  // UI can render the appropriate visualization.
+  if (Array.isArray(body.report_data) && body.report_data.length > 0) {
+    const reportValues = body.report_data.map(
+      (rd: { data_type: string; data: unknown }) => ({
+        instrumentRunId: file.instrumentRunId,
+        fileId: numericId,
+        dataType: rd.data_type,
+        data: rd.data,
+      })
+    );
+
+    await db.insert(runReportData).values(reportValues);
+  }
+
+  // Re-fetch the updated file to return current state.
+  const [updated] = await db
+    .select()
+    .from(files)
+    .where(eq(files.id, numericId))
+    .limit(1);
+
+  return Response.json({
+    id: updated.id,
+    instrument_run_id: updated.instrumentRunId,
+    filename: updated.filename,
+    relative_path: updated.relativePath,
+    s3_bucket: updated.s3Bucket,
+    s3_key: updated.s3Key,
+    content_type: updated.contentType,
+    size_bytes: updated.sizeBytes,
+    category: updated.category,
+    status: updated.status,
+    metadata: updated.metadata,
+    error_message: updated.errorMessage,
+    detected_at: updated.detectedAt,
+    upload_requested_at: updated.uploadRequestedAt,
+    uploaded_at: updated.uploadedAt,
+    processed_at: updated.processedAt,
+    created_at: updated.createdAt,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/files/:fileId
+//
+// Soft-delete for dismissing individual detected/upload_requested files from
+// the UI. Files that have already been uploaded to S3 (status "uploaded" or
+// later) cannot be dismissed here — use the run-level DELETE instead.
+// ---------------------------------------------------------------------------
+
+export async function DELETE(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { fileId } = await params;
+  const numericId = parseInt(fileId, 10);
+  if (isNaN(numericId)) {
+    return apiError(400, VALIDATION_ERROR, "Invalid file ID");
+  }
+
+  const [file] = await db
+    .select()
+    .from(files)
+    .where(eq(files.id, numericId))
+    .limit(1);
+
+  if (!file) {
+    return apiError(404, NOT_FOUND, `File '${fileId}' not found`);
+  }
+
+  if (file.deletedAt) {
+    return apiError(409, CONFLICT, "File is already deleted");
+  }
+
+  // Only pre-upload files can be dismissed. Once uploaded to S3, deletion
+  // must go through the run-level DELETE which handles S3 lifecycle.
+  if (file.status !== "detected" && file.status !== "upload_requested") {
+    return apiError(
+      409,
+      CONFLICT,
+      `Cannot dismiss a file in '${file.status}' status — only 'detected' or 'upload_requested' files can be dismissed`
+    );
+  }
+
+  const now = new Date();
+
+  await db.update(files).set({ deletedAt: now }).where(eq(files.id, numericId));
+
+  // Touch the parent run so the UI can detect the change.
+  await db
+    .update(instrumentRuns)
+    .set({ updatedAt: now })
+    .where(eq(instrumentRuns.id, file.instrumentRunId));
+
+  return Response.json({
+    id: file.id,
+    filename: file.filename,
+    deleted_at: now,
+  });
+}

--- a/web-app/app/api/v1/instrument-runs/route.ts
+++ b/web-app/app/api/v1/instrument-runs/route.ts
@@ -1,0 +1,42 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import { apiError, UNAUTHORIZED } from "@/lib/api/errors";
+import { buildRunListQuery } from "@/lib/api/instrument-runs";
+import { parseIntParam } from "@/lib/api/validators";
+import type { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/instrument-runs
+//
+// Cross-instrument run list for the dashboard. Same response shape as the
+// per-instrument endpoint but without requiring an instrumentId in the path.
+// Accepts an optional instrument_id query param to narrow results.
+// ---------------------------------------------------------------------------
+
+export async function GET(request: NextRequest) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { searchParams } = request.nextUrl;
+
+  const result = await buildRunListQuery({
+    instrumentId: searchParams.get("instrument_id") ?? undefined,
+    source: searchParams.get("source") ?? undefined,
+    search: searchParams.get("search") ?? undefined,
+    sort: searchParams.get("sort") ?? undefined,
+    order: searchParams.get("order") ?? undefined,
+    page: parseIntParam(searchParams.get("page"), {
+      default: 1,
+      min: 1,
+    }),
+    perPage: parseIntParam(searchParams.get("per_page"), {
+      default: 25,
+      min: 1,
+      max: 100,
+    }),
+    includeDeleted: searchParams.get("include_deleted") === "true",
+  });
+
+  return Response.json(result);
+}

--- a/web-app/app/api/v1/instruments/[instrumentId]/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/route.ts
@@ -1,0 +1,131 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import {
+  apiError,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
+import { db } from "@/lib/db";
+import { instrumentRuns, instruments, watchers } from "@/lib/db/schema";
+import { and, count, eq, isNull } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ instrumentId: string }> }
+) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { instrumentId } = await params;
+
+  const [instrument] = await db
+    .select()
+    .from(instruments)
+    .where(eq(instruments.id, instrumentId))
+    .limit(1);
+
+  if (!instrument) {
+    return apiError(404, NOT_FOUND, `Instrument '${instrumentId}' not found`);
+  }
+
+  // Counts exclude soft-deleted records to reflect the "active" totals.
+  const [runCountResult, watcherCountResult] = await Promise.all([
+    db
+      .select({ value: count() })
+      .from(instrumentRuns)
+      .where(
+        and(
+          eq(instrumentRuns.instrumentId, instrumentId),
+          isNull(instrumentRuns.deletedAt)
+        )
+      ),
+    db
+      .select({ value: count() })
+      .from(watchers)
+      .where(
+        and(eq(watchers.instrumentId, instrumentId), isNull(watchers.deletedAt))
+      ),
+  ]);
+
+  return Response.json({
+    id: instrument.id,
+    display_name: instrument.displayName,
+    status: instrument.status,
+    file_patterns: instrument.filePatterns,
+    s3_trigger_suffix: instrument.s3TriggerSuffix,
+    created_at: instrument.createdAt,
+    updated_at: instrument.updatedAt,
+    run_count: runCountResult[0].value,
+    watcher_count: watcherCountResult[0].value,
+  });
+}
+
+const ALLOWED_PATCH_FIELDS = new Set([
+  "status",
+  "file_patterns",
+  "display_name",
+]);
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ instrumentId: string }> }
+) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { instrumentId } = await params;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
+  }
+
+  const unknownKeys = Object.keys(body).filter(
+    (k) => !ALLOWED_PATCH_FIELDS.has(k)
+  );
+  if (unknownKeys.length > 0) {
+    return apiError(400, VALIDATION_ERROR, "Unknown fields", {
+      unknown_fields: unknownKeys,
+      allowed_fields: [...ALLOWED_PATCH_FIELDS],
+    });
+  }
+
+  const [existing] = await db
+    .select({ id: instruments.id })
+    .from(instruments)
+    .where(eq(instruments.id, instrumentId))
+    .limit(1);
+
+  if (!existing) {
+    return apiError(404, NOT_FOUND, `Instrument '${instrumentId}' not found`);
+  }
+
+  // Map API snake_case field names to Drizzle camelCase column names.
+  const updates: Record<string, unknown> = {};
+  if ("status" in body) updates.status = body.status;
+  if ("file_patterns" in body) updates.filePatterns = body.file_patterns;
+  if ("display_name" in body) updates.displayName = body.display_name;
+
+  const [updated] = await db
+    .update(instruments)
+    .set(updates)
+    .where(eq(instruments.id, instrumentId))
+    .returning({
+      id: instruments.id,
+      display_name: instruments.displayName,
+      status: instruments.status,
+      file_patterns: instruments.filePatterns,
+      s3_trigger_suffix: instruments.s3TriggerSuffix,
+      created_at: instruments.createdAt,
+      updated_at: instruments.updatedAt,
+    });
+
+  return Response.json(updated);
+}

--- a/web-app/app/api/v1/instruments/[instrumentId]/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/route.ts
@@ -107,11 +107,26 @@ export async function PATCH(
     return apiError(404, NOT_FOUND, `Instrument '${instrumentId}' not found`);
   }
 
-  // Map API snake_case field names to Drizzle camelCase column names.
+  const VALID_INSTRUMENT_STATUSES = ["pending", "active", "inactive"];
+  if (
+    "status" in body &&
+    !VALID_INSTRUMENT_STATUSES.includes(body.status as string)
+  ) {
+    return apiError(
+      400,
+      VALIDATION_ERROR,
+      `Invalid status — must be one of: ${VALID_INSTRUMENT_STATUSES.join(", ")}`
+    );
+  }
+
   const updates: Record<string, unknown> = {};
   if ("status" in body) updates.status = body.status;
   if ("file_patterns" in body) updates.filePatterns = body.file_patterns;
   if ("display_name" in body) updates.displayName = body.display_name;
+
+  if (Object.keys(updates).length === 0) {
+    return apiError(400, VALIDATION_ERROR, "No valid fields to update");
+  }
 
   const [updated] = await db
     .update(instruments)

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/analyses/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/analyses/route.ts
@@ -1,0 +1,54 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import { apiError, UNAUTHORIZED } from "@/lib/api/errors";
+import type { NextRequest } from "next/server";
+
+type RouteContext = {
+  params: Promise<{ instrumentId: string; runId: string }>;
+};
+
+// ---------------------------------------------------------------------------
+// Analysis endpoints are stubbed until the Lambda invocation infrastructure
+// is wired up. Returns 501 so clients can distinguish "not yet built" from
+// other error states.
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  // Consume params to satisfy Next.js dynamic route requirements.
+  await params;
+
+  return Response.json(
+    {
+      error: {
+        code: "NOT_IMPLEMENTED",
+        message:
+          "Analysis triggering is not yet implemented. This endpoint will invoke a Lambda function in a future release.",
+      },
+    },
+    { status: 501 }
+  );
+}
+
+export async function GET(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  await params;
+
+  return Response.json(
+    {
+      error: {
+        code: "NOT_IMPLEMENTED",
+        message:
+          "Analysis listing is not yet implemented. This endpoint will return analysis results in a future release.",
+      },
+    },
+    { status: 501 }
+  );
+}

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/files/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/files/route.ts
@@ -1,0 +1,131 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import {
+  apiError,
+  CONFLICT,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
+import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
+import { db } from "@/lib/db";
+import { files } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+type RouteContext = {
+  params: Promise<{ instrumentId: string; runId: string }>;
+};
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/instruments/:instrumentId/runs/:runId/files
+//
+// Creates a file record with S3 info — this is the Lambda path. The file
+// starts in "uploaded" status because the Lambda already has the file in S3
+// by the time it calls this endpoint.
+//
+// Idempotent on s3_key: if a file with the same key already exists (partial
+// unique index), returns the existing record with 200 instead of 201.
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { instrumentId, runId } = await params;
+  const run = await lookupRunByNaturalKey(instrumentId, runId);
+
+  if (!run) {
+    return apiError(
+      404,
+      NOT_FOUND,
+      `Run '${runId}' not found for instrument '${instrumentId}'`
+    );
+  }
+
+  if (run.deletedAt) {
+    return apiError(409, CONFLICT, "Cannot add files to a soft-deleted run");
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
+  }
+
+  const s3Bucket =
+    typeof body.s3_bucket === "string" ? body.s3_bucket.trim() : "";
+  const s3Key = typeof body.s3_key === "string" ? body.s3_key.trim() : "";
+  const filename =
+    typeof body.filename === "string" ? body.filename.trim() : "";
+
+  if (!s3Bucket || !s3Key || !filename) {
+    return apiError(
+      400,
+      VALIDATION_ERROR,
+      "s3_bucket, s3_key, and filename are required"
+    );
+  }
+
+  const contentType =
+    typeof body.content_type === "string" ? body.content_type : null;
+  const sizeBytes =
+    typeof body.size_bytes === "number" ? body.size_bytes : null;
+  const category =
+    body.category === "processed" ? ("processed" as const) : ("raw" as const);
+
+  const now = new Date();
+
+  // Insert with "uploaded" status — the Lambda already has the file in S3 by
+  // the time it calls this endpoint. The partial unique index on s3_key
+  // prevents duplicate file records when the Lambda retries after a timeout.
+  const [inserted] = await db
+    .insert(files)
+    .values({
+      instrumentRunId: run.id,
+      s3Bucket,
+      s3Key,
+      filename,
+      contentType,
+      sizeBytes,
+      category,
+      status: "uploaded",
+      uploadedAt: now,
+    })
+    .onConflictDoNothing()
+    .returning();
+
+  // If onConflictDoNothing fired, the row already exists — return it.
+  if (!inserted) {
+    const [existing] = await db
+      .select()
+      .from(files)
+      .where(eq(files.s3Key, s3Key))
+      .limit(1);
+
+    return Response.json(formatFileResponse(existing), { status: 200 });
+  }
+
+  return Response.json(formatFileResponse(inserted), { status: 201 });
+}
+
+function formatFileResponse(f: typeof files.$inferSelect) {
+  return {
+    id: f.id,
+    instrument_run_id: f.instrumentRunId,
+    s3_bucket: f.s3Bucket,
+    s3_key: f.s3Key,
+    filename: f.filename,
+    content_type: f.contentType,
+    size_bytes: f.sizeBytes,
+    category: f.category,
+    status: f.status,
+    metadata: f.metadata,
+    error_message: f.errorMessage,
+    uploaded_at: f.uploadedAt,
+    processed_at: f.processedAt,
+    created_at: f.createdAt,
+  };
+}

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload/route.ts
@@ -58,14 +58,34 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
     return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
   }
 
-  const fileIds = Array.isArray(body.file_ids) ? body.file_ids : [];
-  if (fileIds.length === 0) {
+  const MAX_FILE_IDS = 100;
+  const rawFileIds = Array.isArray(body.file_ids) ? body.file_ids : [];
+  if (rawFileIds.length === 0) {
     return apiError(
       400,
       VALIDATION_ERROR,
       "file_ids must be a non-empty array"
     );
   }
+  if (rawFileIds.length > MAX_FILE_IDS) {
+    return apiError(
+      400,
+      VALIDATION_ERROR,
+      `file_ids cannot exceed ${MAX_FILE_IDS} entries`
+    );
+  }
+  if (
+    !rawFileIds.every(
+      (id: unknown) => typeof id === "number" && Number.isInteger(id)
+    )
+  ) {
+    return apiError(
+      400,
+      VALIDATION_ERROR,
+      "file_ids must contain only integer values"
+    );
+  }
+  const fileIds: number[] = rawFileIds;
 
   // Fetch all specified files in a single query to validate ownership,
   // status, and soft-delete state in bulk.

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload/route.ts
@@ -1,0 +1,148 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import {
+  apiError,
+  CONFLICT,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
+import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
+import { db } from "@/lib/db";
+import { files, instrumentRuns } from "@/lib/db/schema";
+import { eq, inArray } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+type RouteContext = {
+  params: Promise<{ instrumentId: string; runId: string }>;
+};
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/instruments/:instrumentId/runs/:runId/request-upload
+//
+// Transitions detected files to upload_requested status. Called by the web UI
+// when a user selects files (or an entire run) to upload. Files already in
+// upload_requested status are silently skipped (idempotent). Files that have
+// progressed past upload_requested, are soft-deleted, or belong to a different
+// run are rejected.
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { instrumentId, runId } = await params;
+  const run = await lookupRunByNaturalKey(instrumentId, runId);
+
+  if (!run) {
+    return apiError(
+      404,
+      NOT_FOUND,
+      `Run '${runId}' not found for instrument '${instrumentId}'`
+    );
+  }
+
+  if (run.deletedAt) {
+    return apiError(
+      409,
+      CONFLICT,
+      "Cannot request uploads for a soft-deleted run"
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
+  }
+
+  const fileIds = Array.isArray(body.file_ids) ? body.file_ids : [];
+  if (fileIds.length === 0) {
+    return apiError(
+      400,
+      VALIDATION_ERROR,
+      "file_ids must be a non-empty array"
+    );
+  }
+
+  // Fetch all specified files in a single query to validate ownership,
+  // status, and soft-delete state in bulk.
+  const requestedFiles = await db
+    .select()
+    .from(files)
+    .where(inArray(files.id, fileIds));
+
+  const requestedById = new Map(requestedFiles.map((f) => [f.id, f]));
+
+  // Validate every requested file before making any mutations. This ensures
+  // atomicity: either all files pass validation and get queued, or none do.
+  // Without this pre-check, a partial failure could leave the batch in an
+  // inconsistent state that's confusing for the UI.
+  for (const fid of fileIds) {
+    const f = requestedById.get(fid);
+    if (!f) {
+      return apiError(400, VALIDATION_ERROR, `File ${fid} not found`);
+    }
+    if (f.instrumentRunId !== run.id) {
+      return apiError(
+        400,
+        VALIDATION_ERROR,
+        `File ${fid} does not belong to this run`
+      );
+    }
+    if (f.deletedAt) {
+      return apiError(400, VALIDATION_ERROR, `File ${fid} has been deleted`);
+    }
+    // Allow detected → upload_requested; skip files already in
+    // upload_requested (idempotent). Reject any other status.
+    if (f.status !== "detected" && f.status !== "upload_requested") {
+      return apiError(
+        400,
+        VALIDATION_ERROR,
+        `File ${fid} is in '${f.status}' status and cannot be queued for upload`
+      );
+    }
+  }
+
+  const now = new Date();
+
+  // Only transition files that are still in "detected" — skip those already
+  // in "upload_requested" to make the endpoint idempotent.
+  const toTransition = fileIds.filter(
+    (fid: number) => requestedById.get(fid)!.status === "detected"
+  );
+
+  if (toTransition.length > 0) {
+    await db
+      .update(files)
+      .set({ status: "upload_requested", uploadRequestedAt: now })
+      .where(inArray(files.id, toTransition));
+  }
+
+  // Touch the parent run so watchers can detect changes via updated_at.
+  await db
+    .update(instrumentRuns)
+    .set({ updatedAt: now })
+    .where(eq(instrumentRuns.id, run.id));
+
+  // Build the response with the upload_requested_at for all files (both
+  // newly transitioned and already-queued).
+  const responseFiles = fileIds.map((fid: number) => {
+    const f = requestedById.get(fid)!;
+    return {
+      id: f.id,
+      filename: f.filename,
+      upload_requested_at:
+        f.status === "upload_requested" ? f.uploadRequestedAt : now,
+    };
+  });
+
+  return Response.json({
+    instrument_id: run.instrumentId,
+    run_id: run.runId,
+    files_queued: fileIds.length,
+    files: responseFiles,
+  });
+}

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/route.ts
@@ -1,0 +1,244 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import {
+  apiError,
+  CONFLICT,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
+import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
+import { db } from "@/lib/db";
+import { files, instrumentRuns, runReportData } from "@/lib/db/schema";
+import { getPresignedDownloadUrl } from "@/lib/s3";
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+type RouteContext = {
+  params: Promise<{ instrumentId: string; runId: string }>;
+};
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/instruments/:instrumentId/runs/:runId
+//
+// Full run detail — files (with pre-signed download URLs), report_data, and
+// run-level metadata. Files and report data are fetched in parallel to
+// minimize response latency.
+// ---------------------------------------------------------------------------
+
+export async function GET(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { instrumentId, runId } = await params;
+  const run = await lookupRunByNaturalKey(instrumentId, runId);
+
+  if (!run) {
+    return apiError(
+      404,
+      NOT_FOUND,
+      `Run '${runId}' not found for instrument '${instrumentId}'`
+    );
+  }
+
+  // Fetch files and report data concurrently — no dependency between them.
+  const [fileRows, reportRows] = await Promise.all([
+    db
+      .select()
+      .from(files)
+      .where(eq(files.instrumentRunId, run.id))
+      .orderBy(files.createdAt),
+    db
+      .select({
+        data_type: runReportData.dataType,
+        file_id: runReportData.fileId,
+        data: runReportData.data,
+      })
+      .from(runReportData)
+      .where(eq(runReportData.instrumentRunId, run.id)),
+  ]);
+
+  // Generate short-lived pre-signed URLs only for files that have been
+  // uploaded to S3 (s3Key is non-null). Detected/queued files get null.
+  const filesWithUrls = await Promise.all(
+    fileRows.map(async (f) => ({
+      id: f.id,
+      filename: f.filename,
+      relative_path: f.relativePath,
+      s3_key: f.s3Key,
+      content_type: f.contentType,
+      size_bytes: f.sizeBytes,
+      category: f.category,
+      status: f.status,
+      metadata: f.metadata,
+      error_message: f.errorMessage,
+      detected_at: f.detectedAt,
+      upload_requested_at: f.uploadRequestedAt,
+      uploaded_at: f.uploadedAt,
+      processed_at: f.processedAt,
+      download_url:
+        f.s3Bucket && f.s3Key
+          ? await getPresignedDownloadUrl(f.s3Bucket, f.s3Key)
+          : null,
+      created_at: f.createdAt,
+    }))
+  );
+
+  return Response.json({
+    id: run.id,
+    instrument_id: run.instrumentId,
+    instrument_display_name: run.instrumentDisplayName,
+    run_id: run.runId,
+    source: run.source,
+    watcher_id: run.watcherId,
+    created_at: run.createdAt,
+    updated_at: run.updatedAt,
+    deleted_at: run.deletedAt,
+    metadata: run.metadata,
+    files: filesWithUrls,
+    report_data: reportRows,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/instruments/:instrumentId/runs/:runId
+//
+// Supports two payload shapes:
+//   - { metadata: {...} } — full replacement of run-level metadata
+//   - { detected_files: [...] } — upsert new detected files (watcher path)
+// Rejects updates to soft-deleted runs with 409.
+// ---------------------------------------------------------------------------
+
+export async function PATCH(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { instrumentId, runId } = await params;
+  const run = await lookupRunByNaturalKey(instrumentId, runId);
+
+  if (!run) {
+    return apiError(
+      404,
+      NOT_FOUND,
+      `Run '${runId}' not found for instrument '${instrumentId}'`
+    );
+  }
+
+  if (run.deletedAt) {
+    return apiError(409, CONFLICT, "Cannot update a soft-deleted run");
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
+  }
+
+  // Metadata is a full replacement (not a deep merge). The Lambda or analysis
+  // pipeline writes the complete metadata object after processing. Patch-by-key
+  // would require a read-then-merge cycle that adds complexity with no benefit
+  // at current scale.
+  if ("metadata" in body) {
+    if (
+      typeof body.metadata !== "object" ||
+      body.metadata === null ||
+      Array.isArray(body.metadata)
+    ) {
+      return apiError(400, VALIDATION_ERROR, "metadata must be a JSON object");
+    }
+
+    await db
+      .update(instrumentRuns)
+      .set({ metadata: body.metadata })
+      .where(eq(instrumentRuns.id, run.id));
+  }
+
+  // Handle detected_files upsert (watcher reporting new files for a run).
+  const detectedFiles = Array.isArray(body.detected_files)
+    ? body.detected_files
+    : [];
+
+  if (detectedFiles.length > 0) {
+    const now = new Date();
+    const fileValues = detectedFiles.map(
+      (f: {
+        relative_path: string;
+        filename: string;
+        size_bytes?: number;
+      }) => ({
+        instrumentRunId: run.id,
+        relativePath: f.relative_path,
+        filename: f.filename,
+        sizeBytes: f.size_bytes ?? null,
+        status: "detected" as const,
+        detectedAt: now,
+      })
+    );
+
+    // Relies on the partial unique index (instrument_run_id, relative_path)
+    // to skip files already reported for this run.
+    await db.insert(files).values(fileValues).onConflictDoNothing();
+  }
+
+  // Re-fetch the updated run to return current state.
+  const updated = await lookupRunByNaturalKey(instrumentId, runId);
+
+  return Response.json({
+    id: updated!.id,
+    instrument_id: updated!.instrumentId,
+    instrument_display_name: updated!.instrumentDisplayName,
+    run_id: updated!.runId,
+    source: updated!.source,
+    watcher_id: updated!.watcherId,
+    metadata: updated!.metadata,
+    created_at: updated!.createdAt,
+    updated_at: updated!.updatedAt,
+    deleted_at: updated!.deletedAt,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/instruments/:instrumentId/runs/:runId
+//
+// Soft-delete only — sets deleted_at. Does NOT cascade to files or remove
+// S3 objects. S3 cleanup is handled by a separate lifecycle job after a
+// configurable retention period.
+// ---------------------------------------------------------------------------
+
+export async function DELETE(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { instrumentId, runId } = await params;
+  const run = await lookupRunByNaturalKey(instrumentId, runId);
+
+  if (!run) {
+    return apiError(
+      404,
+      NOT_FOUND,
+      `Run '${runId}' not found for instrument '${instrumentId}'`
+    );
+  }
+
+  if (run.deletedAt) {
+    return apiError(409, CONFLICT, "Run is already deleted");
+  }
+
+  const now = new Date();
+  await db
+    .update(instrumentRuns)
+    .set({ deletedAt: now })
+    .where(eq(instrumentRuns.id, run.id));
+
+  return Response.json({
+    instrument_id: run.instrumentId,
+    run_id: run.runId,
+    deleted_at: now,
+  });
+}

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/route.ts
@@ -1,0 +1,216 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import {
+  apiError,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
+import { buildRunListQuery } from "@/lib/api/instrument-runs";
+import { parseIntParam } from "@/lib/api/validators";
+import { db } from "@/lib/db";
+import { files, instrumentRuns, instruments, watchers } from "@/lib/db/schema";
+import { and, eq, isNull } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+type RouteContext = {
+  params: Promise<{ instrumentId: string }>;
+};
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/instruments/:instrumentId/runs
+//
+// Idempotent run creation. Two callers use different payloads:
+//   - Lambda: { run_id, source: "lambda" }
+//   - Watcher: { run_id, source: "watcher", watcher_id, detected_files[] }
+// If the run already exists (same instrument_id + run_id), returns 200 with
+// the existing record instead of 201. This handles the race where a Lambda
+// auto-creates a run that was already reported by the watcher.
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { instrumentId } = await params;
+
+  const [instrument] = await db
+    .select({ id: instruments.id })
+    .from(instruments)
+    .where(eq(instruments.id, instrumentId))
+    .limit(1);
+
+  if (!instrument) {
+    return apiError(404, NOT_FOUND, `Instrument '${instrumentId}' not found`);
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
+  }
+
+  const runId = typeof body.run_id === "string" ? body.run_id.trim() : "";
+  if (!runId) {
+    return apiError(400, VALIDATION_ERROR, "run_id is required");
+  }
+
+  const source = body.source;
+  if (source !== "lambda" && source !== "watcher") {
+    return apiError(
+      400,
+      VALIDATION_ERROR,
+      'source must be "lambda" or "watcher"'
+    );
+  }
+
+  const watcherId =
+    typeof body.watcher_id === "string" ? body.watcher_id : null;
+
+  // Validate watcher_id references an active watcher for this instrument.
+  if (watcherId) {
+    const [watcher] = await db
+      .select({ id: watchers.id })
+      .from(watchers)
+      .where(
+        and(
+          eq(watchers.id, watcherId),
+          eq(watchers.instrumentId, instrumentId),
+          isNull(watchers.deletedAt)
+        )
+      )
+      .limit(1);
+
+    if (!watcher) {
+      return apiError(
+        400,
+        VALIDATION_ERROR,
+        `Watcher '${watcherId}' not found or not active for this instrument`
+      );
+    }
+  }
+
+  // Upsert: attempt insert, do nothing on conflict. Then select the row
+  // regardless of whether it was just created or already existed.
+  const [inserted] = await db
+    .insert(instrumentRuns)
+    .values({
+      instrumentId,
+      runId,
+      source,
+      watcherId,
+    })
+    .onConflictDoNothing({
+      target: [instrumentRuns.instrumentId, instrumentRuns.runId],
+    })
+    .returning({ id: instrumentRuns.id });
+
+  const isNew = !!inserted;
+
+  // If onConflictDoNothing fired, `inserted` is undefined — fetch the
+  // existing row by the natural key.
+  const [run] = isNew
+    ? await db
+        .select()
+        .from(instrumentRuns)
+        .where(eq(instrumentRuns.id, inserted.id))
+        .limit(1)
+    : await db
+        .select()
+        .from(instrumentRuns)
+        .where(
+          and(
+            eq(instrumentRuns.instrumentId, instrumentId),
+            eq(instrumentRuns.runId, runId)
+          )
+        )
+        .limit(1);
+
+  // Watcher payloads may include detected files to bulk-insert alongside
+  // the run. Duplicates (same run + relative_path) are silently skipped.
+  const detectedFiles = Array.isArray(body.detected_files)
+    ? body.detected_files
+    : [];
+
+  if (detectedFiles.length > 0) {
+    const now = new Date();
+    const fileValues = detectedFiles.map(
+      (f: {
+        relative_path: string;
+        filename: string;
+        size_bytes?: number;
+      }) => ({
+        instrumentRunId: run.id,
+        relativePath: f.relative_path,
+        filename: f.filename,
+        sizeBytes: f.size_bytes ?? null,
+        status: "detected" as const,
+        detectedAt: now,
+      })
+    );
+
+    // Relies on the partial unique index (instrument_run_id, relative_path)
+    // to skip files already reported in a previous request for this run.
+    await db.insert(files).values(fileValues).onConflictDoNothing();
+  }
+
+  return Response.json(
+    {
+      id: run.id,
+      instrument_id: run.instrumentId,
+      run_id: run.runId,
+      source: run.source,
+    },
+    { status: isNew ? 201 : 200 }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/instruments/:instrumentId/runs
+//
+// Paginated list with file count aggregation. Delegates to the shared
+// buildRunListQuery helper so the cross-instrument endpoint can reuse it.
+// ---------------------------------------------------------------------------
+
+export async function GET(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { instrumentId } = await params;
+
+  const [instrument] = await db
+    .select({ id: instruments.id })
+    .from(instruments)
+    .where(eq(instruments.id, instrumentId))
+    .limit(1);
+
+  if (!instrument) {
+    return apiError(404, NOT_FOUND, `Instrument '${instrumentId}' not found`);
+  }
+
+  const { searchParams } = request.nextUrl;
+
+  const result = await buildRunListQuery({
+    instrumentId,
+    source: searchParams.get("source") ?? undefined,
+    search: searchParams.get("search") ?? undefined,
+    sort: searchParams.get("sort") ?? undefined,
+    order: searchParams.get("order") ?? undefined,
+    page: parseIntParam(searchParams.get("page"), {
+      default: 1,
+      min: 1,
+    }),
+    perPage: parseIntParam(searchParams.get("per_page"), {
+      default: 25,
+      min: 1,
+      max: 100,
+    }),
+    includeDeleted: searchParams.get("include_deleted") === "true",
+  });
+
+  return Response.json(result);
+}

--- a/web-app/app/api/v1/instruments/route.ts
+++ b/web-app/app/api/v1/instruments/route.ts
@@ -1,0 +1,92 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import {
+  apiError,
+  CONFLICT,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
+import { isValidKebabCase } from "@/lib/api/validators";
+import { db } from "@/lib/db";
+import { instruments } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const rows = await db
+    .select({
+      id: instruments.id,
+      display_name: instruments.displayName,
+      status: instruments.status,
+      file_patterns: instruments.filePatterns,
+      s3_trigger_suffix: instruments.s3TriggerSuffix,
+    })
+    .from(instruments);
+
+  return Response.json(rows);
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  let body: { id?: string; display_name?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
+  }
+
+  const id = typeof body.id === "string" ? body.id.trim() : "";
+  if (!id) {
+    return apiError(400, VALIDATION_ERROR, "id is required");
+  }
+  if (!isValidKebabCase(id)) {
+    return apiError(
+      400,
+      VALIDATION_ERROR,
+      "id must be lowercase kebab-case (e.g., my-instrument)"
+    );
+  }
+
+  const existing = await db
+    .select({ id: instruments.id })
+    .from(instruments)
+    .where(eq(instruments.id, id))
+    .limit(1);
+
+  if (existing.length > 0) {
+    return apiError(409, CONFLICT, `Instrument '${id}' already exists`);
+  }
+
+  // Default display name is derived from the kebab-case ID:
+  // "spectramax-id3-plate-reader" → "Spectramax Id3 Plate Reader"
+  const displayName =
+    typeof body.display_name === "string" && body.display_name.trim()
+      ? body.display_name.trim()
+      : id
+          .split("-")
+          .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+          .join(" ");
+
+  // New instruments start as "pending" until confirmed by an admin.
+  const [created] = await db
+    .insert(instruments)
+    .values({ id, displayName, status: "pending" })
+    .returning({
+      id: instruments.id,
+      display_name: instruments.displayName,
+      status: instruments.status,
+      file_patterns: instruments.filePatterns,
+      s3_trigger_suffix: instruments.s3TriggerSuffix,
+      created_at: instruments.createdAt,
+    });
+
+  return Response.json(created, { status: 201 });
+}

--- a/web-app/app/api/v1/watchers/[watcherId]/config-checksum/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/config-checksum/route.ts
@@ -1,0 +1,35 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import { apiError, NOT_FOUND, UNAUTHORIZED } from "@/lib/api/errors";
+import { isValidUUID } from "@/lib/api/validators";
+import { findActiveWatcher } from "@/lib/api/watchers";
+import type { NextRequest } from "next/server";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ watcherId: string }> }
+) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { watcherId } = await params;
+  if (!isValidUUID(watcherId)) {
+    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+  }
+
+  const watcher = await findActiveWatcher(watcherId);
+  if (!watcher) {
+    return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  if (!watcher.configChecksum) {
+    return apiError(
+      404,
+      NOT_FOUND,
+      "No config has been pushed for this watcher"
+    );
+  }
+
+  return Response.json({ config_checksum: watcher.configChecksum });
+}

--- a/web-app/app/api/v1/watchers/[watcherId]/config-checksum/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/config-checksum/route.ts
@@ -1,5 +1,10 @@
 import { authenticateRequest } from "@/lib/api/auth";
-import { apiError, NOT_FOUND, UNAUTHORIZED } from "@/lib/api/errors";
+import {
+  apiError,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
 import { isValidUUID } from "@/lib/api/validators";
 import { findActiveWatcher } from "@/lib/api/watchers";
 import type { NextRequest } from "next/server";
@@ -15,7 +20,7 @@ export async function GET(
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {
-    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+    return apiError(400, VALIDATION_ERROR, "Invalid watcher ID format");
   }
 
   const watcher = await findActiveWatcher(watcherId);

--- a/web-app/app/api/v1/watchers/[watcherId]/config/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/config/route.ts
@@ -23,7 +23,7 @@ export async function PUT(
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {
-    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+    return apiError(400, VALIDATION_ERROR, "Invalid watcher ID format");
   }
 
   const watcher = await findActiveWatcher(watcherId);

--- a/web-app/app/api/v1/watchers/[watcherId]/config/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/config/route.ts
@@ -1,0 +1,61 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import {
+  apiError,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
+import { isValidUUID } from "@/lib/api/validators";
+import { findActiveWatcher } from "@/lib/api/watchers";
+import { db } from "@/lib/db";
+import { watchers } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ watcherId: string }> }
+) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { watcherId } = await params;
+  if (!isValidUUID(watcherId)) {
+    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+  }
+
+  const watcher = await findActiveWatcher(watcherId);
+  if (!watcher) {
+    return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  let body: { config_checksum?: string; config_yaml?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
+  }
+
+  if (
+    typeof body.config_checksum !== "string" ||
+    typeof body.config_yaml !== "string"
+  ) {
+    return apiError(
+      400,
+      VALIDATION_ERROR,
+      "config_checksum and config_yaml are required"
+    );
+  }
+
+  await db
+    .update(watchers)
+    .set({
+      configChecksum: body.config_checksum,
+      configYaml: body.config_yaml,
+    })
+    .where(eq(watchers.id, watcherId));
+
+  return Response.json({ config_checksum: body.config_checksum });
+}

--- a/web-app/app/api/v1/watchers/[watcherId]/events/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/events/route.ts
@@ -37,7 +37,7 @@ export async function POST(
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {
-    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+    return apiError(400, VALIDATION_ERROR, "Invalid watcher ID format");
   }
 
   const watcher = await findActiveWatcher(watcherId);
@@ -117,7 +117,7 @@ export async function GET(
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {
-    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+    return apiError(400, VALIDATION_ERROR, "Invalid watcher ID format");
   }
 
   const watcher = await findActiveWatcher(watcherId);

--- a/web-app/app/api/v1/watchers/[watcherId]/events/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/events/route.ts
@@ -1,0 +1,172 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import {
+  apiError,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
+import {
+  isValidUUID,
+  parseDateParam,
+  parseIntParam,
+} from "@/lib/api/validators";
+import { findActiveWatcher } from "@/lib/api/watchers";
+import { db } from "@/lib/db";
+import { watcherEvents } from "@/lib/db/schema";
+import { and, desc, eq, gte, inArray } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+const VALID_EVENT_TYPES = new Set([
+  "watcher_started",
+  "watcher_stopped",
+  "file_uploaded",
+  "upload_failed",
+  "run_reported",
+  "config_synced",
+  "error",
+]);
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ watcherId: string }> }
+) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { watcherId } = await params;
+  if (!isValidUUID(watcherId)) {
+    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+  }
+
+  const watcher = await findActiveWatcher(watcherId);
+  if (!watcher) {
+    return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  let body: { events?: unknown[] };
+  try {
+    body = await request.json();
+  } catch {
+    return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
+  }
+
+  if (!Array.isArray(body.events) || body.events.length === 0) {
+    return apiError(
+      400,
+      VALIDATION_ERROR,
+      "events array is required and must not be empty"
+    );
+  }
+
+  if (body.events.length > 100) {
+    return apiError(400, VALIDATION_ERROR, "Maximum 100 events per request");
+  }
+
+  type EventInput = {
+    event_type: string;
+    timestamp: string;
+    message: string;
+    details?: Record<string, unknown>;
+  };
+
+  const values = [];
+  for (let i = 0; i < body.events.length; i++) {
+    const evt = body.events[i] as EventInput;
+    if (!evt.event_type || !evt.timestamp || !evt.message) {
+      return apiError(
+        400,
+        VALIDATION_ERROR,
+        `Event at index ${i} requires event_type, timestamp, and message`
+      );
+    }
+    if (!VALID_EVENT_TYPES.has(evt.event_type)) {
+      return apiError(
+        400,
+        VALIDATION_ERROR,
+        `Invalid event_type '${evt.event_type}' at index ${i}`
+      );
+    }
+    const ts = new Date(evt.timestamp);
+    if (isNaN(ts.getTime())) {
+      return apiError(400, VALIDATION_ERROR, `Invalid timestamp at index ${i}`);
+    }
+    values.push({
+      watcherId,
+      eventType: evt.event_type as typeof watcherEvents.$inferInsert.eventType,
+      message: evt.message,
+      details: evt.details ?? null,
+      timestamp: ts,
+    });
+  }
+
+  await db.insert(watcherEvents).values(values);
+
+  return Response.json({ received: values.length }, { status: 201 });
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ watcherId: string }> }
+) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { watcherId } = await params;
+  if (!isValidUUID(watcherId)) {
+    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+  }
+
+  const watcher = await findActiveWatcher(watcherId);
+  if (!watcher) {
+    return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  const { searchParams } = request.nextUrl;
+  const limit = parseIntParam(searchParams.get("limit"), {
+    default: 50,
+    min: 1,
+    max: 500,
+  });
+  const since = parseDateParam(searchParams.get("since"));
+  const eventTypeFilter = searchParams.get("event_type");
+
+  const conditions = [eq(watcherEvents.watcherId, watcherId)];
+  if (since) {
+    conditions.push(gte(watcherEvents.timestamp, since));
+  }
+  if (eventTypeFilter) {
+    // Accepts comma-separated types (e.g. "error,upload_failed");
+    // silently drops unrecognized values to avoid 400s on typos.
+    const types = eventTypeFilter
+      .split(",")
+      .filter((t) => VALID_EVENT_TYPES.has(t));
+    if (types.length > 0) {
+      conditions.push(
+        inArray(
+          watcherEvents.eventType,
+          types as (typeof watcherEvents.$inferInsert.eventType)[]
+        )
+      );
+    }
+  }
+
+  const rows = await db
+    .select({
+      id: watcherEvents.id,
+      event_type: watcherEvents.eventType,
+      message: watcherEvents.message,
+      details: watcherEvents.details,
+      timestamp: watcherEvents.timestamp,
+      created_at: watcherEvents.createdAt,
+    })
+    .from(watcherEvents)
+    .where(and(...conditions))
+    .orderBy(desc(watcherEvents.timestamp))
+    .limit(limit);
+
+  return Response.json({ data: rows });
+}

--- a/web-app/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
@@ -23,7 +23,7 @@ export async function POST(
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {
-    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+    return apiError(400, VALIDATION_ERROR, "Invalid watcher ID format");
   }
 
   const watcher = await findActiveWatcher(watcherId);
@@ -38,9 +38,21 @@ export async function POST(
     return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
   }
 
+  const VALID_WATCHER_STATUSES = ["registered", "watching", "stopped"] as const;
   const status = body.status as string | undefined;
   if (!status) {
     return apiError(400, VALIDATION_ERROR, "status is required");
+  }
+  if (
+    !VALID_WATCHER_STATUSES.includes(
+      status as (typeof VALID_WATCHER_STATUSES)[number]
+    )
+  ) {
+    return apiError(
+      400,
+      VALIDATION_ERROR,
+      `Invalid status '${status}' — must be one of: ${VALID_WATCHER_STATUSES.join(", ")}`
+    );
   }
 
   const timestamp = body.timestamp

--- a/web-app/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
@@ -1,0 +1,83 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import {
+  apiError,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
+import { isValidUUID } from "@/lib/api/validators";
+import { findActiveWatcher } from "@/lib/api/watchers";
+import { db } from "@/lib/db";
+import { watcherHeartbeats, watchers } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ watcherId: string }> }
+) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { watcherId } = await params;
+  if (!isValidUUID(watcherId)) {
+    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+  }
+
+  const watcher = await findActiveWatcher(watcherId);
+  if (!watcher) {
+    return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
+  }
+
+  const status = body.status as string | undefined;
+  if (!status) {
+    return apiError(400, VALIDATION_ERROR, "status is required");
+  }
+
+  const timestamp = body.timestamp
+    ? new Date(body.timestamp as string)
+    : new Date();
+  if (isNaN(timestamp.getTime())) {
+    return apiError(400, VALIDATION_ERROR, "Invalid timestamp");
+  }
+
+  // Two parallel writes: (1) append to the heartbeat history log, and
+  // (2) update the watcher's denormalized last_heartbeat_at + status so
+  // staleness checks don't need to scan the heartbeats table.
+  //
+  // API field names differ from DB columns — the watcher CLI sends verbose
+  // names (e.g. "files_uploaded_since_last_heartbeat") that map to shorter
+  // column names (e.g. "files_uploaded_since_last").
+  await Promise.all([
+    db.insert(watcherHeartbeats).values({
+      watcherId,
+      timestamp,
+      status,
+      uploadMode: (body.upload_mode as "auto" | "manual") ?? null,
+      filesUploadedSinceLast:
+        (body.files_uploaded_since_last_heartbeat as number) ?? 0,
+      runsReportedSinceLast:
+        (body.runs_reported_since_last_heartbeat as number) ?? 0,
+      errorsSinceLast: (body.errors_since_last_heartbeat as number) ?? 0,
+      uptimeSeconds: (body.uptime_seconds as number) ?? null,
+    }),
+    db
+      .update(watchers)
+      .set({
+        lastHeartbeatAt: new Date(),
+        status: status as "registered" | "watching" | "stopped",
+      })
+      .where(eq(watchers.id, watcherId)),
+  ]);
+
+  return Response.json({ ok: true });
+}

--- a/web-app/app/api/v1/watchers/[watcherId]/heartbeats/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/heartbeats/route.ts
@@ -1,0 +1,64 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import { apiError, NOT_FOUND, UNAUTHORIZED } from "@/lib/api/errors";
+import {
+  isValidUUID,
+  parseDateParam,
+  parseIntParam,
+} from "@/lib/api/validators";
+import { findActiveWatcher } from "@/lib/api/watchers";
+import { db } from "@/lib/db";
+import { watcherHeartbeats } from "@/lib/db/schema";
+import { and, desc, eq, gte } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ watcherId: string }> }
+) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { watcherId } = await params;
+  if (!isValidUUID(watcherId)) {
+    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+  }
+
+  const watcher = await findActiveWatcher(watcherId);
+  if (!watcher) {
+    return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  const { searchParams } = request.nextUrl;
+  const limit = parseIntParam(searchParams.get("limit"), {
+    default: 100,
+    min: 1,
+    max: 1000,
+  });
+  const since = parseDateParam(searchParams.get("since"));
+
+  const conditions = [eq(watcherHeartbeats.watcherId, watcherId)];
+  if (since) {
+    conditions.push(gte(watcherHeartbeats.timestamp, since));
+  }
+
+  const rows = await db
+    .select({
+      id: watcherHeartbeats.id,
+      timestamp: watcherHeartbeats.timestamp,
+      status: watcherHeartbeats.status,
+      upload_mode: watcherHeartbeats.uploadMode,
+      files_uploaded_since_last: watcherHeartbeats.filesUploadedSinceLast,
+      runs_reported_since_last: watcherHeartbeats.runsReportedSinceLast,
+      errors_since_last: watcherHeartbeats.errorsSinceLast,
+      uptime_seconds: watcherHeartbeats.uptimeSeconds,
+      created_at: watcherHeartbeats.createdAt,
+    })
+    .from(watcherHeartbeats)
+    .where(and(...conditions))
+    .orderBy(desc(watcherHeartbeats.timestamp))
+    .limit(limit);
+
+  return Response.json({ data: rows });
+}

--- a/web-app/app/api/v1/watchers/[watcherId]/heartbeats/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/heartbeats/route.ts
@@ -1,5 +1,10 @@
 import { authenticateRequest } from "@/lib/api/auth";
-import { apiError, NOT_FOUND, UNAUTHORIZED } from "@/lib/api/errors";
+import {
+  apiError,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
 import {
   isValidUUID,
   parseDateParam,
@@ -22,7 +27,7 @@ export async function GET(
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {
-    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+    return apiError(400, VALIDATION_ERROR, "Invalid watcher ID format");
   }
 
   const watcher = await findActiveWatcher(watcherId);

--- a/web-app/app/api/v1/watchers/[watcherId]/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/route.ts
@@ -1,5 +1,11 @@
 import { authenticateRequest } from "@/lib/api/auth";
-import { apiError, CONFLICT, NOT_FOUND, UNAUTHORIZED } from "@/lib/api/errors";
+import {
+  apiError,
+  CONFLICT,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
 import { isValidUUID } from "@/lib/api/validators";
 import { computeEffectiveStatus, findActiveWatcher } from "@/lib/api/watchers";
 import { db } from "@/lib/db";
@@ -18,7 +24,7 @@ export async function GET(
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {
-    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+    return apiError(400, VALIDATION_ERROR, "Invalid watcher ID format");
   }
 
   const watcher = await findActiveWatcher(watcherId);
@@ -58,7 +64,7 @@ export async function DELETE(
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {
-    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+    return apiError(400, VALIDATION_ERROR, "Invalid watcher ID format");
   }
 
   // Intentionally does NOT use findActiveWatcher() here — we need to

--- a/web-app/app/api/v1/watchers/[watcherId]/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/route.ts
@@ -1,0 +1,90 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import { apiError, CONFLICT, NOT_FOUND, UNAUTHORIZED } from "@/lib/api/errors";
+import { isValidUUID } from "@/lib/api/validators";
+import { computeEffectiveStatus, findActiveWatcher } from "@/lib/api/watchers";
+import { db } from "@/lib/db";
+import { instruments, watchers } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ watcherId: string }> }
+) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { watcherId } = await params;
+  if (!isValidUUID(watcherId)) {
+    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+  }
+
+  const watcher = await findActiveWatcher(watcherId);
+  if (!watcher) {
+    return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  const [instrument] = await db
+    .select({ displayName: instruments.displayName })
+    .from(instruments)
+    .where(eq(instruments.id, watcher.instrumentId))
+    .limit(1);
+
+  return Response.json({
+    id: watcher.id,
+    instrument_id: watcher.instrumentId,
+    instrument_display_name: instrument?.displayName ?? null,
+    hostname: watcher.hostname,
+    os_info: watcher.osInfo,
+    config_checksum: watcher.configChecksum,
+    config_yaml: watcher.configYaml,
+    status: computeEffectiveStatus(watcher),
+    last_heartbeat_at: watcher.lastHeartbeatAt,
+    created_at: watcher.createdAt,
+    updated_at: watcher.updatedAt,
+  });
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ watcherId: string }> }
+) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { watcherId } = await params;
+  if (!isValidUUID(watcherId)) {
+    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+  }
+
+  // Intentionally does NOT use findActiveWatcher() here — we need to
+  // distinguish "not found" (404) from "already soft-deleted" (409).
+  const [watcher] = await db
+    .select({
+      id: watchers.id,
+      deletedAt: watchers.deletedAt,
+    })
+    .from(watchers)
+    .where(eq(watchers.id, watcherId))
+    .limit(1);
+
+  if (!watcher) {
+    return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  if (watcher.deletedAt) {
+    return apiError(409, CONFLICT, "Watcher is already deleted");
+  }
+
+  const now = new Date();
+  await db
+    .update(watchers)
+    .set({ deletedAt: now })
+    .where(eq(watchers.id, watcherId));
+
+  return Response.json({ id: watcherId, deleted_at: now });
+}

--- a/web-app/app/api/v1/watchers/[watcherId]/upload-queue/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/upload-queue/route.ts
@@ -1,0 +1,54 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import { apiError, NOT_FOUND, UNAUTHORIZED } from "@/lib/api/errors";
+import { isValidUUID } from "@/lib/api/validators";
+import { findActiveWatcher } from "@/lib/api/watchers";
+import { db } from "@/lib/db";
+import { files, instrumentRuns } from "@/lib/db/schema";
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ watcherId: string }> }
+) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { watcherId } = await params;
+  if (!isValidUUID(watcherId)) {
+    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+  }
+
+  const watcher = await findActiveWatcher(watcherId);
+  if (!watcher) {
+    return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  // A file is "pending upload" when a user requested it via the web UI
+  // (upload_requested_at is set) but it hasn't been uploaded yet
+  // (uploaded_at is NULL). Scoped to the watcher's instrument so each
+  // watcher only sees files relevant to its instrument.
+  const rows = await db
+    .select({
+      id: files.id,
+      instrument_id: instrumentRuns.instrumentId,
+      run_id: instrumentRuns.runId,
+      relative_path: files.relativePath,
+      filename: files.filename,
+      size_bytes: files.sizeBytes,
+    })
+    .from(files)
+    .innerJoin(instrumentRuns, eq(files.instrumentRunId, instrumentRuns.id))
+    .where(
+      and(
+        eq(instrumentRuns.instrumentId, watcher.instrumentId),
+        isNotNull(files.uploadRequestedAt),
+        isNull(files.uploadedAt),
+        isNull(files.deletedAt)
+      )
+    );
+
+  return Response.json({ files: rows });
+}

--- a/web-app/app/api/v1/watchers/[watcherId]/upload-queue/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/upload-queue/route.ts
@@ -1,5 +1,10 @@
 import { authenticateRequest } from "@/lib/api/auth";
-import { apiError, NOT_FOUND, UNAUTHORIZED } from "@/lib/api/errors";
+import {
+  apiError,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
 import { isValidUUID } from "@/lib/api/validators";
 import { findActiveWatcher } from "@/lib/api/watchers";
 import { db } from "@/lib/db";
@@ -18,7 +23,7 @@ export async function GET(
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {
-    return apiError(400, NOT_FOUND, "Invalid watcher ID format");
+    return apiError(400, VALIDATION_ERROR, "Invalid watcher ID format");
   }
 
   const watcher = await findActiveWatcher(watcherId);

--- a/web-app/app/api/v1/watchers/register/route.ts
+++ b/web-app/app/api/v1/watchers/register/route.ts
@@ -1,0 +1,67 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import {
+  apiError,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
+import { db } from "@/lib/db";
+import { instruments, watchers } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+export async function POST(request: NextRequest) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  let body: {
+    instrument_id?: string;
+    hostname?: string;
+    os_info?: string;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
+  }
+
+  const instrumentId =
+    typeof body.instrument_id === "string" ? body.instrument_id.trim() : "";
+  if (!instrumentId) {
+    return apiError(400, VALIDATION_ERROR, "instrument_id is required");
+  }
+
+  const [instrument] = await db
+    .select({ id: instruments.id, status: instruments.status })
+    .from(instruments)
+    .where(eq(instruments.id, instrumentId))
+    .limit(1);
+
+  if (!instrument) {
+    return apiError(404, NOT_FOUND, `Instrument '${instrumentId}' not found`);
+  }
+
+  // Only active or pending instruments accept new watchers; inactive ones
+  // are fully decommissioned and should not have new watchers registering.
+  if (instrument.status !== "active" && instrument.status !== "pending") {
+    return apiError(
+      400,
+      VALIDATION_ERROR,
+      `Instrument '${instrumentId}' is ${instrument.status} and cannot accept new watchers`
+    );
+  }
+
+  const [created] = await db
+    .insert(watchers)
+    .values({
+      instrumentId,
+      hostname: body.hostname ?? null,
+      osInfo: body.os_info ?? null,
+      status: "registered",
+    })
+    .returning({ id: watchers.id });
+
+  return Response.json({ watcher_id: created.id }, { status: 201 });
+}

--- a/web-app/app/api/v1/watchers/route.ts
+++ b/web-app/app/api/v1/watchers/route.ts
@@ -1,0 +1,72 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import { apiError, UNAUTHORIZED } from "@/lib/api/errors";
+import { computeEffectiveStatus, STALE_THRESHOLD_MS } from "@/lib/api/watchers";
+import { db } from "@/lib/db";
+import { instruments, watchers } from "@/lib/db/schema";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { searchParams } = request.nextUrl;
+  const instrumentIdFilter = searchParams.get("instrument_id");
+  const statusFilter = searchParams.get("status");
+  const includeDeleted = searchParams.get("include_deleted") === "true";
+
+  const conditions = [];
+
+  if (!includeDeleted) {
+    conditions.push(isNull(watchers.deletedAt));
+  }
+
+  if (instrumentIdFilter) {
+    conditions.push(eq(watchers.instrumentId, instrumentIdFilter));
+  }
+
+  if (statusFilter === "stale") {
+    // "stale" is virtual — push the staleness check into the WHERE clause
+    // so we don't fetch all watchers just to filter in JS. A watcher is stale
+    // if its last heartbeat is too old, OR it has no heartbeat at all and
+    // isn't in the initial "registered" state (which is exempt).
+    const threshold = new Date(Date.now() - STALE_THRESHOLD_MS);
+    conditions.push(
+      sql`(${watchers.lastHeartbeatAt} < ${threshold} OR (${watchers.lastHeartbeatAt} IS NULL AND ${watchers.status} != 'registered'))`
+    );
+  } else if (statusFilter) {
+    conditions.push(
+      eq(watchers.status, statusFilter as "registered" | "watching" | "stopped")
+    );
+  }
+
+  const rows = await db
+    .select({
+      id: watchers.id,
+      instrument_id: watchers.instrumentId,
+      instrument_display_name: instruments.displayName,
+      hostname: watchers.hostname,
+      os_info: watchers.osInfo,
+      status: watchers.status,
+      last_heartbeat_at: watchers.lastHeartbeatAt,
+      created_at: watchers.createdAt,
+      updated_at: watchers.updatedAt,
+      deleted_at: watchers.deletedAt,
+    })
+    .from(watchers)
+    .leftJoin(instruments, eq(watchers.instrumentId, instruments.id))
+    .where(conditions.length > 0 ? and(...conditions) : undefined);
+
+  // Override stored status with the computed effective status (may be "stale").
+  const data = rows.map((row) => ({
+    ...row,
+    status: computeEffectiveStatus({
+      status: row.status,
+      lastHeartbeatAt: row.last_heartbeat_at,
+    }),
+  }));
+
+  return Response.json({ data });
+}

--- a/web-app/lib/api/errors.ts
+++ b/web-app/lib/api/errors.ts
@@ -1,0 +1,17 @@
+export const VALIDATION_ERROR = "VALIDATION_ERROR";
+export const NOT_FOUND = "NOT_FOUND";
+export const CONFLICT = "CONFLICT";
+export const UNAUTHORIZED = "UNAUTHORIZED";
+export const INTERNAL_ERROR = "INTERNAL_ERROR";
+
+export function apiError(
+  status: number,
+  code: string,
+  message: string,
+  details?: Record<string, unknown>
+) {
+  return Response.json(
+    { error: { code, message, ...(details && { details }) } },
+    { status }
+  );
+}

--- a/web-app/lib/api/instrument-runs.ts
+++ b/web-app/lib/api/instrument-runs.ts
@@ -82,7 +82,11 @@ export async function buildRunListQuery(filters: RunListFilters) {
   }
 
   if (filters.search) {
-    conditions.push(ilike(instrumentRuns.runId, `%${filters.search}%`));
+    const escaped = filters.search
+      .replace(/\\/g, "\\\\")
+      .replace(/%/g, "\\%")
+      .replace(/_/g, "\\_");
+    conditions.push(ilike(instrumentRuns.runId, `%${escaped}%`));
   }
 
   const where = conditions.length > 0 ? and(...conditions) : undefined;

--- a/web-app/lib/api/instrument-runs.ts
+++ b/web-app/lib/api/instrument-runs.ts
@@ -1,0 +1,147 @@
+import { db } from "@/lib/db";
+import { files, instrumentRuns, instruments } from "@/lib/db/schema";
+import type { SQL } from "drizzle-orm";
+import { and, asc, desc, eq, ilike, isNull, sql } from "drizzle-orm";
+
+// ---------------------------------------------------------------------------
+// Run lookup by natural key (instrumentId, runId) — shared across detail,
+// patch, delete, and child-resource endpoints.
+// ---------------------------------------------------------------------------
+
+// API URLs use human-readable natural keys (e.g., "spectramax-id3-plate-reader"
+// + "2026-03-26_experiment") rather than the internal UUID surrogate PK. This
+// function resolves that pair to a full run row with the instrument display name.
+export async function lookupRunByNaturalKey(
+  instrumentId: string,
+  runId: string
+) {
+  const [row] = await db
+    .select({
+      id: instrumentRuns.id,
+      instrumentId: instrumentRuns.instrumentId,
+      runId: instrumentRuns.runId,
+      source: instrumentRuns.source,
+      watcherId: instrumentRuns.watcherId,
+      metadata: instrumentRuns.metadata,
+      createdAt: instrumentRuns.createdAt,
+      updatedAt: instrumentRuns.updatedAt,
+      deletedAt: instrumentRuns.deletedAt,
+      filesPurgedAt: instrumentRuns.filesPurgedAt,
+      instrumentDisplayName: instruments.displayName,
+    })
+    .from(instrumentRuns)
+    .innerJoin(instruments, eq(instrumentRuns.instrumentId, instruments.id))
+    .where(
+      and(
+        eq(instrumentRuns.instrumentId, instrumentId),
+        eq(instrumentRuns.runId, runId)
+      )
+    )
+    .limit(1);
+
+  return row ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Paginated run list with per-run file count aggregation.
+// Used by both per-instrument and cross-instrument list endpoints.
+// ---------------------------------------------------------------------------
+
+type RunListFilters = {
+  instrumentId?: string;
+  source?: string;
+  search?: string;
+  sort?: string;
+  order?: string;
+  page: number;
+  perPage: number;
+  includeDeleted: boolean;
+};
+
+const ALLOWED_SORT_FIELDS: Record<
+  string,
+  (typeof instrumentRuns)["createdAt" | "updatedAt"]
+> = {
+  created_at: instrumentRuns.createdAt,
+  updated_at: instrumentRuns.updatedAt,
+};
+
+export async function buildRunListQuery(filters: RunListFilters) {
+  const conditions: SQL[] = [];
+
+  if (filters.instrumentId) {
+    conditions.push(eq(instrumentRuns.instrumentId, filters.instrumentId));
+  }
+
+  if (!filters.includeDeleted) {
+    conditions.push(isNull(instrumentRuns.deletedAt));
+  }
+
+  if (filters.source === "lambda" || filters.source === "watcher") {
+    conditions.push(eq(instrumentRuns.source, filters.source));
+  }
+
+  if (filters.search) {
+    conditions.push(ilike(instrumentRuns.runId, `%${filters.search}%`));
+  }
+
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  // Single-query aggregation: counts per-run file stats using FILTER (WHERE ...)
+  // to avoid N+1 queries. All non-deleted files are counted.
+  const fileCount = sql<number>`cast(count(${files.id}) filter (where ${files.deletedAt} is null) as int)`;
+  const filesCompleted = sql<number>`cast(count(${files.id}) filter (where ${files.status} = 'completed' and ${files.deletedAt} is null) as int)`;
+  const filesFailed = sql<number>`cast(count(${files.id}) filter (where ${files.status} = 'failed' and ${files.deletedAt} is null) as int)`;
+  // "Pending upload" = files on the instrument PC that haven't reached S3 yet.
+  // A non-zero count signals the run has files requiring manual upload action.
+  const filesPendingUpload = sql<number>`cast(count(${files.id}) filter (where ${files.status} in ('detected', 'upload_requested') and ${files.deletedAt} is null) as int)`;
+
+  const sortCol =
+    ALLOWED_SORT_FIELDS[filters.sort ?? "created_at"] ??
+    instrumentRuns.createdAt;
+  const orderFn = filters.order === "asc" ? asc : desc;
+
+  // Total count for pagination (runs only, no joins needed for the count).
+  const [{ total }] = await db
+    .select({ total: sql<number>`cast(count(*) as int)` })
+    .from(instrumentRuns)
+    .where(where);
+
+  const totalPages = Math.ceil(total / filters.perPage);
+  const offset = (filters.page - 1) * filters.perPage;
+
+  const rows = await db
+    .select({
+      id: instrumentRuns.id,
+      instrument_id: instrumentRuns.instrumentId,
+      instrument_display_name: instruments.displayName,
+      run_id: instrumentRuns.runId,
+      source: instrumentRuns.source,
+      metadata: instrumentRuns.metadata,
+      created_at: instrumentRuns.createdAt,
+      updated_at: instrumentRuns.updatedAt,
+      deleted_at: instrumentRuns.deletedAt,
+      file_count: fileCount,
+      files_completed: filesCompleted,
+      files_failed: filesFailed,
+      files_pending_upload: filesPendingUpload,
+    })
+    .from(instrumentRuns)
+    .innerJoin(instruments, eq(instrumentRuns.instrumentId, instruments.id))
+    .leftJoin(files, eq(files.instrumentRunId, instrumentRuns.id))
+    .where(where)
+    .groupBy(instrumentRuns.id, instruments.displayName)
+    .orderBy(orderFn(sortCol))
+    .limit(filters.perPage)
+    .offset(offset);
+
+  return {
+    data: rows,
+    pagination: {
+      page: filters.page,
+      per_page: filters.perPage,
+      total,
+      total_pages: totalPages,
+    },
+  };
+}

--- a/web-app/lib/api/validators.ts
+++ b/web-app/lib/api/validators.ts
@@ -1,0 +1,30 @@
+const KEBAB_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isValidKebabCase(id: string): boolean {
+  return KEBAB_RE.test(id);
+}
+
+export function isValidUUID(id: string): boolean {
+  return UUID_RE.test(id);
+}
+
+export function parseIntParam(
+  value: string | null,
+  opts: { default: number; min?: number; max?: number }
+): number {
+  if (value === null) return opts.default;
+  const n = parseInt(value, 10);
+  if (isNaN(n)) return opts.default;
+  let clamped = n;
+  if (opts.min != null) clamped = Math.max(opts.min, clamped);
+  if (opts.max != null) clamped = Math.min(opts.max, clamped);
+  return clamped;
+}
+
+export function parseDateParam(value: string | null): Date | null {
+  if (!value) return null;
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? null : d;
+}

--- a/web-app/lib/api/watchers.ts
+++ b/web-app/lib/api/watchers.ts
@@ -1,0 +1,35 @@
+import { db } from "@/lib/db";
+import { watchers } from "@/lib/db/schema";
+import { and, eq, isNull } from "drizzle-orm";
+
+export const STALE_THRESHOLD_MS = 5 * 60 * 1000;
+
+export async function findActiveWatcher(watcherId: string) {
+  const [watcher] = await db
+    .select()
+    .from(watchers)
+    .where(and(eq(watchers.id, watcherId), isNull(watchers.deletedAt)))
+    .limit(1);
+
+  return watcher ?? null;
+}
+
+type WatcherLike = {
+  status: string;
+  lastHeartbeatAt: Date | null;
+};
+
+/**
+ * Derives the display status from stored status + heartbeat recency.
+ * "stale" is never stored in the DB — it's a virtual status computed here.
+ * Watchers in "registered" state haven't sent their first heartbeat yet,
+ * so they're exempt from staleness checks.
+ */
+export function computeEffectiveStatus(watcher: WatcherLike): string {
+  if (watcher.status === "registered") return "registered";
+
+  if (!watcher.lastHeartbeatAt) return "stale";
+
+  const age = Date.now() - watcher.lastHeartbeatAt.getTime();
+  return age > STALE_THRESHOLD_MS ? "stale" : watcher.status;
+}

--- a/web-app/lib/s3.ts
+++ b/web-app/lib/s3.ts
@@ -1,0 +1,19 @@
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+const DEFAULT_EXPIRY_SECONDS = 15 * 60; // 15 minutes
+
+// Singleton client — reused across Lambda invocations in the same process.
+// Falls back to IAM role credentials when env vars are absent (deployed on AWS).
+const s3 = new S3Client({
+  region: process.env.AWS_REGION ?? "us-west-2",
+});
+
+export async function getPresignedDownloadUrl(
+  bucket: string,
+  key: string,
+  expiresIn: number = DEFAULT_EXPIRY_SECONDS
+): Promise<string> {
+  const command = new GetObjectCommand({ Bucket: bucket, Key: key });
+  return getSignedUrl(s3, command, { expiresIn });
+}

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@auth/drizzle-adapter": "^1.11.1",
+        "@aws-sdk/client-s3": "^3.1021.0",
+        "@aws-sdk/s3-request-presigner": "^3.1021.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
@@ -92,6 +94,891 @@
       "license": "ISC",
       "dependencies": {
         "@auth/core": "0.41.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1021.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1021.0.tgz",
+      "integrity": "sha512-BCfggq8gYSjlKOZlMSVApix3cgKAQIWGeoJFX/AU5HMvqz1BZBEw83jJFL9LYrqTPCocH8NGl++1Xr70ro+jcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/credential-provider-node": "^3.972.29",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.8",
+        "@aws-sdk/middleware-expect-continue": "^3.972.8",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.6",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-location-constraint": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.27",
+        "@aws-sdk/middleware-ssec": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.15",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.14",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.13",
+        "@smithy/eventstream-serde-browser": "^4.2.12",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
+        "@smithy/eventstream-serde-node": "^4.2.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-blob-browser": "^4.2.13",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/hash-stream-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/md5-js": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-retry": "^4.4.46",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.44",
+        "@smithy/util-defaults-mode-node": "^4.2.48",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.973.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.26.tgz",
+      "integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.16",
+        "@smithy/core": "^3.23.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.5.tgz",
+      "integrity": "sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.24.tgz",
+      "integrity": "sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.26.tgz",
+      "integrity": "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.21",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.28.tgz",
+      "integrity": "sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/credential-provider-env": "^3.972.24",
+        "@aws-sdk/credential-provider-http": "^3.972.26",
+        "@aws-sdk/credential-provider-login": "^3.972.28",
+        "@aws-sdk/credential-provider-process": "^3.972.24",
+        "@aws-sdk/credential-provider-sso": "^3.972.28",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.28.tgz",
+      "integrity": "sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.29.tgz",
+      "integrity": "sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.24",
+        "@aws-sdk/credential-provider-http": "^3.972.26",
+        "@aws-sdk/credential-provider-ini": "^3.972.28",
+        "@aws-sdk/credential-provider-process": "^3.972.24",
+        "@aws-sdk/credential-provider-sso": "^3.972.28",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.24.tgz",
+      "integrity": "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.28.tgz",
+      "integrity": "sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/token-providers": "3.1021.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.28.tgz",
+      "integrity": "sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.8.tgz",
+      "integrity": "sha512-WR525Rr2QJSETa9a050isktyWi/4yIGcmY3BQ1kpHqb0LqUglQHCS8R27dTJxxWNZvQ0RVGtEZjTCbZJpyF3Aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.8.tgz",
+      "integrity": "sha512-5DTBTiotEES1e2jOHAq//zyzCjeMB78lEHd35u15qnrid4Nxm7diqIf9fQQ3Ov0ChH1V3Vvt13thOnrACmfGVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.6.tgz",
+      "integrity": "sha512-YckB8k1ejbyCg/g36gUMFLNzE4W5cERIa4MtsdO+wpTmJEP0+TB7okWIt7d8TDOvnb7SwvxJ21E4TGOBxFpSWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/crc64-nvme": "^3.972.5",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.8.tgz",
+      "integrity": "sha512-KaUoFuoFPziIa98DSQsTPeke1gvGXlc5ZGMhy+b+nLxZ4A7jmJgLzjEF95l8aOQN2T/qlPP3MrAyELm8ExXucw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
+      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.27.tgz",
+      "integrity": "sha512-gomO6DZwx+1D/9mbCpcqO5tPBqYBK7DtdgjTIjZ4yvfh/S7ETwAPS0XbJgP2JD8Ycr5CwVrEkV1sFtu3ShXeOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.8.tgz",
+      "integrity": "sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.28.tgz",
+      "integrity": "sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.13",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.13",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.18.tgz",
+      "integrity": "sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.14",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.13",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-retry": "^4.4.46",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.44",
+        "@smithy/util-defaults-mode-node": "^4.2.48",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
+      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1021.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1021.0.tgz",
+      "integrity": "sha512-kkIzsIAc7wnG7vVRkZFIwJ3noOyF3S6ozOQ9t2KxzPde1LsmpmPwYbmiB91DzdfuGySdk4Hpb0JmHh4KhGECXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "^3.996.15",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-format-url": "^3.972.8",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.15.tgz",
+      "integrity": "sha512-Ukw2RpqvaL96CjfH/FgfBmy/ZosHBqoHBCFsN61qGg99F33vpntIVii8aNeh65XuOja73arSduskoa4OJea9RQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.27",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1021.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1021.0.tgz",
+      "integrity": "sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.8.tgz",
+      "integrity": "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.14.tgz",
+      "integrity": "sha512-vNSB/DYaPOyujVZBg/zUznH9QC142MaTHVmaFlF7uzzfg3CgT9f/l4C0Yi+vU/tbBhxVcXVB90Oohk5+o+ZbWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
+      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4328,6 +5215,724 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
+      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
+      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
+      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.13",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.13.tgz",
+      "integrity": "sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
+      "integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.12.tgz",
+      "integrity": "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.12.tgz",
+      "integrity": "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.12.tgz",
+      "integrity": "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.12.tgz",
+      "integrity": "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.15",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.13.tgz",
+      "integrity": "sha512-YrF4zWKh+ghLuquldj6e/RzE3xZYL8wIPfkt0MqCRphVICjyyjH8OwKD7LLlKpVEbk4FLizFfC1+gwK6XQdR3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.2.2",
+        "@smithy/chunked-blob-reader-native": "^4.2.3",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.12.tgz",
+      "integrity": "sha512-O3YbmGExeafuM/kP7Y8r6+1y0hIh3/zn6GROx0uNlB54K9oihAL75Qtc+jFfLNliTi6pxOAYZrRKD9A7iA6UFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.12.tgz",
+      "integrity": "sha512-W/oIpHCpWU2+iAkfZYyGWE+qkpuf3vEXHLxQQDx9FPNZTTdnul0dZ2d/gUFrtQ5je1G2kp4cjG0/24YueG2LbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.28",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.28.tgz",
+      "integrity": "sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.13",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.46",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.46.tgz",
+      "integrity": "sha512-SpvWNNOPOrKQGUqZbEPO+es+FRXMWvIyzUKUOYdDgdlA6BdZj/R58p4umoQ76c2oJC44PiM7mKizyyex1IJzow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.16.tgz",
+      "integrity": "sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.13",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.1.tgz",
+      "integrity": "sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.8.tgz",
+      "integrity": "sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.13",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.21",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.44",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.44.tgz",
+      "integrity": "sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.48",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.48.tgz",
+      "integrity": "sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.13.tgz",
+      "integrity": "sha512-qQQsIvL0MGIbUjeSrg0/VlQ3jGNKyM3/2iU3FPNgy01z+Sp4OvcaxbgIoFOTvB61ZoohtutuOvOcgmhbD0katQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.21.tgz",
+      "integrity": "sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.14.tgz",
+      "integrity": "sha512-2zqq5o/oizvMaFUlNiTyZ7dbgYv1a893aGut2uaxtbzTx/VYYnRxWzDHuD/ftgcw94ffenua+ZNLrbqwUYE+Bg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -5744,6 +7349,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
@@ -7577,6 +9188,41 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -10306,6 +11952,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -11817,6 +13478,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -20,6 +20,8 @@
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.11.1",
+    "@aws-sdk/client-s3": "^3.1021.0",
+    "@aws-sdk/s3-request-presigner": "^3.1021.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",


### PR DESCRIPTION
## Summary

Implements the full REST API layer (`/api/v1/`) for the core domain: instruments, file-system watchers, instrument runs, and run files. These endpoints support two primary callers: (1) on-premise watcher agents that detect and upload instrument output files, and (2) AWS Lambda processors that register files and report analysis results. A cross-instrument dashboard endpoint is also included.

## Changes

- **Instruments** (`/api/v1/instruments`)
  - `GET` / `POST` — list all instruments, create new (kebab-case ID, defaults to "pending")
  - `GET` / `PATCH` on `[instrumentId]` — detail view with run/watcher counts, update status/display_name/file_patterns

- **Watchers** (`/api/v1/watchers`)
  - `POST /register` — register a new watcher against an instrument
  - `GET` / `GET [watcherId]` / `DELETE [watcherId]` — list (with computed "stale" status), detail, soft-delete
  - `POST [watcherId]/heartbeat` — heartbeat with status transition
  - `GET [watcherId]/heartbeats` — heartbeat history
  - `POST [watcherId]/events` — bulk event ingestion
  - `GET [watcherId]/config` — fetch YAML config
  - `GET [watcherId]/config-checksum` — lightweight ETag-style config polling
  - `GET [watcherId]/upload-queue` — files pending upload for this watcher

- **Instrument Runs** (`/api/v1/instruments/[instrumentId]/runs`)
  - `POST` — idempotent run creation (handles watcher vs. Lambda source, with detected_files upsert)
  - `GET` — paginated list with per-run file count aggregation (file_count, files_completed, files_failed, files_pending_upload)
  - `GET` / `PATCH` / `DELETE` on `[runId]` — detail with files + pre-signed download URLs + report_data, metadata update + detected_files upsert, soft-delete
  - `POST [runId]/request-upload` — batch transition of detected files to upload_requested
  - `POST [runId]/files` — Lambda file registration (starts as "uploaded", idempotent on s3_key)
  - `POST` / `GET` on `[runId]/analyses` — stubbed (501) pending Lambda infrastructure

- **Cross-instrument runs** (`/api/v1/instrument-runs`) — dashboard listing with optional instrument_id filter

- **Files** (`/api/v1/files/[fileId]`)
  - `PATCH` — status state machine (detected → uploaded → processing → completed/failed) with S3 info, metadata, and report_data insertion
  - `DELETE` — soft-delete for pre-upload files only
  - `GET /download` — pre-signed S3 URL via 302 redirect

- **Shared libraries**
  - `lib/api/errors.ts` — standardized error response helper
  - `lib/api/validators.ts` — kebab-case, UUID, int/date param parsing
  - `lib/api/instrument-runs.ts` — natural-key lookup, paginated run list builder with FILTER aggregation
  - `lib/api/watchers.ts` — active watcher lookup, computed "stale" status
  - `lib/s3.ts` — S3 client singleton + pre-signed download URL generation

- **Dependencies** — added `@aws-sdk/client-s3` and `@aws-sdk/s3-request-presigner`

## Breaking changes

None. All endpoints are new additions under `/api/v1/`.

## Driveby changes

None.

## Testing

Tests (and any corresponding fixes) will be implemented in a follow-up PR.