### PR TITLE
Add instrument run detail page with file management, report data, and soft-delete/restore

### DIFF
--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/restore/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/restore/route.ts
@@ -55,10 +55,18 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
 
   const restored = await lookupRunByNaturalKey(instrumentId, runId);
 
+  if (!restored) {
+    return apiError(
+      404,
+      NOT_FOUND,
+      `Run '${runId}' could not be found after restore`
+    );
+  }
+
   return Response.json({
-    id: restored!.id,
-    instrument_id: restored!.instrumentId,
-    run_id: restored!.runId,
-    deleted_at: restored!.deletedAt,
+    id: restored.id,
+    instrument_id: restored.instrumentId,
+    run_id: restored.runId,
+    deleted_at: restored.deletedAt,
   });
 }

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/restore/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/restore/route.ts
@@ -1,0 +1,64 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import { apiError, CONFLICT, NOT_FOUND, UNAUTHORIZED } from "@/lib/api/errors";
+import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
+import { db } from "@/lib/db";
+import { instrumentRuns } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+type RouteContext = {
+  params: Promise<{ instrumentId: string; runId: string }>;
+};
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/instruments/:instrumentId/runs/:runId/restore
+//
+// Restores a soft-deleted run by clearing deleted_at. Rejects if the run was
+// never deleted (409) or if S3 objects have already been purged (409).
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { instrumentId, runId } = await params;
+  const run = await lookupRunByNaturalKey(instrumentId, runId);
+
+  if (!run) {
+    return apiError(
+      404,
+      NOT_FOUND,
+      `Run '${runId}' not found for instrument '${instrumentId}'`
+    );
+  }
+
+  if (!run.deletedAt) {
+    return apiError(409, CONFLICT, "Run is not deleted — nothing to restore");
+  }
+
+  // After the 30-day retention window, a background job permanently removes S3
+  // objects and sets filesPurgedAt. At that point the run is unrecoverable.
+  if (run.filesPurgedAt) {
+    return apiError(
+      409,
+      CONFLICT,
+      "Cannot restore a run whose files have been permanently purged"
+    );
+  }
+
+  await db
+    .update(instrumentRuns)
+    .set({ deletedAt: null })
+    .where(eq(instrumentRuns.id, run.id));
+
+  const restored = await lookupRunByNaturalKey(instrumentId, runId);
+
+  return Response.json({
+    id: restored!.id,
+    instrument_id: restored!.instrumentId,
+    run_id: restored!.runId,
+    deleted_at: restored!.deletedAt,
+  });
+}

