### PR TITLE
Add project documentation and user guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,74 @@
 # Data Hub
+
+Data Hub is a platform for automatically ingesting, processing, and visualizing data from laboratory instruments. Lab instrument PCs run a **watcher** agent that uploads raw files to S3, an AWS **Lambda** function processes them through instrument-specific pipelines, and a **Next.js** web application provides a dashboard and REST API backed by PostgreSQL.
+
+```mermaid
+flowchart LR
+    W[Watcher] -->|raw files| S3[S3]
+    S3 -->|trigger| L[Lambda]
+    W -->|heartbeats, runs| API[API]
+    L -->|results| API
+    API --> DB[(PostgreSQL)]
+    API --> UI[Web app]
+```
+
+## Repository structure
+
+| Directory | Description | Docs |
+| --- | --- | --- |
+| `web-app/` | Next.js web application and REST API (Vercel) | [API reference](docs/api.md) |
+| `lambda/` | AWS Lambda function for instrument data processing | [Lambda docs](docs/lambda.md) |
+| `watcher/` | CLI agent for lab instrument PCs | [Watcher docs](docs/watcher.md) |
+| `packages/shared/` | Shared Python library (S3, enums, Slack, test infra) | [Shared library](docs/shared-library.md) |
+| `docs/` | Project documentation | — |
+
+## Quick start
+
+```sh
+# Install Python packages (all workspace members).
+uv sync --all-packages
+
+# Install web app dependencies.
+cd web-app && npm install && cd ..
+
+# Set up environment variables for the web app.
+cd web-app && vercel env pull && cd ..
+
+# Create and initialize the local database.
+cd web-app && createdb data-hub-local && npm run db:push && cd ..
+
+# Start the dev server.
+make dev
+```
+
+See the full [Getting Started guide](docs/getting-started.md) for prerequisites and details.
+
+## Documentation
+
+- [Architecture](docs/architecture.md) — system overview, data flow, and design decisions
+- [Getting started](docs/getting-started.md) — development setup, environment variables, running locally
+- [Watcher](docs/watcher.md) — CLI commands, configuration, run detection, upload modes
+- [Lambda](docs/lambda.md) — processing pipeline, supported instruments, adding new instruments
+- [REST API](docs/api.md) — endpoint reference and authentication
+- [Shared library](docs/shared-library.md) — module reference for `data-hub-shared`
+- [CI and deployment](docs/ci-and-deployment.md) — GitHub Actions, Vercel, Render, Lambda deployment
+- [Conventions](docs/conventions.md) — S3 key layout, instrument IDs, code style, environments
+
+## Development
+
+```sh
+# Run formatting, linting, and type checking.
+make check-all
+
+# Run all Python tests.
+make py-test
+
+# Run Python unit tests only.
+make py-test-unit
+
+# Run Python integration tests (requires Postgres).
+make py-test-integration
+
+# Run API integration tests (requires Postgres).
+make fe-test-integration
+```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ See the full [Getting Started guide](docs/getting-started.md) for prerequisites 
 
 ## Documentation
 
+### Guides
+
+- [Adding an instrument](docs/guides/adding-an-instrument.md) — end-to-end: watcher setup, activation, optional Lambda preprocessing
+- [Installing a watcher](docs/guides/installing-a-watcher.md) — lab operator focused: init, watch, troubleshooting
+- [Managing tokens](docs/guides/managing-tokens.md) — creating, using, and revoking API tokens
+
+### Reference
+
 - [Architecture](docs/architecture.md) — system overview, data flow, and design decisions
 - [Getting started](docs/getting-started.md) — development setup, environment variables, running locally
 - [Watcher](docs/watcher.md) — CLI commands, configuration, run detection, upload modes

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,85 @@
+# REST API
+
+The Data Hub API is served by the Next.js web application at `/api/v1/`. It is used by the watcher, the Lambda function, and the web dashboard.
+
+## Authentication
+
+The API supports two authentication methods:
+
+- **Session cookies** — used by the web dashboard (Google OAuth via NextAuth).
+- **Bearer tokens** — used by the watcher and Lambda. Tokens are created in the web dashboard under personal access tokens and sent in the `Authorization: Bearer <token>` header.
+
+Tokens are hashed with SHA-256 before storage. The plaintext token is shown once at creation time.
+
+## Endpoints
+
+### Instruments
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/v1/instruments` | List all instruments |
+| `POST` | `/api/v1/instruments` | Create a new instrument |
+| `GET` | `/api/v1/instruments/:instrumentId` | Get instrument details (includes run and watcher counts) |
+
+### Runs
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/v1/instruments/:instrumentId/runs` | List runs for an instrument |
+| `POST` | `/api/v1/instruments/:instrumentId/runs` | Create a new run |
+| `GET` | `/api/v1/instruments/:instrumentId/runs/:runId` | Get run details |
+| `PATCH` | `/api/v1/instruments/:instrumentId/runs/:runId` | Update a run |
+| `DELETE` | `/api/v1/instruments/:instrumentId/runs/:runId` | Soft-delete a run |
+| `POST` | `/api/v1/instruments/:instrumentId/runs/:runId/restore` | Restore a soft-deleted run |
+| `GET` | `/api/v1/instrument-runs` | List runs across all instruments |
+
+### Files
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/api/v1/instruments/:instrumentId/runs/:runId/files` | Create a file record |
+| `GET` | `/api/v1/files/:fileId` | Get file details |
+| `PATCH` | `/api/v1/files/:fileId` | Update file metadata |
+| `GET` | `/api/v1/files/:fileId/download` | Get a pre-signed S3 download URL |
+| `POST` | `/api/v1/instruments/:instrumentId/runs/:runId/request-upload` | Request file upload (manual mode) |
+
+### Analyses
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/api/v1/instruments/:instrumentId/runs/:runId/analyses` | Create an analysis record |
+
+### Watchers
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/v1/watchers` | List all watchers |
+| `POST` | `/api/v1/watchers/register` | Register a new watcher |
+| `GET` | `/api/v1/watchers/:watcherId` | Get watcher details |
+| `POST` | `/api/v1/watchers/:watcherId/heartbeat` | Send a heartbeat |
+| `GET` | `/api/v1/watchers/:watcherId/heartbeats` | Get heartbeat history |
+| `POST` | `/api/v1/watchers/:watcherId/events` | Submit watcher events |
+| `GET` | `/api/v1/watchers/:watcherId/config` | Get synced config YAML |
+| `PUT` | `/api/v1/watchers/:watcherId/config` | Push config YAML and checksum |
+| `GET` | `/api/v1/watchers/:watcherId/config-checksum` | Get the config checksum |
+| `GET` | `/api/v1/watchers/:watcherId/upload-queue` | Get pending upload queue |
+
+### Tokens
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/v1/tokens` | List personal access tokens |
+| `POST` | `/api/v1/tokens` | Create a new token |
+| `DELETE` | `/api/v1/tokens/:id` | Revoke a token |
+
+## Error responses
+
+Errors follow a consistent shape:
+
+```json
+{
+  "code": "NOT_FOUND",
+  "message": "Instrument not found.",
+  "details": null
+}
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,39 +6,19 @@ Data Hub is a platform for automatically ingesting, processing, and visualizing 
 
 ```mermaid
 flowchart LR
