### PR TITLE
Add instrument and watcher management pages

### DIFF
--- a/.github/workflows/lint-and-typecheck-python.yml
+++ b/.github/workflows/lint-and-typecheck-python.yml
@@ -35,7 +35,7 @@ jobs:
         run: uv sync --all-packages
 
       - name: Lint
-        run: make lint-py
+        run: make py-lint
 
       - name: Type check
-        run: make typecheck-py
+        run: make py-typecheck

--- a/Makefile
+++ b/Makefile
@@ -1,54 +1,66 @@
-.PHONY: lint-py
-lint-py:
+# Python.
+.PHONY: py-lint
+py-lint:
 	uv run ruff check .
 	uv run ruff format --check .
 
-.PHONY: format-py
-format-py:
+.PHONY: py-format
+py-format:
 	uv run ruff check --fix .
 	uv run ruff format .
 
-.PHONY: typecheck-py
-typecheck-py:
+.PHONY: py-typecheck
+py-typecheck:
 	uv run pyright --project pyproject.toml
 
-.PHONY: test-py
-test-py:
+.PHONY: py-test
+py-test:
 	uv run pytest -v .
 
-.PHONY: format-fe
-format-fe:
+# Web app.
+.PHONY: fe-format
+fe-format:
 	cd web-app && npm run format
 
-.PHONY: lint-fe
-lint-fe:
+.PHONY: fe-lint
+fe-lint:
 	cd web-app && npm run lint
 
-.PHONY: typecheck-fe
-typecheck-fe:
+.PHONY: fe-typecheck
+fe-typecheck:
 	cd web-app && npm run typecheck
 
-.PHONY: test-fe
-test-fe:
+.PHONY: fe-test
+fe-test:
 	cd web-app && npm run test:integration
 
-.PHONY: check-py
-check-py:
-	make format-py
-	make lint-py
-	make typecheck-py
+.PHONY: dev
+dev:
+	cd web-app && npm run dev
 
-.PHONY: check-fe
-check-fe:
-	make format-fe
-	make lint-fe
-	make typecheck-fe
+.PHONY: fe-build
+fe-build:
+	cd web-app && npm run build
+
+# Checks.
+.PHONY: py-check
+py-check:
+	make py-format
+	make py-lint
+	make py-typecheck
+
+.PHONY: fe-check
+fe-check:
+	make fe-format
+	make fe-lint
+	make fe-typecheck
 
 .PHONY: check-all
 check-all:
-	make check-py
-	make check-fe
+	make py-check
+	make fe-check
 
+# Docker.
 .PHONY: docker-build
 docker-build:
 	source .env && export GIT_AUTH_TOKEN=$$GH_PERSONAL_ACCESS_TOKEN && docker build --secret id=GIT_AUTH_TOKEN -t data-hub-utils .