--- a/web-app/app/instruments/[instrumentId]/runs/[runId]/page.tsx
+++ b/web-app/app/instruments/[instrumentId]/runs/[runId]/page.tsx
@@ -78,7 +78,7 @@ export default async function RunDetailPage({ params }: Props) {
         isDeleted={isDeleted}
       />
 
-      {(fileReportData.length > 0 || hasReportData) && (
+      {fileReportData.length > 0 && (
         <RunReportSection reportData={fileReportData} files={files} />
       )}
 

--- a/web-app/app/instruments/[instrumentId]/runs/[runId]/page.tsx
+++ b/web-app/app/instruments/[instrumentId]/runs/[runId]/page.tsx
@@ -1,0 +1,88 @@
+import { DeleteRunDialog } from "@/components/runs/delete-run-dialog";
+import { RestoreRunButton } from "@/components/runs/restore-run-button";
+import { RunAnalysisSection } from "@/components/runs/run-analysis-section";
+import { RunFilesSection } from "@/components/runs/run-files-section";
+import { RunHeader } from "@/components/runs/run-header";
+import { RunMetadata } from "@/components/runs/run-metadata";
+import { RunReportSection } from "@/components/runs/run-report-section";
+import {
+  getRunFiles,
+  getRunReportData,
+  lookupRunByNaturalKey,
+} from "@/lib/api/instrument-runs";
+import { auth } from "@/lib/auth";
+import { notFound, redirect } from "next/navigation";
+import type { Metadata } from "next/types";
+
+type Props = {
+  params: Promise<{ instrumentId: string; runId: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { instrumentId, runId } = await params;
+  const run = await lookupRunByNaturalKey(instrumentId, runId);
+  if (!run) return { title: "Run Not Found" };
+  return {
+    title: `Run: ${run.runId} | ${run.instrumentDisplayName}`,
+  };
+}
+
+export default async function RunDetailPage({ params }: Props) {
+  const session = await auth();
+  if (!session) redirect("/login");
+
+  const { instrumentId, runId } = await params;
+
+  const run = await lookupRunByNaturalKey(instrumentId, runId);
+  if (!run) notFound();
+
+  const [files, reportData] = await Promise.all([
+    getRunFiles(run.id),
+    getRunReportData(run.id),
+  ]);
+
+  const isDeleted = run.deletedAt !== null;
+  // Restoring is only possible before the nightly purge job removes S3 objects.
+  const canRestore = isDeleted && run.filesPurgedAt === null;
+  const activeFileCount = files.filter((f) => f.deletedAt === null).length;
+  const hasReportData = reportData.length > 0;
+
+  // Report entries split into two groups:
+  //  - analysisData: run-level results not tied to a specific file (e.g. aggregated stats)
+  //  - fileReportData: parsed output from individual files (e.g. per-file plate maps)
+  const analysisData = reportData.filter((r) => r.fileId === null);
+  const fileReportData = reportData.filter((r) => r.fileId !== null);
+
+  return (
+    <div className="mx-auto flex max-w-7xl flex-col gap-6 p-6">
+      <RunHeader run={run}>
+        {!isDeleted && (
+          <DeleteRunDialog
+            instrumentId={instrumentId}
+            runId={runId}
+            fileCount={activeFileCount}
+            hasReportData={hasReportData}
+          />
+        )}
+        {canRestore && (
+          <RestoreRunButton instrumentId={instrumentId} runId={runId} />
+        )}
+      </RunHeader>
+
+      <RunMetadata metadata={run.metadata as Record<string, unknown>} />
+
+      <RunFilesSection
+        files={files}
+        instrumentId={instrumentId}
+        runId={runId}
+        isDeleted={isDeleted}
+      />
+
+      {(fileReportData.length > 0 || hasReportData) && (
+        <RunReportSection reportData={fileReportData} files={files} />
+      )}
+
+      <RunAnalysisSection analysisData={analysisData} />
+    </div>
+  );
+}

--- a/web-app/components/runs/delete-run-dialog.tsx
+++ b/web-app/components/runs/delete-run-dialog.tsx
@@ -40,7 +40,8 @@ export function DeleteRunDialog({
   const requiresConfirmation = hasReportData;
   const isConfirmed = !requiresConfirmation || confirmValue === runId;
 
-  function handleDelete() {
+  function handleDelete(e: React.MouseEvent) {
+    e.preventDefault();
     startTransition(async () => {
       const res = await fetch(
         `/api/v1/instruments/${instrumentId}/runs/${runId}`,

--- a/web-app/components/runs/delete-run-dialog.tsx
+++ b/web-app/components/runs/delete-run-dialog.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Loader2, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+export function DeleteRunDialog({
+  instrumentId,
+  runId,
+  fileCount,
+  hasReportData,
+}: {
+  instrumentId: string;
+  runId: string;
+  fileCount: number;
+  hasReportData: boolean;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [confirmValue, setConfirmValue] = useState("");
+  const [open, setOpen] = useState(false);
+
+  // Runs with report data require typing the run ID to confirm deletion because
+  // regenerating parsed results (plate maps, analysis) is expensive.
+  const requiresConfirmation = hasReportData;
+  const isConfirmed = !requiresConfirmation || confirmValue === runId;
+
+  function handleDelete() {
+    startTransition(async () => {
+      const res = await fetch(
+        `/api/v1/instruments/${instrumentId}/runs/${runId}`,
+        { method: "DELETE" }
+      );
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        toast.error(body?.error?.message ?? "Failed to delete run");
+        return;
+      }
+
+      toast.success("Run deleted");
+      setOpen(false);
+      router.refresh();
+    });
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1 text-xs text-destructive hover:text-destructive"
+        >
+          <Trash2 className="size-3" />
+          Delete
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete run?</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2">
+              <p>
+                This will soft-delete the run{" "}
+                <strong className="font-mono">{runId}</strong>
+                {fileCount > 0 && <> and its {fileCount} file(s)</>}. S3 objects
+                will be permanently purged after 30 days.
+              </p>
+              {requiresConfirmation && (
+                <div className="space-y-1.5 pt-2">
+                  <Label htmlFor="confirm-run-id" className="text-xs">
+                    Type <strong className="font-mono">{runId}</strong> to
+                    confirm
+                  </Label>
+                  <Input
+                    id="confirm-run-id"
+                    value={confirmValue}
+                    onChange={(e) => setConfirmValue(e.target.value)}
+                    placeholder={runId}
+                    className="font-mono text-sm"
+                    autoComplete="off"
+                  />
+                </div>
+              )}
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => setConfirmValue("")}>
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={isPending || !isConfirmed}
+          >
+            {isPending && <Loader2 className="size-4 animate-spin" />}
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/web-app/components/runs/file-card.tsx
+++ b/web-app/components/runs/file-card.tsx
@@ -1,6 +1,17 @@
 "use client";
 
 import { FileStatusBadge } from "@/components/runs/file-status-badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -183,16 +194,34 @@ export function FileCard({
               )}
               Upload
             </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 gap-1 text-xs text-muted-foreground"
-              onClick={handleDismiss}
-              disabled={isPending}
-            >
-              <X className="size-3" />
-              Dismiss
-            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 gap-1 text-xs text-muted-foreground"
+                  disabled={isPending}
+                >
+                  <X className="size-3" />
+                  Dismiss
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Dismiss file?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    <strong className="font-mono">{file.filename}</strong> will
+                    be soft-deleted. The watcher will skip it on future scans.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleDismiss}>
+                    Dismiss
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </>
         )}
 

--- a/web-app/components/runs/file-card.tsx
+++ b/web-app/components/runs/file-card.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { FileStatusBadge } from "@/components/runs/file-status-badge";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import type { RunFile } from "@/lib/api/instrument-runs";
+import {
+  AlertCircle,
+  Download,
+  Eye,
+  FileText,
+  Loader2,
+  Upload,
+  X,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import { toast } from "sonner";
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null || bytes === undefined) return "—";
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+}
+
+function formatDate(date: Date | null): string {
+  if (!date) return "—";
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(date));
+}
+
+export function FileCard({
+  file,
+  instrumentId,
+  runId,
+  selectable,
+  selected,
+  onToggle,
+}: {
+  file: RunFile;
+  instrumentId: string;
+  runId: string;
+  selectable: boolean;
+  selected: boolean;
+  onToggle: (fileId: number) => void;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const isDismissed = file.deletedAt !== null;
+  const isDetected = file.status === "detected";
+  const isUploadRequested = file.status === "upload_requested";
+  // Files past "uploaded" have already reached S3 and can be downloaded, even if
+  // downstream processing failed.
+  const isDownloadable = [
+    "uploaded",
+    "processing",
+    "completed",
+    "failed",
+  ].includes(file.status);
+  const isFailed = file.status === "failed";
+
+  // Signals the watcher agent on the instrument PC to transfer this file to S3.
+  // The file transitions from "detected" → "upload_requested" until the watcher
+  // picks it up and streams the bytes.
+  function handleUpload() {
+    startTransition(async () => {
+      const res = await fetch(
+        `/api/v1/instruments/${instrumentId}/runs/${runId}/request-upload`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ file_ids: [file.id] }),
+        }
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        toast.error(body?.error?.message ?? "Failed to request upload");
+        return;
+      }
+      toast.success(`Upload requested for ${file.filename}`);
+      router.refresh();
+    });
+  }
+
+  function handleDismiss() {
+    startTransition(async () => {
+      const res = await fetch(`/api/v1/files/${file.id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        toast.error(body?.error?.message ?? "Failed to dismiss file");
+        return;
+      }
+      toast.success(`Dismissed ${file.filename}`);
+      router.refresh();
+    });
+  }
+
+  const metadataEntries = file.metadata
+    ? Object.entries(file.metadata as Record<string, unknown>)
+    : [];
+
+  return (
+    <div
+      className={`flex items-start gap-3 rounded-lg border p-3 ${
+        isDismissed ? "border-dashed opacity-50" : ""
+      } ${isFailed ? "border-destructive/30 bg-destructive/5" : ""}`}
+    >
+      {selectable && !isDismissed && (
+        <Checkbox
+          checked={selected}
+          onCheckedChange={() => onToggle(file.id)}
+          className="mt-1"
+        />
+      )}
+
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        <div className="flex items-center gap-2">
+          <FileText className="size-4 shrink-0 text-muted-foreground" />
+          <span className="truncate font-mono text-sm font-medium">
+            {file.filename}
+          </span>
+          <FileStatusBadge status={file.status} />
+          <Badge variant="outline" className="text-[10px]">
+            {file.category}
+          </Badge>
+          {isDismissed && (
+            <Badge variant="secondary" className="text-[10px]">
+              Dismissed
+            </Badge>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+          {file.relativePath && (
+            <span className="font-mono">{file.relativePath}</span>
+          )}
+          <span>{formatBytes(file.sizeBytes)}</span>
+          {file.contentType && <span>{file.contentType}</span>}
+          <span>Created {formatDate(file.createdAt)}</span>
+        </div>
+
+        {isFailed && file.errorMessage && (
+          <div className="flex items-start gap-1.5 text-xs text-destructive">
+            <AlertCircle className="mt-0.5 size-3 shrink-0" />
+            <span>{file.errorMessage}</span>
+          </div>
+        )}
+
+        {metadataEntries.length > 0 && (
+          <div className="flex flex-wrap gap-x-4 gap-y-0.5 pt-0.5 text-xs text-muted-foreground">
+            {metadataEntries.map(([k, v]) => (
+              <span key={k}>
+                <span className="font-mono">{k}</span>:{" "}
+                {Array.isArray(v) ? v.join(", ") : String(v)}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex shrink-0 items-center gap-1">
+        {isDetected && !isDismissed && (
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1 text-xs"
+              onClick={handleUpload}
+              disabled={isPending}
+            >
+              {isPending ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <Upload className="size-3" />
+              )}
+              Upload
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 text-xs text-muted-foreground"
+              onClick={handleDismiss}
+              disabled={isPending}
+            >
+              <X className="size-3" />
+              Dismiss
+            </Button>
+          </>
+        )}
+
+        {isUploadRequested && (
+          <span className="flex items-center gap-1 text-xs text-muted-foreground">
+            <Loader2 className="size-3 animate-spin" />
+            Waiting
+          </span>
+        )}
+
+        {isDownloadable && (
+          <div className="flex items-center gap-1">
+            {file.contentType?.startsWith("image/") && (
+              <Button variant="ghost" size="sm" className="h-7 text-xs" asChild>
+                <a
+                  href={`/api/v1/files/${file.id}/download`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Eye className="size-3" />
+                </a>
+              </Button>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1 text-xs"
+              asChild
+            >
+              <a href={`/api/v1/files/${file.id}/download`}>
+                <Download className="size-3" />
+                Download
+              </a>
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-app/components/runs/file-status-badge.tsx
+++ b/web-app/components/runs/file-status-badge.tsx
@@ -1,0 +1,37 @@
+import { Badge } from "@/components/ui/badge";
+
+type FileStatus =
+  | "detected"
+  | "upload_requested"
+  | "uploaded"
+  | "processing"
+  | "completed"
+  | "failed";
+
+const statusConfig: Record<
+  FileStatus,
+  {
+    label: string;
+    variant: "default" | "outline" | "secondary" | "destructive";
+  }
+> = {
+  detected: { label: "Detected", variant: "outline" },
+  upload_requested: { label: "Upload Requested", variant: "secondary" },
+  uploaded: { label: "Uploaded", variant: "secondary" },
+  processing: { label: "Processing", variant: "default" },
+  completed: { label: "Completed", variant: "default" },
+  failed: { label: "Failed", variant: "destructive" },
+};
+
+export function FileStatusBadge({ status }: { status: string }) {
+  const config = statusConfig[status as FileStatus] ?? {
+    label: status,
+    variant: "outline" as const,
+  };
+
+  return (
+    <Badge variant={config.variant} className="text-[10px]">
+      {config.label}
+    </Badge>
+  );
+}

--- a/web-app/components/runs/plate-map-grid.tsx
+++ b/web-app/components/runs/plate-map-grid.tsx
@@ -3,6 +3,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { Fragment } from "react";
 
 type WellData = { well: string; value: unknown };
 
@@ -77,11 +78,8 @@ export function PlateMapGrid({ data }: { data: unknown }) {
 
         {/* Data rows */}
         {rowLabels.map((rowLabel, ri) => (
-          <>
-            <div
-              key={`row-${rowLabel}`}
-              className="flex items-center justify-center py-1 text-xs font-medium text-muted-foreground"
-            >
+          <Fragment key={rowLabel}>
+            <div className="flex items-center justify-center py-1 text-xs font-medium text-muted-foreground">
               {rowLabel}
             </div>
             {colLabels.map((_, ci) => {
@@ -115,7 +113,7 @@ export function PlateMapGrid({ data }: { data: unknown }) {
                 </Tooltip>
               );
             })}
-          </>
+          </Fragment>
         ))}
       </div>
     </div>

--- a/web-app/components/runs/plate-map-grid.tsx
+++ b/web-app/components/runs/plate-map-grid.tsx
@@ -1,0 +1,123 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+type WellData = { well: string; value: unknown };
+
+// Parses standard microplate well notation (e.g. "A1", "H12", "P24").
+// Rows A-P and columns 1-24 cover up to 384-well plates.
+function parseWell(well: string): { row: number; col: number } | null {
+  const match = well.match(/^([A-P])(\d{1,2})$/i);
+  if (!match) return null;
+  return {
+    row: match[1].toUpperCase().charCodeAt(0) - 65,
+    col: parseInt(match[2], 10) - 1,
+  };
+}
+
+function formatCellValue(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "number") {
+    return Number.isInteger(value)
+      ? String(value)
+      : value.toPrecision(4).replace(/\.?0+$/, "");
+  }
+  return String(value);
+}
+
+export function PlateMapGrid({ data }: { data: unknown }) {
+  if (!Array.isArray(data)) return null;
+
+  const wells = data as WellData[];
+  if (wells.length === 0) return null;
+
+  // Grid dimensions are inferred from the data so plates of any size (96, 384,
+  // or custom layouts) render correctly without hard-coding dimensions.
+  let maxRow = 0;
+  let maxCol = 0;
+  const cellMap = new Map<string, unknown>();
+
+  for (const w of wells) {
+    const pos = parseWell(w.well);
+    if (!pos) continue;
+    if (pos.row > maxRow) maxRow = pos.row;
+    if (pos.col > maxCol) maxCol = pos.col;
+    cellMap.set(`${pos.row}-${pos.col}`, w.value);
+  }
+
+  const rows = maxRow + 1;
+  const cols = maxCol + 1;
+
+  const rowLabels = Array.from({ length: rows }, (_, i) =>
+    String.fromCharCode(65 + i)
+  );
+  const colLabels = Array.from({ length: cols }, (_, i) => String(i + 1));
+
+  return (
+    <div className="overflow-x-auto">
+      <div
+        className="inline-grid gap-px text-center"
+        style={{
+          gridTemplateColumns: `2rem repeat(${cols}, minmax(3rem, 1fr))`,
+        }}
+      >
+        {/* Corner */}
+        <div />
+        {/* Column headers */}
+        {colLabels.map((c) => (
+          <div
+            key={c}
+            className="py-1 text-xs font-medium text-muted-foreground"
+          >
+            {c}
+          </div>
+        ))}
+
+        {/* Data rows */}
+        {rowLabels.map((rowLabel, ri) => (
+          <>
+            <div
+              key={`row-${rowLabel}`}
+              className="flex items-center justify-center py-1 text-xs font-medium text-muted-foreground"
+            >
+              {rowLabel}
+            </div>
+            {colLabels.map((_, ci) => {
+              const value = cellMap.get(`${ri}-${ci}`);
+              const display = formatCellValue(value);
+              const full =
+                value !== null && value !== undefined ? String(value) : "";
+              const hasValue = display !== "";
+
+              return (
+                <Tooltip key={`${ri}-${ci}`}>
+                  <TooltipTrigger asChild>
+                    <div
+                      className={`flex items-center justify-center rounded border px-1 py-1.5 font-mono text-[10px] ${
+                        hasValue
+                          ? "border-border bg-muted/50"
+                          : "border-transparent"
+                      }`}
+                    >
+                      {display || "·"}
+                    </div>
+                  </TooltipTrigger>
+                  {hasValue && (
+                    <TooltipContent>
+                      <span className="font-mono">
+                        {rowLabel}
+                        {ci + 1}: {full}
+                      </span>
+                    </TooltipContent>
+                  )}
+                </Tooltip>
+              );
+            })}
+          </>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web-app/components/runs/report-data-table.tsx
+++ b/web-app/components/runs/report-data-table.tsx
@@ -1,0 +1,56 @@
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "number") {
+    return Number.isInteger(value)
+      ? String(value)
+      : value.toPrecision(6).replace(/\.?0+$/, "");
+  }
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+export function ReportDataTable({ data }: { data: unknown }) {
+  if (!Array.isArray(data) || data.length === 0) return null;
+
+  const rows = data as Record<string, unknown>[];
+  const columns = Object.keys(rows[0]);
+
+  return (
+    <ScrollArea className="max-h-96 rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            {columns.map((col) => (
+              <TableHead key={col} className="font-mono text-xs">
+                {col}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row, i) => (
+            <TableRow key={i}>
+              {columns.map((col) => (
+                <TableCell key={col} className="font-mono text-xs">
+                  {formatCell(row[col])}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+  );
+}

--- a/web-app/components/runs/restore-run-button.tsx
+++ b/web-app/components/runs/restore-run-button.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Loader2, RotateCcw } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import { toast } from "sonner";
+
+export function RestoreRunButton({
+  instrumentId,
+  runId,
+}: {
+  instrumentId: string;
+  runId: string;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  function handleRestore() {
+    startTransition(async () => {
+      const res = await fetch(
+        `/api/v1/instruments/${instrumentId}/runs/${runId}/restore`,
+        { method: "POST" }
+      );
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        toast.error(body?.error?.message ?? "Failed to restore run");
+        return;
+      }
+
+      toast.success("Run restored");
+      router.refresh();
+    });
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="h-7 gap-1 text-xs"
+      onClick={handleRestore}
+      disabled={isPending}
+    >
+      {isPending ? (
+        <Loader2 className="size-3 animate-spin" />
+      ) : (
+        <RotateCcw className="size-3" />
+      )}
+      Restore
+    </Button>
+  );
+}

--- a/web-app/components/runs/run-analysis-section.tsx
+++ b/web-app/components/runs/run-analysis-section.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { ReportDataTable } from "@/components/runs/report-data-table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { RunReportEntry } from "@/lib/api/instrument-runs";
+import { FlaskConical } from "lucide-react";
+
+export function RunAnalysisSection({
+  analysisData,
+}: {
+  analysisData: RunReportEntry[];
+}) {
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <span>Analysis</span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span tabIndex={0}>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 gap-1 text-xs"
+                  disabled
+                >
+                  <FlaskConical className="size-3" />
+                  Run Analysis
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>Coming soon</TooltipContent>
+          </Tooltip>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {analysisData.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No analysis results yet. The analysis pipeline is not yet available.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {analysisData.map((entry) => (
+              <div key={entry.id} className="flex flex-col gap-1.5">
+                <Badge
+                  variant="outline"
+                  className="w-fit font-mono text-[10px]"
+                >
+                  {entry.dataType}
+                </Badge>
+                <ReportDataTable data={entry.data} />
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web-app/components/runs/run-files-section.tsx
+++ b/web-app/components/runs/run-files-section.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { FileCard } from "@/components/runs/file-card";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import type { RunFile } from "@/lib/api/instrument-runs";
+import { Loader2, Upload, X } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useMemo, useState, useTransition } from "react";
+import { toast } from "sonner";
+
+export function RunFilesSection({
+  files,
+  instrumentId,
+  runId,
+  isDeleted,
+}: {
+  files: RunFile[];
+  instrumentId: string;
+  runId: string;
+  isDeleted: boolean;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [showDismissed, setShowDismissed] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+
+  const activeFiles = useMemo(
+    () => files.filter((f) => f.deletedAt === null),
+    [files]
+  );
+
+  const dismissedFiles = useMemo(
+    () => files.filter((f) => f.deletedAt !== null),
+    [files]
+  );
+
+  const visibleFiles = showDismissed ? files : activeFiles;
+
+  // Only "detected" files (seen by the watcher on disk but not yet in S3) can be
+  // selected for bulk upload or dismissal. Files further along the pipeline are
+  // already being processed or stored.
+  const selectableFiles = useMemo(
+    () => activeFiles.filter((f) => f.status === "detected"),
+    [activeFiles]
+  );
+
+  const selectedDetectedIds = useMemo(
+    () => selectableFiles.filter((f) => selectedIds.has(f.id)).map((f) => f.id),
+    [selectableFiles, selectedIds]
+  );
+
+  function toggleFile(fileId: number) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(fileId)) next.delete(fileId);
+      else next.add(fileId);
+      return next;
+    });
+  }
+
+  function handleBulkUpload() {
+    if (selectedDetectedIds.length === 0) return;
+    startTransition(async () => {
+      const res = await fetch(
+        `/api/v1/instruments/${instrumentId}/runs/${runId}/request-upload`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ file_ids: selectedDetectedIds }),
+        }
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        toast.error(body?.error?.message ?? "Failed to request uploads");
+        return;
+      }
+      toast.success(
+        `Upload requested for ${selectedDetectedIds.length} file(s)`
+      );
+      setSelectedIds(new Set());
+      router.refresh();
+    });
+  }
+
+  // Dismiss = soft-delete. No batch endpoint exists, so individual DELETEs are
+  // fanned out in parallel. The watcher will skip dismissed files on future scans.
+  function handleBulkDismiss() {
+    if (selectedDetectedIds.length === 0) return;
+    startTransition(async () => {
+      const results = await Promise.allSettled(
+        selectedDetectedIds.map((fid) =>
+          fetch(`/api/v1/files/${fid}`, { method: "DELETE" })
+        )
+      );
+      const failed = results.filter((r) => r.status === "rejected").length;
+      if (failed > 0) {
+        toast.error(`${failed} file(s) failed to dismiss`);
+      } else {
+        toast.success(`Dismissed ${selectedDetectedIds.length} file(s)`);
+      }
+      setSelectedIds(new Set());
+      router.refresh();
+    });
+  }
+
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <span>
+            Files{" "}
+            <span className="ml-1 font-mono text-xs font-normal text-muted-foreground">
+              {activeFiles.length}
+              {dismissedFiles.length > 0 &&
+                ` (+${dismissedFiles.length} dismissed)`}
+            </span>
+          </span>
+          {dismissedFiles.length > 0 && (
+            <div className="flex items-center gap-2">
+              <Label
+                htmlFor="show-dismissed"
+                className="text-xs font-normal text-muted-foreground"
+              >
+                Show dismissed
+              </Label>
+              <Switch
+                id="show-dismissed"
+                size="sm"
+                checked={showDismissed}
+                onCheckedChange={setShowDismissed}
+              />
+            </div>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2">
+        {selectedDetectedIds.length > 0 && !isDeleted && (
+          <div className="flex items-center gap-2 rounded-md border bg-muted/50 px-3 py-2 text-sm">
+            <span className="text-muted-foreground">
+              {selectedDetectedIds.length} selected
+            </span>
+            <div className="ml-auto flex gap-1">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1 text-xs"
+                onClick={handleBulkUpload}
+                disabled={isPending}
+              >
+                {isPending ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <Upload className="size-3" />
+                )}
+                Upload selected
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1 text-xs text-muted-foreground"
+                onClick={handleBulkDismiss}
+                disabled={isPending}
+              >
+                <X className="size-3" />
+                Dismiss selected
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {visibleFiles.length === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">
+            No files for this run.
+          </p>
+        ) : (
+          visibleFiles.map((file) => (
+            <FileCard
+              key={file.id}
+              file={file}
+              instrumentId={instrumentId}
+              runId={runId}
+              selectable={
+                !isDeleted &&
+                file.status === "detected" &&
+                file.deletedAt === null
+              }
+              selected={selectedIds.has(file.id)}
+              onToggle={toggleFile}
+            />
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web-app/components/runs/run-files-section.tsx
+++ b/web-app/components/runs/run-files-section.tsx
@@ -1,12 +1,23 @@
 "use client";
 
 import { FileCard } from "@/components/runs/file-card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import type { RunFile } from "@/lib/api/instrument-runs";
-import { Loader2, Upload, X } from "lucide-react";
+import { CheckSquare, Loader2, Upload, X } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
@@ -52,6 +63,10 @@ export function RunFilesSection({
     [selectableFiles, selectedIds]
   );
 
+  const allDetectedSelected =
+    selectableFiles.length > 0 &&
+    selectableFiles.every((f) => selectedIds.has(f.id));
+
   function toggleFile(fileId: number) {
     setSelectedIds((prev) => {
       const next = new Set(prev);
@@ -59,6 +74,10 @@ export function RunFilesSection({
       else next.add(fileId);
       return next;
     });
+  }
+
+  function selectAllDetected() {
+    setSelectedIds(new Set(selectableFiles.map((f) => f.id)));
   }
 
   function handleBulkUpload() {
@@ -95,7 +114,10 @@ export function RunFilesSection({
           fetch(`/api/v1/files/${fid}`, { method: "DELETE" })
         )
       );
-      const failed = results.filter((r) => r.status === "rejected").length;
+      const failed = results.filter(
+        (r) =>
+          r.status === "rejected" || (r.status === "fulfilled" && !r.value.ok)
+      ).length;
       if (failed > 0) {
         toast.error(`${failed} file(s) failed to dismiss`);
       } else {
@@ -118,22 +140,37 @@ export function RunFilesSection({
                 ` (+${dismissedFiles.length} dismissed)`}
             </span>
           </span>
-          {dismissedFiles.length > 0 && (
-            <div className="flex items-center gap-2">
-              <Label
-                htmlFor="show-dismissed"
-                className="text-xs font-normal text-muted-foreground"
-              >
-                Show dismissed
-              </Label>
-              <Switch
-                id="show-dismissed"
-                size="sm"
-                checked={showDismissed}
-                onCheckedChange={setShowDismissed}
-              />
-            </div>
-          )}
+          <div className="flex items-center gap-2">
+            {!isDeleted &&
+              selectableFiles.length > 0 &&
+              !allDetectedSelected && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 gap-1 text-xs"
+                  onClick={selectAllDetected}
+                >
+                  <CheckSquare className="size-3" />
+                  Select all
+                </Button>
+              )}
+            {dismissedFiles.length > 0 && (
+              <>
+                <Label
+                  htmlFor="show-dismissed"
+                  className="text-xs font-normal text-muted-foreground"
+                >
+                  Show dismissed
+                </Label>
+                <Switch
+                  id="show-dismissed"
+                  size="sm"
+                  checked={showDismissed}
+                  onCheckedChange={setShowDismissed}
+                />
+              </>
+            )}
+          </div>
         </CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-2">
@@ -157,16 +194,36 @@ export function RunFilesSection({
                 )}
                 Upload selected
               </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 gap-1 text-xs text-muted-foreground"
-                onClick={handleBulkDismiss}
-                disabled={isPending}
-              >
-                <X className="size-3" />
-                Dismiss selected
-              </Button>
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1 text-xs text-muted-foreground"
+                    disabled={isPending}
+                  >
+                    <X className="size-3" />
+                    Dismiss selected
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>
+                      Dismiss {selectedDetectedIds.length} file(s)?
+                    </AlertDialogTitle>
+                    <AlertDialogDescription>
+                      The selected files will be soft-deleted. The watcher will
+                      skip them on future scans.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction onClick={handleBulkDismiss}>
+                      Dismiss
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
             </div>
           </div>
         )}

--- a/web-app/components/runs/run-header.tsx
+++ b/web-app/components/runs/run-header.tsx
@@ -1,0 +1,78 @@
+import { Badge } from "@/components/ui/badge";
+import type { RunDetail } from "@/lib/api/instrument-runs";
+import { ArrowLeft, Trash2 } from "lucide-react";
+import Link from "next/link";
+
+const sourceBadge: Record<
+  "lambda" | "watcher",
+  { label: string; variant: "default" | "outline" | "secondary" }
+> = {
+  lambda: { label: "Lambda", variant: "secondary" },
+  watcher: { label: "Watcher", variant: "outline" },
+};
+
+function formatTimestamp(date: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+export function RunHeader({
+  run,
+  children,
+}: {
+  run: RunDetail;
+  children?: React.ReactNode;
+}) {
+  const sb = sourceBadge[run.source];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Link
+        href={`/instruments/${run.instrumentId}`}
+        className="flex w-fit items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="size-3.5" />
+        {run.instrumentDisplayName}
+      </Link>
+
+      {run.deletedAt && (
+        <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-2.5 text-sm text-destructive">
+          <Trash2 className="size-4 shrink-0" />
+          <span>
+            Deleted {formatTimestamp(run.deletedAt)}
+            {run.filesPurgedAt && (
+              <> &middot; Files purged {formatTimestamp(run.filesPurgedAt)}</>
+            )}
+          </span>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <h1 className="font-mono text-2xl font-semibold tracking-tight">
+            {run.runId}
+          </h1>
+          <Badge variant={sb.variant} className="text-[10px]">
+            {sb.label}
+          </Badge>
+        </div>
+
+        <div className="flex items-center gap-2">{children}</div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+        <span>Created {formatTimestamp(run.createdAt)}</span>
+        <span className="text-muted-foreground/40">&middot;</span>
+        <span>Updated {formatTimestamp(run.updatedAt)}</span>
+        {run.watcherId && (
+          <>
+            <span className="text-muted-foreground/40">&middot;</span>
+            <span className="font-mono">{run.watcherId}</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-app/components/runs/run-metadata.tsx
+++ b/web-app/components/runs/run-metadata.tsx
@@ -1,0 +1,47 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+function formatValue(value: unknown): string {
+  if (Array.isArray(value)) return value.join(", ");
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+export function RunMetadata({
+  metadata,
+}: {
+  metadata: Record<string, unknown>;
+}) {
+  const entries = Object.entries(metadata);
+
+  if (entries.length === 0) {
+    return (
+      <Card size="sm">
+        <CardHeader>
+          <CardTitle>Metadata</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">No metadata recorded.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <CardTitle>Metadata</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
+          {entries.map(([key, value]) => (
+            <div key={key} className="col-span-2 grid grid-cols-subgrid">
+              <dt className="font-mono text-xs text-muted-foreground">{key}</dt>
+              <dd className="break-all">{formatValue(value)}</dd>
+            </div>
+          ))}
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web-app/components/runs/run-report-section.tsx
+++ b/web-app/components/runs/run-report-section.tsx
@@ -1,0 +1,105 @@
+import { PlateMapGrid } from "@/components/runs/plate-map-grid";
+import { ReportDataTable } from "@/components/runs/report-data-table";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { RunFile, RunReportEntry } from "@/lib/api/instrument-runs";
+
+// Dispatches to a specialised renderer based on dataType. Plate maps get a
+// visual grid; everything else falls through to a generic key/value table.
+function ReportEntryRenderer({ entry }: { entry: RunReportEntry }) {
+  if (entry.dataType === "plate_map") {
+    return <PlateMapGrid data={entry.data} />;
+  }
+  return <ReportDataTable data={entry.data} />;
+}
+
+export function RunReportSection({
+  reportData,
+  files,
+}: {
+  reportData: RunReportEntry[];
+  files: RunFile[];
+}) {
+  if (reportData.length === 0) {
+    return (
+      <Card size="sm">
+        <CardHeader>
+          <CardTitle>Report Data</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            No report data has been generated for this run.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const fileMap = new Map(files.map((f) => [f.id, f]));
+
+  // Report entries are grouped for display:
+  //  - runLevel: aggregate results computed across all files (fileId is null)
+  //  - byFile: per-file parsed output, keyed by file ID for collapsible sections
+  const runLevel = reportData.filter((r) => r.fileId === null);
+  const byFile = new Map<number, RunReportEntry[]>();
+  for (const entry of reportData) {
+    if (entry.fileId !== null) {
+      const group = byFile.get(entry.fileId) ?? [];
+      group.push(entry);
+      byFile.set(entry.fileId, group);
+    }
+  }
+
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <CardTitle>
+          Report Data{" "}
+          <span className="ml-1 font-mono text-xs font-normal text-muted-foreground">
+            {reportData.length} dataset(s)
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        {runLevel.length > 0 && (
+          <div className="flex flex-col gap-3">
+            <h3 className="text-sm font-medium">Run Analysis</h3>
+            {runLevel.map((entry) => (
+              <div key={entry.id} className="flex flex-col gap-1.5">
+                <Badge
+                  variant="outline"
+                  className="w-fit font-mono text-[10px]"
+                >
+                  {entry.dataType}
+                </Badge>
+                <ReportEntryRenderer entry={entry} />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {Array.from(byFile.entries()).map(([fileId, entries]) => {
+          const file = fileMap.get(fileId);
+          return (
+            <div key={fileId} className="flex flex-col gap-3">
+              <h3 className="text-sm font-medium">
+                {file?.filename ?? `File #${fileId}`}
+              </h3>
+              {entries.map((entry) => (
+                <div key={entry.id} className="flex flex-col gap-1.5">
+                  <Badge
+                    variant="outline"
+                    className="w-fit font-mono text-[10px]"
+                  >
+                    {entry.dataType}
+                  </Badge>
+                  <ReportEntryRenderer entry={entry} />
+                </div>
+              ))}
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web-app/components/runs/run-report-section.tsx
+++ b/web-app/components/runs/run-report-section.tsx
@@ -37,10 +37,6 @@ export function RunReportSection({
 
   const fileMap = new Map(files.map((f) => [f.id, f]));
 
-  // Report entries are grouped for display:
-  //  - runLevel: aggregate results computed across all files (fileId is null)
-  //  - byFile: per-file parsed output, keyed by file ID for collapsible sections
-  const runLevel = reportData.filter((r) => r.fileId === null);
   const byFile = new Map<number, RunReportEntry[]>();
   for (const entry of reportData) {
     if (entry.fileId !== null) {
@@ -61,23 +57,6 @@ export function RunReportSection({
         </CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-6">
-        {runLevel.length > 0 && (
-          <div className="flex flex-col gap-3">
-            <h3 className="text-sm font-medium">Run Analysis</h3>
-            {runLevel.map((entry) => (
-              <div key={entry.id} className="flex flex-col gap-1.5">
-                <Badge
-                  variant="outline"
-                  className="w-fit font-mono text-[10px]"
-                >
-                  {entry.dataType}
-                </Badge>
-                <ReportEntryRenderer entry={entry} />
-              </div>
-            ))}
-          </div>
-        )}
-
         {Array.from(byFile.entries()).map(([fileId, entries]) => {
           const file = fileMap.get(fileId);
           return (

--- a/web-app/lib/api/instrument-runs.ts
+++ b/web-app/lib/api/instrument-runs.ts
@@ -1,5 +1,10 @@
 import { db } from "@/lib/db";
-import { files, instrumentRuns, instruments } from "@/lib/db/schema";
+import {
+  files,
+  instrumentRuns,
+  instruments,
+  runReportData,
+} from "@/lib/db/schema";
 import type { SQL } from "drizzle-orm";
 import {
   and,
@@ -187,4 +192,54 @@ export async function buildRunListQuery(filters: RunListFilters) {
       total_pages: totalPages,
     },
   };
+}
+
+// ---------------------------------------------------------------------------
+// Shared types for the run detail page
+// ---------------------------------------------------------------------------
+
+export type RunDetail = NonNullable<
+  Awaited<ReturnType<typeof lookupRunByNaturalKey>>
+>;
+
+export type RunFile = typeof files.$inferSelect;
+
+export type RunReportEntry = {
+  id: number;
+  dataType: string;
+  fileId: number | null;
+  data: unknown;
+};
+
+// ---------------------------------------------------------------------------
+// Per-run file list — all files (including soft-deleted) ordered by creation.
+// ---------------------------------------------------------------------------
+
+export async function getRunFiles(runInternalId: string): Promise<RunFile[]> {
+  return db
+    .select()
+    .from(files)
+    .where(eq(files.instrumentRunId, runInternalId))
+    .orderBy(files.createdAt);
+}
+
+// ---------------------------------------------------------------------------
+// Per-run report data — all report entries for a run, ordered by id.
+// ---------------------------------------------------------------------------
+
+export async function getRunReportData(
+  runInternalId: string
+): Promise<RunReportEntry[]> {
+  const rows = await db
+    .select({
+      id: runReportData.id,
+      dataType: runReportData.dataType,
+      fileId: runReportData.fileId,
+      data: runReportData.data,
+    })
+    .from(runReportData)
+    .where(eq(runReportData.instrumentRunId, runInternalId))
+    .orderBy(runReportData.id);
+
+  return rows;
 }


### PR DESCRIPTION
## Summary

Adds the `/instruments/[instrumentId]/runs/[runId]` detail page where users can view a single instrument run's metadata, manage its files (upload, download, dismiss), view parsed report data (plate maps, tabular datasets), and soft-delete or restore the run.

## Changes

- **Run detail page** (`app/instruments/[instrumentId]/runs/[runId]/page.tsx`): Server component that fetches the run, its files, and report data, then composes the detail view from section components.
- **Run header** (`components/runs/run-header.tsx`): Displays the run ID, source badge (Lambda/Watcher), timestamps, and a deletion banner when the run is soft-deleted.
- **Run metadata** (`components/runs/run-metadata.tsx`): Renders the run's arbitrary JSON metadata as a key/value grid.
- **File management section** (`components/runs/run-files-section.tsx`, `file-card.tsx`, `file-status-badge.tsx`): Lists all files in the run with status badges, per-file upload/dismiss actions, bulk select-all with batch upload and dismiss, and a toggle to show dismissed (soft-deleted) files.
- **Report data section** (`components/runs/run-report-section.tsx`, `report-data-table.tsx`, `plate-map-grid.tsx`): Renders parsed report data grouped by source file. Plate maps get a dedicated well-grid visualisation with tooltips; other data types fall through to a scrollable table.
- **Analysis section** (`components/runs/run-analysis-section.tsx`): Placeholder section for run-level analysis results with a disabled "Run Analysis" button (coming soon).
- **Delete run dialog** (`components/runs/delete-run-dialog.tsx`): Confirmation dialog for soft-deleting a run. Runs with report data require typing the run ID to confirm since re-processing is expensive.
- **Restore run button & API** (`components/runs/restore-run-button.tsx`, `api/v1/instruments/[instrumentId]/runs/[runId]/restore/route.ts`): POST endpoint that clears `deleted_at` on a soft-deleted run, with guards against restoring already-active runs (409) or runs whose S3 files have been permanently purged (409).
- **Data access layer** (`lib/api/instrument-runs.ts`): Added `RunDetail`, `RunFile`, and `RunReportEntry` types, plus `getRunFiles()` and `getRunReportData()` query functions.

## Breaking changes

None.

## Driveby changes

None.

## Testing

Testing will be completed in a follow-up PR.