### PR TITLE
Extract shared test infrastructure and add watcher integration tests

### DIFF
--- a/lambda/tests/integration/conftest.py
+++ b/lambda/tests/integration/conftest.py
@@ -6,43 +6,25 @@ full HTTP path with only S3 downloads and Slack mocked.
 """
 
 from __future__ import annotations
-import hashlib
 import os
-import secrets
 import shutil
-import socket
-import subprocess
-import time
 from collections.abc import Callable, Generator
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-import psycopg2
 import pytest
+
+from data_hub_shared.testing import (
+    IntegrationEnv,
+    seed_instruments,
+    start_test_server,
+    truncate_tables,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
-_TEST_DB = "data_hub_test"
-_PG_HOST = "127.0.0.1"
-_PG_PORT = 5432
-_PG_USER = "postgres"
-_PG_PASSWORD = "postgres"
-_PG_ADMIN_DSN = (
-    f"dbname=postgres user={_PG_USER} password={_PG_PASSWORD} host={_PG_HOST} port={_PG_PORT}"
-)
-_PG_TEST_DSN = (
-    f"dbname={_TEST_DB} user={_PG_USER} password={_PG_PASSWORD} host={_PG_HOST} port={_PG_PORT}"
-)
-_DATABASE_URL = f"postgres://{_PG_USER}:{_PG_PASSWORD}@{_PG_HOST}:{_PG_PORT}/{_TEST_DB}"
-
-# Must match the token generation logic in web-app/lib/tokens.ts
-_TOKEN_PREFIX = "dhub_"
-# conftest.py lives at lambda/tests/integration/ — walk up 3 levels to the repo root.
-_WEB_APP_DIR = Path(__file__).resolve().parents[3] / "web-app"
 
 # Instruments seeded at session scope — must match the kebab-case IDs used
 # by the Python `Instrument` enum and the S3 key prefix convention.
@@ -55,97 +37,8 @@ _INSTRUMENTS: dict[str, str] = {
 
 
 # ---------------------------------------------------------------------------
-# Data class yielded by the session fixture
+# Lambda-specific helpers
 # ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class IntegrationEnv:
-    """Holds all parameters needed by integration tests."""
-
-    base_url: str
-    api_token: str
-    db_dsn: str
-    tmp_data_dir: Path
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _get_free_port() -> int:
-    """Bind to port 0, grab the OS-assigned port, then release it.
-
-    There is a TOCTOU race between releasing the socket and the server
-    binding to the returned port — another process could claim it in
-    between.  Extremely unlikely in CI (single job per runner) and rare
-    on developer machines, but possible with parallel test runs.
-    """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-def _wait_for_server(
-    url: str,
-    timeout: float = 120,
-    proc: subprocess.Popen[bytes] | None = None,
-) -> None:
-    """Poll *url* until it returns a non-5xx response.
-
-    If *proc* is supplied the function checks whether the server process is
-    still alive on every iteration.  When the process exits prematurely its
-    stdout/stderr are included in the error message so the root cause is
-    immediately visible.
-    """
-    import urllib.error
-    import urllib.request
-
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if proc is not None and proc.poll() is not None:
-            stdout = (proc.stdout.read() if proc.stdout else b"").decode(errors="replace")
-            stderr = (proc.stderr.read() if proc.stderr else b"").decode(errors="replace")
-            raise RuntimeError(
-                f"Server process exited with code {proc.returncode} before becoming ready.\n"
-                f"--- stdout ---\n{stdout[-4000:]}\n"
-                f"--- stderr ---\n{stderr[-4000:]}"
-            )
-        try:
-            resp = urllib.request.urlopen(url, timeout=5)  # noqa: S310
-            if resp.status < 500:
-                return
-        except urllib.error.HTTPError:
-            # Any HTTP response (even 5xx) proves the server is listening.
-            return
-        except (urllib.error.URLError, OSError):
-            pass
-        time.sleep(0.5)
-
-    extra = ""
-    if proc is not None:
-        alive = proc.poll() is None
-        extra = f" (process still running: {alive})"
-        if not alive:
-            stdout = (proc.stdout.read() if proc.stdout else b"").decode(errors="replace")
-            stderr = (proc.stderr.read() if proc.stderr else b"").decode(errors="replace")
-            extra += f"\n--- stdout ---\n{stdout[-4000:]}\n--- stderr ---\n{stderr[-4000:]}"
-    raise TimeoutError(f"Server at {url} did not start within {timeout}s{extra}")
-
-
-def _generate_token() -> str:
-    return _TOKEN_PREFIX + secrets.token_hex(32)
-
-
-def _hash_token(plaintext: str) -> str:
-    return hashlib.sha256(plaintext.encode()).hexdigest()
-
-
-def _token_display_prefix(plaintext: str) -> str:
-    # Stored in the DB for display (e.g. "dhub_a1b2…"). The server matches
-    # this pattern: the full prefix ("dhub_") plus the first 4 hex chars.
-    return plaintext[: len(_TOKEN_PREFIX) + 4]
 
 
 def _reset_singletons() -> None:
@@ -161,12 +54,7 @@ def _reset_singletons() -> None:
     import data_hub_lambda.config as _lcfg_mod
     import data_hub_shared.config as _scfg_mod
 
-    # Drop the cached HTTP client; get_client() will lazily create a new one
-    # using the now-updated lambda_config values.
     _api_mod._client = None
-    # Re-run __init__ on the *same* object instances rather than assigning new
-    # ones.  This is necessary because process_file modules already hold
-    # direct references via `from data_hub_shared.config import config`.
     _scfg_mod.config.__init__()  # type: ignore[misc]
     _lcfg_mod.lambda_config.__init__()  # type: ignore[misc]
 
@@ -182,129 +70,21 @@ def integration_env(
 ) -> Generator[IntegrationEnv, None, None]:
     """Start a real Next.js server, push the DB schema, and seed auth + instruments."""
 
-    # 1. Ensure the test database exists.
-    admin_conn = psycopg2.connect(_PG_ADMIN_DSN)
-    admin_conn.autocommit = True
-    with admin_conn.cursor() as cur:
-        cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (_TEST_DB,))
-        if not cur.fetchone():
-            cur.execute(f"CREATE DATABASE {_TEST_DB}")  # noqa: S608
-    admin_conn.close()
+    with start_test_server() as env:
+        seed_instruments(env.db_dsn, _INSTRUMENTS)
 
-    # 2. Push the Drizzle schema (mirrors web-app/tests/integration/global-setup.ts).
-    # `--force` skips the interactive confirmation prompt for destructive changes.
-    subprocess.run(
-        ["npx", "drizzle-kit", "push", "--force"],
-        cwd=str(_WEB_APP_DIR),
-        env={**os.environ, "DATABASE_URL": _DATABASE_URL},
-        check=True,
-        capture_output=True,
-    )
-
-    # 3. Build and start the Next.js production server.
-    port = _get_free_port()
-    base_url = f"http://127.0.0.1:{port}"
-
-    # AUTH_SECRET is required by NextAuth even though tests bypass sessions
-    # (PAT auth).  AUTH_GOOGLE_* stubs prevent startup errors from the
-    # Google OAuth provider config.  AWS creds are needed so the S3
-    # pre-signer can compute HMAC signatures (it never makes network calls).
-    server_env = {
-        **os.environ,
-        "DATABASE_URL": _DATABASE_URL,
-        "AUTH_SECRET": "test-secret-at-least-32-characters-long!!",
-        "AUTH_GOOGLE_ID": "stub",
-        "AUTH_GOOGLE_SECRET": "stub",
-        "AWS_ACCESS_KEY_ID": os.environ.get("AWS_ACCESS_KEY_ID", "test-key"),
-        "AWS_SECRET_ACCESS_KEY": os.environ.get("AWS_SECRET_ACCESS_KEY", "test-secret"),
-        "AWS_REGION": os.environ.get("AWS_REGION", "us-east-1"),
-    }
-
-    build_result = subprocess.run(
-        ["npx", "next", "build"],
-        cwd=str(_WEB_APP_DIR),
-        env=server_env,
-        capture_output=True,
-    )
-    if build_result.returncode != 0:
-        raise RuntimeError(
-            f"Next.js build failed (exit {build_result.returncode}).\n"
-            f"--- stdout ---\n{build_result.stdout.decode(errors='replace')[-4000:]}\n"
-            f"--- stderr ---\n{build_result.stderr.decode(errors='replace')[-4000:]}"
-        )
-
-    server_proc = subprocess.Popen(
-        ["npx", "next", "start", "-p", str(port)],
-        cwd=str(_WEB_APP_DIR),
-        env=server_env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-
-    try:
-        # 4. Wait for the server to become ready.
-        _wait_for_server(base_url, proc=server_proc)
-
-        # 5. Seed a user + personal access token directly via psycopg2.
-        # We bypass the API for seeding because PAT creation requires an
-        # authenticated session, and there is no session-based auth in tests.
-        # The server only stores the SHA-256 hash — the plaintext is returned
-        # here for use in `Authorization: Bearer dhub_…` headers.
-        token_plaintext = _generate_token()
-        conn = psycopg2.connect(_PG_TEST_DSN)
-        conn.autocommit = True
-        with conn.cursor() as cur:
-            user_id = secrets.token_hex(16)
-            cur.execute(
-                'INSERT INTO "user" (id, name, email) VALUES (%s, %s, %s)',
-                (user_id, "Integration Test User", f"integ-{user_id[:8]}@example.com"),
-            )
-            cur.execute(
-                """INSERT INTO personal_access_tokens
-                       (user_id, name, token_hash, token_prefix)
-                   VALUES (%s, %s, %s, %s)""",
-                (
-                    user_id,
-                    "integration-test-token",
-                    _hash_token(token_plaintext),
-                    _token_display_prefix(token_plaintext),
-                ),
-            )
-
-            # 6. Seed instrument rows.
-            for inst_id, display_name in _INSTRUMENTS.items():
-                cur.execute(
-                    """INSERT INTO instruments (id, display_name)
-                       VALUES (%s, %s)
-                       ON CONFLICT (id) DO NOTHING""",
-                    (inst_id, display_name),
-                )
-        conn.close()
-
-        # 7. Set env vars for Lambda modules and reset singletons so
+        # Set env vars for Lambda modules and reset singletons so
         # DataHubClient / Config pick up the test server URL.
         tmp_data = tmp_path_factory.mktemp("data")
-        os.environ["DATA_HUB_API_URL"] = f"{base_url}/api/v1"
-        os.environ["DATA_HUB_API_KEY"] = token_plaintext
+        os.environ["DATA_HUB_API_URL"] = f"{env.base_url}/api/v1"
+        os.environ["DATA_HUB_API_KEY"] = env.api_token
         os.environ["AWS_S3_RAW_DATA_BUCKET"] = "test-bucket"
         os.environ["AWS_S3_PROCESSED_DATA_BUCKET"] = "test-processed-bucket"
         os.environ["LOCAL_DATA_DIRPATH"] = str(tmp_data)
 
         _reset_singletons()
 
-        yield IntegrationEnv(
-            base_url=base_url,
-            api_token=token_plaintext,
-            db_dsn=_PG_TEST_DSN,
-            tmp_data_dir=tmp_data,
-        )
-    finally:
-        # 8. Teardown — kill the Next.js server.
-        server_proc.terminate()
-        try:
-            server_proc.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            server_proc.kill()
+        yield env
 
         # Clear env vars so subsequent tests don't inherit them.
         for key in (
@@ -330,12 +110,7 @@ _DATA_TABLES = ["run_report_data", "files", "instrument_runs"]
 @pytest.fixture(autouse=True)
 def reset_db(integration_env: IntegrationEnv) -> None:
     """Truncate data tables between tests, preserving instruments and the PAT."""
-    conn = psycopg2.connect(integration_env.db_dsn)
-    conn.autocommit = True
-    with conn.cursor() as cur:
-        for table in _DATA_TABLES:
-            cur.execute(f"TRUNCATE TABLE {table} CASCADE")  # noqa: S608
-    conn.close()
+    truncate_tables(integration_env.db_dsn, _DATA_TABLES)
 
 
 # ---------------------------------------------------------------------------
@@ -403,8 +178,6 @@ def mock_s3_download(
     instead of hitting real S3."""
 
     def _fake_download(s3_uri: str, local_path: Path, **_: Any) -> None:
-        # Extract the S3 key (everything after the bucket name) from the URI.
-        # e.g. "s3://test-bucket/azure-cielo-qpcr/file.csv" -> "azure-cielo-qpcr/file.csv"
         key = s3_uri.split("//", 1)[1].split("/", 1)[1]
         src = s3_fixture_files.get(key)
         if src is None:
@@ -415,10 +188,6 @@ def mock_s3_download(
         local_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, local_path)
 
-    # Patch at the *source module* rather than each import site. This works
-    # because process_file modules import the module object
-    # (`from data_hub_shared import s3_utils`) and resolve `download_file`
-    # via attribute lookup at call time, so they see the patched version.
     with patch("data_hub_shared.s3_utils.download_file", side_effect=_fake_download) as mock:
         yield mock
 

--- a/lambda/tests/integration/test_lambda_api.py
+++ b/lambda/tests/integration/test_lambda_api.py
@@ -16,7 +16,7 @@ import pytest
 import requests
 
 from data_hub_lambda.handler import lambda_handler
-from integration.conftest import IntegrationEnv
+from data_hub_shared.testing import IntegrationEnv
 
 _FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures"
 

--- a/packages/shared/src/data_hub_shared/testing.py
+++ b/packages/shared/src/data_hub_shared/testing.py
@@ -1,0 +1,283 @@
+"""Shared integration-test infrastructure for Lambda and Watcher test suites.
+
+Provides server lifecycle management (DB creation, schema push, Next.js
+build/start), auth seeding, instrument seeding, and direct-DB helpers so
+that both suites spin up an identical environment with minimal boilerplate.
+"""
+
+from __future__ import annotations
+import hashlib
+import os
+import secrets
+import socket
+import subprocess
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+import psycopg2
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TEST_DB = "data_hub_test"
+_PG_HOST = "127.0.0.1"
+_PG_PORT = 5432
+_PG_USER = "postgres"
+_PG_PASSWORD = "postgres"
+_PG_ADMIN_DSN = (
+    f"dbname=postgres user={_PG_USER} password={_PG_PASSWORD} host={_PG_HOST} port={_PG_PORT}"
+)
+_PG_TEST_DSN = (
+    f"dbname={_TEST_DB} user={_PG_USER} password={_PG_PASSWORD} host={_PG_HOST} port={_PG_PORT}"
+)
+_DATABASE_URL = f"postgres://{_PG_USER}:{_PG_PASSWORD}@{_PG_HOST}:{_PG_PORT}/{_TEST_DB}"
+
+_TOKEN_PREFIX = "dhub_"
+
+# testing.py lives at packages/shared/src/data_hub_shared/ — walk up 4 levels to the repo root.
+_WEB_APP_DIR = Path(__file__).resolve().parents[4] / "web-app"
+
+
+# ---------------------------------------------------------------------------
+# Data class yielded by the session fixture
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class IntegrationEnv:
+    """Holds all parameters needed by integration tests."""
+
+    base_url: str
+    api_token: str
+    db_dsn: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def get_free_port() -> int:
+    """Bind to port 0, grab the OS-assigned port, then release it."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_server(
+    url: str,
+    timeout: float = 120,
+    proc: subprocess.Popen[bytes] | None = None,
+) -> None:
+    """Poll *url* until it returns a non-5xx response.
+
+    If *proc* is supplied the function checks whether the server process is
+    still alive on every iteration.  When the process exits prematurely its
+    stdout/stderr are included in the error message so the root cause is
+    immediately visible.
+    """
+    import urllib.error
+    import urllib.request
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc is not None and proc.poll() is not None:
+            stdout = (proc.stdout.read() if proc.stdout else b"").decode(errors="replace")
+            stderr = (proc.stderr.read() if proc.stderr else b"").decode(errors="replace")
+            raise RuntimeError(
+                f"Server process exited with code {proc.returncode} before becoming ready.\n"
+                f"--- stdout ---\n{stdout[-4000:]}\n"
+                f"--- stderr ---\n{stderr[-4000:]}"
+            )
+        try:
+            resp = urllib.request.urlopen(url, timeout=5)  # noqa: S310
+            if resp.status < 500:
+                return
+        except urllib.error.HTTPError:
+            return
+        except (urllib.error.URLError, OSError):
+            pass
+        time.sleep(0.5)
+
+    extra = ""
+    if proc is not None:
+        alive = proc.poll() is None
+        extra = f" (process still running: {alive})"
+        if not alive:
+            stdout = (proc.stdout.read() if proc.stdout else b"").decode(errors="replace")
+            stderr = (proc.stderr.read() if proc.stderr else b"").decode(errors="replace")
+            extra += f"\n--- stdout ---\n{stdout[-4000:]}\n--- stderr ---\n{stderr[-4000:]}"
+    raise TimeoutError(f"Server at {url} did not start within {timeout}s{extra}")
+
+
+# ---------------------------------------------------------------------------
+# Token helpers — must match web-app/lib/tokens.ts
+# ---------------------------------------------------------------------------
+
+
+def _generate_token() -> str:
+    return _TOKEN_PREFIX + secrets.token_hex(32)
+
+
+def _hash_token(plaintext: str) -> str:
+    return hashlib.sha256(plaintext.encode()).hexdigest()
+
+
+def _token_display_prefix(plaintext: str) -> str:
+    return plaintext[: len(_TOKEN_PREFIX) + 4]
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def seed_auth(dsn: str) -> str:
+    """Insert a user and personal access token, returning the plaintext token."""
+    token_plaintext = _generate_token()
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        user_id = secrets.token_hex(16)
+        cur.execute(
+            'INSERT INTO "user" (id, name, email) VALUES (%s, %s, %s)',
+            (user_id, "Integration Test User", f"integ-{user_id[:8]}@example.com"),
+        )
+        cur.execute(
+            """INSERT INTO personal_access_tokens
+                   (user_id, name, token_hash, token_prefix)
+               VALUES (%s, %s, %s, %s)""",
+            (
+                user_id,
+                "integration-test-token",
+                _hash_token(token_plaintext),
+                _token_display_prefix(token_plaintext),
+            ),
+        )
+    conn.close()
+    return token_plaintext
+
+
+def seed_instruments(dsn: str, instruments: dict[str, str]) -> None:
+    """Insert instrument rows (ON CONFLICT DO NOTHING)."""
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        for inst_id, display_name in instruments.items():
+            cur.execute(
+                """INSERT INTO instruments (id, display_name)
+                   VALUES (%s, %s)
+                   ON CONFLICT (id) DO NOTHING""",
+                (inst_id, display_name),
+            )
+    conn.close()
+
+
+def truncate_tables(dsn: str, tables: list[str]) -> None:
+    """Truncate the given tables with CASCADE."""
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        for table in tables:
+            cur.execute(f"TRUNCATE TABLE {table} CASCADE")  # noqa: S608
+    conn.close()
+
+
+def db_query(
+    dsn: str, sql: str, params: tuple[object, ...] | None = None
+) -> list[tuple[object, ...]]:
+    """Execute a SELECT and return all rows."""
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+        rows: list[tuple[object, ...]] = cur.fetchall()
+    conn.close()
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Server lifecycle context manager
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def start_test_server() -> Generator[IntegrationEnv, None, None]:
+    """Create the test DB, push schema, build + start Next.js, seed auth, and yield."""
+
+    # 1. Ensure the test database exists.
+    admin_conn = psycopg2.connect(_PG_ADMIN_DSN)
+    admin_conn.autocommit = True
+    with admin_conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (_TEST_DB,))
+        if not cur.fetchone():
+            cur.execute(f"CREATE DATABASE {_TEST_DB}")  # noqa: S608
+    admin_conn.close()
+
+    # 2. Push the Drizzle schema.
+    subprocess.run(
+        ["npx", "drizzle-kit", "push", "--force"],
+        cwd=str(_WEB_APP_DIR),
+        env={**os.environ, "DATABASE_URL": _DATABASE_URL},
+        check=True,
+        capture_output=True,
+    )
+
+    # 3. Build and start the Next.js production server.
+    port = get_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    server_env = {
+        **os.environ,
+        "DATABASE_URL": _DATABASE_URL,
+        "AUTH_SECRET": "test-secret-at-least-32-characters-long!!",
+        "AUTH_GOOGLE_ID": "stub",
+        "AUTH_GOOGLE_SECRET": "stub",
+        "AWS_ACCESS_KEY_ID": os.environ.get("AWS_ACCESS_KEY_ID", "test-key"),
+        "AWS_SECRET_ACCESS_KEY": os.environ.get("AWS_SECRET_ACCESS_KEY", "test-secret"),
+        "AWS_REGION": os.environ.get("AWS_REGION", "us-east-1"),
+    }
+
+    build_result = subprocess.run(
+        ["npx", "next", "build"],
+        cwd=str(_WEB_APP_DIR),
+        env=server_env,
+        capture_output=True,
+    )
+    if build_result.returncode != 0:
+        raise RuntimeError(
+            f"Next.js build failed (exit {build_result.returncode}).\n"
+            f"--- stdout ---\n{build_result.stdout.decode(errors='replace')[-4000:]}\n"
+            f"--- stderr ---\n{build_result.stderr.decode(errors='replace')[-4000:]}"
+        )
+
+    server_proc = subprocess.Popen(
+        ["npx", "next", "start", "-p", str(port)],
+        cwd=str(_WEB_APP_DIR),
+        env=server_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    try:
+        # 4. Wait for the server to become ready.
+        wait_for_server(base_url, proc=server_proc)
+
+        # 5. Seed auth.
+        token_plaintext = seed_auth(_PG_TEST_DSN)
+
+        yield IntegrationEnv(
+            base_url=base_url,
+            api_token=token_plaintext,
+            db_dsn=_PG_TEST_DSN,
+        )
+    finally:
+        server_proc.terminate()
+        try:
+            server_proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            server_proc.kill()

--- a/packages/shared/src/data_hub_shared/testing.py
+++ b/packages/shared/src/data_hub_shared/testing.py
@@ -200,6 +200,15 @@ def db_query(
     return rows
 
 
+def db_update(dsn: str, sql: str, params: tuple[object, ...] | None = None) -> None:
+    """Execute an UPDATE/INSERT directly for simulating server-side actions."""
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+    conn.close()
+
+
 # ---------------------------------------------------------------------------
 # Server lifecycle context manager
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ no-lines-before = ["future", "standard-library"]
 testpaths = ["lambda/tests", "watcher/tests", "packages/shared/tests"]
 addopts = "--import-mode=importlib"
 markers = ["integration: Tests requiring Postgres + Next.js server"]
+filterwarnings = ["ignore::DeprecationWarning:matplotlib"]
 
 [tool.pyright]
 include = ["lambda", "watcher", "packages/shared"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ no-lines-before = ["future", "standard-library"]
 [tool.pytest.ini_options]
 testpaths = ["lambda/tests", "watcher/tests", "packages/shared/tests"]
 addopts = "--import-mode=importlib"
-markers = ["integration: Lambda-to-API integration tests (require Postgres + Next.js)"]
+markers = ["integration: Tests requiring Postgres + Next.js server"]
 
 [tool.pyright]
 include = ["lambda", "watcher", "packages/shared"]

--- a/watcher/src/data_hub_watcher/models.py
+++ b/watcher/src/data_hub_watcher/models.py
@@ -151,15 +151,6 @@ class EventsResponse(BaseModel):
     received: int
 
 
-class RunFileResponse(BaseModel):
-    model_config = _API_MODEL_CONFIG
-
-    id: int
-    filename: str
-    relative_path: str | None = None
-    status: str | None = None
-
-
 class RunResponse(BaseModel):
     model_config = _API_MODEL_CONFIG
 
@@ -167,7 +158,6 @@ class RunResponse(BaseModel):
     instrument_id: str
     run_id: str
     source: Literal["lambda", "watcher"]
-    files: list[RunFileResponse] = Field(default_factory=list)
 
 
 class RunDetailResponse(BaseModel):

--- a/watcher/src/data_hub_watcher/run_detector.py
+++ b/watcher/src/data_hub_watcher/run_detector.py
@@ -203,11 +203,6 @@ class RunDetector:
             self._state_db.record_run_reported(run.run_id)
             self._counters.runs_reported += 1
 
-            file_id_by_name = {rf.filename: rf.id for rf in resp.files}
-            for f in run.files:
-                if f.filename in file_id_by_name:
-                    f.file_id = file_id_by_name[f.filename]
-
             self._reporter.queue_event(
                 WatcherEvent(
                     event_type=EventType.RUN_REPORTED,

--- a/watcher/tests/conftest.py
+++ b/watcher/tests/conftest.py
@@ -66,8 +66,13 @@ _WATCHER_TABLES = [
 
 @pytest.fixture(autouse=True)
 def reset_watcher_data(integration_env: IntegrationEnv) -> None:
-    """Truncate watcher-related tables between tests, preserving instruments and the PAT."""
+    """Truncate watcher-related tables between tests, preserving the seeded instrument and PAT."""
     truncate_tables(integration_env.db_dsn, _WATCHER_TABLES)
+    db_update(
+        integration_env.db_dsn,
+        "DELETE FROM instruments WHERE id != %s",
+        (INSTRUMENT_ID,),
+    )
 
 
 __all__ = [

--- a/watcher/tests/conftest.py
+++ b/watcher/tests/conftest.py
@@ -1,0 +1,97 @@
+"""Session-scoped and function-scoped fixtures for Watcher -> API integration tests.
+
+These fixtures spin up a real Next.js server backed by Postgres so that
+`DataHubClient` methods exercise the full HTTP path — mirroring how the
+watcher operates on a real lab instrument PC.
+"""
+
+from __future__ import annotations
+from collections.abc import Generator
+
+import psycopg2
+import pytest
+
+from data_hub_shared.testing import (
+    IntegrationEnv,
+    db_query,
+    seed_instruments,
+    start_test_server,
+    truncate_tables,
+)
+from data_hub_watcher.api_client import DataHubClient
+
+INSTRUMENT_ID = "watcher-contract-test"
+
+# ---------------------------------------------------------------------------
+# Session-scoped fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def integration_env() -> Generator[IntegrationEnv, None, None]:
+    """Start a real Next.js server, push the DB schema, and seed auth + instruments."""
+    with start_test_server() as env:
+        seed_instruments(env.db_dsn, {INSTRUMENT_ID: "Contract Test Instrument"})
+        yield env
+
+
+@pytest.fixture(scope="session")
+def client(integration_env: IntegrationEnv) -> DataHubClient:
+    """A DataHubClient wired to the test server."""
+    return DataHubClient(
+        base_url=f"{integration_env.base_url}/api/v1",
+        api_key=integration_env.api_token,
+    )
+
+
+@pytest.fixture(scope="session")
+def instrument_id() -> str:
+    """The pre-seeded instrument ID shared across all watcher tests."""
+    return INSTRUMENT_ID
+
+
+# ---------------------------------------------------------------------------
+# Per-test DB reset
+# ---------------------------------------------------------------------------
+
+_WATCHER_TABLES = [
+    "run_report_data",
+    "files",
+    "instrument_runs",
+    "watcher_events",
+    "watcher_heartbeats",
+    "watchers",
+]
+
+
+@pytest.fixture(autouse=True)
+def reset_watcher_data(integration_env: IntegrationEnv) -> None:
+    """Truncate watcher-related tables between tests, preserving instruments and the PAT."""
+    truncate_tables(integration_env.db_dsn, _WATCHER_TABLES)
+
+
+# ---------------------------------------------------------------------------
+# Helpers re-exported for test modules
+# ---------------------------------------------------------------------------
+
+
+def db_update(dsn: str, sql: str, params: tuple[object, ...] | None = None) -> None:
+    """Execute an UPDATE/INSERT directly for simulating server-side actions."""
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+    conn.close()
+
+
+__all__ = [
+    "INSTRUMENT_ID",
+    "DataHubClient",
+    "IntegrationEnv",
+    "db_query",
+    "db_update",
+    "integration_env",
+    "client",
+    "instrument_id",
+    "reset_watcher_data",
+]

--- a/watcher/tests/conftest.py
+++ b/watcher/tests/conftest.py
@@ -8,12 +8,12 @@ watcher operates on a real lab instrument PC.
 from __future__ import annotations
 from collections.abc import Generator
 
-import psycopg2
 import pytest
 
 from data_hub_shared.testing import (
     IntegrationEnv,
     db_query,
+    db_update,
     seed_instruments,
     start_test_server,
     truncate_tables,
@@ -68,20 +68,6 @@ _WATCHER_TABLES = [
 def reset_watcher_data(integration_env: IntegrationEnv) -> None:
     """Truncate watcher-related tables between tests, preserving instruments and the PAT."""
     truncate_tables(integration_env.db_dsn, _WATCHER_TABLES)
-
-
-# ---------------------------------------------------------------------------
-# Helpers re-exported for test modules
-# ---------------------------------------------------------------------------
-
-
-def db_update(dsn: str, sql: str, params: tuple[object, ...] | None = None) -> None:
-    """Execute an UPDATE/INSERT directly for simulating server-side actions."""
-    conn = psycopg2.connect(dsn)
-    conn.autocommit = True
-    with conn.cursor() as cur:
-        cur.execute(sql, params)
-    conn.close()
 
 
 __all__ = [

--- a/watcher/tests/test_auto_upload_flow.py
+++ b/watcher/tests/test_auto_upload_flow.py
@@ -107,23 +107,6 @@ class TestReportRun:
         assert rows[0][0] == "detected"
         assert rows[0][1] is not None
 
-    def test_report_run_does_not_return_file_ids(
-        self, client: DataHubClient, instrument_id: str
-    ) -> None:
-        watcher = client.register_watcher(instrument_id)
-        result = client.report_run(
-            instrument_id,
-            {
-                "run_id": "EXP-002",
-                "source": "watcher",
-                "watcher_id": watcher.watcher_id,
-                "detected_files": [
-                    {"filename": "data.csv", "relative_path": "EXP-002/data.csv"},
-                ],
-            },
-        )
-        assert result.files == []
-
     def test_report_run_idempotent(
         self,
         client: DataHubClient,

--- a/watcher/tests/test_auto_upload_flow.py
+++ b/watcher/tests/test_auto_upload_flow.py
@@ -1,0 +1,310 @@
+"""Integration tests: auto-upload flow.
+
+Mirrors the full lifecycle of a watcher in auto-upload mode on a real
+instrument:
+
+    register -> heartbeat("watching") -> report_run (1 file)
+      -> update_run (add 2nd file) -> mark_file_uploaded
+      -> verify upload queue state -> heartbeat("stopped")
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from data_hub_shared.testing import IntegrationEnv, db_query
+from data_hub_watcher.api_client import DataHubClient
+
+pytestmark = pytest.mark.integration
+
+
+def _register_and_report(
+    client: DataHubClient,
+    instrument_id: str,
+    *,
+    run_id: str = "EXP-001",
+    files: list[dict[str, str]] | None = None,
+) -> tuple[str, str]:
+    """Register a watcher and report a run. Returns (watcher_id, run_id)."""
+    watcher = client.register_watcher(instrument_id, hostname="LAB-PC-01")
+    detected = files or [{"filename": "data_001.csv", "relative_path": "EXP-001/data_001.csv"}]
+    client.report_run(
+        instrument_id,
+        {
+            "run_id": run_id,
+            "source": "watcher",
+            "watcher_id": watcher.watcher_id,
+            "detected_files": detected,
+        },
+    )
+    return watcher.watcher_id, run_id
+
+
+def _get_file_id(dsn: str, run_id: str, filename: str) -> int:
+    rows = db_query(
+        dsn,
+        """SELECT f.id FROM files f
+           JOIN instrument_runs r ON f.instrument_run_id = r.id
+           WHERE r.run_id = %s AND f.filename = %s""",
+        (run_id, filename),
+    )
+    assert rows, f"No file found for run={run_id}, filename={filename}"
+    file_id = rows[0][0]
+    assert isinstance(file_id, int)
+    return file_id
+
+
+# ------------------------------------------------------------------
+# report_run
+# ------------------------------------------------------------------
+
+
+class TestReportRun:
+    def test_report_run_creates_run_with_source_watcher(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        result = client.report_run(
+            instrument_id,
+            {
+                "run_id": "EXP-001",
+                "source": "watcher",
+                "watcher_id": watcher.watcher_id,
+                "detected_files": [
+                    {"filename": "data_001.csv", "relative_path": "EXP-001/data_001.csv"},
+                ],
+            },
+        )
+        assert result.source == "watcher"
+        assert result.run_id == "EXP-001"
+
+        rows = db_query(
+            integration_env.db_dsn,
+            "SELECT source, watcher_id FROM instrument_runs WHERE run_id = %s",
+            ("EXP-001",),
+        )
+        assert rows[0][0] == "watcher"
+        assert rows[0][1] == watcher.watcher_id
+
+    def test_report_run_creates_detected_files(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        _register_and_report(client, instrument_id)
+
+        rows = db_query(
+            integration_env.db_dsn,
+            """SELECT f.status, f.detected_at FROM files f
+               JOIN instrument_runs r ON f.instrument_run_id = r.id
+               WHERE r.run_id = 'EXP-001'""",
+        )
+        assert len(rows) == 1
+        assert rows[0][0] == "detected"
+        assert rows[0][1] is not None
+
+    def test_report_run_does_not_return_file_ids(
+        self, client: DataHubClient, instrument_id: str
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        result = client.report_run(
+            instrument_id,
+            {
+                "run_id": "EXP-002",
+                "source": "watcher",
+                "watcher_id": watcher.watcher_id,
+                "detected_files": [
+                    {"filename": "data.csv", "relative_path": "EXP-002/data.csv"},
+                ],
+            },
+        )
+        assert result.files == []
+
+    def test_report_run_idempotent(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        run_data = {
+            "run_id": "EXP-001",
+            "source": "watcher",
+            "watcher_id": watcher.watcher_id,
+            "detected_files": [
+                {"filename": "data.csv", "relative_path": "EXP-001/data.csv"},
+            ],
+        }
+        r1 = client.report_run(instrument_id, run_data)
+        r2 = client.report_run(instrument_id, run_data)
+        assert r1.id == r2.id
+
+        rows = db_query(
+            integration_env.db_dsn,
+            "SELECT count(*) FROM instrument_runs WHERE run_id = 'EXP-001'",
+        )
+        assert rows[0][0] == 1
+
+    def test_report_run_idempotent_does_not_duplicate_files(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        run_data = {
+            "run_id": "EXP-001",
+            "source": "watcher",
+            "watcher_id": watcher.watcher_id,
+            "detected_files": [
+                {"filename": "data.csv", "relative_path": "EXP-001/data.csv"},
+            ],
+        }
+        client.report_run(instrument_id, run_data)
+        client.report_run(instrument_id, run_data)
+
+        rows = db_query(
+            integration_env.db_dsn,
+            """SELECT count(*) FROM files f
+               JOIN instrument_runs r ON f.instrument_run_id = r.id
+               WHERE r.run_id = 'EXP-001'""",
+        )
+        assert rows[0][0] == 1
+
+
+# ------------------------------------------------------------------
+# update_run
+# ------------------------------------------------------------------
+
+
+class TestUpdateRun:
+    def test_update_run_adds_new_file(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher_id, run_id = _register_and_report(
+            client,
+            instrument_id,
+            files=[{"filename": "file_a.csv", "relative_path": "EXP-001/file_a.csv"}],
+        )
+        client.update_run(
+            instrument_id,
+            run_id,
+            {
+                "detected_files": [
+                    {"filename": "file_a.csv", "relative_path": "EXP-001/file_a.csv"},
+                    {"filename": "file_b.csv", "relative_path": "EXP-001/file_b.csv"},
+                ],
+            },
+        )
+
+        rows = db_query(
+            integration_env.db_dsn,
+            """SELECT f.filename FROM files f
+               JOIN instrument_runs r ON f.instrument_run_id = r.id
+               WHERE r.run_id = %s ORDER BY f.filename""",
+            (run_id,),
+        )
+        assert [r[0] for r in rows] == ["file_a.csv", "file_b.csv"]
+
+    def test_update_run_returns_run_detail(self, client: DataHubClient, instrument_id: str) -> None:
+        watcher_id, run_id = _register_and_report(client, instrument_id)
+        detail = client.update_run(instrument_id, run_id, {"detected_files": []})
+        assert detail.source == "watcher"
+        assert detail.watcher_id == watcher_id
+        assert detail.instrument_display_name == "Contract Test Instrument"
+
+
+# ------------------------------------------------------------------
+# mark_file_uploaded
+# ------------------------------------------------------------------
+
+
+class TestMarkFileUploaded:
+    def test_mark_file_uploaded_transitions_detected_to_uploaded(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        _register_and_report(client, instrument_id)
+        file_id = _get_file_id(integration_env.db_dsn, "EXP-001", "data_001.csv")
+
+        result = client.mark_file_uploaded(
+            file_id,
+            {
+                "s3_bucket": "test-bucket",
+                "s3_key": f"{instrument_id}/EXP-001/data_001.csv",
+                "content_type": "text/csv",
+                "status": "uploaded",
+            },
+        )
+        assert result.status == "uploaded"
+        assert result.s3_bucket == "test-bucket"
+        assert result.s3_key == f"{instrument_id}/EXP-001/data_001.csv"
+        assert result.content_type == "text/csv"
+        assert result.uploaded_at is not None
+
+
+# ------------------------------------------------------------------
+# Full end-to-end lifecycle
+# ------------------------------------------------------------------
+
+
+class TestFullAutoModeLifecycle:
+    def test_full_auto_mode_lifecycle(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        # 1. Register
+        watcher = client.register_watcher(instrument_id, hostname="LAB-PC-01")
+        wid = watcher.watcher_id
+
+        # 2. Heartbeat -> watching
+        hb = client.send_heartbeat(wid, {"status": "watching"})
+        assert hb.ok is True
+
+        # 3. Report run with one file
+        client.report_run(
+            instrument_id,
+            {
+                "run_id": "LIFECYCLE-001",
+                "source": "watcher",
+                "watcher_id": wid,
+                "detected_files": [
+                    {"filename": "raw.csv", "relative_path": "LIFECYCLE-001/raw.csv"},
+                ],
+            },
+        )
+
+        # 4. Get file ID from DB and mark uploaded
+        file_id = _get_file_id(integration_env.db_dsn, "LIFECYCLE-001", "raw.csv")
+        uploaded = client.mark_file_uploaded(
+            file_id,
+            {
+                "s3_bucket": "test-bucket",
+                "s3_key": f"{instrument_id}/LIFECYCLE-001/raw.csv",
+                "content_type": "text/csv",
+                "status": "uploaded",
+            },
+        )
+        assert uploaded.status == "uploaded"
+
+        # 5. Heartbeat -> stopped
+        client.send_heartbeat(wid, {"status": "stopped"})
+
+        # 6. Verify final watcher status
+        rows = db_query(
+            integration_env.db_dsn,
+            "SELECT status FROM watchers WHERE id = %s",
+            (wid,),
+        )
+        assert rows[0][0] == "stopped"

--- a/watcher/tests/test_error_paths.py
+++ b/watcher/tests/test_error_paths.py
@@ -1,0 +1,188 @@
+"""Integration tests: consolidated error paths.
+
+Boundary conditions and edge cases — 404s, 400s, 409s across every major
+endpoint to verify the API returns proper error codes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from data_hub_shared.testing import IntegrationEnv, db_query, db_update
+from data_hub_watcher.api_client import ApiError, DataHubClient
+
+pytestmark = pytest.mark.integration
+
+
+def _get_file_id(dsn: str, run_id: str, filename: str) -> int:
+    rows = db_query(
+        dsn,
+        """SELECT f.id FROM files f
+           JOIN instrument_runs r ON f.instrument_run_id = r.id
+           WHERE r.run_id = %s AND f.filename = %s""",
+        (run_id, filename),
+    )
+    assert rows, f"No file found for run={run_id}, filename={filename}"
+    file_id = rows[0][0]
+    assert isinstance(file_id, int)
+    return file_id
+
+
+# ------------------------------------------------------------------
+# 404s
+# ------------------------------------------------------------------
+
+
+class TestNotFound:
+    def test_register_unknown_instrument_404(self, client: DataHubClient) -> None:
+        with pytest.raises(ApiError) as exc_info:
+            client.register_watcher("nonexistent-instrument")
+        assert exc_info.value.status_code == 404
+
+    def test_mark_uploaded_nonexistent_file_404(self, client: DataHubClient) -> None:
+        with pytest.raises(ApiError) as exc_info:
+            client.mark_file_uploaded(
+                99999,
+                {
+                    "s3_bucket": "b",
+                    "s3_key": "k",
+                    "content_type": "text/csv",
+                    "status": "uploaded",
+                },
+            )
+        assert exc_info.value.status_code == 404
+
+
+# ------------------------------------------------------------------
+# 400s
+# ------------------------------------------------------------------
+
+
+class TestBadRequest:
+    def test_heartbeat_invalid_status_400(self, client: DataHubClient, instrument_id: str) -> None:
+        watcher = client.register_watcher(instrument_id)
+        with pytest.raises(ApiError) as exc_info:
+            client.send_heartbeat(watcher.watcher_id, {"status": "bogus"})
+        assert exc_info.value.status_code == 400
+
+    def test_events_invalid_event_type_400(self, client: DataHubClient, instrument_id: str) -> None:
+        watcher = client.register_watcher(instrument_id)
+        with pytest.raises(ApiError) as exc_info:
+            client.send_events(
+                watcher.watcher_id,
+                [{"event_type": "not_real", "message": "nope"}],
+            )
+        assert exc_info.value.status_code == 400
+
+    def test_report_run_empty_run_id_400(self, client: DataHubClient, instrument_id: str) -> None:
+        watcher = client.register_watcher(instrument_id)
+        with pytest.raises(ApiError) as exc_info:
+            client.report_run(
+                instrument_id,
+                {
+                    "run_id": "",
+                    "source": "watcher",
+                    "watcher_id": watcher.watcher_id,
+                    "detected_files": [],
+                },
+            )
+        assert exc_info.value.status_code == 400
+
+    def test_report_run_invalid_source_400(self, client: DataHubClient, instrument_id: str) -> None:
+        watcher = client.register_watcher(instrument_id)
+        with pytest.raises(ApiError) as exc_info:
+            client.report_run(
+                instrument_id,
+                {
+                    "run_id": "EXP-001",
+                    "source": "invalid",
+                    "watcher_id": watcher.watcher_id,
+                    "detected_files": [],
+                },
+            )
+        assert exc_info.value.status_code == 400
+
+    def test_report_run_invalid_watcher_id_400(
+        self, client: DataHubClient, instrument_id: str
+    ) -> None:
+        with pytest.raises(ApiError) as exc_info:
+            client.report_run(
+                instrument_id,
+                {
+                    "run_id": "EXP-001",
+                    "source": "watcher",
+                    "watcher_id": "00000000-0000-0000-0000-000000000000",
+                    "detected_files": [],
+                },
+            )
+        assert exc_info.value.status_code == 400
+
+
+# ------------------------------------------------------------------
+# 409s
+# ------------------------------------------------------------------
+
+
+class TestConflict:
+    def test_mark_uploaded_invalid_transition_409(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        client.report_run(
+            instrument_id,
+            {
+                "run_id": "EXP-CONFLICT",
+                "source": "watcher",
+                "watcher_id": watcher.watcher_id,
+                "detected_files": [
+                    {"filename": "f.csv", "relative_path": "EXP-CONFLICT/f.csv"},
+                ],
+            },
+        )
+        file_id = _get_file_id(integration_env.db_dsn, "EXP-CONFLICT", "f.csv")
+
+        s3_info = {
+            "s3_bucket": "b",
+            "s3_key": "k",
+            "content_type": "text/csv",
+            "status": "uploaded",
+        }
+        client.mark_file_uploaded(file_id, s3_info)
+
+        with pytest.raises(ApiError) as exc_info:
+            client.mark_file_uploaded(file_id, s3_info)
+        assert exc_info.value.status_code == 409
+
+    def test_update_deleted_run_409(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        client.report_run(
+            instrument_id,
+            {
+                "run_id": "EXP-DELETE",
+                "source": "watcher",
+                "watcher_id": watcher.watcher_id,
+                "detected_files": [],
+            },
+        )
+
+        db_update(
+            integration_env.db_dsn,
+            "UPDATE instrument_runs SET deleted_at = NOW() WHERE run_id = %s",
+            ("EXP-DELETE",),
+        )
+
+        with pytest.raises(ApiError) as exc_info:
+            client.update_run(
+                instrument_id,
+                "EXP-DELETE",
+                {"detected_files": []},
+            )
+        assert exc_info.value.status_code == 409

--- a/watcher/tests/test_heartbeat_and_events.py
+++ b/watcher/tests/test_heartbeat_and_events.py
@@ -1,0 +1,180 @@
+"""Integration tests: heartbeat status transitions and event reporting.
+
+Tests the watcher's ongoing lifecycle — heartbeat-driven status transitions
+(registered -> watching -> stopped), counter persistence, and event batches.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from data_hub_shared.testing import IntegrationEnv, db_query, db_update
+from data_hub_watcher.api_client import ApiError, DataHubClient
+
+pytestmark = pytest.mark.integration
+
+
+# ------------------------------------------------------------------
+# Heartbeat
+# ------------------------------------------------------------------
+
+
+class TestHeartbeat:
+    def test_heartbeat_returns_ok(self, client: DataHubClient, instrument_id: str) -> None:
+        watcher = client.register_watcher(instrument_id)
+        result = client.send_heartbeat(watcher.watcher_id, {"status": "watching"})
+        assert result.ok is True
+
+    def test_heartbeat_transitions_status_to_watching(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        client.send_heartbeat(watcher.watcher_id, {"status": "watching"})
+
+        rows = db_query(
+            integration_env.db_dsn,
+            "SELECT status, last_heartbeat_at FROM watchers WHERE id = %s",
+            (watcher.watcher_id,),
+        )
+        assert rows[0][0] == "watching"
+        assert rows[0][1] is not None
+
+    def test_heartbeat_with_counters_persisted(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        client.send_heartbeat(
+            watcher.watcher_id,
+            {
+                "status": "watching",
+                "files_uploaded_since_last_heartbeat": 3,
+                "runs_reported_since_last_heartbeat": 1,
+                "errors_since_last_heartbeat": 0,
+                "uptime_seconds": 120,
+                "upload_mode": "auto",
+            },
+        )
+
+        rows = db_query(
+            integration_env.db_dsn,
+            """SELECT files_uploaded_since_last_heartbeat,
+                      runs_reported_since_last_heartbeat,
+                      errors_since_last_heartbeat,
+                      uptime_seconds,
+                      upload_mode
+               FROM watcher_heartbeats
+               WHERE watcher_id = %s""",
+            (watcher.watcher_id,),
+        )
+        assert len(rows) == 1
+        assert rows[0] == (3, 1, 0, 120, "auto")
+
+    def test_heartbeat_stopped_updates_status(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        client.send_heartbeat(watcher.watcher_id, {"status": "watching"})
+        client.send_heartbeat(watcher.watcher_id, {"status": "stopped"})
+
+        rows = db_query(
+            integration_env.db_dsn,
+            "SELECT status FROM watchers WHERE id = %s",
+            (watcher.watcher_id,),
+        )
+        assert rows[0][0] == "stopped"
+
+    def test_heartbeat_deleted_watcher_404(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        db_update(
+            integration_env.db_dsn,
+            "UPDATE watchers SET deleted_at = NOW() WHERE id = %s",
+            (watcher.watcher_id,),
+        )
+        with pytest.raises(ApiError) as exc_info:
+            client.send_heartbeat(watcher.watcher_id, {"status": "watching"})
+        assert exc_info.value.status_code == 404
+
+
+# ------------------------------------------------------------------
+# Events
+# ------------------------------------------------------------------
+
+
+class TestEvents:
+    def test_send_events_batch(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        result = client.send_events(
+            watcher.watcher_id,
+            [
+                {"event_type": "watcher_started", "message": "Watcher started on LAB-PC-01"},
+                {"event_type": "run_detected", "message": "Detected run EXP-001"},
+            ],
+        )
+        assert result.received == 2
+
+        rows = db_query(
+            integration_env.db_dsn,
+            "SELECT event_type, message FROM watcher_events"
+            " WHERE watcher_id = %s ORDER BY created_at",
+            (watcher.watcher_id,),
+        )
+        assert len(rows) == 2
+        assert rows[0][0] == "watcher_started"
+        assert rows[1][0] == "run_detected"
+
+    def test_send_events_watcher_started_and_stopped(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        client.send_events(
+            watcher.watcher_id,
+            [{"event_type": "watcher_started", "message": "Started"}],
+        )
+        client.send_events(
+            watcher.watcher_id,
+            [{"event_type": "watcher_stopped", "message": "Stopped"}],
+        )
+
+        rows = db_query(
+            integration_env.db_dsn,
+            "SELECT event_type FROM watcher_events WHERE watcher_id = %s ORDER BY created_at",
+            (watcher.watcher_id,),
+        )
+        assert [r[0] for r in rows] == ["watcher_started", "watcher_stopped"]
+
+    def test_send_events_invalid_type_400(self, client: DataHubClient, instrument_id: str) -> None:
+        watcher = client.register_watcher(instrument_id)
+        with pytest.raises(ApiError) as exc_info:
+            client.send_events(
+                watcher.watcher_id,
+                [{"event_type": "bogus", "message": "bad event"}],
+            )
+        assert exc_info.value.status_code == 400
+
+    def test_send_events_empty_list_400(self, client: DataHubClient, instrument_id: str) -> None:
+        watcher = client.register_watcher(instrument_id)
+        with pytest.raises(ApiError) as exc_info:
+            client.send_events(watcher.watcher_id, [])
+        assert exc_info.value.status_code == 400

--- a/watcher/tests/test_heartbeat_and_events.py
+++ b/watcher/tests/test_heartbeat_and_events.py
@@ -5,6 +5,7 @@ Tests the watcher's ongoing lifecycle — heartbeat-driven status transitions
 """
 
 from __future__ import annotations
+from datetime import datetime, timezone
 
 import pytest
 
@@ -63,9 +64,9 @@ class TestHeartbeat:
 
         rows = db_query(
             integration_env.db_dsn,
-            """SELECT files_uploaded_since_last_heartbeat,
-                      runs_reported_since_last_heartbeat,
-                      errors_since_last_heartbeat,
+            """SELECT files_uploaded_since_last,
+                      runs_reported_since_last,
+                      errors_since_last,
                       uptime_seconds,
                       upload_mode
                FROM watcher_heartbeats
@@ -122,11 +123,20 @@ class TestEvents:
         integration_env: IntegrationEnv,
     ) -> None:
         watcher = client.register_watcher(instrument_id)
+        now = datetime.now(timezone.utc).isoformat()
         result = client.send_events(
             watcher.watcher_id,
             [
-                {"event_type": "watcher_started", "message": "Watcher started on LAB-PC-01"},
-                {"event_type": "run_detected", "message": "Detected run EXP-001"},
+                {
+                    "event_type": "watcher_started",
+                    "timestamp": now,
+                    "message": "Watcher started on LAB-PC-01",
+                },
+                {
+                    "event_type": "run_reported",
+                    "timestamp": now,
+                    "message": "Detected run EXP-001",
+                },
             ],
         )
         assert result.received == 2
@@ -139,7 +149,7 @@ class TestEvents:
         )
         assert len(rows) == 2
         assert rows[0][0] == "watcher_started"
-        assert rows[1][0] == "run_detected"
+        assert rows[1][0] == "run_reported"
 
     def test_send_events_watcher_started_and_stopped(
         self,
@@ -148,13 +158,14 @@ class TestEvents:
         integration_env: IntegrationEnv,
     ) -> None:
         watcher = client.register_watcher(instrument_id)
+        now = datetime.now(timezone.utc).isoformat()
         client.send_events(
             watcher.watcher_id,
-            [{"event_type": "watcher_started", "message": "Started"}],
+            [{"event_type": "watcher_started", "timestamp": now, "message": "Started"}],
         )
         client.send_events(
             watcher.watcher_id,
-            [{"event_type": "watcher_stopped", "message": "Stopped"}],
+            [{"event_type": "watcher_stopped", "timestamp": now, "message": "Stopped"}],
         )
 
         rows = db_query(
@@ -166,10 +177,11 @@ class TestEvents:
 
     def test_send_events_invalid_type_400(self, client: DataHubClient, instrument_id: str) -> None:
         watcher = client.register_watcher(instrument_id)
+        now = datetime.now(timezone.utc).isoformat()
         with pytest.raises(ApiError) as exc_info:
             client.send_events(
                 watcher.watcher_id,
-                [{"event_type": "bogus", "message": "bad event"}],
+                [{"event_type": "bogus", "timestamp": now, "message": "bad event"}],
             )
         assert exc_info.value.status_code == 400
 

--- a/watcher/tests/test_instrument_lifecycle.py
+++ b/watcher/tests/test_instrument_lifecycle.py
@@ -1,0 +1,54 @@
+"""Integration tests: instrument management endpoints used during `data-hub-watcher init`.
+
+Tests list, create, get-detail, duplicate conflict, and not-found flows
+that the watcher CLI exercises when setting up a new instrument.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from data_hub_watcher.api_client import ApiError, DataHubClient
+
+pytestmark = pytest.mark.integration
+
+
+class TestListInstruments:
+    def test_list_instruments(self, client: DataHubClient, instrument_id: str) -> None:
+        instruments = client.list_instruments()
+        ids = [inst.id for inst in instruments]
+        assert instrument_id in ids
+
+
+class TestCreateInstrument:
+    def test_create_instrument(self, client: DataHubClient) -> None:
+        result = client.create_instrument("new-test-instrument")
+        assert result.id == "new-test-instrument"
+        assert result.status == "pending"
+        assert result.display_name  # auto-generated, non-empty
+
+    def test_create_instrument_with_display_name(self, client: DataHubClient) -> None:
+        result = client.create_instrument("named-instrument", display_name="My Custom Name")
+        assert result.id == "named-instrument"
+        assert result.display_name == "My Custom Name"
+
+    def test_create_instrument_duplicate_409(
+        self, client: DataHubClient, instrument_id: str
+    ) -> None:
+        with pytest.raises(ApiError) as exc_info:
+            client.create_instrument(instrument_id)
+        assert exc_info.value.status_code == 409
+
+
+class TestGetInstrumentDetail:
+    def test_get_instrument_detail(self, client: DataHubClient, instrument_id: str) -> None:
+        detail = client.get_instrument(instrument_id)
+        assert detail.id == instrument_id
+        assert detail.display_name == "Contract Test Instrument"
+        assert detail.run_count == 0
+        assert detail.watcher_count == 0
+
+    def test_get_instrument_not_found_404(self, client: DataHubClient) -> None:
+        with pytest.raises(ApiError) as exc_info:
+            client.get_instrument("nonexistent-instrument")
+        assert exc_info.value.status_code == 404

--- a/watcher/tests/test_manual_upload_flow.py
+++ b/watcher/tests/test_manual_upload_flow.py
@@ -1,0 +1,169 @@
+"""Integration tests: manual-upload flow.
+
+Mirrors the manual-upload mode where scientists review files before
+uploading:
+
+    report_run (files detected) -> admin sets upload_requested_at (via DB)
+      -> poll upload queue -> mark_file_uploaded -> poll again (empty)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from data_hub_shared.testing import IntegrationEnv, db_query, db_update
+from data_hub_watcher.api_client import DataHubClient
+
+pytestmark = pytest.mark.integration
+
+
+def _setup_run_with_file(
+    client: DataHubClient,
+    instrument_id: str,
+    *,
+    run_id: str = "MANUAL-001",
+    filename: str = "data.csv",
+) -> str:
+    """Register watcher, report run with one file, return watcher_id."""
+    watcher = client.register_watcher(instrument_id)
+    client.report_run(
+        instrument_id,
+        {
+            "run_id": run_id,
+            "source": "watcher",
+            "watcher_id": watcher.watcher_id,
+            "detected_files": [
+                {"filename": filename, "relative_path": f"{run_id}/{filename}"},
+            ],
+        },
+    )
+    return watcher.watcher_id
+
+
+def _get_file_id(dsn: str, run_id: str, filename: str) -> int:
+    rows = db_query(
+        dsn,
+        """SELECT f.id FROM files f
+           JOIN instrument_runs r ON f.instrument_run_id = r.id
+           WHERE r.run_id = %s AND f.filename = %s""",
+        (run_id, filename),
+    )
+    assert rows, f"No file found for run={run_id}, filename={filename}"
+    file_id = rows[0][0]
+    assert isinstance(file_id, int)
+    return file_id
+
+
+class TestManualUploadQueue:
+    def test_detected_files_not_in_upload_queue(
+        self, client: DataHubClient, instrument_id: str
+    ) -> None:
+        watcher_id = _setup_run_with_file(client, instrument_id)
+        queue = client.get_upload_queue(watcher_id)
+        assert queue.files == []
+
+    def test_upload_requested_file_appears_in_queue(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher_id = _setup_run_with_file(client, instrument_id)
+        file_id = _get_file_id(integration_env.db_dsn, "MANUAL-001", "data.csv")
+
+        db_update(
+            integration_env.db_dsn,
+            "UPDATE files SET upload_requested_at = NOW(),"
+            " status = 'upload_requested' WHERE id = %s",
+            (file_id,),
+        )
+
+        queue = client.get_upload_queue(watcher_id)
+        assert len(queue.files) == 1
+        f = queue.files[0]
+        assert f.id == file_id
+        assert f.instrument_id == instrument_id
+        assert f.run_id == "MANUAL-001"
+        assert f.filename == "data.csv"
+
+    def test_uploaded_file_leaves_queue(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher_id = _setup_run_with_file(client, instrument_id)
+        file_id = _get_file_id(integration_env.db_dsn, "MANUAL-001", "data.csv")
+
+        db_update(
+            integration_env.db_dsn,
+            "UPDATE files SET upload_requested_at = NOW(),"
+            " status = 'upload_requested' WHERE id = %s",
+            (file_id,),
+        )
+
+        client.mark_file_uploaded(
+            file_id,
+            {
+                "s3_bucket": "test-bucket",
+                "s3_key": f"{instrument_id}/MANUAL-001/data.csv",
+                "content_type": "text/csv",
+                "status": "uploaded",
+            },
+        )
+
+        queue = client.get_upload_queue(watcher_id)
+        assert queue.files == []
+
+    def test_queue_excludes_deleted_files(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher_id = _setup_run_with_file(client, instrument_id)
+        file_id = _get_file_id(integration_env.db_dsn, "MANUAL-001", "data.csv")
+
+        db_update(
+            integration_env.db_dsn,
+            "UPDATE files SET upload_requested_at = NOW(),"
+            " status = 'upload_requested' WHERE id = %s",
+            (file_id,),
+        )
+        db_update(
+            integration_env.db_dsn,
+            "UPDATE files SET deleted_at = NOW() WHERE id = %s",
+            (file_id,),
+        )
+
+        queue = client.get_upload_queue(watcher_id)
+        assert queue.files == []
+
+    def test_queue_scoped_to_watcher_instrument(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        other_inst = "other-manual-instrument"
+        client.create_instrument(other_inst, display_name="Other Instrument")
+
+        watcher_a = _setup_run_with_file(client, instrument_id, run_id="RUN-A", filename="a.csv")
+        watcher_b = _setup_run_with_file(client, other_inst, run_id="RUN-B", filename="b.csv")
+
+        file_a = _get_file_id(integration_env.db_dsn, "RUN-A", "a.csv")
+        file_b = _get_file_id(integration_env.db_dsn, "RUN-B", "b.csv")
+
+        for fid in (file_a, file_b):
+            db_update(
+                integration_env.db_dsn,
+                "UPDATE files SET upload_requested_at = NOW(), status = 'upload_requested'"
+                " WHERE id = %s",
+                (fid,),
+            )
+
+        queue_a = client.get_upload_queue(watcher_a)
+        queue_b = client.get_upload_queue(watcher_b)
+
+        assert {f.filename for f in queue_a.files} == {"a.csv"}
+        assert {f.filename for f in queue_b.files} == {"b.csv"}

--- a/watcher/tests/test_watcher_registration.py
+++ b/watcher/tests/test_watcher_registration.py
@@ -1,0 +1,111 @@
+"""Integration tests: watcher registration and config management.
+
+Tests the `data-hub-watcher init` and startup flows — registering a watcher
+against an instrument, pushing YAML config, and verifying checksum round-trips.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from data_hub_shared.testing import IntegrationEnv, db_query, db_update
+from data_hub_watcher.api_client import ApiError, DataHubClient
+
+pytestmark = pytest.mark.integration
+
+
+# ------------------------------------------------------------------
+# Registration
+# ------------------------------------------------------------------
+
+
+class TestRegisterWatcher:
+    def test_register_watcher(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        result = client.register_watcher(instrument_id, hostname="LAB-PC-01", os_info="Windows 11")
+        assert result.watcher_id
+
+        rows = db_query(
+            integration_env.db_dsn,
+            "SELECT status FROM watchers WHERE id = %s",
+            (result.watcher_id,),
+        )
+        assert rows[0][0] == "registered"
+
+    def test_register_watcher_unknown_instrument_404(self, client: DataHubClient) -> None:
+        with pytest.raises(ApiError) as exc_info:
+            client.register_watcher("nonexistent-instrument")
+        assert exc_info.value.status_code == 404
+
+    def test_register_watcher_inactive_instrument_400(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        db_update(
+            integration_env.db_dsn,
+            "UPDATE instruments SET status = 'inactive' WHERE id = %s",
+            (instrument_id,),
+        )
+        try:
+            with pytest.raises(ApiError) as exc_info:
+                client.register_watcher(instrument_id)
+            assert exc_info.value.status_code == 400
+        finally:
+            db_update(
+                integration_env.db_dsn,
+                "UPDATE instruments SET status = 'active' WHERE id = %s",
+                (instrument_id,),
+            )
+
+    def test_register_watcher_increments_watcher_count(
+        self, client: DataHubClient, instrument_id: str
+    ) -> None:
+        client.register_watcher(instrument_id, hostname="LAB-PC-01")
+        detail = client.get_instrument(instrument_id)
+        assert detail.watcher_count == 1
+
+
+# ------------------------------------------------------------------
+# Config push / checksum
+# ------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_push_config(self, client: DataHubClient, instrument_id: str) -> None:
+        watcher = client.register_watcher(instrument_id)
+        result = client.push_config(
+            watcher.watcher_id,
+            config_yaml="version: 1\nenvironment: staging\n",
+            checksum="abc123",
+        )
+        assert result.config_checksum == "abc123"
+
+    def test_get_config_checksum_round_trip(
+        self, client: DataHubClient, instrument_id: str
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        client.push_config(watcher.watcher_id, config_yaml="v: 1", checksum="round-trip-hash")
+        result = client.get_config_checksum(watcher.watcher_id)
+        assert result is not None
+        assert result.config_checksum == "round-trip-hash"
+
+    def test_push_config_overwrite(self, client: DataHubClient, instrument_id: str) -> None:
+        watcher = client.register_watcher(instrument_id)
+        client.push_config(watcher.watcher_id, config_yaml="old: true", checksum="old-hash")
+        client.push_config(watcher.watcher_id, config_yaml="new: true", checksum="new-hash")
+        result = client.get_config_checksum(watcher.watcher_id)
+        assert result is not None
+        assert result.config_checksum == "new-hash"
+
+    def test_get_config_checksum_before_push_returns_none(
+        self, client: DataHubClient, instrument_id: str
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        result = client.get_config_checksum(watcher.watcher_id)
+        assert result is None


### PR DESCRIPTION
## Summary

- Extracts server lifecycle, auth seeding, and DB helpers from the lambda integration conftest into a shared `data_hub_shared.testing` module so both Lambda and Watcher test suites reuse identical infrastructure.
- Adds 6 new integration test modules (44 tests) for the watcher's `DataHubClient`, organized by real-world operational flows: instrument lifecycle, watcher registration, heartbeats/events, auto-upload, manual-upload, and error paths.
- Removes the unused `RunFileResponse` model and `files` field from `RunResponse` to align with the actual API contract (POST /runs never returns files).

## Changes

- **`packages/shared/src/data_hub_shared/testing.py`** (new) — Shared integration-test infrastructure: `IntegrationEnv` dataclass, `start_test_server()` context manager (DB creation, schema push, Next.js build/start, auth seeding, teardown), `seed_instruments()`, `truncate_tables()`, `db_query()`, `db_update()`, and token/port helpers.
- **`lambda/tests/integration/conftest.py`** — Replaced ~200 lines of inline helpers with imports from `data_hub_shared.testing`. Lambda-specific fixtures (S3 mocks, Slack mock, singleton reset, mock context) remain in-place.
- **`lambda/tests/integration/test_lambda_api.py`** — Updated `IntegrationEnv` import path from `integration.conftest` to `data_hub_shared.testing`.
- **`watcher/tests/conftest.py`** (new) — Session-scoped server fixture, `DataHubClient` fixture, instrument seeding, and per-test watcher table truncation.
- **`watcher/tests/test_instrument_lifecycle.py`** (new) — Tests for list, create, get-detail, duplicate 409, not-found 404.
- **`watcher/tests/test_watcher_registration.py`** (new) — Tests for register, unknown instrument 404, inactive instrument 400, watcher count increment, config push/overwrite/checksum round-trip.
- **`watcher/tests/test_heartbeat_and_events.py`** (new) — Tests for heartbeat status transitions, counter persistence, deleted watcher 404, event batches, invalid type 400, empty list 400.
- **`watcher/tests/test_auto_upload_flow.py`** (new) — Tests for report_run (source, files, idempotency), update_run, mark_file_uploaded, and a full register-through-stopped E2E lifecycle.
- **`watcher/tests/test_manual_upload_flow.py`** (new) — Tests for upload queue: detected files excluded, upload_requested appears, uploaded leaves queue, deleted files excluded, queue scoped to instrument.
- **`watcher/tests/test_error_paths.py`** (new) — Consolidated 404/400/409 error cases across all major endpoints.
- **`watcher/src/data_hub_watcher/models.py`** — Removed `RunFileResponse` and `files` field from `RunResponse` (API never returns files in this response).
- **`watcher/src/data_hub_watcher/run_detector.py`** — Removed dead `file_id_by_name` mapping logic that depended on the removed `files` field.
- **`pyproject.toml`** — Updated integration marker description; added matplotlib deprecation warning filter.

## Breaking changes

- `RunResponse.files` field is removed from the watcher's Pydantic model. Any code that accessed `response.files` after calling `report_run()` will need updating. The field was always empty in practice (the API never populated it), so this is unlikely to affect real usage.
- `IntegrationEnv` no longer has a `tmp_data_dir` field — lambda conftest creates this locally now. Any test code importing `IntegrationEnv` and accessing `.tmp_data_dir` would need to be updated (only the lambda conftest used it).

## Driveby changes

- Removed several redundant inline comments from the lambda conftest (`_fake_download`, `_reset_singletons`, etc.).
- Added `filterwarnings = ["ignore::DeprecationWarning:matplotlib"]` to `pyproject.toml` to suppress noisy matplotlib deprecation warnings during test runs.

## Testing

- [x] `make py-test-integration` passes — picks up all 6 new watcher test modules plus existing lambda tests via the `integration` marker
- [x] `make check-all` passes (formatting, lint, type checks)
- [x] Existing lambda integration tests still pass after the conftest refactoring
- [x] CI `python-integration-tests` job passes (no workflow changes needed — existing job already runs `make py-test-integration` with Postgres + Node + Python)