--- a/web-app/app/instruments/[instrumentId]/page.tsx
+++ b/web-app/app/instruments/[instrumentId]/page.tsx
@@ -1,0 +1,72 @@
+import { RunsPagination } from "@/components/dashboard/runs-pagination";
+import { InstrumentHeader } from "@/components/instruments/instrument-header";
+import { InstrumentRunsTable } from "@/components/instruments/instrument-runs-table";
+import { InstrumentRunsToolbar } from "@/components/instruments/instrument-runs-toolbar";
+import { buildRunListQuery } from "@/lib/api/instrument-runs";
+import { getInstrumentById } from "@/lib/api/instruments";
+import { auth } from "@/lib/auth";
+import { instrumentDetailParamsCache } from "@/lib/search-params";
+import { notFound, redirect } from "next/navigation";
+import type { Metadata } from "next/types";
+
+type Props = {
+  params: Promise<{ instrumentId: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { instrumentId } = await params;
+  const instrument = await getInstrumentById(instrumentId);
+  return {
+    title: instrument?.displayName ?? instrumentId,
+  };
+}
+
+export default async function InstrumentDetailPage({
+  params,
+  searchParams,
+}: Props) {
+  const session = await auth();
+  if (!session) redirect("/login");
+
+  const { instrumentId } = await params;
+  const filters = instrumentDetailParamsCache.parse(await searchParams);
+
+  // Parallel fetch: instrument metadata (for header) and paginated runs
+  // (for table) are independent queries — neither depends on the other.
+  const [instrument, runResult] = await Promise.all([
+    getInstrumentById(instrumentId),
+    buildRunListQuery({
+      instrumentId,
+      search: filters.search || undefined,
+      dateFrom: filters.date_from ?? undefined,
+      dateTo: filters.date_to ?? undefined,
+      page: filters.page,
+      perPage: filters.per_page,
+      includeDeleted: filters.include_deleted,
+    }),
+  ]);
+
+  if (!instrument) notFound();
+
+  // Computed separately from the toolbar's client-side check because this
+  // server component needs it for the empty-state message distinction.
+  const hasFilters =
+    filters.search !== "" ||
+    filters.date_from !== null ||
+    filters.date_to !== null ||
+    filters.include_deleted;
+
+  return (
+    <div className="mx-auto flex max-w-7xl flex-col gap-6 p-6">
+      <InstrumentHeader instrument={instrument} />
+      <InstrumentRunsToolbar />
+      <InstrumentRunsTable
+        data={runResult.data}
+        instrumentId={instrumentId}
+        hasFilters={hasFilters}
+      />
+      <RunsPagination pagination={runResult.pagination} />
+    </div>
+  );
+}

--- a/web-app/app/instruments/page.tsx
+++ b/web-app/app/instruments/page.tsx
@@ -1,0 +1,25 @@
+import { InstrumentsTable } from "@/components/instruments/instruments-table";
+import { getInstrumentListWithCounts } from "@/lib/api/instruments";
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import type { Metadata } from "next/types";
+
+export const metadata: Metadata = {
+  title: "Instruments",
+};
+
+export default async function InstrumentsPage() {
+  const session = await auth();
+  if (!session) redirect("/login");
+
+  const instruments = await getInstrumentListWithCounts();
+
+  return (
+    <div className="mx-auto flex max-w-7xl flex-col gap-6 p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold tracking-tight">Instruments</h1>
+      </div>
+      <InstrumentsTable data={instruments} />
+    </div>
+  );
+}

--- a/web-app/app/watchers/[watcherId]/page.tsx
+++ b/web-app/app/watchers/[watcherId]/page.tsx
@@ -44,7 +44,7 @@ export default async function WatcherDetailPage({
     : undefined;
 
   // Three independent queries — none depends on the others' results.
-  const [watcher, heartbeats, events] = await Promise.all([
+  const [watcher, heartbeatResult, eventResult] = await Promise.all([
     getWatcherById(watcherId),
     getWatcherHeartbeats(watcherId, { since: heartbeatSince }),
     getWatcherEvents(watcherId, {
@@ -60,9 +60,12 @@ export default async function WatcherDetailPage({
     <div className="mx-auto flex max-w-7xl flex-col gap-6 p-6">
       <WatcherHeader watcher={watcher} />
       <WatcherConfig configYaml={watcher.configYaml} />
-      <HeartbeatTable heartbeats={heartbeats} />
+      <HeartbeatTable
+        heartbeats={heartbeatResult.rows}
+        truncated={heartbeatResult.truncated}
+      />
       <EventLogToolbar />
-      <EventLog events={events} />
+      <EventLog events={eventResult.rows} truncated={eventResult.truncated} />
     </div>
   );
 }

--- a/web-app/app/watchers/[watcherId]/page.tsx
+++ b/web-app/app/watchers/[watcherId]/page.tsx
@@ -1,0 +1,68 @@
+import { EventLog } from "@/components/watchers/event-log";
+import { EventLogToolbar } from "@/components/watchers/event-log-toolbar";
+import { HeartbeatTable } from "@/components/watchers/heartbeat-table";
+import { WatcherConfig } from "@/components/watchers/watcher-config";
+import { WatcherHeader } from "@/components/watchers/watcher-header";
+import {
+  getWatcherById,
+  getWatcherEvents,
+  getWatcherHeartbeats,
+} from "@/lib/api/watchers";
+import { auth } from "@/lib/auth";
+import { watcherDetailParamsCache } from "@/lib/search-params";
+import { notFound, redirect } from "next/navigation";
+import type { Metadata } from "next/types";
+
+type Props = {
+  params: Promise<{ watcherId: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { watcherId } = await params;
+  const watcher = await getWatcherById(watcherId);
+  return {
+    title: watcher?.hostname ?? watcherId.slice(0, 8),
+  };
+}
+
+export default async function WatcherDetailPage({
+  params,
+  searchParams,
+}: Props) {
+  const session = await auth();
+  if (!session) redirect("/login");
+
+  const { watcherId } = await params;
+  const filters = watcherDetailParamsCache.parse(await searchParams);
+
+  // undefined defers to the data layer's default 24h lookback window, which
+  // avoids calling Date.now() in the render path (React purity rule).
+  const heartbeatSince = filters.since ? new Date(filters.since) : undefined;
+  const eventsSince = filters.events_since
+    ? new Date(filters.events_since)
+    : undefined;
+
+  // Three independent queries — none depends on the others' results.
+  const [watcher, heartbeats, events] = await Promise.all([
+    getWatcherById(watcherId),
+    getWatcherHeartbeats(watcherId, { since: heartbeatSince }),
+    getWatcherEvents(watcherId, {
+      since: eventsSince,
+      eventTypes:
+        filters.event_type.length > 0 ? filters.event_type : undefined,
+    }),
+  ]);
+
+  if (!watcher) notFound();
+
+  return (
+    <div className="mx-auto flex max-w-7xl flex-col gap-6 p-6">
+      <WatcherHeader watcher={watcher} />
+      <WatcherConfig configYaml={watcher.configYaml} />
+      <HeartbeatTable heartbeats={heartbeats} />
+      <EventLogToolbar />
+      <EventLog events={events} />
+    </div>
+  );
+}

--- a/web-app/app/watchers/page.tsx
+++ b/web-app/app/watchers/page.tsx
@@ -1,4 +1,4 @@
-import { WatchersToolbar } from "@/components/watchers/watchers-toolbar";
+import { WatchersView } from "@/components/watchers/watchers-view";
 import { getWatcherList } from "@/lib/api/watchers";
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
@@ -25,7 +25,7 @@ export default async function WatchersPage() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold tracking-tight">Watchers</h1>
       </div>
-      <WatchersToolbar activeData={active} deregisteredData={deregistered} />
+      <WatchersView activeData={active} deregisteredData={deregistered} />
     </div>
   );
 }

--- a/web-app/app/watchers/page.tsx
+++ b/web-app/app/watchers/page.tsx
@@ -1,0 +1,31 @@
+import { WatchersToolbar } from "@/components/watchers/watchers-toolbar";
+import { getWatcherList } from "@/lib/api/watchers";
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import type { Metadata } from "next/types";
+
+export const metadata: Metadata = {
+  title: "Watchers",
+};
+
+export default async function WatchersPage() {
+  const session = await auth();
+  if (!session) redirect("/login");
+
+  // Fetch all watchers in a single query and partition client-side. The total
+  // count is small (typically <50), so this avoids two separate DB round-trips
+  // and lets the toggle between active/deregistered be instant (no refetch).
+  const allWatchers = await getWatcherList({ includeDeleted: true });
+
+  const active = allWatchers.filter((w) => !w.deletedAt);
+  const deregistered = allWatchers.filter((w) => w.deletedAt);
+
+  return (
+    <div className="mx-auto flex max-w-7xl flex-col gap-6 p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold tracking-tight">Watchers</h1>
+      </div>
+      <WatchersToolbar activeData={active} deregisteredData={deregistered} />
+    </div>
+  );
+}

--- a/web-app/components/instruments/edit-instrument-dialog.tsx
+++ b/web-app/components/instruments/edit-instrument-dialog.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Loader2, Pencil } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+export function EditInstrumentDialog({
+  instrumentId,
+  displayName,
+  filePatterns,
+}: {
+  instrumentId: string;
+  displayName: string;
+  filePatterns: string[];
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState(displayName);
+  const [patterns, setPatterns] = useState(filePatterns.join(", "));
+  const [isPending, startTransition] = useTransition();
+
+  function handleSave() {
+    startTransition(async () => {
+      const parsedPatterns = patterns
+        .split(",")
+        .map((p) => p.trim())
+        .filter(Boolean);
+
+      const res = await fetch(`/api/v1/instruments/${instrumentId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          display_name: name.trim(),
+          file_patterns: parsedPatterns,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        toast.error(body?.error ?? "Failed to update instrument");
+        return;
+      }
+
+      toast.success("Instrument updated");
+      setOpen(false);
+      router.refresh();
+    });
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => {
+        setOpen(value);
+        // Re-sync form state from props on open so the dialog reflects any
+        // server-side changes since the last time it was opened.
+        if (value) {
+          setName(displayName);
+          setPatterns(filePatterns.join(", "));
+        }
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm" className="h-7 w-7 p-0">
+          <Pencil className="size-3.5" />
+          <span className="sr-only">Edit instrument</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit instrument</DialogTitle>
+          <DialogDescription>
+            Update the display name or file patterns for{" "}
+            <span className="font-mono">{instrumentId}</span>.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-2">
+            <Label htmlFor="edit-name">Display name</Label>
+            <Input
+              id="edit-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={100}
+              autoFocus
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="edit-patterns">File patterns</Label>
+            <Input
+              id="edit-patterns"
+              placeholder="e.g. *.xls, *.csv"
+              value={patterns}
+              onChange={(e) => setPatterns(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Comma-separated glob patterns.
+            </p>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button onClick={handleSave} disabled={!name.trim() || isPending}>
+            {isPending && (
+              <Loader2 className="animate-spin" data-icon="inline-start" />
+            )}
+            Save changes
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web-app/components/instruments/instrument-header.tsx
+++ b/web-app/components/instruments/instrument-header.tsx
@@ -1,0 +1,104 @@
+import { Badge } from "@/components/ui/badge";
+import type { InstrumentDetail } from "@/lib/api/instruments";
+import { Activity, ArrowLeft, Radio, WifiOff } from "lucide-react";
+import Link from "next/link";
+
+const statusBadge: Record<
+  InstrumentDetail["status"],
+  { label: string; variant: "default" | "outline" | "secondary" }
+> = {
+  active: { label: "Active", variant: "default" },
+  pending: { label: "Pending", variant: "outline" },
+  inactive: { label: "Inactive", variant: "secondary" },
+};
+
+type WatcherVariant = "online" | "offline" | "no_watcher";
+
+const watcherBadge: Record<
+  WatcherVariant,
+  {
+    label: string;
+    variant: "default" | "destructive" | "outline";
+    icon: typeof Activity;
+  }
+> = {
+  online: { label: "Online", variant: "default", icon: Radio },
+  offline: { label: "Offline", variant: "destructive", icon: WifiOff },
+  no_watcher: { label: "No Watcher", variant: "outline", icon: WifiOff },
+};
+
+// An instrument is "online" if at least one watcher is actively heartbeating.
+// Registered watchers that have gone silent are treated as "offline".
+function getWatcherVariant(instrument: InstrumentDetail): WatcherVariant {
+  if (instrument.watcherCount === 0) return "no_watcher";
+  return instrument.watchersOnline > 0 ? "online" : "offline";
+}
+
+export function InstrumentHeader({
+  instrument,
+}: {
+  instrument: InstrumentDetail;
+}) {
+  const sb = statusBadge[instrument.status];
+  const wv = getWatcherVariant(instrument);
+  const wb = watcherBadge[wv];
+  const WatcherIcon = wb.icon;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Link
+        href="/instruments"
+        className="flex w-fit items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="size-3.5" />
+        Back to instruments
+      </Link>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <h1 className="text-2xl font-semibold tracking-tight">
+            {instrument.displayName}
+          </h1>
+          <Badge variant={sb.variant} className="text-[10px]">
+            {sb.label}
+          </Badge>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Badge variant={wb.variant} className="gap-1 text-[10px]">
+            <WatcherIcon className="size-3" />
+            {wb.label}
+            {instrument.watcherCount > 0 && (
+              <span className="ml-0.5 font-mono">
+                ({instrument.watchersOnline}/{instrument.watcherCount})
+              </span>
+            )}
+          </Badge>
+          <Badge variant="outline" className="font-mono text-[10px]">
+            {instrument.runCount} {instrument.runCount === 1 ? "run" : "runs"}
+          </Badge>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-mono text-xs text-muted-foreground">
+          {instrument.id}
+        </span>
+        {instrument.filePatterns && instrument.filePatterns.length > 0 && (
+          <>
+            <span className="text-muted-foreground">·</span>
+            {instrument.filePatterns.map((p) => (
+              <Badge
+                key={p}
+                variant="outline"
+                className="font-mono text-[10px] font-normal"
+              >
+                {p}
+              </Badge>
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-app/components/instruments/instrument-runs-table.tsx
+++ b/web-app/components/instruments/instrument-runs-table.tsx
@@ -1,0 +1,149 @@
+import { FileStatusSummary } from "@/components/dashboard/file-status-summary";
+import { RelativeTime } from "@/components/dashboard/relative-time";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import { SearchX } from "lucide-react";
+import Link from "next/link";
+
+type RunRow = {
+  id: string;
+  instrument_id: string;
+  instrument_display_name: string;
+  run_id: string;
+  source: string;
+  metadata: unknown;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  file_count: number;
+  files_completed: number;
+  files_failed: number;
+  files_pending_upload: number;
+};
+
+// Shows at most 3 key-value pairs from the run's freeform JSON metadata
+// to keep the table column compact; the future run detail page shows all.
+function MetadataSummary({ metadata }: { metadata: unknown }) {
+  if (!metadata || typeof metadata !== "object") return null;
+  const entries = Object.entries(metadata as Record<string, unknown>).slice(
+    0,
+    3
+  );
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {entries.map(([key, value]) => (
+        <Badge
+          key={key}
+          variant="outline"
+          className="max-w-[200px] truncate font-mono text-[10px] font-normal"
+        >
+          {key}: {String(value)}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+export function InstrumentRunsTable({
+  data,
+  instrumentId,
+  hasFilters,
+}: {
+  data: RunRow[];
+  instrumentId: string;
+  hasFilters: boolean;
+}) {
+  if (data.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed py-16">
+        <SearchX className="size-8 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">
+          {hasFilters
+            ? "No runs match your filters."
+            : "No instrument runs yet."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Run ID</TableHead>
+            <TableHead>Files</TableHead>
+            <TableHead>Metadata</TableHead>
+            <TableHead>Source</TableHead>
+            <TableHead className="text-right">Created</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.map((row) => {
+            const isDeleted = row.deleted_at !== null;
+            return (
+              <TableRow key={row.id} className={cn(isDeleted && "opacity-50")}>
+                <TableCell>
+                  {/* Links to the future run detail page (not yet built). */}
+                  <Link
+                    href={`/instruments/${instrumentId}/runs/${row.run_id}`}
+                    className="hover:underline"
+                  >
+                    <span
+                      className={cn(
+                        "font-mono text-sm",
+                        isDeleted && "line-through"
+                      )}
+                    >
+                      {row.run_id}
+                    </span>
+                  </Link>
+                  {isDeleted && (
+                    <Badge
+                      variant="outline"
+                      className="ml-1.5 text-[10px] font-normal"
+                    >
+                      deleted
+                    </Badge>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <FileStatusSummary
+                    fileCount={row.file_count}
+                    filesCompleted={row.files_completed}
+                    filesFailed={row.files_failed}
+                    filesPendingUpload={row.files_pending_upload}
+                  />
+                </TableCell>
+                <TableCell>
+                  <MetadataSummary metadata={row.metadata} />
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    variant="outline"
+                    className="font-mono text-[10px] font-normal"
+                  >
+                    {row.source}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-right">
+                  <RelativeTime date={row.created_at.toISOString()} />
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/web-app/components/instruments/instrument-runs-toolbar.tsx
+++ b/web-app/components/instruments/instrument-runs-toolbar.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { instrumentDetailSearchParams } from "@/lib/search-params";
+import { CalendarDays, Search, Trash2, X } from "lucide-react";
+import { useQueryStates } from "nuqs";
+
+export function InstrumentRunsToolbar() {
+  // shallow: false triggers a server-side re-fetch on every URL change so the
+  // table data stays in sync. throttleMs debounces rapid keystrokes in search.
+  const [filters, setFilters] = useQueryStates(instrumentDetailSearchParams, {
+    shallow: false,
+    throttleMs: 300,
+  });
+
+  const hasFilters =
+    filters.search !== "" ||
+    filters.date_from !== null ||
+    filters.date_to !== null ||
+    filters.include_deleted;
+
+  function clearFilters() {
+    setFilters({
+      search: "",
+      date_from: null,
+      date_to: null,
+      include_deleted: false,
+      page: 1,
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="relative w-64">
+          <Search className="absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search runs..."
+            value={filters.search}
+            onChange={(e) => setFilters({ search: e.target.value, page: 1 })}
+            className="pl-9"
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          {hasFilters && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={clearFilters}
+              className="h-8 gap-1 text-xs"
+            >
+              <X className="size-3" />
+              Clear
+            </Button>
+          )}
+
+          <div className="flex items-center gap-2">
+            <CalendarDays className="size-3.5 text-muted-foreground" />
+            <Input
+              type="date"
+              value={filters.date_from ?? ""}
+              onChange={(e) =>
+                setFilters({
+                  date_from: e.target.value || null,
+                  page: 1,
+                })
+              }
+              className="h-9 w-36 text-xs"
+              aria-label="Date from"
+            />
+            <span className="text-xs text-muted-foreground">&ndash;</span>
+            <Input
+              type="date"
+              value={filters.date_to ?? ""}
+              onChange={(e) =>
+                setFilters({
+                  date_to: e.target.value || null,
+                  page: 1,
+                })
+              }
+              className="h-9 w-36 text-xs"
+              aria-label="Date to"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Switch
+              id="include-deleted-detail"
+              checked={filters.include_deleted}
+              onCheckedChange={(checked) =>
+                setFilters({ include_deleted: checked, page: 1 })
+              }
+            />
+            <Label
+              htmlFor="include-deleted-detail"
+              className="flex cursor-pointer items-center gap-1 text-xs"
+            >
+              <Trash2 className="size-3" />
+              Deleted
+            </Label>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-app/components/instruments/instruments-table.tsx
+++ b/web-app/components/instruments/instruments-table.tsx
@@ -1,0 +1,118 @@
+import { EditInstrumentDialog } from "@/components/instruments/edit-instrument-dialog";
+import { StatusActions } from "@/components/instruments/status-actions";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { InstrumentListItem } from "@/lib/api/instruments";
+import { FlaskConical, SearchX } from "lucide-react";
+import Link from "next/link";
+
+const statusBadge: Record<
+  InstrumentListItem["status"],
+  { label: string; variant: "default" | "outline" | "secondary" }
+> = {
+  active: { label: "Active", variant: "default" },
+  pending: { label: "Pending", variant: "outline" },
+  inactive: { label: "Inactive", variant: "secondary" },
+};
+
+export function InstrumentsTable({ data }: { data: InstrumentListItem[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed py-16">
+        <SearchX className="size-8 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">
+          No instruments configured yet.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Instrument</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>File Patterns</TableHead>
+            <TableHead className="text-right">Watchers</TableHead>
+            <TableHead className="text-right">Runs</TableHead>
+            <TableHead className="w-[100px]" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.map((row) => {
+            const sb = statusBadge[row.status];
+            return (
+              <TableRow key={row.id}>
+                <TableCell>
+                  <Link
+                    href={`/instruments/${row.id}`}
+                    className="flex items-center gap-1.5 hover:underline"
+                  >
+                    <FlaskConical className="size-3.5 shrink-0 text-muted-foreground" />
+                    <span className="text-sm font-medium">
+                      {row.displayName}
+                    </span>
+                  </Link>
+                  <span className="mt-0.5 block font-mono text-[10px] text-muted-foreground">
+                    {row.id}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <Badge variant={sb.variant} className="text-[10px]">
+                    {sb.label}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  {row.filePatterns && row.filePatterns.length > 0 ? (
+                    <div className="flex flex-wrap gap-1">
+                      {row.filePatterns.map((p) => (
+                        <Badge
+                          key={p}
+                          variant="outline"
+                          className="font-mono text-[10px] font-normal"
+                        >
+                          {p}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">—</span>
+                  )}
+                </TableCell>
+                <TableCell className="text-right font-mono text-sm">
+                  {row.watcherCount}
+                </TableCell>
+                <TableCell className="text-right font-mono text-sm">
+                  {row.runCount}
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center justify-end gap-1">
+                    {/* Only pending instruments need the approval action;
+                        active/inactive instruments are already confirmed. */}
+                    {row.status === "pending" && (
+                      <StatusActions instrumentId={row.id} />
+                    )}
+                    <EditInstrumentDialog
+                      instrumentId={row.id}
+                      displayName={row.displayName}
+                      filePatterns={row.filePatterns ?? []}
+                    />
+                  </div>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/web-app/components/instruments/status-actions.tsx
+++ b/web-app/components/instruments/status-actions.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Check, Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import { toast } from "sonner";
+
+// Instruments registered by a watcher start as "pending" and require admin
+// approval. This button transitions them to "active" via the PATCH API.
+export function StatusActions({ instrumentId }: { instrumentId: string }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  function handleConfirm() {
+    startTransition(async () => {
+      const res = await fetch(`/api/v1/instruments/${instrumentId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "active" }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        toast.error(body?.error ?? "Failed to confirm instrument");
+        return;
+      }
+
+      toast.success("Instrument confirmed");
+      router.refresh();
+    });
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleConfirm}
+      disabled={isPending}
+      className="h-7 gap-1 text-xs"
+    >
+      {isPending ? (
+        <Loader2 className="size-3 animate-spin" />
+      ) : (
+        <Check className="size-3" />
+      )}
+      Confirm
+    </Button>
+  );
+}

--- a/web-app/components/nav-links.tsx
+++ b/web-app/components/nav-links.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const links = [
+  { href: "/", label: "Dashboard" },
+  { href: "/instruments", label: "Instruments" },
+  { href: "/settings", label: "Settings" },
+] as const;
+
+export function NavLinks() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex items-center gap-4">
+      {links.map(({ href, label }) => {
+        // Dashboard uses exact match so it doesn't highlight for every route;
+        // other links use prefix match to stay active on nested pages
+        // (e.g. /instruments/:id still highlights "Instruments").
+        const isActive =
+          href === "/"
+            ? pathname === "/"
+            : pathname === href || pathname.startsWith(`${href}/`);
+
+        return (
+          <Link
+            key={href}
+            href={href}
+            className={cn(
+              "text-sm transition-colors hover:text-foreground",
+              isActive ? "font-medium text-foreground" : "text-muted-foreground"
+            )}
+          >
+            {label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/web-app/components/nav-links.tsx
+++ b/web-app/components/nav-links.tsx
@@ -4,11 +4,7 @@ import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-const links = [
-  { href: "/", label: "Dashboard" },
-  { href: "/instruments", label: "Instruments" },
-  { href: "/settings", label: "Settings" },
-] as const;
+const links = [{ href: "/instruments", label: "Instruments" }] as const;
 
 export function NavLinks() {
   const pathname = usePathname();
@@ -16,13 +12,9 @@ export function NavLinks() {
   return (
     <nav className="flex items-center gap-4">
       {links.map(({ href, label }) => {
-        // Dashboard uses exact match so it doesn't highlight for every route;
-        // other links use prefix match to stay active on nested pages
-        // (e.g. /instruments/:id still highlights "Instruments").
-        const isActive =
-          href === "/"
-            ? pathname === "/"
-            : pathname === href || pathname.startsWith(`${href}/`);
+        // Use prefix match to stay active on nested pages (e.g.
+        // /instruments/:id still highlights "Instruments").
+        const isActive = pathname === href || pathname.startsWith(`${href}/`);
 
         return (
           <Link

--- a/web-app/components/nav-links.tsx
+++ b/web-app/components/nav-links.tsx
@@ -4,7 +4,10 @@ import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-const links = [{ href: "/instruments", label: "Instruments" }] as const;
+const links = [
+  { href: "/instruments", label: "Instruments" },
+  { href: "/watchers", label: "Watchers" },
+] as const;
 
 export function NavLinks() {
   const pathname = usePathname();

--- a/web-app/components/navbar.tsx
+++ b/web-app/components/navbar.tsx
@@ -1,4 +1,5 @@
 import { UserMenu } from "@/components/dashboard/user-menu";
+import { NavLinks } from "@/components/nav-links";
 import { signOut } from "@/lib/auth";
 import type { Session } from "next-auth";
 import Link from "next/link";
@@ -7,9 +8,12 @@ export function Navbar({ session }: { session: Session }) {
   return (
     <header className="border-b bg-background">
       <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-3">
-        <Link href="/" className="text-lg font-medium tracking-tight">
-          Data Hub
-        </Link>
+        <div className="flex items-center gap-6">
+          <Link href="/" className="text-lg font-medium tracking-tight">
+            Data Hub
+          </Link>
+          <NavLinks />
+        </div>
         <UserMenu
           user={session.user}
           signOutAction={async () => {

--- a/web-app/components/watchers/deregister-dialog.tsx
+++ b/web-app/components/watchers/deregister-dialog.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Loader2, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import { toast } from "sonner";
+
+export function DeregisterDialog({
+  watcherId,
+  hostname,
+}: {
+  watcherId: string;
+  hostname: string | null;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  // Soft-deletes the watcher via the existing API (sets deleted_at). The
+  // watcher CLI will receive a 404 on its next heartbeat and shut down.
+  // useTransition keeps the dialog responsive during the network round-trip.
+  function handleDeregister() {
+    startTransition(async () => {
+      const res = await fetch(`/api/v1/watchers/${watcherId}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        toast.error(body?.error ?? "Failed to deregister watcher");
+        return;
+      }
+
+      toast.success("Watcher deregistered");
+      // Invalidate the server component tree so the watcher disappears from
+      // the active list (or shifts to the deregistered partition).
+      router.refresh();
+    });
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1 text-xs text-destructive hover:text-destructive"
+        >
+          <Trash2 className="size-3" />
+          Deregister
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Deregister watcher?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Stop the watcher service on the instrument PC before deregistering.
+            {hostname && (
+              <>
+                {" "}
+                The watcher on <strong>{hostname}</strong> will no longer be
+                able to send heartbeats or events.
+              </>
+            )}
+            {!hostname &&
+              " The watcher will no longer be able to send heartbeats or events."}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={handleDeregister}
+            disabled={isPending}
+          >
+            {isPending && <Loader2 className="size-4 animate-spin" />}
+            Deregister
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/web-app/components/watchers/event-log-toolbar.tsx
+++ b/web-app/components/watchers/event-log-toolbar.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { watcherDetailSearchParams } from "@/lib/search-params";
+import { CalendarDays, Filter, X } from "lucide-react";
+import { useQueryStates } from "nuqs";
+
+const EVENT_TYPES = [
+  { value: "watcher_started", label: "Started" },
+  { value: "watcher_stopped", label: "Stopped" },
+  { value: "file_uploaded", label: "File Uploaded" },
+  { value: "upload_failed", label: "Upload Failed" },
+  { value: "run_reported", label: "Run Reported" },
+  { value: "config_synced", label: "Config Synced" },
+  { value: "error", label: "Error" },
+] as const;
+
+export function EventLogToolbar() {
+  // shallow: false pushes filter changes to the URL and triggers a full
+  // server-side re-render, so the event list refetches with the new filters.
+  const [filters, setFilters] = useQueryStates(watcherDetailSearchParams, {
+    shallow: false,
+    throttleMs: 300,
+  });
+
+  const hasFilters =
+    filters.event_type.length > 0 || filters.events_since !== null;
+
+  function toggleEventType(type: string) {
+    const current = filters.event_type;
+    const next = current.includes(type)
+      ? current.filter((t) => t !== type)
+      : [...current, type];
+    setFilters({ event_type: next });
+  }
+
+  function clearFilters() {
+    setFilters({
+      event_type: [],
+      events_since: null,
+    });
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm" className="h-8 gap-1 text-xs">
+            <Filter className="size-3" />
+            Event Type
+            {filters.event_type.length > 0 && (
+              <span className="ml-1 rounded-full bg-primary px-1.5 text-[10px] text-primary-foreground">
+                {filters.event_type.length}
+              </span>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-48 p-2" align="start">
+          <div className="flex flex-col gap-1">
+            {EVENT_TYPES.map((et) => (
+              <label
+                key={et.value}
+                className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-muted"
+              >
+                <Checkbox
+                  checked={filters.event_type.includes(et.value)}
+                  onCheckedChange={() => toggleEventType(et.value)}
+                />
+                {et.label}
+              </label>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <div className="flex items-center gap-2">
+        <CalendarDays className="size-3.5 text-muted-foreground" />
+        <Input
+          type="date"
+          value={filters.events_since ?? ""}
+          onChange={(e) => setFilters({ events_since: e.target.value || null })}
+          className="h-8 w-36 text-xs"
+          aria-label="Events since"
+        />
+      </div>
+
+      {hasFilters && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={clearFilters}
+          className="h-8 gap-1 text-xs"
+        >
+          <X className="size-3" />
+          Clear
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/web-app/components/watchers/event-log.tsx
+++ b/web-app/components/watchers/event-log.tsx
@@ -72,11 +72,22 @@ function EventEntry({ event }: { event: WatcherEventRow }) {
   );
 }
 
-export function EventLog({ events }: { events: WatcherEventRow[] }) {
+export function EventLog({
+  events,
+  truncated = false,
+}: {
+  events: WatcherEventRow[];
+  truncated?: boolean;
+}) {
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-sm font-medium">Event Log</CardTitle>
+        {truncated && events.length > 0 && (
+          <p className="text-xs text-muted-foreground">
+            Showing latest {events.length} events — older entries omitted
+          </p>
+        )}
       </CardHeader>
       <CardContent className="p-0">
         {events.length === 0 ? (

--- a/web-app/components/watchers/event-log.tsx
+++ b/web-app/components/watchers/event-log.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { WatcherEventRow } from "@/lib/api/watchers";
+import { cn, formatRelativeTime } from "@/lib/utils";
+import { ChevronDown, Inbox } from "lucide-react";
+import { useState } from "react";
+
+// Color-coded by severity: green (default) for successful data operations,
+// red (destructive) for failures, blue-ish (outline) for lifecycle events.
+// Unknown event types fall back to "secondary" so new types don't break the UI.
+const eventTypeMeta: Record<
+  string,
+  {
+    variant: "default" | "destructive" | "outline" | "secondary";
+    label: string;
+  }
+> = {
+  file_uploaded: { variant: "default", label: "File Uploaded" },
+  config_synced: { variant: "default", label: "Config Synced" },
+  upload_failed: { variant: "destructive", label: "Upload Failed" },
+  error: { variant: "destructive", label: "Error" },
+  watcher_started: { variant: "outline", label: "Started" },
+  watcher_stopped: { variant: "outline", label: "Stopped" },
+  run_reported: { variant: "outline", label: "Run Reported" },
+};
+
+function EventEntry({ event }: { event: WatcherEventRow }) {
+  const [expanded, setExpanded] = useState(false);
+  const meta = eventTypeMeta[event.eventType] ?? {
+    variant: "secondary" as const,
+    label: event.eventType,
+  };
+  const hasDetails = event.details != null;
+
+  return (
+    <div className="flex flex-col gap-1 border-b px-4 py-3 last:border-0">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Badge variant={meta.variant} className="text-[10px]">
+            {meta.label}
+          </Badge>
+          <span className="text-sm">{event.message}</span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="text-xs text-muted-foreground">
+            {formatRelativeTime(event.timestamp)}
+          </span>
+          {hasDetails && (
+            <button
+              onClick={() => setExpanded(!expanded)}
+              className="text-muted-foreground transition-colors hover:text-foreground"
+              aria-label={expanded ? "Collapse details" : "Expand details"}
+            >
+              <ChevronDown
+                className={cn(
+                  "size-4 transition-transform",
+                  expanded && "rotate-180"
+                )}
+              />
+            </button>
+          )}
+        </div>
+      </div>
+      {expanded && hasDetails && (
+        <pre className="mt-1 overflow-x-auto rounded-md bg-muted p-3 font-mono text-xs leading-relaxed">
+          {JSON.stringify(event.details, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+export function EventLog({ events }: { events: WatcherEventRow[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Event Log</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        {events.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 py-8">
+            <Inbox className="size-6 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              No events in this time range.
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y">
+            {events.map((event) => (
+              <EventEntry key={event.id} event={event} />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web-app/components/watchers/heartbeat-table.tsx
+++ b/web-app/components/watchers/heartbeat-table.tsx
@@ -1,0 +1,111 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { WatcherHeartbeatRow } from "@/lib/api/watchers";
+import { cn } from "@/lib/utils";
+import { HeartPulse } from "lucide-react";
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+export function HeartbeatTable({
+  heartbeats,
+}: {
+  heartbeats: WatcherHeartbeatRow[];
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Heartbeat History</CardTitle>
+        <CardDescription>
+          {heartbeats.length} heartbeat{heartbeats.length !== 1 && "s"}
+          {heartbeats.length > 0 && " (last 24 hours)"}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {heartbeats.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 py-8">
+            <HeartPulse className="size-6 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              No heartbeats in this time range.
+            </p>
+          </div>
+        ) : (
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Timestamp</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Upload Mode</TableHead>
+                  <TableHead className="text-right">Files</TableHead>
+                  <TableHead className="text-right">Runs</TableHead>
+                  <TableHead className="text-right">Errors</TableHead>
+                  <TableHead className="text-right">Uptime</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {heartbeats.map((hb) => (
+                  <TableRow key={hb.id}>
+                    <TableCell className="font-mono text-xs">
+                      {hb.timestamp.toLocaleString("en-US", {
+                        dateStyle: "short",
+                        timeStyle: "medium",
+                      })}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className="text-[10px]">
+                        {hb.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {hb.uploadMode ?? "—"}
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-xs">
+                      {hb.filesUploadedSinceLast ?? 0}
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-xs">
+                      {hb.runsReportedSinceLast ?? 0}
+                    </TableCell>
+                    <TableCell
+                      className={cn(
+                        "text-right font-mono text-xs",
+                        (hb.errorsSinceLast ?? 0) > 0 &&
+                          "font-semibold text-destructive"
+                      )}
+                    >
+                      {hb.errorsSinceLast ?? 0}
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-xs">
+                      {hb.uptimeSeconds != null
+                        ? formatDuration(hb.uptimeSeconds)
+                        : "—"}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web-app/components/watchers/heartbeat-table.tsx
+++ b/web-app/components/watchers/heartbeat-table.tsx
@@ -28,16 +28,22 @@ function formatDuration(seconds: number): string {
 
 export function HeartbeatTable({
   heartbeats,
+  truncated = false,
 }: {
   heartbeats: WatcherHeartbeatRow[];
+  truncated?: boolean;
 }) {
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-sm font-medium">Heartbeat History</CardTitle>
         <CardDescription>
-          {heartbeats.length} heartbeat{heartbeats.length !== 1 && "s"}
+          {truncated
+            ? `Showing latest ${heartbeats.length}`
+            : heartbeats.length}{" "}
+          heartbeat{heartbeats.length !== 1 && "s"}
           {heartbeats.length > 0 && " (last 24 hours)"}
+          {truncated && " — older entries omitted"}
         </CardDescription>
       </CardHeader>
       <CardContent>

--- a/web-app/components/watchers/status-badge.ts
+++ b/web-app/components/watchers/status-badge.ts
@@ -1,0 +1,14 @@
+import type { EffectiveStatus } from "@/lib/api/watchers";
+
+export const statusBadge: Record<
+  EffectiveStatus,
+  {
+    label: string;
+    variant: "default" | "outline" | "secondary" | "destructive";
+  }
+> = {
+  watching: { label: "Watching", variant: "default" },
+  stale: { label: "Stale", variant: "destructive" },
+  stopped: { label: "Stopped", variant: "secondary" },
+  registered: { label: "Registered", variant: "outline" },
+};

--- a/web-app/components/watchers/watcher-config.tsx
+++ b/web-app/components/watchers/watcher-config.tsx
@@ -1,0 +1,26 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { FileText } from "lucide-react";
+
+export function WatcherConfig({ configYaml }: { configYaml: string | null }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Configuration</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {configYaml ? (
+          <pre className="overflow-x-auto rounded-md bg-muted p-4 font-mono text-xs leading-relaxed">
+            {configYaml}
+          </pre>
+        ) : (
+          <div className="flex flex-col items-center justify-center gap-2 py-8">
+            <FileText className="size-6 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              No config pushed yet.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web-app/components/watchers/watcher-header.tsx
+++ b/web-app/components/watchers/watcher-header.tsx
@@ -1,22 +1,10 @@
 import { Badge } from "@/components/ui/badge";
 import { DeregisterDialog } from "@/components/watchers/deregister-dialog";
-import type { EffectiveStatus, WatcherDetail } from "@/lib/api/watchers";
+import { statusBadge } from "@/components/watchers/status-badge";
+import type { WatcherDetail } from "@/lib/api/watchers";
 import { formatRelativeTime } from "@/lib/utils";
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
-
-const statusBadge: Record<
-  EffectiveStatus,
-  {
-    label: string;
-    variant: "default" | "outline" | "secondary" | "destructive";
-  }
-> = {
-  watching: { label: "Watching", variant: "default" },
-  stale: { label: "Stale", variant: "destructive" },
-  stopped: { label: "Stopped", variant: "secondary" },
-  registered: { label: "Registered", variant: "outline" },
-};
 
 export function WatcherHeader({ watcher }: { watcher: WatcherDetail }) {
   const sb = statusBadge[watcher.effectiveStatus];

--- a/web-app/components/watchers/watcher-header.tsx
+++ b/web-app/components/watchers/watcher-header.tsx
@@ -1,0 +1,108 @@
+import { Badge } from "@/components/ui/badge";
+import { DeregisterDialog } from "@/components/watchers/deregister-dialog";
+import type { EffectiveStatus, WatcherDetail } from "@/lib/api/watchers";
+import { formatRelativeTime } from "@/lib/utils";
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+
+const statusBadge: Record<
+  EffectiveStatus,
+  {
+    label: string;
+    variant: "default" | "outline" | "secondary" | "destructive";
+  }
+> = {
+  watching: { label: "Watching", variant: "default" },
+  stale: { label: "Stale", variant: "destructive" },
+  stopped: { label: "Stopped", variant: "secondary" },
+  registered: { label: "Registered", variant: "outline" },
+};
+
+export function WatcherHeader({ watcher }: { watcher: WatcherDetail }) {
+  const sb = statusBadge[watcher.effectiveStatus];
+  const isDeregistered = !!watcher.deletedAt;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Link
+        href="/watchers"
+        className="flex w-fit items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="size-3.5" />
+        Back to watchers
+      </Link>
+
+      {/* Deregistered watchers get a muted, dashed-border treatment to
+          visually signal that this is historical data. The deregister action
+          is hidden since the watcher is already soft-deleted. */}
+      <div
+        className={
+          isDeregistered
+            ? "flex flex-col gap-3 rounded-lg border border-dashed p-4 opacity-70"
+            : "flex flex-col gap-3"
+        }
+      >
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-semibold tracking-tight">
+              {watcher.hostname ?? "Unnamed Watcher"}
+            </h1>
+            <Badge variant={sb.variant} className="text-[10px]">
+              {sb.label}
+            </Badge>
+            {isDeregistered && (
+              <Badge variant="secondary" className="text-[10px]">
+                Deregistered
+              </Badge>
+            )}
+          </div>
+
+          {!isDeregistered && (
+            <DeregisterDialog
+              watcherId={watcher.id}
+              hostname={watcher.hostname}
+            />
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+          <span className="font-mono">{watcher.id}</span>
+          <span>·</span>
+          <Link
+            href={`/instruments/${watcher.instrumentId}`}
+            className="hover:text-foreground hover:underline"
+          >
+            {watcher.instrumentDisplayName ?? watcher.instrumentId}
+          </Link>
+          {watcher.osInfo && (
+            <>
+              <span>·</span>
+              <span>{watcher.osInfo}</span>
+            </>
+          )}
+          {watcher.lastHeartbeatAt && (
+            <>
+              <span>·</span>
+              <span>
+                Last heartbeat {formatRelativeTime(watcher.lastHeartbeatAt)}
+              </span>
+            </>
+          )}
+          {isDeregistered && watcher.deletedAt && (
+            <>
+              <span>·</span>
+              <span>
+                Deregistered{" "}
+                {watcher.deletedAt.toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                })}
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-app/components/watchers/watchers-table.tsx
+++ b/web-app/components/watchers/watchers-table.tsx
@@ -8,23 +8,11 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { DeregisterDialog } from "@/components/watchers/deregister-dialog";
-import type { EffectiveStatus, WatcherListItem } from "@/lib/api/watchers";
+import { statusBadge } from "@/components/watchers/status-badge";
+import type { WatcherListItem } from "@/lib/api/watchers";
 import { cn, formatRelativeTime } from "@/lib/utils";
 import { SearchX } from "lucide-react";
 import Link from "next/link";
-
-const statusBadge: Record<
-  EffectiveStatus,
-  {
-    label: string;
-    variant: "default" | "outline" | "secondary" | "destructive";
-  }
-> = {
-  watching: { label: "Watching", variant: "default" },
-  stale: { label: "Stale", variant: "destructive" },
-  stopped: { label: "Stopped", variant: "secondary" },
-  registered: { label: "Registered", variant: "outline" },
-};
 
 export function WatchersTable({
   data,

--- a/web-app/components/watchers/watchers-table.tsx
+++ b/web-app/components/watchers/watchers-table.tsx
@@ -1,0 +1,128 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { DeregisterDialog } from "@/components/watchers/deregister-dialog";
+import type { EffectiveStatus, WatcherListItem } from "@/lib/api/watchers";
+import { cn, formatRelativeTime } from "@/lib/utils";
+import { SearchX } from "lucide-react";
+import Link from "next/link";
+
+const statusBadge: Record<
+  EffectiveStatus,
+  {
+    label: string;
+    variant: "default" | "outline" | "secondary" | "destructive";
+  }
+> = {
+  watching: { label: "Watching", variant: "default" },
+  stale: { label: "Stale", variant: "destructive" },
+  stopped: { label: "Stopped", variant: "secondary" },
+  registered: { label: "Registered", variant: "outline" },
+};
+
+export function WatchersTable({
+  data,
+  isDeregisteredView = false,
+}: {
+  data: WatcherListItem[];
+  isDeregisteredView?: boolean;
+}) {
+  if (data.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed py-16">
+        <SearchX className="size-8 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">
+          {isDeregisteredView
+            ? "No deregistered watchers."
+            : "No active watchers."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Watcher ID</TableHead>
+            <TableHead>Instrument</TableHead>
+            <TableHead>Hostname</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Last Heartbeat</TableHead>
+            {!isDeregisteredView && <TableHead className="w-[80px]" />}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.map((row) => {
+            const sb = statusBadge[row.effectiveStatus];
+            return (
+              <TableRow
+                key={row.id}
+                className={cn(isDeregisteredView && "opacity-60")}
+              >
+                <TableCell>
+                  <Link
+                    href={`/watchers/${row.id}`}
+                    className="font-mono text-xs hover:underline"
+                  >
+                    {row.id.slice(0, 8)}…
+                  </Link>
+                </TableCell>
+                <TableCell>
+                  {row.instrumentDisplayName ? (
+                    <Link
+                      href={`/instruments/${row.instrumentId}`}
+                      className="text-sm hover:underline"
+                    >
+                      {row.instrumentDisplayName}
+                    </Link>
+                  ) : (
+                    <span className="font-mono text-xs text-muted-foreground">
+                      {row.instrumentId}
+                    </span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <span className="text-sm">
+                    {row.hostname ?? (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <Badge variant={sb.variant} className="text-[10px]">
+                    {sb.label}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <span className="text-xs text-muted-foreground">
+                    {row.lastHeartbeatAt
+                      ? formatRelativeTime(row.lastHeartbeatAt)
+                      : "—"}
+                  </span>
+                </TableCell>
+                {!isDeregisteredView && (
+                  <TableCell>
+                    {!row.deletedAt && (
+                      <DeregisterDialog
+                        watcherId={row.id}
+                        hostname={row.hostname}
+                      />
+                    )}
+                  </TableCell>
+                )}
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/web-app/components/watchers/watchers-toolbar.tsx
+++ b/web-app/components/watchers/watchers-toolbar.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { WatchersTable } from "@/components/watchers/watchers-table";
+import type { WatcherListItem } from "@/lib/api/watchers";
+import { useState } from "react";
+
+type Tab = "active" | "deregistered";
+
+// Both partitions are pre-fetched on the server and passed down, so toggling
+// between Active / Deregistered is purely client-side (no URL state or
+// refetch needed — the watcher count is small enough to hold both in memory).
+export function WatchersToolbar({
+  activeData,
+  deregisteredData,
+}: {
+  activeData: WatcherListItem[];
+  deregisteredData: WatcherListItem[];
+}) {
+  const [tab, setTab] = useState<Tab>("active");
+
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <ToggleGroup
+          type="single"
+          value={tab}
+          onValueChange={(v) => {
+            if (v) setTab(v as Tab);
+          }}
+          variant="outline"
+          size="sm"
+        >
+          <ToggleGroupItem value="active">
+            Active ({activeData.length})
+          </ToggleGroupItem>
+          <ToggleGroupItem value="deregistered">
+            Deregistered ({deregisteredData.length})
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+      <WatchersTable
+        data={tab === "active" ? activeData : deregisteredData}
+        isDeregisteredView={tab === "deregistered"}
+      />
+    </>
+  );
+}

--- a/web-app/components/watchers/watchers-view.tsx
+++ b/web-app/components/watchers/watchers-view.tsx
@@ -10,7 +10,7 @@ type Tab = "active" | "deregistered";
 // Both partitions are pre-fetched on the server and passed down, so toggling
 // between Active / Deregistered is purely client-side (no URL state or
 // refetch needed — the watcher count is small enough to hold both in memory).
-export function WatchersToolbar({
+export function WatchersView({
   activeData,
   deregisteredData,
 }: {

--- a/web-app/lib/api/instruments.ts
+++ b/web-app/lib/api/instruments.ts
@@ -1,0 +1,139 @@
+import { db } from "@/lib/db";
+import { instrumentRuns, instruments, watchers } from "@/lib/db/schema";
+import { and, count, eq, isNull, sql } from "drizzle-orm";
+
+export type InstrumentListItem = {
+  id: string;
+  displayName: string;
+  status: "pending" | "active" | "inactive";
+  filePatterns: string[] | null;
+  runCount: number;
+  watcherCount: number;
+  createdAt: Date;
+};
+
+// Uses pre-aggregated sub-selects instead of direct joins to avoid row
+// multiplication (instruments × runs × watchers would inflate counts).
+export async function getInstrumentListWithCounts(): Promise<
+  InstrumentListItem[]
+> {
+  const runCountSq = db
+    .select({
+      instrumentId: instrumentRuns.instrumentId,
+      count: sql<number>`cast(count(*) as int)`.as("run_count"),
+    })
+    .from(instrumentRuns)
+    .where(isNull(instrumentRuns.deletedAt))
+    .groupBy(instrumentRuns.instrumentId)
+    .as("run_counts");
+
+  const watcherCountSq = db
+    .select({
+      instrumentId: watchers.instrumentId,
+      count: sql<number>`cast(count(*) as int)`.as("watcher_count"),
+    })
+    .from(watchers)
+    .where(isNull(watchers.deletedAt))
+    .groupBy(watchers.instrumentId)
+    .as("watcher_counts");
+
+  const rows = await db
+    .select({
+      id: instruments.id,
+      displayName: instruments.displayName,
+      status: instruments.status,
+      filePatterns: instruments.filePatterns,
+      createdAt: instruments.createdAt,
+      runCount: sql<number>`coalesce(${runCountSq.count}, 0)`,
+      watcherCount: sql<number>`coalesce(${watcherCountSq.count}, 0)`,
+    })
+    .from(instruments)
+    .leftJoin(runCountSq, eq(runCountSq.instrumentId, instruments.id))
+    .leftJoin(watcherCountSq, eq(watcherCountSq.instrumentId, instruments.id))
+    .orderBy(instruments.displayName);
+
+  return rows;
+}
+
+// Must match the same staleness window used in dashboard.ts so both pages
+// agree on whether a watcher is "online". A watcher is stale when its last
+// heartbeat is older than this threshold, even if its DB status is "watching".
+const HEARTBEAT_STALE_MINUTES = 5;
+
+export type InstrumentDetail = {
+  id: string;
+  displayName: string;
+  status: "pending" | "active" | "inactive";
+  filePatterns: string[] | null;
+  s3TriggerSuffix: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  runCount: number;
+  watcherCount: number;
+  watchersOnline: number;
+  watchersOffline: number;
+};
+
+export async function getInstrumentById(
+  instrumentId: string
+): Promise<InstrumentDetail | null> {
+  const [instrument] = await db
+    .select()
+    .from(instruments)
+    .where(eq(instruments.id, instrumentId))
+    .limit(1);
+
+  if (!instrument) return null;
+
+  // Fetch run count and watcher rows in parallel — watcher rows are returned
+  // individually so we can classify each as online/offline based on heartbeat.
+  const [runCountResult, watcherRows] = await Promise.all([
+    db
+      .select({ value: count() })
+      .from(instrumentRuns)
+      .where(
+        and(
+          eq(instrumentRuns.instrumentId, instrumentId),
+          isNull(instrumentRuns.deletedAt)
+        )
+      ),
+    db
+      .select({
+        status: watchers.status,
+        lastHeartbeatAt: watchers.lastHeartbeatAt,
+      })
+      .from(watchers)
+      .where(
+        and(eq(watchers.instrumentId, instrumentId), isNull(watchers.deletedAt))
+      ),
+  ]);
+
+  const staleThreshold = new Date(
+    Date.now() - HEARTBEAT_STALE_MINUTES * 60 * 1000
+  );
+
+  let watchersOnline = 0;
+  let watchersOffline = 0;
+  for (const w of watcherRows) {
+    const isOnline =
+      w.status === "watching" &&
+      w.lastHeartbeatAt &&
+      w.lastHeartbeatAt > staleThreshold;
+    if (isOnline) watchersOnline++;
+    else watchersOffline++;
+  }
+
+  return {
+    id: instrument.id,
+    displayName: instrument.displayName,
+    status: instrument.status,
+    filePatterns: instrument.filePatterns,
+    s3TriggerSuffix: instrument.s3TriggerSuffix,
+    createdAt: instrument.createdAt,
+    updatedAt: instrument.updatedAt,
+    runCount: runCountResult[0].value,
+    watcherCount: watcherRows.length,
+    watchersOnline,
+    watchersOffline,
+  };
+}

--- a/web-app/lib/api/instruments.ts
+++ b/web-app/lib/api/instruments.ts
@@ -1,6 +1,7 @@
 import { db } from "@/lib/db";
 import { instrumentRuns, instruments, watchers } from "@/lib/db/schema";
 import { and, count, eq, isNull, sql } from "drizzle-orm";
+import { cache } from "react";
 
 export type InstrumentListItem = {
   id: string;
@@ -74,7 +75,7 @@ export type InstrumentDetail = {
   watchersOffline: number;
 };
 
-export async function getInstrumentById(
+export const getInstrumentById = cache(async function getInstrumentById(
   instrumentId: string
 ): Promise<InstrumentDetail | null> {
   const [instrument] = await db
@@ -136,4 +137,4 @@ export async function getInstrumentById(
     watchersOnline,
     watchersOffline,
   };
-}
+});

--- a/web-app/lib/api/watchers.ts
+++ b/web-app/lib/api/watchers.ts
@@ -56,7 +56,6 @@ export type WatcherListItem = {
   hostname: string | null;
   effectiveStatus: EffectiveStatus;
   lastHeartbeatAt: Date | null;
-  uptimeSeconds: number | null;
   createdAt: Date;
   deletedAt: Date | null;
 };
@@ -85,29 +84,18 @@ export async function getWatcherList(opts: {
     .where(conditions.length > 0 ? and(...conditions) : undefined)
     .orderBy(desc(watchers.createdAt));
 
-  return rows.map((row) => {
-    // Approximate uptime: seconds since last heartbeat. Only meaningful when
-    // the watcher is actively running (status = "watching").
-    const lastHb = row.lastHeartbeatAt;
-    const uptimeSeconds =
-      lastHb && row.status === "watching"
-        ? Math.round((Date.now() - lastHb.getTime()) / 1000)
-        : null;
-
-    return {
-      id: row.id,
-      instrumentId: row.instrumentId,
-      instrumentDisplayName: row.instrumentDisplayName,
-      hostname: row.hostname,
-      // Deregistered watchers always show as "stopped" regardless of their
-      // last DB status — they can no longer heartbeat so staleness is moot.
-      effectiveStatus: row.deletedAt ? "stopped" : computeEffectiveStatus(row),
-      lastHeartbeatAt: row.lastHeartbeatAt,
-      uptimeSeconds,
-      createdAt: row.createdAt,
-      deletedAt: row.deletedAt,
-    };
-  });
+  return rows.map((row) => ({
+    id: row.id,
+    instrumentId: row.instrumentId,
+    instrumentDisplayName: row.instrumentDisplayName,
+    hostname: row.hostname,
+    // Deregistered watchers always show as "stopped" regardless of their
+    // last DB status — they can no longer heartbeat so staleness is moot.
+    effectiveStatus: row.deletedAt ? "stopped" : computeEffectiveStatus(row),
+    lastHeartbeatAt: row.lastHeartbeatAt,
+    createdAt: row.createdAt,
+    deletedAt: row.deletedAt,
+  }));
 }
 
 // ---------------------------------------------------------------------------
@@ -150,12 +138,6 @@ export const getWatcherById = cache(async function getWatcherById(
 
   if (!row) return null;
 
-  const lastHb = row.lastHeartbeatAt;
-  const uptimeSeconds =
-    lastHb && row.status === "watching"
-      ? Math.round((Date.now() - lastHb.getTime()) / 1000)
-      : null;
-
   return {
     id: row.id,
     instrumentId: row.instrumentId,
@@ -164,7 +146,6 @@ export const getWatcherById = cache(async function getWatcherById(
     osInfo: row.osInfo,
     effectiveStatus: row.deletedAt ? "stopped" : computeEffectiveStatus(row),
     lastHeartbeatAt: row.lastHeartbeatAt,
-    uptimeSeconds,
     configYaml: row.configYaml,
     configChecksum: row.configChecksum,
     createdAt: row.createdAt,
@@ -194,10 +175,12 @@ export type WatcherHeartbeatRow = {
 // rule forbids.
 const DEFAULT_LOOKBACK_MS = 24 * 60 * 60 * 1000;
 
+export type PaginatedResult<T> = { rows: T[]; truncated: boolean };
+
 export async function getWatcherHeartbeats(
   watcherId: string,
   opts: { since?: Date; limit?: number } = {}
-): Promise<WatcherHeartbeatRow[]> {
+): Promise<PaginatedResult<WatcherHeartbeatRow>> {
   const limit = opts.limit ?? 200;
   const since = opts.since ?? new Date(Date.now() - DEFAULT_LOOKBACK_MS);
   const conditions = [
@@ -219,9 +202,10 @@ export async function getWatcherHeartbeats(
     .from(watcherHeartbeats)
     .where(and(...conditions))
     .orderBy(desc(watcherHeartbeats.timestamp))
-    .limit(limit);
+    .limit(limit + 1);
 
-  return rows;
+  const truncated = rows.length > limit;
+  return { rows: truncated ? rows.slice(0, limit) : rows, truncated };
 }
 
 // ---------------------------------------------------------------------------
@@ -239,7 +223,7 @@ export type WatcherEventRow = {
 export async function getWatcherEvents(
   watcherId: string,
   opts: { since?: Date; eventTypes?: string[]; limit?: number } = {}
-): Promise<WatcherEventRow[]> {
+): Promise<PaginatedResult<WatcherEventRow>> {
   const limit = opts.limit ?? 200;
   const since = opts.since ?? new Date(Date.now() - DEFAULT_LOOKBACK_MS);
   const conditions = [
@@ -270,7 +254,8 @@ export async function getWatcherEvents(
     .from(watcherEvents)
     .where(and(...conditions))
     .orderBy(desc(watcherEvents.timestamp))
-    .limit(limit);
+    .limit(limit + 1);
 
-  return rows;
+  const truncated = rows.length > limit;
+  return { rows: truncated ? rows.slice(0, limit) : rows, truncated };
 }

--- a/web-app/lib/api/watchers.ts
+++ b/web-app/lib/api/watchers.ts
@@ -1,6 +1,13 @@
 import { db } from "@/lib/db";
-import { watchers } from "@/lib/db/schema";
-import { and, eq, isNull } from "drizzle-orm";
+import {
+  instruments,
+  watcherEventTypeEnum,
+  watcherEvents,
+  watcherHeartbeats,
+  watchers,
+} from "@/lib/db/schema";
+import { and, desc, eq, gte, inArray, isNull } from "drizzle-orm";
+import { cache } from "react";
 
 export const STALE_THRESHOLD_MS = 5 * 60 * 1000;
 
@@ -19,17 +26,251 @@ type WatcherLike = {
   lastHeartbeatAt: Date | null;
 };
 
+export type EffectiveStatus = "registered" | "watching" | "stopped" | "stale";
+
 /**
  * Derives the display status from stored status + heartbeat recency.
  * "stale" is never stored in the DB — it's a virtual status computed here.
  * Watchers in "registered" state haven't sent their first heartbeat yet,
  * so they're exempt from staleness checks.
  */
-export function computeEffectiveStatus(watcher: WatcherLike): string {
+export function computeEffectiveStatus(watcher: WatcherLike): EffectiveStatus {
   if (watcher.status === "registered") return "registered";
 
   if (!watcher.lastHeartbeatAt) return "stale";
 
   const age = Date.now() - watcher.lastHeartbeatAt.getTime();
-  return age > STALE_THRESHOLD_MS ? "stale" : watcher.status;
+  return age > STALE_THRESHOLD_MS
+    ? "stale"
+    : (watcher.status as EffectiveStatus);
+}
+
+// ---------------------------------------------------------------------------
+// List page
+// ---------------------------------------------------------------------------
+
+export type WatcherListItem = {
+  id: string;
+  instrumentId: string;
+  instrumentDisplayName: string | null;
+  hostname: string | null;
+  effectiveStatus: EffectiveStatus;
+  lastHeartbeatAt: Date | null;
+  uptimeSeconds: number | null;
+  createdAt: Date;
+  deletedAt: Date | null;
+};
+
+// Fetches all watchers (optionally including soft-deleted ones) with their
+// parent instrument's display name. The total count is small enough that we
+// fetch everything and partition active vs deregistered in JS on the server.
+export async function getWatcherList(opts: {
+  includeDeleted: boolean;
+}): Promise<WatcherListItem[]> {
+  const conditions = opts.includeDeleted ? [] : [isNull(watchers.deletedAt)];
+
+  const rows = await db
+    .select({
+      id: watchers.id,
+      instrumentId: watchers.instrumentId,
+      instrumentDisplayName: instruments.displayName,
+      hostname: watchers.hostname,
+      status: watchers.status,
+      lastHeartbeatAt: watchers.lastHeartbeatAt,
+      createdAt: watchers.createdAt,
+      deletedAt: watchers.deletedAt,
+    })
+    .from(watchers)
+    .leftJoin(instruments, eq(instruments.id, watchers.instrumentId))
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
+    .orderBy(desc(watchers.createdAt));
+
+  return rows.map((row) => {
+    // Approximate uptime: seconds since last heartbeat. Only meaningful when
+    // the watcher is actively running (status = "watching").
+    const lastHb = row.lastHeartbeatAt;
+    const uptimeSeconds =
+      lastHb && row.status === "watching"
+        ? Math.round((Date.now() - lastHb.getTime()) / 1000)
+        : null;
+
+    return {
+      id: row.id,
+      instrumentId: row.instrumentId,
+      instrumentDisplayName: row.instrumentDisplayName,
+      hostname: row.hostname,
+      // Deregistered watchers always show as "stopped" regardless of their
+      // last DB status — they can no longer heartbeat so staleness is moot.
+      effectiveStatus: row.deletedAt ? "stopped" : computeEffectiveStatus(row),
+      lastHeartbeatAt: row.lastHeartbeatAt,
+      uptimeSeconds,
+      createdAt: row.createdAt,
+      deletedAt: row.deletedAt,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Detail page
+// ---------------------------------------------------------------------------
+
+export type WatcherDetail = WatcherListItem & {
+  osInfo: string | null;
+  configYaml: string | null;
+  configChecksum: string | null;
+  updatedAt: Date;
+};
+
+// React.cache() deduplicates calls within a single request — used by both
+// generateMetadata (for the page title) and the page body (for rendering).
+export const getWatcherById = cache(async function getWatcherById(
+  watcherId: string
+): Promise<WatcherDetail | null> {
+  const [row] = await db
+    .select({
+      id: watchers.id,
+      instrumentId: watchers.instrumentId,
+      instrumentDisplayName: instruments.displayName,
+      hostname: watchers.hostname,
+      osInfo: watchers.osInfo,
+      status: watchers.status,
+      lastHeartbeatAt: watchers.lastHeartbeatAt,
+      configYaml: watchers.configYaml,
+      configChecksum: watchers.configChecksum,
+      createdAt: watchers.createdAt,
+      updatedAt: watchers.updatedAt,
+      deletedAt: watchers.deletedAt,
+    })
+    .from(watchers)
+    .leftJoin(instruments, eq(instruments.id, watchers.instrumentId))
+    // No deletedAt filter — the detail page renders deregistered watchers too,
+    // with muted styling and historical data still visible.
+    .where(eq(watchers.id, watcherId))
+    .limit(1);
+
+  if (!row) return null;
+
+  const lastHb = row.lastHeartbeatAt;
+  const uptimeSeconds =
+    lastHb && row.status === "watching"
+      ? Math.round((Date.now() - lastHb.getTime()) / 1000)
+      : null;
+
+  return {
+    id: row.id,
+    instrumentId: row.instrumentId,
+    instrumentDisplayName: row.instrumentDisplayName,
+    hostname: row.hostname,
+    osInfo: row.osInfo,
+    effectiveStatus: row.deletedAt ? "stopped" : computeEffectiveStatus(row),
+    lastHeartbeatAt: row.lastHeartbeatAt,
+    uptimeSeconds,
+    configYaml: row.configYaml,
+    configChecksum: row.configChecksum,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    deletedAt: row.deletedAt,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Heartbeats
+// ---------------------------------------------------------------------------
+
+export type WatcherHeartbeatRow = {
+  id: number;
+  timestamp: Date;
+  status: string;
+  uploadMode: string | null;
+  filesUploadedSinceLast: number | null;
+  runsReportedSinceLast: number | null;
+  errorsSinceLast: number | null;
+  uptimeSeconds: number | null;
+};
+
+// Default time window for heartbeat/event queries when no explicit range is
+// given. Kept in the data layer (not the page component) to avoid calling
+// Date.now() during server component render, which the React purity lint
+// rule forbids.
+const DEFAULT_LOOKBACK_MS = 24 * 60 * 60 * 1000;
+
+export async function getWatcherHeartbeats(
+  watcherId: string,
+  opts: { since?: Date; limit?: number } = {}
+): Promise<WatcherHeartbeatRow[]> {
+  const limit = opts.limit ?? 200;
+  const since = opts.since ?? new Date(Date.now() - DEFAULT_LOOKBACK_MS);
+  const conditions = [
+    eq(watcherHeartbeats.watcherId, watcherId),
+    gte(watcherHeartbeats.timestamp, since),
+  ];
+
+  const rows = await db
+    .select({
+      id: watcherHeartbeats.id,
+      timestamp: watcherHeartbeats.timestamp,
+      status: watcherHeartbeats.status,
+      uploadMode: watcherHeartbeats.uploadMode,
+      filesUploadedSinceLast: watcherHeartbeats.filesUploadedSinceLast,
+      runsReportedSinceLast: watcherHeartbeats.runsReportedSinceLast,
+      errorsSinceLast: watcherHeartbeats.errorsSinceLast,
+      uptimeSeconds: watcherHeartbeats.uptimeSeconds,
+    })
+    .from(watcherHeartbeats)
+    .where(and(...conditions))
+    .orderBy(desc(watcherHeartbeats.timestamp))
+    .limit(limit);
+
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+export type WatcherEventRow = {
+  id: number;
+  eventType: string;
+  message: string;
+  details: unknown;
+  timestamp: Date;
+};
+
+export async function getWatcherEvents(
+  watcherId: string,
+  opts: { since?: Date; eventTypes?: string[]; limit?: number } = {}
+): Promise<WatcherEventRow[]> {
+  const limit = opts.limit ?? 200;
+  const since = opts.since ?? new Date(Date.now() - DEFAULT_LOOKBACK_MS);
+  const conditions = [
+    eq(watcherEvents.watcherId, watcherId),
+    gte(watcherEvents.timestamp, since),
+  ];
+  // URL params arrive as plain strings — validate against the Drizzle enum
+  // values so the inArray query is type-safe and ignores bogus filter values.
+  if (opts.eventTypes && opts.eventTypes.length > 0) {
+    const validTypes = watcherEventTypeEnum.enumValues;
+    const filtered = opts.eventTypes.filter(
+      (t): t is (typeof validTypes)[number] =>
+        (validTypes as readonly string[]).includes(t)
+    );
+    if (filtered.length > 0) {
+      conditions.push(inArray(watcherEvents.eventType, filtered));
+    }
+  }
+
+  const rows = await db
+    .select({
+      id: watcherEvents.id,
+      eventType: watcherEvents.eventType,
+      message: watcherEvents.message,
+      details: watcherEvents.details,
+      timestamp: watcherEvents.timestamp,
+    })
+    .from(watcherEvents)
+    .where(and(...conditions))
+    .orderBy(desc(watcherEvents.timestamp))
+    .limit(limit);
+
+  return rows;
 }

--- a/web-app/lib/search-params.ts
+++ b/web-app/lib/search-params.ts
@@ -23,6 +23,21 @@ export const dashboardParamsCache = createSearchParamsCache(
   dashboardSearchParams
 );
 
+// Mirrors dashboardSearchParams but omits `instrument_id` (implicit from the
+// route segment) and sort/order (defaults to created_at desc).
+export const instrumentDetailSearchParams = {
+  search: parseAsString.withDefault(""),
+  date_from: parseAsString,
+  date_to: parseAsString,
+  include_deleted: parseAsBoolean.withDefault(false),
+  page: parseAsInteger.withDefault(1),
+  per_page: parseAsInteger.withDefault(25),
+};
+
+export const instrumentDetailParamsCache = createSearchParamsCache(
+  instrumentDetailSearchParams
+);
+
 export function hasActiveFilters(params: {
   search: string;
   instrument_id: string[];

--- a/web-app/lib/search-params.ts
+++ b/web-app/lib/search-params.ts
@@ -38,10 +38,9 @@ export const instrumentDetailParamsCache = createSearchParamsCache(
   instrumentDetailSearchParams
 );
 
-// Watcher detail page filters. `since` controls the heartbeat time range,
-// `events_since` controls the event log time range, and `event_type` filters
-// events by type. All are optional — omitting them defaults to the last 24h
-// with all event types included (handled in the data layer).
+// Watcher detail page filters. `event_type` and `events_since` are controlled
+// by EventLogToolbar. `since` (heartbeat time range) has no toolbar UI yet —
+// it exists to support deep-linking; defaults to 24h in the data layer.
 export const watcherDetailSearchParams = {
   event_type: parseAsArrayOf(parseAsString).withDefault([]),
   since: parseAsString,

--- a/web-app/lib/search-params.ts
+++ b/web-app/lib/search-params.ts
@@ -38,6 +38,20 @@ export const instrumentDetailParamsCache = createSearchParamsCache(
   instrumentDetailSearchParams
 );
 
+// Watcher detail page filters. `since` controls the heartbeat time range,
+// `events_since` controls the event log time range, and `event_type` filters
+// events by type. All are optional — omitting them defaults to the last 24h
+// with all event types included (handled in the data layer).
+export const watcherDetailSearchParams = {
+  event_type: parseAsArrayOf(parseAsString).withDefault([]),
+  since: parseAsString,
+  events_since: parseAsString,
+};
+
+export const watcherDetailParamsCache = createSearchParamsCache(
+  watcherDetailSearchParams
+);
+
 export function hasActiveFilters(params: {
   search: string;
   instrument_id: string[];


### PR DESCRIPTION
## Summary

- Adds dedicated list and detail pages for **instruments** (`/instruments`, `/instruments/[instrumentId]`) and **watchers** (`/watchers`, `/watchers/[watcherId]`), providing first-class navigation to manage both entities outside of the dashboard.
- Introduces admin actions: confirm pending instruments, edit instrument metadata (display name, file patterns), and deregister watchers.
- Reorganizes the Makefile to use a consistent `{scope}-{action}` naming convention (e.g. `py-lint`, `fe-typecheck`).

## Changes

- **`/instruments` list page** — table of all instruments with status badges, file patterns, watcher/run counts, inline confirm (pending → active) action, and an edit dialog for display name and file patterns.
- **`/instruments/[instrumentId]` detail page** — instrument header with status/watcher-online badges, filterable runs table with search, date range, include-deleted toggle, and pagination. Parallel data fetching for instrument metadata and paginated runs.
- **`/watchers` list page** — active/deregistered tab view, effective status derived from heartbeat recency (registered, watching, stale, stopped), deregister confirmation dialog.
- **`/watchers/[watcherId]` detail page** — watcher header with effective status badge and OS info, YAML config viewer, heartbeat history table, event log with type filter and date range. All three queries (watcher, heartbeats, events) fetched in parallel.
- **Navbar** — added `NavLinks` client component with prefix-match active state for Instruments and Watchers.
- **Data layer** (`lib/api/instruments.ts`, `lib/api/watchers.ts`) — new server-side query functions using Drizzle with `react.cache()` deduplication, sub-select aggregations to avoid join row multiplication, and heartbeat staleness computation.
- **Search params** (`lib/search-params.ts`) — added `instrumentDetailSearchParams` and `watcherDetailSearchParams` caches using nuqs for type-safe URL-driven filter state.

## Breaking changes

- Makefile targets have been renamed (e.g. `lint-py` → `py-lint`, `check-fe` → `fe-check`). The CI workflow is updated to match, but any local scripts or aliases referencing old target names will break.

## Driveby changes

- Makefile reorganized with section comments and added `dev` / `fe-build` convenience targets.
- CI workflow (`.github/workflows/lint-and-typecheck-python.yml`) updated to use the new Makefile target names.

## Testing

- [x] Visit `/instruments` — verify instrument list renders with status badges, watcher/run counts, and edit/confirm actions.
- [x] Click an instrument row — verify `/instruments/[instrumentId]` shows the header, runs table, and all toolbar filters (search, date range, include deleted) work correctly.
- [x] Confirm a pending instrument via the Confirm button and verify it transitions to Active.
- [x] Edit an instrument's display name and file patterns via the edit dialog.
- [x] Visit `/watchers` — verify the active/deregistered tabs partition correctly and effective status badges display (watching, stale, registered, stopped).
- [x] Click a watcher row — verify `/watchers/[watcherId]` shows config YAML, heartbeat table, and event log with type/date filters.
- [x] Deregister a watcher via the dialog and verify it moves to the deregistered tab.
- [x] Verify navbar links highlight correctly on nested routes (e.g. `/instruments/abc` highlights "Instruments").
- [x] Run `make check-all` and verify all lint, format, and type checks pass.