-    subgraph Lab["Lab instrument PCs"]
-        W["Watcher (CLI agent)"]
-    end
-
-    subgraph AWS
-        S3["S3 bucket"]
-        L["Lambda"]
-    end
-
-    subgraph Vercel
-        API["Next.js API"]
-        UI["Web dashboard"]
-        DB[(PostgreSQL)]
-    end
-
-    Slack["Slack"]
-
-    W -- "upload raw files" --> S3
-    W -- "heartbeats, events, runs" --> API
-    S3 -- "trigger" --> L
-    L -- "download raw files" --> S3
-    L -- "create runs, upload results" --> API
-    L -- "success/failure alerts" --> Slack
-    API --> DB
-    UI --> API
-    UI --> DB
+    W[Watcher] -->|raw files| S3[S3]
+    S3 -->|trigger| L[Lambda]
+    W -->|heartbeats, runs| API[API]
+    L -->|results| API
+    API --> DB[(PostgreSQL)]
+    API --> UI[Web app]
 ```
 
 ## Components
 
 | Directory | Package | Description |
 | --- | --- | --- |
-| `web-app/` | — | Next.js web application and REST API. Deployed on Vercel. |
+| `web-app/` | `data-hub-web-app` | Next.js web application and REST API. Deployed on Vercel. |
 | `lambda/` | `data-hub-lambda` | AWS Lambda function triggered by S3 uploads. Runs instrument-specific processing pipelines. |
 | `watcher/` | `data-hub-watcher` | CLI agent installed on lab instrument PCs. Detects new files, uploads them to S3, and reports status to the API. |
 | `packages/shared/` | `data-hub-shared` | Shared Python library providing S3 utilities, instrument enums, Slack integration, and test infrastructure. |
@@ -52,9 +32,9 @@ flowchart LR
 3. It groups files into runs (by filename prefix or subdirectory) and reports each run to the **API**.
 4. It uploads raw files to **S3** at the key `{instrument_id}/{run_id}/{filename}`.
 5. The S3 upload triggers the **Lambda** function.
-6. Lambda downloads the file, dispatches to the appropriate instrument processor, and generates a report.
+6. Lambda downloads the file and dispatches to the appropriate instrument processor for preprocessing (e.g., extracting metadata).
 7. Lambda creates/updates the run and files via the **API** and sends a **Slack** notification.
-8. Users view results in the **web dashboard**.
+8. Users view the run in the **web dashboard**.
 
 ### Manual upload (manual mode)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,72 @@
+# Architecture
+
+Data Hub is a platform for automatically ingesting, processing, and visualizing data from laboratory instruments. It is structured as a monorepo with four components that work together through S3, a REST API, and a shared Python library.
+
+## System overview
+
+```mermaid
+flowchart LR
+    subgraph Lab["Lab instrument PCs"]
+        W["Watcher (CLI agent)"]
+    end
+
+    subgraph AWS
+        S3["S3 bucket"]
+        L["Lambda"]
+    end
+
+    subgraph Vercel
+        API["Next.js API"]
+        UI["Web dashboard"]
+        DB[(PostgreSQL)]
+    end
+
+    Slack["Slack"]
+
+    W -- "upload raw files" --> S3
+    W -- "heartbeats, events, runs" --> API
+    S3 -- "trigger" --> L
+    L -- "download raw files" --> S3
+    L -- "create runs, upload results" --> API
+    L -- "success/failure alerts" --> Slack
+    API --> DB
+    UI --> API
+    UI --> DB
+```
+
+## Components
+
+| Directory | Package | Description |
+| --- | --- | --- |
+| `web-app/` | — | Next.js web application and REST API. Deployed on Vercel. |
+| `lambda/` | `data-hub-lambda` | AWS Lambda function triggered by S3 uploads. Runs instrument-specific processing pipelines. |
+| `watcher/` | `data-hub-watcher` | CLI agent installed on lab instrument PCs. Detects new files, uploads them to S3, and reports status to the API. |
+| `packages/shared/` | `data-hub-shared` | Shared Python library providing S3 utilities, instrument enums, Slack integration, and test infrastructure. |
+
+## Data flow
+
+### Automatic upload (auto mode)
+
+1. A lab instrument writes output files to a watched directory.
+2. The **watcher** detects new stable files using filesystem events (`watchdog`).
+3. It groups files into runs (by filename prefix or subdirectory) and reports each run to the **API**.
+4. It uploads raw files to **S3** at the key `{instrument_id}/{run_id}/{filename}`.
+5. The S3 upload triggers the **Lambda** function.
+6. Lambda downloads the file, dispatches to the appropriate instrument processor, and generates a report.
+7. Lambda creates/updates the run and files via the **API** and sends a **Slack** notification.
+8. Users view results in the **web dashboard**.
+
+### Manual upload (manual mode)
+
+Steps 1–3 are the same, but the watcher does not upload immediately. Instead:
+
+4. The server adds files to an upload queue.
+5. On each heartbeat tick, the watcher polls the upload queue and uploads requested files.
+6. Steps 5–8 from automatic mode follow.
+
+## Key design decisions
+
+- **S3 as the integration boundary.** The watcher and Lambda never communicate directly. S3 acts as a durable hand-off point: the watcher writes, Lambda reads.
+- **API-driven coordination.** The watcher registers with the API, syncs its YAML config, and sends periodic heartbeats. This lets the web dashboard show watcher health and manage upload queues.
+- **Shared library for contracts.** Instrument IDs, S3 utilities, and environment config live in `data-hub-shared` so they stay consistent across Lambda and the watcher without duplicating code.
+- **Integration tests against a real server.** The shared `testing.py` module spins up a real Next.js server backed by a Postgres database, so Lambda and watcher integration tests exercise the actual API surface.

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -1,0 +1,105 @@
+# CI and deployment
+
+## GitHub Actions
+
+Two workflows run on pushes to `staging`/`production` and on pull requests targeting those branches.
+
+### Lint and typecheck (`lint-and-typecheck.yml`)
+
+Runs formatting, linting, and type checking for both Python and the web app in parallel.
+
+**Python job:**
+1. Install dependencies with `uv sync --all-packages`.
+2. `make py-lint` — Ruff linter and format check.
+3. `make py-typecheck` — Pyright.
+
+**Web app job:**
+1. Install dependencies with `npm ci`.
+2. `npm run format:check` — Prettier.
+3. `npm run lint` — ESLint.
+4. `npm run typecheck` — TypeScript compiler.
+
+### Tests (`test.yml`)
+
+Runs three test jobs in parallel.
+
+**Python unit tests:**
+- `make py-test-unit` — runs all pytest tests not marked `integration`.
+
+**Python integration tests:**
+- Starts a Postgres 17 service container.
+- Installs both Node.js 24 and Python packages.
+- `make py-test-integration` — runs pytest tests marked `integration`. These build and start a real Next.js production server, seed a test database, and exercise the Lambda and watcher against the live API.
+
+**API integration tests:**
+- Same Postgres + Node.js setup as above.
+- `make fe-test-integration` — runs Vitest integration tests in the web app that test the API routes.
+
+## Branch strategy
+
+| Branch | Purpose |
+| --- | --- |
+| `staging` | Pre-production environment. PRs are merged here first. |
+| `production` | Live environment. Changes are promoted from `staging`. |
+
+Feature branches target `staging` via pull requests. CI runs on every PR and on merges to both branches.
+
+## Deployment
+
+### Web application (Vercel)
+
+The Next.js app is deployed on [Vercel](https://vercel.com/arcadia-science/data-hub). Every branch and commit generates a preview deployment. Merges to `staging` and `production` deploy to their respective environments automatically.
+
+Environment variables are managed in the Vercel dashboard and can be pulled locally with:
+
+```sh
+cd web-app
+vercel env pull
+```
+
+### Database (Render)
+
+Staging and production each have a dedicated PostgreSQL instance hosted on [Render](https://dashboard.render.com/project/prj-d75d0jma2pns738r4110).
+
+Schema changes are applied with Drizzle:
+
+```sh
+cd web-app
+
+# Generate migration files from schema changes.
+npm run db:generate
+
+# Apply migrations.
+npm run db:migrate
+
+# Or push directly (skips migration files).
+npm run db:push
+```
+
+### Lambda (AWS)
+
+The Lambda function is deployed as a Docker container image.
+
+```sh
+# Build the container image.
+make docker-build
+```
+
+This requires a `GH_PERSONAL_ACCESS_TOKEN` in your `.env` file (for a private Git dependency). The image is built from `lambda/Dockerfile` and uses the `public.ecr.aws/lambda/python:3.12` base image.
+
+Deployment to AWS (pushing to ECR and updating the Lambda function) is handled outside this repository.
+
+## Running checks locally
+
+Always run the full check suite before pushing:
+
+```sh
+make check-all
+```
+
+This is equivalent to:
+
+```sh
+make py-check    # py-format + py-lint + py-typecheck
+make fe-check    # fe-format + fe-lint + fe-typecheck
+```

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -63,7 +63,7 @@ Run `make check-all` before pushing. CI enforces the same checks.
 
 | Environment | API URL | S3 bucket |
 | --- | --- | --- |
-| Staging | `https://data-hub-staging.arcadiascience.com/api/v1` | `arcadia-raw-data-hub-staging` |
+| Staging | `https://data-hub-env-staging-arcadia-science.vercel.app/api/v1` | `arcadia-raw-data-hub-staging` |
 | Production | `https://data-hub.arcadiascience.com/api/v1` | `arcadia-raw-data-hub-production` |
 
 ## Testing

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,74 @@
+# Conventions
+
+Team agreements and standards for the Data Hub codebase.
+
+## S3 key layout
+
+All raw data files are stored in S3 with the key pattern:
+
+```
+{instrument_id}/{run_id}/{filename}
+```
+
+- **`instrument_id`** — kebab-case identifier matching the `Instrument` enum (e.g., `akta-fplc`).
+- **`run_id`** — unique identifier for the run, either extracted from the filename prefix or from a subdirectory name.
+- **`filename`** — the original filename.
+
+The S3 bucket name follows the template `arcadia-raw-data-hub-{environment}`, where `environment` is `staging` or `production`.
+
+## Instrument IDs
+
+Instrument IDs are kebab-case strings (lowercase letters, numbers, hyphens). They serve as:
+
+- S3 key prefixes
+- API resource identifiers
+- Enum values in `data_hub_shared.enums.Instrument`
+
+When adding a new instrument, the ID must be registered in three places:
+
+1. `Instrument` enum in `packages/shared/src/data_hub_shared/enums.py`
+2. `INSTRUMENT_ID_TO_NAME_MAP` in `packages/shared/src/data_hub_shared/constants.py`
+3. Dispatch logic in `lambda/src/data_hub_lambda/handler.py`
+
+## Environment variables
+
+Environment-specific configuration is managed through environment variables, never hard-coded. Each component has its own set:
+
+- **Web app** — managed in Vercel, pulled with `vercel env pull`. See [getting started](getting-started.md#web-application).
+- **Lambda** — set in the AWS Lambda runtime configuration. See [getting started](getting-started.md#lambda--shared-library).
+- **Watcher** — configured via YAML file, not environment variables (except `DATA_HUB_API_KEY` and `DATA_HUB_CONFIG_PATH`).
+
+## Code style
+
+### Python
+
+- Formatter and linter: [Ruff](https://docs.astral.sh/ruff/)
+- Type checker: [Pyright](https://github.com/microsoft/pyright)
+- Line length: 100
+- Quote style: double quotes
+- Import sorting: isort-compatible via Ruff, ordered by type
+- Lint rules enabled: `B` (bugbear), `E` (pycodestyle errors), `F` (pyflakes), `I` (isort), `UP` (pyupgrade), `W` (pycodestyle warnings)
+
+### TypeScript / JavaScript
+
+- Formatter: [Prettier](https://prettier.io/)
+- Linter: [ESLint](https://eslint.org/)
+- Type checker: TypeScript compiler (`tsc`)
+
+### Pre-commit
+
+Run `make check-all` before pushing. CI enforces the same checks.
+
+## Environments
+
+| Environment | API URL | S3 bucket |
+| --- | --- | --- |
+| Staging | `https://data-hub-staging.arcadiascience.com/api/v1` | `arcadia-raw-data-hub-staging` |
+| Production | `https://data-hub.arcadiascience.com/api/v1` | `arcadia-raw-data-hub-production` |
+
+## Testing
+
+- Tests are co-located with each package: `lambda/tests/`, `watcher/tests/`, `packages/shared/tests/`.
+- Integration tests are marked with `@pytest.mark.integration` and require Postgres + a running Next.js server.
+- The shared `testing.py` module provides the `start_test_server()` context manager that handles all setup and teardown.
+- Unit tests should not require any external services.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,7 +47,7 @@ vercel env pull
 
 ### Lambda / shared library
 
-These are set in the Lambda runtime environment and are only needed locally for integration tests:
+These are set in the Lambda runtime environment:
 
 | Variable | Required | Purpose |
 | --- | --- | --- |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,134 @@
+# Getting started
+
+This guide walks through setting up the full Data Hub development environment.
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+| --- | --- | --- |
+| Python | >= 3.12 | Lambda, watcher, shared library |
+| [uv](https://docs.astral.sh/uv/) | latest | Python package manager and workspace orchestrator |
+| Node.js | >= 22 | Web application |
+| PostgreSQL | >= 15 | Database (local development) |
+| Docker | latest | Lambda container builds |
+
+## Clone and install
+
+```sh
+git clone <repo-url>
+cd data-hub
+
+# Install all Python packages across the workspace.
+uv sync --all-packages
+
+# Install web app dependencies.
+cd web-app && npm install && cd ..
+```
+
+The Python workspace is managed by uv. The root `pyproject.toml` defines three workspace members — `lambda`, `watcher`, and `packages/shared` — and all are installed together by `uv sync --all-packages`.
+
+## Environment variables
+
+### Web application
+
+The web app requires the following variables. The easiest way to get them is via the Vercel CLI:
+
+```sh
+cd web-app
+vercel env pull
+```
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `DATABASE_URL` | Yes | PostgreSQL connection string |
+| `AUTH_GOOGLE_ID` | Yes | Google OAuth client ID |
+| `AUTH_GOOGLE_SECRET` | Yes | Google OAuth client secret |
+| `AUTH_SECRET` | Yes | NextAuth session encryption key |
+
+### Lambda / shared library
+
+These are set in the Lambda runtime environment and are only needed locally for integration tests:
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `AWS_REGION` | No | AWS region (defaults to `us-east-1`) |
+| `AWS_ACCESS_KEY_ID` | No | AWS credentials |
+| `AWS_SECRET_ACCESS_KEY` | No | AWS credentials |
+| `AWS_S3_RAW_DATA_BUCKET` | No | S3 bucket for raw data |
+| `AWS_S3_PROCESSED_DATA_BUCKET` | No | S3 bucket for processed data |
+| `SLACK_WEBHOOK_URL` | No | Slack webhook for notifications |
+
+### Watcher
+
+The watcher reads its configuration from a YAML file at `~/.data-hub/config.yaml`. See the [watcher docs](watcher.md) for details. The only environment variable it uses is `DATA_HUB_API_KEY` (optional, can also be provided interactively during `init`).
+
+## Database setup
+
+```sh
+cd web-app
+
+# Create a local PostgreSQL database.
+createdb data-hub-local
+
+# Push the Drizzle schema (no migration files generated).
+npm run db:push
+```
+
+Other database commands:
+
+| Command | Description |
+| --- | --- |
+| `npm run db:generate` | Generate Drizzle migration files |
+| `npm run db:migrate` | Apply pending migrations |
+| `npm run db:push` | Push schema directly (no migration files) |
+| `npm run db:studio` | Open Drizzle Studio GUI |
+| `npm run db:reset` | Drop and re-create the public schema |
+
+## Running locally
+
+```sh
+# Start the web app dev server (Turbopack).
+make dev
+
+# Or equivalently:
+cd web-app && npm run dev
+```
+
+The app runs at [http://localhost:3000](http://localhost:3000).
+
+## Running checks
+
+Before pushing, run the full formatting, lint, and type-check suite:
+
+```sh
+make check-all
+```
+
+This runs both Python and web app checks:
+
+| Target | What it does |
+| --- | --- |
+| `make py-format` | Auto-fix with Ruff |
+| `make py-lint` | Ruff linter |
+| `make py-typecheck` | Pyright |
+| `make fe-format` | Prettier |
+| `make fe-lint` | ESLint |
+| `make fe-typecheck` | TypeScript compiler |
+
+## Running tests
+
+```sh
+# Python unit tests only.
+make py-test-unit
+
+# Python integration tests (requires Postgres + builds/starts Next.js).
+make py-test-integration
+
+# All Python tests.
+make py-test
+
+# Web app API integration tests (requires Postgres + builds/starts Next.js).
+make fe-test-integration
+```
+
+Integration tests use a `data_hub_test` Postgres database and spin up a real Next.js production server. See [CI and deployment](ci-and-deployment.md) for how these run in GitHub Actions.

--- a/docs/guides/adding-an-instrument.md
+++ b/docs/guides/adding-an-instrument.md
@@ -1,0 +1,127 @@
+# Adding a new instrument
+
+This guide walks through the end-to-end process of adding a new lab instrument to Data Hub: creating the instrument, installing a watcher, and optionally adding Lambda preprocessing.
+
+## Prerequisites
+
+- A personal access token (see [Managing tokens](managing-tokens.md))
+- Access to the instrument PC where files are generated
+- Python >= 3.12 and [uv](https://docs.astral.sh/uv/) installed on the instrument PC
+
+## Step 1: Install the watcher on the instrument PC
+
+Follow the [Installing a watcher](installing-a-watcher.md) guide. During `data-hub-watcher init`, choose "Register a new instrument" and provide:
+
+- **Instrument ID** — a kebab-case identifier (e.g., `bio-rad-cfx96`). This becomes the S3 key prefix and the permanent identifier across the system.
+- **Display name** — a human-readable name (e.g., "Bio-Rad CFX96"). Defaults to a title-cased version of the ID.
+
+The instrument is created with status `pending`.
+
+## Step 2: Activate the instrument
+
+An admin must confirm the instrument before the watcher can start uploading.
+
+1. Open the Data Hub web app.
+2. Navigate to the **Instruments** page.
+3. Find the new instrument — it will have a yellow `pending` badge.
+4. Click the **Confirm** button next to it.
+
+The instrument status changes to `active` and the watcher can now run.
+
+## Step 3: Start watching
+
+On the instrument PC:
+
+```sh
+data-hub-watcher watch
+```
+
+The watcher will detect new files, group them into runs, upload them to S3, and report everything to the API. Files become viewable in the web dashboard immediately after upload.
+
+See the [watcher reference](../watcher.md) for details on upload modes, run detection, and configuration options.
+
+## Step 4 (optional): Add Lambda preprocessing
+
+If the new instrument needs automated preprocessing (metadata extraction, image processing, etc.), you'll need to add a processor to the Lambda function. This requires changes to the codebase.
+
+### 1. Register the instrument in the shared library
+
+Add the instrument to `packages/shared/src/data_hub_shared/enums.py`:
+
+```python
+class Instrument(Enum):
+    # ... existing instruments ...
+    BIO_RAD_CFX96 = "bio-rad-cfx96"
+```
+
+Add a display name mapping in `packages/shared/src/data_hub_shared/constants.py`:
+
+```python
+INSTRUMENT_ID_TO_NAME_MAP: dict[str, str] = {
+    # ... existing entries ...
+    Instrument.BIO_RAD_CFX96.value: "Bio-Rad CFX96",
+}
+```
+
+### 2. Create a processor module
+
+Create a new directory and `process_file.py` under `lambda/src/data_hub_lambda/`:
+
+```
+lambda/src/data_hub_lambda/bio_rad_cfx96/
+├── __init__.py
+└── process_file.py
+```
+
+The processor must expose a `process_file` function:
+
+```python
+def process_file(run_id: str, filename: str) -> str:
+    """Preprocess a file and return the URL to the run in the web dashboard."""
+    ...
+```
+
+A typical processor:
+
+1. Gets an API client and the S3 bucket from config.
+2. Calls `client.ensure_run()` to create or find the run.
+3. Calls `client.create_file()` to register the file.
+4. Downloads the raw file from S3.
+5. Performs instrument-specific preprocessing (parsing, metadata extraction, etc.).
+6. Updates the file status to `completed`.
+7. Returns the web app URL for the run.
+
+See any existing processor (e.g., `lambda/src/data_hub_lambda/azure_cielo_qpcr/process_file.py`) for a complete example.
+
+### 3. Register the dispatch
+
+Add an `elif` branch in the `lambda_handler` function in `lambda/src/data_hub_lambda/handler.py`:
+
+```python
+elif instrument_id == Instrument.BIO_RAD_CFX96.value:
+    result_url = bio_rad_cfx96.process_file(
+        run_id=event_info.run_id,
+        filename=event_info.filename,
+    )
+```
+
+Don't forget to add the import at the top of `handler.py`.
+
+### 4. Add tests
+
+Add unit tests in `lambda/tests/` for the new processor. Integration tests will automatically cover the new instrument if it's registered in the shared library.
+
+### 5. Configure the S3 trigger
+
+The S3 bucket needs an event notification configured to trigger the Lambda function for the new instrument's file types. This is done in AWS outside this repository.
+
+## What you get without Lambda
+
+Even without Step 4, you get a fully functional instrument in Data Hub:
+
+- The watcher uploads raw files to S3.
+- Runs and files appear in the web dashboard.
+- Files are downloadable via pre-signed S3 URLs.
+- Watcher health monitoring (heartbeats, events) works in the dashboard.
+
+Lambda preprocessing adds automated metadata extraction and Slack notifications on top of that.

--- a/docs/guides/installing-a-watcher.md
+++ b/docs/guides/installing-a-watcher.md
@@ -1,0 +1,181 @@
+# Installing a watcher
+
+This guide is for lab operators setting up the Data Hub Watcher on an instrument PC. The watcher monitors a directory for new files, uploads them to S3, and reports run data to the Data Hub web app.
+
+## Prerequisites
+
+- **Python >= 3.12** installed on the instrument PC
+- **A personal access token** — ask your Data Hub admin to create one for you, or create one yourself at **Settings > Access Tokens** in the web app (see [Managing tokens](managing-tokens.md))
+- **The watch directory** — the folder where the instrument writes its output files
+- **File patterns** — the file extensions you want to upload (e.g., `*.csv`, `*.xlsx`, `*.tiff`)
+
+## Installation
+
+### From the repository (recommended for development)
+
+```sh
+git clone <repo-url>
+cd data-hub
+uv sync --all-packages
+```
+
+### Standalone install
+
+```sh
+pip install ./watcher
+```
+
+### Windows service support
+
+If you want the watcher to run as a Windows service:
+
+```sh
+pip install "./watcher[windows-service]"
+```
+
+## Setup
+
+Run the interactive setup wizard:
+
+```sh
+data-hub-watcher init
+```
+
+The wizard will walk you through:
+
+1. **Environment** — choose `staging` (for testing) or `production`.
+
+2. **API key** — paste the personal access token. You can also set the `DATA_HUB_API_KEY` environment variable to skip this prompt.
+
+3. **Instrument** — select an existing instrument from the list, or register a new one by choosing the last option. New instruments start as `pending` and must be activated by an admin in the web app before the watcher can start.
+
+4. **Watch directory** — the absolute path to the folder the instrument writes to.
+
+5. **File patterns** — comma-separated glob patterns (e.g., `*.csv,*.xlsx`). Only files matching these patterns will be uploaded.
+
+6. **Run detection method**:
+   - **`prefix`** — extracts a run ID from each filename using a regex. The default pattern `^([^_]+)` captures everything before the first underscore (e.g., `RUN001_data.csv` → run ID `RUN001`).
+   - **`directory`** — each subdirectory under the watch directory is treated as a separate run.
+
+7. **Stability period** — how many seconds a file must remain unchanged (size + modification time) before it's considered fully written. Increase this for instruments that produce large files slowly. Default is 5 seconds.
+
+8. **Upload mode**:
+   - **`auto`** — files are uploaded to S3 immediately after detection.
+   - **`manual`** — files are reported to the server but not uploaded until an admin approves them via the upload queue.
+
+The wizard saves configuration to `~/.data-hub/config.yaml` and syncs it to the server.
+
+## Starting the watcher
+
+First, verify your setup with a dry run:
+
+```sh
+data-hub-watcher watch --dry-run
+```
+
+This validates the config, checks that the API is reachable and the instrument is active, and previews what files would be uploaded — without actually starting the monitor.
+
+When you're ready:
+
+```sh
+data-hub-watcher watch
+```
+
+The watcher will now:
+
+- Monitor the watch directory for new and modified files.
+- Wait for files to stabilize before processing them.
+- Group files into runs and report them to the API.
+- Upload files to S3 (in auto mode) or wait for server approval (in manual mode).
+- Send heartbeats every 60 seconds so the web dashboard shows watcher health.
+
+Press `Ctrl+C` to stop.
+
+## Running as a Windows service
+
+On Windows, you can install the watcher as a service so it starts automatically:
+
+```sh
+data-hub-watcher service install
+data-hub-watcher service start
+```
+
+Other service commands:
+
+```sh
+data-hub-watcher service status    # Check if the service is running
+data-hub-watcher service stop      # Stop the service
+data-hub-watcher service uninstall # Remove the service
+```
+
+## Changing configuration
+
+To re-prompt each config field with current values as defaults:
+
+```sh
+data-hub-watcher config edit
+```
+
+To open the YAML file directly in your editor:
+
+```sh
+data-hub-watcher config open
+```
+
+To view the current config:
+
+```sh
+data-hub-watcher config show
+```
+
+Changes are automatically synced to the server after editing.
+
+## Manual uploads
+
+To upload a specific file outside the normal watch loop:
+
+```sh
+data-hub-watcher upload --file /path/to/file.csv --run-id RUN001
+```
+
+To process the server-side upload queue (manual mode):
+
+```sh
+data-hub-watcher upload
+```
+
+Add `--dry-run` to preview without uploading.
+
+## Troubleshooting
+
+### "Instrument is still pending activation"
+
+The instrument was registered but hasn't been confirmed by an admin yet. Ask your admin to click "Confirm" on the instrument in the web app's Instruments page.
+
+### "Connection error" or "Request timed out"
+
+The watcher can't reach the Data Hub API. Check:
+
+- Your internet connection.
+- That the correct environment is set in the config (`staging` vs `production`).
+- That the API URL is reachable: `https://data-hub.arcadiascience.com` (production) or `https://data-hub-env-staging-arcadia-science.vercel.app` (staging).
+
+### Files aren't being detected
+
+- Verify the watch directory is correct: `data-hub-watcher config show`
+- Check that file patterns match your files. The watcher uses glob matching (e.g., `*.csv` matches `data.csv` but not `data.CSV` on case-sensitive systems).
+- Run `data-hub-watcher watch --dry-run` to see what files the watcher would pick up.
+
+### Files are detected but not uploading
+
+- In **manual mode**, files are not uploaded until approved via the upload queue. Check the web dashboard.
+- Check `~/.data-hub/watcher.log` for error details.
+- Verify your API token hasn't expired.
+
+### Logs
+
+The watcher writes rotating logs to `~/.data-hub/watcher.log` (10 MB, 5 backups). Check this file for detailed error information. You can also run with `--verbose` for debug-level console output:
+
+```sh
+data-hub-watcher --verbose watch
+```

--- a/docs/guides/managing-tokens.md
+++ b/docs/guides/managing-tokens.md
@@ -1,0 +1,107 @@
+# Managing tokens
+
+Personal access tokens authenticate the watcher and other API clients with the Data Hub API. This guide covers creating, using, and revoking tokens.
+
+## Creating a token
+
+### In the web app
+
+1. Sign in to the Data Hub web app.
+2. Go to **Settings > Access Tokens**.
+3. Click **Create Token**.
+4. Enter a descriptive name (e.g., "FPLC watcher - Lab 201").
+5. Optionally set an expiration date.
+6. Click **Create**.
+
+The plaintext token is displayed once — **copy it immediately**. It cannot be retrieved again. The token starts with `dhub_` followed by a 64-character hex string.
+
+### Via the API
+
+```sh
+curl -X POST https://data-hub.arcadiascience.com/api/v1/tokens \
+  -H "Cookie: <session-cookie>" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "FPLC watcher", "expires_at": "2027-01-01T00:00:00Z"}'
+```
+
+The `expires_at` field is optional. If omitted, the token never expires.
+
+The response includes the plaintext token in the `token` field — this is the only time it's returned.
+
+## Using a token
+
+### With the watcher
+
+During `data-hub-watcher init`, paste the token when prompted for the API key. Alternatively, set it as an environment variable:
+
+```sh
+export DATA_HUB_API_KEY=dhub_abc123...
+data-hub-watcher init
+```
+
+The watcher stores the API key in its environment configuration and uses it for all subsequent API calls.
+
+### With the API directly
+
+Pass the token in the `Authorization` header:
+
+```sh
+curl https://data-hub.arcadiascience.com/api/v1/instruments \
+  -H "Authorization: Bearer dhub_abc123..."
+```
+
+## Viewing tokens
+
+Go to **Settings > Access Tokens** in the web app. The table shows:
+
+| Column | Description |
+| --- | --- |
+| **Name** | The label you gave the token |
+| **Token** | The prefix only (e.g., `dhub_a1b2...`) — the full token is never stored |
+| **Last used** | When the token was last used to authenticate an API request |
+| **Expires** | Expiration date, or "Never" |
+| **Created** | When the token was created |
+
+## Revoking a token
+
+### In the web app
+
+1. Go to **Settings > Access Tokens**.
+2. Click the delete button next to the token you want to revoke.
+3. Confirm the deletion.
+
+The token is immediately invalidated. Any watcher or client using it will start receiving `401 Unauthorized` errors.
+
+### Via the API
+
+```sh
+curl -X DELETE https://data-hub.arcadiascience.com/api/v1/tokens/<token-id> \
+  -H "Cookie: <session-cookie>"
+```
+
+## Security notes
+
+- Tokens are hashed with SHA-256 before storage. The plaintext is never persisted.
+- Each token is scoped to the user who created it.
+- You can only delete your own tokens.
+- Use descriptive names so you can identify which watcher or client each token belongs to.
+- Set expiration dates for tokens used in temporary setups.
+- Revoke tokens immediately when a watcher is decommissioned or a token may have been exposed.
+
+## After revoking a token
+
+If you revoke a token that a running watcher is using, the watcher will start failing on its next heartbeat or API call. To fix it:
+
+1. Create a new token.
+2. On the instrument PC, re-run the setup wizard:
+
+   ```sh
+   data-hub-watcher init
+   ```
+
+3. Enter the new token when prompted.
+4. Restart the watcher:
+
+   ```sh
+   data-hub-watcher watch
+   ```

--- a/docs/lambda.md
+++ b/docs/lambda.md
@@ -1,14 +1,14 @@
 # Lambda
 
-The Data Hub Lambda function processes raw instrument data uploaded to S3. It is triggered by S3 events, runs an instrument-specific processing pipeline, and reports results back through the API and Slack.
+The Data Hub Lambda function preprocesses raw instrument data uploaded to S3. It is triggered by S3 events, runs an instrument-specific preprocessing pipeline, and reports results back through the API and Slack.
 
 ## How it works
 
 1. An S3 `PutObject` event triggers the Lambda function.
 2. The handler parses the S3 key to extract the instrument ID, run ID, and filename. The expected key layout is `{instrument_id}/{run_id}/{filename}`.
 3. It dispatches to the appropriate instrument processor based on the instrument ID.
-4. The processor downloads the raw file from S3, generates a report (charts, analyses), and creates/updates the run and files via the Data Hub API.
-5. On success, a Slack message is sent with a link to view the report in the web dashboard.
+4. The processor downloads the raw file from S3, preprocesses it (e.g., extracting metadata), and creates/updates the run and files via the Data Hub API.
+5. On success, a Slack message is sent with a link to view the run in the web dashboard.
 6. On failure, a Slack message is sent with a link to the CloudWatch logs.
 
 ## Supported instruments
@@ -22,7 +22,7 @@ The Data Hub Lambda function processes raw instrument data uploaded to S3. It is
 | SpectraMax iD3 Plate Reader | `spectramax_plate_reader` | `spectramax-id3-plate-reader` |
 | SpectraMax iD5 Plate Reader | `spectramax_plate_reader` | `spectramax-id5-plate-reader` |
 
-Each processor module exposes a `process_file()` function that accepts the run ID and filename (and instrument ID for SpectraMax readers) and returns a URL to the generated report.
+Each processor module exposes a `process_file()` function that accepts the run ID and filename (and instrument ID for SpectraMax readers) and returns a URL to the run in the web dashboard.
 
 ## Adding a new instrument
 
@@ -32,7 +32,7 @@ Each processor module exposes a `process_file()` function that accepts the run I
 
    ```python
    def process_file(run_id: str, filename: str) -> str:
-       """Process a file and return the URL to the generated report."""
+       """Process a file and return the URL to the run in the web dashboard."""
        ...
    ```
 
@@ -62,7 +62,7 @@ The entry point is `data_hub_lambda.handler.lambda_handler`.
 The Lambda function depends on a scientific Python stack:
 
 - `pandas` — data manipulation
-- `matplotlib` — chart generation
+- `matplotlib` — plotting
 - `scikit-image` — image processing
 - `tifffile` — TIFF file reading
 - `pydantic` — data validation

--- a/docs/lambda.md
+++ b/docs/lambda.md
@@ -1,0 +1,71 @@
+# Lambda
+
+The Data Hub Lambda function processes raw instrument data uploaded to S3. It is triggered by S3 events, runs an instrument-specific processing pipeline, and reports results back through the API and Slack.
+
+## How it works
+
+1. An S3 `PutObject` event triggers the Lambda function.
+2. The handler parses the S3 key to extract the instrument ID, run ID, and filename. The expected key layout is `{instrument_id}/{run_id}/{filename}`.
+3. It dispatches to the appropriate instrument processor based on the instrument ID.
+4. The processor downloads the raw file from S3, generates a report (charts, analyses), and creates/updates the run and files via the Data Hub API.
+5. On success, a Slack message is sent with a link to view the report in the web dashboard.
+6. On failure, a Slack message is sent with a link to the CloudWatch logs.
+
+## Supported instruments
+
+| Instrument | Module | Instrument ID |
+| --- | --- | --- |
+| Agilent 4150 TapeStation | `agilent_4150_tapestation` | `agilent-4150-tapestation` |
+| Akta FPLC | `akta_fplc` | `akta-fplc` |
+| Azure 600 Gel Doc | `azure_600_gel_doc` | `azure-600-gel-doc` |
+| Azure Cielo qPCR | `azure_cielo_qpcr` | `azure-cielo-qpcr` |
+| SpectraMax iD3 Plate Reader | `spectramax_plate_reader` | `spectramax-id3-plate-reader` |
+| SpectraMax iD5 Plate Reader | `spectramax_plate_reader` | `spectramax-id5-plate-reader` |
+
+Each processor module exposes a `process_file()` function that accepts the run ID and filename (and instrument ID for SpectraMax readers) and returns a URL to the generated report.
+
+## Adding a new instrument
+
+1. **Register the instrument.** Add a new member to the `Instrument` enum in `packages/shared/src/data_hub_shared/enums.py` and a corresponding entry in the `INSTRUMENT_ID_TO_NAME_MAP` in `packages/shared/src/data_hub_shared/constants.py`.
+
+2. **Create a processor module.** Add a new module under `lambda/src/data_hub_lambda/` (e.g., `new_instrument.py`). It must expose:
+
+   ```python
+   def process_file(run_id: str, filename: str) -> str:
+       """Process a file and return the URL to the generated report."""
+       ...
+   ```
+
+3. **Register the dispatch.** Add an `elif` branch in the `lambda_handler` function in `lambda/src/data_hub_lambda/handler.py` that maps the new instrument ID to your `process_file` function.
+
+4. **Add tests.** Add unit tests in `lambda/tests/` for the new processor.
+
+## Docker build
+
+The Lambda function is packaged as a container image:
+
+```sh
+make docker-build
+```
+
+This requires a `GH_PERSONAL_ACCESS_TOKEN` in your `.env` file (used for a private Git dependency during `uv export`).
+
+The Dockerfile is a multi-stage build:
+
+1. **Builder stage**: Uses `uv` to export and install third-party dependencies into the Lambda task root.
+2. **Final stage**: Copies the installed dependencies plus the `data_hub_shared` and `data_hub_lambda` source packages.
+
+The entry point is `data_hub_lambda.handler.lambda_handler`.
+
+## Dependencies
+
+The Lambda function depends on a scientific Python stack:
+
+- `pandas` — data manipulation
+- `matplotlib` — chart generation
+- `scikit-image` — image processing
+- `tifffile` — TIFF file reading
+- `pydantic` — data validation
+- `requests` — HTTP client for the Data Hub API
+- `aws-lambda-typing` — type stubs for Lambda events/context
+- `data-hub-shared` — shared utilities (S3, Slack, enums)

--- a/docs/shared-library.md
+++ b/docs/shared-library.md
@@ -1,0 +1,102 @@
+# Shared library
+
+`data-hub-shared` is a Python package that provides utilities and contracts shared between the Lambda function and the watcher. It lives in `packages/shared/`.
+
+## Modules
+
+### `enums`
+
+Defines the `Instrument` enum, whose kebab-case values are used as S3 key prefixes and as the canonical instrument identifiers throughout the system.
+
+```python
+from data_hub_shared.enums import Instrument
+
+Instrument.AKTA_FPLC.value  # "akta-fplc"
+```
+
+Currently supported instruments:
+
+| Enum member | Value |
+| --- | --- |
+| `AGILENT_4150_TAPESTATION` | `agilent-4150-tapestation` |
+| `AKTA_FPLC` | `akta-fplc` |
+| `AZURE_600_GEL_DOC` | `azure-600-gel-doc` |
+| `AZURE_CIELO_QPCR` | `azure-cielo-qpcr` |
+| `SPECTRAMAX_ID3_PLATE_READER` | `spectramax-id3-plate-reader` |
+| `SPECTRAMAX_ID5_PLATE_READER` | `spectramax-id5-plate-reader` |
+
+### `constants`
+
+Maps between instrument IDs and human-readable display names:
+
+```python
+from data_hub_shared.constants import INSTRUMENT_ID_TO_NAME_MAP, INSTRUMENT_NAME_TO_ID_MAP
+```
+
+### `config`
+
+Shared environment-based configuration. Instantiated as a module-level singleton `config`:
+
+```python
+from data_hub_shared.config import config
+
+config.AWS_S3_RAW_DATA_BUCKET
+config.SLACK_WEBHOOK_URL
+```
+
+| Attribute | Source env var | Default |
+| --- | --- | --- |
+| `LOCAL_DATA_DIRPATH` | `LOCAL_DATA_DIRPATH` | `/tmp/data` |
+| `AWS_REGION` | `AWS_REGION` | `None` |
+| `AWS_ACCESS_KEY_ID` | `AWS_ACCESS_KEY_ID` | `None` |
+| `AWS_SECRET_ACCESS_KEY` | `AWS_SECRET_ACCESS_KEY` | `None` |
+| `AWS_SESSION_TOKEN` | `AWS_SESSION_TOKEN` | `None` |
+| `AWS_S3_RAW_DATA_BUCKET` | `AWS_S3_RAW_DATA_BUCKET` | `None` |
+| `AWS_S3_PROCESSED_DATA_BUCKET` | `AWS_S3_PROCESSED_DATA_BUCKET` | `None` |
+| `SLACK_WEBHOOK_URL` | `SLACK_WEBHOOK_URL` | `None` |
+
+### `s3_utils`
+
+Boto3-based S3 utilities. Callers can pass an explicit `s3_client` or let the module create one from ambient credentials.
+
+| Function | Description |
+| --- | --- |
+| `get_s3_client()` | Create a boto3 S3 client |
+| `parse_s3_uri(uri)` | Split `s3://bucket/key` into `(bucket, key)` |
+| `upload_file(local_path, s3_uri)` | Upload a file to S3 (auto-detects content type) |
+| `download_file(s3_uri, local_path)` | Download a file from S3 |
+| `list_objects(s3_uri_prefix, suffix)` | List object URIs under a prefix |
+| `upload_folder(local_path, s3_uri_prefix)` | Upload all files in a directory |
+| `get_content_type(file_path)` | Guess MIME type for a file |
+
+### `slack`
+
+Posts messages to a Slack channel via a webhook URL:
+
+```python
+from data_hub_shared import slack
+
+slack.send_message("Hello from Data Hub!")
+```
+
+If `SLACK_WEBHOOK_URL` is not set, messages are silently skipped with a warning log.
+
+### `logger`
+
+Provides a `get_named_logger(name)` helper for consistent logging setup.
+
+### `testing`
+
+Integration test infrastructure used by both Lambda and watcher test suites. Provides:
+
+- **`start_test_server()`** — context manager that creates a test Postgres database, pushes the Drizzle schema, builds and starts a Next.js production server, seeds auth, and yields an `IntegrationEnv` with the base URL, API token, and DB DSN.
+- **`seed_auth(dsn)`** — inserts a test user and personal access token, returning the plaintext token.
+- **`seed_instruments(dsn, instruments)`** — inserts instrument rows.
+- **`truncate_tables(dsn, tables)`** — truncates tables with CASCADE.
+- **`db_query(dsn, sql)`** / **`db_update(dsn, sql)`** — direct DB access for test assertions and setup.
+
+## Dependencies
+
+- `boto3` — AWS SDK for S3 operations
+- `requests` — HTTP client for Slack webhooks
+- `psycopg2-binary` — PostgreSQL driver (dev dependency, used by `testing.py`)

--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -16,10 +16,11 @@ pip install ./watcher
 data-hub-watcher --help
 ```
 
-On Windows, the watcher can optionally be installed as a Windows service (requires `pywin32`):
+On Windows, the watcher can optionally be installed as a Windows service (requires `pywin32`). Install the extra, then use the `service install` CLI command to register it with Windows:
 
 ```sh
 pip install "./watcher[windows-service]"
+data-hub-watcher service install
 ```
 
 ## Quick start
@@ -92,6 +93,8 @@ Subcommands for managing the YAML config file:
 | `config path` | Print the resolved config file path |
 
 ### `service` (Windows only)
+
+Requires the `windows-service` extra (`pip install "./watcher[windows-service]"`).
 
 Manage the watcher as a Windows service:
 

--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -1,0 +1,142 @@
+# Watcher
+
+The Data Hub Watcher is a CLI agent that runs on lab instrument PCs. It monitors a directory for new files, groups them into runs, uploads them to S3, and reports status to the Data Hub API.
+
+## Installation
+
+The watcher is a Python package with a CLI entry point:
+
+```sh
+# From the repo root (development):
+uv sync --all-packages
+uv run data-hub-watcher --help
+
+# Or install as a standalone tool:
+pip install ./watcher
+data-hub-watcher --help
+```
+
+On Windows, the watcher can optionally be installed as a Windows service (requires `pywin32`):
+
+```sh
+pip install "./watcher[windows-service]"
+```
+
+## Quick start
+
+```sh
+# Run the interactive setup wizard.
+data-hub-watcher init
+
+# Start watching for files.
+data-hub-watcher watch
+```
+
+## Commands
+
+### `init`
+
+Interactive setup wizard that:
+
+1. Prompts for the environment (`staging` or `production`).
+2. Prompts for an API key (or reads `DATA_HUB_API_KEY` from the environment).
+3. Fetches existing instruments from the API or registers a new one.
+4. Prompts for the watch directory, file patterns, run detection method, stability period, and upload mode.
+5. Registers the watcher with the API.
+6. Saves the config to `~/.data-hub/config.yaml` and syncs it to the API.
+
+### `watch`
+
+Starts the file monitoring loop. Before entering the loop it:
+
+- Validates the config and checks that the instrument is active (not pending).
+- Syncs the config checksum with the API.
+- Initializes the local state database (`~/.data-hub/watcher.db`).
+- Retries any runs that were detected but not successfully reported (crash recovery).
+
+While running:
+
+- **File monitor** watches the directory for new/modified files using `watchdog` and waits for each file to stabilize (size + mtime unchanged for the configured stability period).
+- **Run detector** groups stable files into runs using the configured method (prefix regex or subdirectory).
+- **Uploader** uploads files to S3 at `{instrument_id}/{run_id}/{filename}` (auto mode) or polls the server's upload queue (manual mode).
+- **Heartbeat loop** sends periodic heartbeats (every 60 seconds) to the API. In manual mode, it also polls the upload queue on each tick.
+- **Event reporter** batches and flushes lifecycle events (started, stopped, file uploaded, errors) to the API.
+
+Use `--dry-run` to validate config and preview what would happen without starting the monitor.
+
+### `upload`
+
+One-shot file upload for manual use:
+
+```sh
+# Upload a specific file.
+data-hub-watcher upload --file /path/to/file.csv --run-id RUN001
+
+# Process the server-side upload queue.
+data-hub-watcher upload
+
+# Preview without uploading.
+data-hub-watcher upload --dry-run
+```
+
+### `config`
+
+Subcommands for managing the YAML config file:
+
+| Subcommand | Description |
+| --- | --- |
+| `config show` | Pretty-print the current config |
+| `config validate` | Validate the config file (offline) |
+| `config edit` | Re-prompt each field with current values as defaults |
+| `config open` | Open the config in your editor, then re-validate |
+| `config path` | Print the resolved config file path |
+
+### `service` (Windows only)
+
+Manage the watcher as a Windows service:
+
+| Subcommand | Description |
+| --- | --- |
+| `service install` | Install the Windows service |
+| `service uninstall` | Remove the Windows service |
+| `service start` | Start the service |
+| `service stop` | Stop the service |
+| `service status` | Show service status |
+
+## Configuration
+
+The config file lives at `~/.data-hub/config.yaml` by default. Override with `--config` or the `DATA_HUB_CONFIG_PATH` environment variable.
+
+### Config file format
+
+```yaml
+version: 1
+environment: production          # "staging" or "production"
+watcher_id: <assigned-by-api>
+instrument:
+  id: akta-fplc                  # kebab-case instrument ID
+  watch_directory: /path/to/data
+  file_patterns:
+    - "*.csv"
+    - "*.xlsx"
+  enabled: true
+  upload_mode: auto              # "auto" or "manual"
+  stability_period_seconds: 5    # 1–300
+  run_detection:
+    method: prefix               # "prefix" or "directory"
+    prefix_pattern: "^([^_]+)"   # regex with one capture group (run ID)
+```
+
+### Run detection methods
+
+- **`prefix`**: The run ID is extracted from each filename using a regex with one capture group. For example, `^([^_]+)` matches everything before the first underscore, so `RUN001_data.csv` yields run ID `RUN001`.
+- **`directory`**: Each subdirectory under the watch directory is treated as a separate run. The subdirectory name is the run ID.
+
+### Upload modes
+
+- **`auto`**: Files are uploaded to S3 immediately after run detection.
+- **`manual`**: Runs are reported to the API without uploading. The server decides which files to upload via a queue, polled on each heartbeat tick. Useful when uploads need human approval.
+
+## Local state
+
+The watcher maintains a SQLite database at `~/.data-hub/watcher.db` to track which files have been uploaded. Records older than 90 days are pruned automatically. Logs are written to `~/.data-hub/watcher.log` (10 MB rotating, 5 backups).

--- a/lambda/src/data_hub_lambda/handler.py
+++ b/lambda/src/data_hub_lambda/handler.py
@@ -160,14 +160,14 @@ def lambda_handler(event: dict[str, Any], context: Context) -> None:
 
         slack.send_message(
             f"*{instrument_name}*\n"
-            f"A report was generated for run `{run_id}`!\n"
+            f"Finished preprocessing run `{run_id}`!\n"
             f"<{result_url}|View in Data Hub>"
         )
     except Exception:
-        logger.exception("Failed to generate report for run %s.", run_id)
+        logger.exception("Failed to preprocess run %s.", run_id)
         logs_url = get_cloudwatch_logs_url(context)
         slack.send_message(
             f"*{instrument_name}*\n"
-            f"Failed to generate report for run `{run_id}`!\n"
+            f"Failed to preprocess run `{run_id}`!\n"
             f"<{logs_url}|View CloudWatch logs>"
         )

--- a/lambda/src/data_hub_lambda/handler.py
+++ b/lambda/src/data_hub_lambda/handler.py
@@ -16,7 +16,6 @@ from data_hub_lambda import (
     azure_cielo_qpcr,
     spectramax_plate_reader,
 )
-from data_hub_lambda.agilent_4150_tapestation.utils import parse_run_id_from_filename
 from data_hub_shared import slack
 from data_hub_shared.constants import INSTRUMENT_ID_TO_NAME_MAP
 from data_hub_shared.enums import Instrument
@@ -59,34 +58,17 @@ def parse_s3_event(event: S3Event) -> S3EventInfo:
     s3_bucket: str = record["s3"]["bucket"]["name"]  # type: ignore[index]
     s3_key: str = unquote_plus(record["s3"]["object"]["key"])  # type: ignore[index]
 
-    # S3 key layout is {instrument_id}/{filename} — the run_id is encoded in
-    # the filename itself and must be extracted per-instrument below. This
-    # differs from the watcher's 3-segment layout ({instrument_id}/{run_id}/{filename}).
-    # TODO: Consolidate this once we have a unified S3 key layout.
-    pattern = r"^/?([^/]+)/([^/]+)$"
+    # S3 key layout: {instrument_id}/{run_id}/{filename}
+    pattern = r"^/?([^/]+)/([^/]+)/([^/]+)$"
     match = re.match(pattern, s3_key)
     if not match:
         raise ValueError(f"Object key does not match expected pattern: {s3_key}")
 
     instrument_id = match.group(1)
-    filename = match.group(2)
+    run_id = match.group(2)
+    filename = match.group(3)
 
-    if instrument_id == Instrument.AZURE_CIELO_QPCR.value:
-        run_id = azure_cielo_qpcr.parse_run_id(filename)
-        if not run_id:
-            raise ValueError(f"No run ID found in filename: {filename}")
-    elif instrument_id == Instrument.AGILENT_4150_TAPESTATION.value:
-        run_id = parse_run_id_from_filename(filename)
-    elif instrument_id == Instrument.AKTA_FPLC.value:
-        run_id = filename.replace(".pdf", "")
-    elif instrument_id in (
-        Instrument.SPECTRAMAX_ID3_PLATE_READER.value,
-        Instrument.SPECTRAMAX_ID5_PLATE_READER.value,
-    ):
-        run_id = filename.replace(".xls", "")
-    elif instrument_id == Instrument.AZURE_600_GEL_DOC.value:
-        run_id = filename.replace(".tif", "")
-    else:
+    if instrument_id not in {member.value for member in Instrument}:
         raise ValueError(f"This instrument is not currently supported: {instrument_id}")
 
     return S3EventInfo(

--- a/watcher/src/data_hub_watcher/constants.py
+++ b/watcher/src/data_hub_watcher/constants.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 API_URLS: dict[str, str] = {
-    "staging": "https://data-hub-staging.arcadiascience.com/api/v1",
+    "staging": "https://data-hub-env-staging-arcadia-science.vercel.app/api/v1",
     "production": "https://data-hub.arcadiascience.com/api/v1",
 }
 


### PR DESCRIPTION
## Summary

Adds comprehensive project documentation covering architecture, developer setup, component references, and task-oriented user guides. Also includes two small code changes that were made while writing the docs: unifying the S3 key parsing in the Lambda handler and correcting "report generation" language to "preprocessing."

## Changes

- **Root `README.md`** — expanded from a single title line into a full project overview with a Mermaid architecture diagram, repository structure table, quick-start instructions, and a documentation index split into Guides and Reference sections.
- **`docs/` reference pages** — 8 new files covering architecture, getting started, watcher CLI reference, Lambda processing, REST API endpoints, shared library modules, CI/deployment, and team conventions.
- **`docs/guides/`** — 3 new task-oriented guides:
  - `adding-an-instrument.md` — end-to-end walkthrough for watcher setup, instrument activation, and optional Lambda preprocessing.
  - `installing-a-watcher.md` — lab-operator-focused guide with setup, configuration, Windows service, and troubleshooting.
  - `managing-tokens.md` — creating, using, and revoking personal access tokens.
- **`lambda/src/data_hub_lambda/handler.py`** — `parse_s3_event` now extracts the run ID from the S3 key (`{instrument_id}/{run_id}/{filename}`) instead of parsing it per-instrument from the filename. Removes the per-instrument `run_id` extraction branches and the `parse_run_id_from_filename` import. Slack messages and log lines updated from "report generated" to "preprocessing."
- **`watcher/src/data_hub_watcher/constants.py`** — staging API URL updated to the Vercel preview deployment URL.

## Breaking changes

- The Lambda handler now expects S3 keys in the 3-segment format `{instrument_id}/{run_id}/{filename}`. Any S3 event notifications using the old 2-segment format (`{instrument_id}/{filename}`) will fail with a `ValueError`. Ensure all S3 triggers are producing the new key layout before deploying.

## Driveby changes

- Updated the watcher staging API URL from `data-hub-staging.arcadiascience.com` to `data-hub-env-staging-arcadia-science.vercel.app`.

## Testing

- [x] `make check-all` passes (formatting, linting, type checking for Python and web app)
- [x] `make py-test-unit` passes
- [x] Verify Mermaid diagram renders correctly in GitHub PR preview
- [x] Spot-check documentation links resolve correctly on GitHub