### PR TITLE
Add SAM infrastructure, Lambda deploy workflow, and fix S3 key paths

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -59,5 +59,4 @@ jobs:
               "DataHubApiUrl=${{ secrets.DATA_HUB_API_URL }}" \
               "DataHubApiKey=${{ secrets.DATA_HUB_API_KEY }}" \
               "SlackWebhookUrl=${{ secrets.SLACK_WEBHOOK_URL }}" \
-              "LambdaAuthToken=${{ secrets.LAMBDA_AUTH_TOKEN }}" \
               "OidcProviderArn=${{ secrets.OIDC_PROVIDER_ARN }}"

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -37,8 +37,10 @@ jobs:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           IMAGE_TAG: ${{ github.ref_name }}-${{ github.sha }}
         run: |
-          IMAGE_URI="${ECR_REGISTRY}/arcadia-data-hub:${IMAGE_TAG}"
+          IMAGE_URI="${ECR_REGISTRY}/data-hub:${IMAGE_TAG}"
           docker build \
+            --provenance=false \
+            --platform linux/amd64 \
             -f lambda/Dockerfile \
             -t "${IMAGE_URI}" \
             .
@@ -59,4 +61,5 @@ jobs:
               "DataHubApiUrl=${{ secrets.DATA_HUB_API_URL }}" \
               "DataHubApiKey=${{ secrets.DATA_HUB_API_KEY }}" \
               "SlackWebhookUrl=${{ secrets.SLACK_WEBHOOK_URL }}" \
+              "Environment=${{ github.ref_name }}" \
               "OidcProviderArn=${{ secrets.OIDC_PROVIDER_ARN }}"

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -36,11 +36,9 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           IMAGE_TAG: ${{ github.ref_name }}-${{ github.sha }}
-          GIT_AUTH_TOKEN: ${{ secrets.GIT_AUTH_TOKEN }}
         run: |
           IMAGE_URI="${ECR_REGISTRY}/arcadia-data-hub:${IMAGE_TAG}"
           docker build \
-            --secret id=GIT_AUTH_TOKEN,env=GIT_AUTH_TOKEN \
             -f lambda/Dockerfile \
             -t "${IMAGE_URI}" \
             .

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -1,0 +1,65 @@
+name: Deploy Lambda function
+
+on:
+  push:
+    branches:
+      - staging
+      - production
+    paths:
+      - lambda/**
+      - packages/shared/**
+      - infra/**
+      - uv.lock
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-west-1
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push Docker image
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          IMAGE_TAG: ${{ github.ref_name }}-${{ github.sha }}
+          GIT_AUTH_TOKEN: ${{ secrets.GIT_AUTH_TOKEN }}
+        run: |
+          IMAGE_URI="${ECR_REGISTRY}/arcadia-data-hub:${IMAGE_TAG}"
+          docker build \
+            --secret id=GIT_AUTH_TOKEN,env=GIT_AUTH_TOKEN \
+            -f lambda/Dockerfile \
+            -t "${IMAGE_URI}" \
+            .
+          docker push "${IMAGE_URI}"
+          echo "IMAGE_URI=${IMAGE_URI}" >> "$GITHUB_ENV"
+
+      - uses: aws-actions/setup-sam@v2
+
+      - name: Deploy SAM stack
+        working-directory: infra
+        run: |
+          sam deploy \
+            --config-env "${{ github.ref_name }}" \
+            --no-confirm-changeset \
+            --no-fail-on-empty-changeset \
+            --parameter-overrides \
+              "EcrImageUri=${IMAGE_URI}" \
+              "DataHubApiUrl=${{ secrets.DATA_HUB_API_URL }}" \
+              "DataHubApiKey=${{ secrets.DATA_HUB_API_KEY }}" \
+              "SlackWebhookUrl=${{ secrets.SLACK_WEBHOOK_URL }}" \
+              "LambdaAuthToken=${{ secrets.LAMBDA_AUTH_TOKEN }}" \
+              "OidcProviderArn=${{ secrets.OIDC_PROVIDER_ARN }}"

--- a/Makefile
+++ b/Makefile
@@ -72,3 +72,21 @@ check-all:
 .PHONY: docker-build
 docker-build:
 	source .env && export GIT_AUTH_TOKEN=$$GH_PERSONAL_ACCESS_TOKEN && docker build -f lambda/Dockerfile --secret id=GIT_AUTH_TOKEN -t data-hub-lambda .
+
+# SAM infrastructure.
+.PHONY: sam-bootstrap
+sam-bootstrap:
+	aws cloudformation deploy \
+		--template-file infra/bootstrap.yaml \
+		--stack-name data-hub-bootstrap \
+		--region us-west-1 \
+		--capabilities CAPABILITY_NAMED_IAM \
+		--tags project=arcadia-data-hub
+
+.PHONY: sam-deploy-staging
+sam-deploy-staging:
+	cd infra && sam deploy --config-env staging
+
+.PHONY: sam-deploy-production
+sam-deploy-production:
+	cd infra && sam deploy --config-env production

--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,9 @@ check-all:
 	make fe-check
 
 # Lambda.
-.PHONY: docker-build
-docker-build:
-	docker build -f lambda/Dockerfile -t data-hub-lambda .
+.PHONY: docker-build-lambda
+docker-build-lambda:
+	docker build --provenance=false --platform linux/amd64 -f lambda/Dockerfile -t data-hub-lambda .
 
 # SAM infrastructure.
 .PHONY: sam-bootstrap
@@ -83,10 +83,34 @@ sam-bootstrap:
 		--capabilities CAPABILITY_NAMED_IAM \
 		--tags project=arcadia-data-hub
 
-.PHONY: sam-deploy-staging
-sam-deploy-staging:
-	cd infra && sam deploy --config-env staging
+# Usage: make sam-deploy ENV=staging
+.PHONY: sam-deploy
+sam-deploy:
+ifndef ENV
+	$(error ENV is required, e.g. make sam-deploy ENV=staging)
+endif
+	cd infra && sam deploy --config-env $(ENV) \
+		--parameter-overrides \
+		"Environment=$(ENV)" \
+		"EcrImageUri=$(ECR_IMAGE_URI)" \
+		"DataHubApiUrl=$(DATA_HUB_API_URL)" \
+		"DataHubApiKey=$(DATA_HUB_API_KEY)" \
+		"SlackWebhookUrl=$(SLACK_WEBHOOK_URL)" \
+		"OidcProviderArn=$(OIDC_PROVIDER_ARN)"
 
-.PHONY: sam-deploy-production
-sam-deploy-production:
-	cd infra && sam deploy --config-env production
+# Usage: make sam-teardown ENV=staging
+.PHONY: sam-teardown
+sam-teardown:
+ifndef ENV
+	$(error ENV is required, e.g. make sam-teardown ENV=staging)
+endif
+ifeq ($(ENV),production)
+	$(error Refusing to tear down production — do this manually)
+endif
+	@echo "Tearing down data-hub-$(ENV)..."
+	aws cloudformation delete-stack --stack-name data-hub-$(ENV) --region us-west-1
+	aws cloudformation wait stack-delete-complete --stack-name data-hub-$(ENV) --region us-west-1
+	@echo "Removing retained S3 buckets..."
+	-aws s3 rb s3://arcadia-data-hub-raw-$(ENV) --force
+	-aws s3 rb s3://arcadia-data-hub-processed-$(ENV) --force
+	@echo "Teardown complete."

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ check-all:
 # Lambda.
 .PHONY: docker-build
 docker-build:
-	source .env && export GIT_AUTH_TOKEN=$$GH_PERSONAL_ACCESS_TOKEN && docker build -f lambda/Dockerfile --secret id=GIT_AUTH_TOKEN -t data-hub-lambda .
+	docker build -f lambda/Dockerfile -t data-hub-lambda .
 
 # SAM infrastructure.
 .PHONY: sam-bootstrap

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -132,7 +132,6 @@ export ECR_IMAGE_URI="<ECR_REPOSITORY_URI>:staging-initial"
 export DATA_HUB_API_URL="https://data-hub-env-staging-arcadia-science.vercel.app/api/v1"
 export DATA_HUB_API_KEY="<your-api-key>"
 export SLACK_WEBHOOK_URL="<your-slack-webhook>"
-export LAMBDA_AUTH_TOKEN="<your-auth-token>"
 export OIDC_PROVIDER_ARN="<arn-from-step-1>"
 
 make sam-deploy-staging
@@ -161,7 +160,6 @@ In your GitHub repo, go to **Settings → Environments**, create a `staging` env
 | `DATA_HUB_API_URL` | Base API URL for the environment |
 | `DATA_HUB_API_KEY` | API key for Lambda → Data Hub authentication |
 | `SLACK_WEBHOOK_URL` | Slack incoming webhook URL |
-| `LAMBDA_AUTH_TOKEN` | Token for authenticating Lambda function URL requests |
 
 Once secrets are set, the CI workflow handles all subsequent deploys automatically.
 
@@ -173,7 +171,7 @@ On pushes to `staging` or `production`, the **Deploy Lambda** workflow:
 2. Builds and pushes the Docker image to ECR.
 3. Runs `sam deploy` to update the CloudFormation stack.
 
-Secrets (`DATA_HUB_API_KEY`, `SLACK_WEBHOOK_URL`, `LAMBDA_AUTH_TOKEN`, etc.) are stored in GitHub environment secrets scoped to each environment.
+Secrets (`DATA_HUB_API_KEY`, `SLACK_WEBHOOK_URL`, etc.) are stored in GitHub environment secrets scoped to each environment.
 
 > **Note:** The CI deploy role has intentionally narrow permissions — enough to push a new container image and update the existing CloudFormation stack, but _not_ enough to create the stack from scratch or to add/remove S3 buckets, Lambda functions, or S3 event triggers. Initial stack creation and infrastructure-level changes (e.g., adding a new instrument trigger) must be performed by an admin with broader AWS permissions. Once the stack exists, routine image-update deploys through CI work without issue.
 

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -91,6 +91,80 @@ A separate bootstrap stack (`infra/bootstrap.yaml`) creates shared resources —
 make sam-bootstrap
 ```
 
+#### First-time AWS setup
+
+After deploying the bootstrap stack, follow these steps to bring up the first environment. You need admin-level AWS credentials for the initial deploy (the CI role cannot create stacks from scratch).
+
+**1. Get the bootstrap stack outputs:**
+
+```sh
+aws cloudformation describe-stacks \
+  --stack-name data-hub-bootstrap \
+  --region us-west-1 \
+  --query "Stacks[0].Outputs"
+```
+
+Note the `OidcProviderArn` and `EcrRepositoryUri` values — you'll need them in steps 3 and 4 below.
+
+> **Note:** If your AWS account already has an OIDC provider for `token.actions.githubusercontent.com` (from another project), the bootstrap stack will fail with an `AWS::EarlyValidation::ResourceExistenceCheck` error. In that case, remove the `GitHubOidcProvider` resource from `bootstrap.yaml` (or skip the bootstrap stack entirely) and use the existing provider's ARN. Check with `aws iam list-open-id-connect-providers`.
+
+**2. Build and push the Docker image to ECR:**
+
+```sh
+# Log in to ECR.
+aws ecr get-login-password --region us-west-1 \
+  | docker login --username AWS --password-stdin <ACCOUNT_ID>.dkr.ecr.us-west-1.amazonaws.com
+
+# Build the image.
+make docker-build
+
+# Tag and push.
+docker tag data-hub-lambda:latest <ECR_REPOSITORY_URI>:staging-initial
+docker push <ECR_REPOSITORY_URI>:staging-initial
+```
+
+**3. Deploy the per-environment stack:**
+
+Set the required environment variables (the `samconfig.toml` references them via `${...}`) and deploy:
+
+```sh
+export ECR_IMAGE_URI="<ECR_REPOSITORY_URI>:staging-initial"
+export DATA_HUB_API_URL="https://data-hub-env-staging-arcadia-science.vercel.app/api/v1"
+export DATA_HUB_API_KEY="<your-api-key>"
+export SLACK_WEBHOOK_URL="<your-slack-webhook>"
+export LAMBDA_AUTH_TOKEN="<your-auth-token>"
+export OIDC_PROVIDER_ARN="<arn-from-step-1>"
+
+make sam-deploy-staging
+```
+
+Repeat with the production values and `make sam-deploy-production` when ready.
+
+**4. Configure GitHub environment secrets:**
+
+After the stack deploys, grab the deploy role ARN:
+
+```sh
+aws cloudformation describe-stacks \
+  --stack-name data-hub-staging \
+  --region us-west-1 \
+  --query "Stacks[0].Outputs[?OutputKey=='DeployRoleArn'].OutputValue" \
+  --output text
+```
+
+In your GitHub repo, go to **Settings → Environments**, create a `staging` environment (and later `production`), and add these secrets:
+
+| Secret | Value |
+| --- | --- |
+| `AWS_DEPLOY_ROLE_ARN` | Deploy role ARN from the stack output |
+| `OIDC_PROVIDER_ARN` | OIDC provider ARN from the bootstrap stack |
+| `DATA_HUB_API_URL` | Base API URL for the environment |
+| `DATA_HUB_API_KEY` | API key for Lambda → Data Hub authentication |
+| `SLACK_WEBHOOK_URL` | Slack incoming webhook URL |
+| `LAMBDA_AUTH_TOKEN` | Token for authenticating Lambda function URL requests |
+
+Once secrets are set, the CI workflow handles all subsequent deploys automatically.
+
 #### Automated deployment (`deploy-lambda.yml`)
 
 On pushes to `staging` or `production`, the **Deploy Lambda** workflow:
@@ -118,7 +192,7 @@ make sam-deploy-staging
 make sam-deploy-production
 ```
 
-This requires a `GH_PERSONAL_ACCESS_TOKEN` in your `.env` file (for a private Git dependency) and AWS credentials with permission to deploy the stack.
+This requires AWS credentials with permission to deploy the stack.
 
 ## Running checks locally
 

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -116,7 +116,7 @@ aws ecr get-login-password --region us-west-1 \
   | docker login --username AWS --password-stdin <ACCOUNT_ID>.dkr.ecr.us-west-1.amazonaws.com
 
 # Build the image.
-make docker-build
+make docker-build-lambda
 
 # Tag and push.
 docker tag data-hub-lambda:latest <ECR_REPOSITORY_URI>:staging-initial
@@ -134,10 +134,10 @@ export DATA_HUB_API_KEY="<your-api-key>"
 export SLACK_WEBHOOK_URL="<your-slack-webhook>"
 export OIDC_PROVIDER_ARN="<arn-from-step-1>"
 
-make sam-deploy-staging
+make sam-deploy ENV=staging
 ```
 
-Repeat with the production values and `make sam-deploy-production` when ready.
+Repeat with the production values and `make sam-deploy ENV=production` when ready.
 
 **4. Configure GitHub environment secrets:**
 
@@ -177,20 +177,24 @@ Secrets (`DATA_HUB_API_KEY`, `SLACK_WEBHOOK_URL`, etc.) are stored in GitHub env
 
 #### Local deployment
 
-You can deploy from your machine after building the Docker image:
+Local deployment requires the following tools in addition to the [general prerequisites](getting-started.md#prerequisites):
+
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) — used for bootstrap commands and ECR login.
+- [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) — used by `make sam-deploy-*` to package and deploy CloudFormation stacks. Install with `brew install aws-sam-cli` on macOS.
+- AWS credentials configured (`aws configure` or environment variables) with permission to deploy the stack.
+
+Once installed, build and deploy:
 
 ```sh
 # Build the container image.
-make docker-build
+make docker-build-lambda
 
 # Deploy to staging (will prompt for changeset confirmation).
-make sam-deploy-staging
+make sam-deploy ENV=staging
 
 # Deploy to production.
-make sam-deploy-production
+make sam-deploy ENV=production
 ```
-
-This requires AWS credentials with permission to deploy the stack.
 
 ## Running checks locally
 

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -78,16 +78,45 @@ npm run db:push
 
 ### Lambda (AWS)
 
-The Lambda function is deployed as a Docker container image.
+The Lambda function is deployed as a Docker container image via [AWS SAM](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/). Infrastructure is defined in `infra/template.yaml` and includes:
+
+- S3 buckets (`arcadia-raw-data-hub-{env}` and `arcadia-processed-data-hub-{env}`)
+- The Lambda function (container image, 1024 MB memory, 300 s timeout, function URL)
+- S3 event triggers for each supported instrument
+- IAM roles for Lambda execution and GitHub Actions deployment (OIDC)
+
+A separate bootstrap stack (`infra/bootstrap.yaml`) creates shared resources — the ECR repository and the GitHub OIDC identity provider — and only needs to be deployed once:
+
+```sh
+make sam-bootstrap
+```
+
+#### Automated deployment (`deploy-lambda.yml`)
+
+On pushes to `staging` or `production`, the **Deploy Lambda** workflow:
+
+1. Assumes the environment's deploy role via OIDC (no long-lived AWS keys).
+2. Builds and pushes the Docker image to ECR.
+3. Runs `sam deploy` to update the CloudFormation stack.
+
+Secrets (`DATA_HUB_API_KEY`, `SLACK_WEBHOOK_URL`, `LAMBDA_AUTH_TOKEN`, etc.) are stored in GitHub environment secrets scoped to each environment.
+
+#### Local deployment
+
+You can deploy from your machine after building the Docker image:
 
 ```sh
 # Build the container image.
 make docker-build
+
+# Deploy to staging (will prompt for changeset confirmation).
+make sam-deploy-staging
+
+# Deploy to production.
+make sam-deploy-production
 ```
 
-This requires a `GH_PERSONAL_ACCESS_TOKEN` in your `.env` file (for a private Git dependency). The image is built from `lambda/Dockerfile` and uses the `public.ecr.aws/lambda/python:3.12` base image.
-
-Deployment to AWS (pushing to ECR and updating the Lambda function) is handled outside this repository.
+This requires a `GH_PERSONAL_ACCESS_TOKEN` in your `.env` file (for a private Git dependency) and AWS credentials with permission to deploy the stack.
 
 ## Running checks locally
 

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -80,7 +80,7 @@ npm run db:push
 
 The Lambda function is deployed as a Docker container image via [AWS SAM](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/). Infrastructure is defined in `infra/template.yaml` and includes:
 
-- S3 buckets (`arcadia-raw-data-hub-{env}` and `arcadia-processed-data-hub-{env}`)
+- S3 buckets (`arcadia-data-hub-raw-{env}` and `arcadia-data-hub-processed-{env}`)
 - The Lambda function (container image, 1024 MB memory, 300 s timeout, function URL)
 - S3 event triggers for each supported instrument
 - IAM roles for Lambda execution and GitHub Actions deployment (OIDC)
@@ -100,6 +100,8 @@ On pushes to `staging` or `production`, the **Deploy Lambda** workflow:
 3. Runs `sam deploy` to update the CloudFormation stack.
 
 Secrets (`DATA_HUB_API_KEY`, `SLACK_WEBHOOK_URL`, `LAMBDA_AUTH_TOKEN`, etc.) are stored in GitHub environment secrets scoped to each environment.
+
+> **Note:** The CI deploy role has intentionally narrow permissions — enough to push a new container image and update the existing CloudFormation stack, but _not_ enough to create the stack from scratch or to add/remove S3 buckets, Lambda functions, or S3 event triggers. Initial stack creation and infrastructure-level changes (e.g., adding a new instrument trigger) must be performed by an admin with broader AWS permissions. Once the stack exists, routine image-update deploys through CI work without issue.
 
 #### Local deployment
 

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -180,7 +180,7 @@ Secrets (`DATA_HUB_API_KEY`, `SLACK_WEBHOOK_URL`, etc.) are stored in GitHub env
 Local deployment requires the following tools in addition to the [general prerequisites](getting-started.md#prerequisites):
 
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) — used for bootstrap commands and ECR login.
-- [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) — used by `make sam-deploy-*` to package and deploy CloudFormation stacks. Install with `brew install aws-sam-cli` on macOS.
+- [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) — used by `make sam-deploy` to package and deploy CloudFormation stacks. Install with `brew install aws-sam-cli` on macOS.
 - AWS credentials configured (`aws configure` or environment variables) with permission to deploy the stack.
 
 Once installed, build and deploy:

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -14,7 +14,7 @@ All raw data files are stored in S3 with the key pattern:
 - **`run_id`** — unique identifier for the run, either extracted from the filename prefix or from a subdirectory name.
 - **`filename`** — the original filename.
 
-The S3 bucket name follows the template `arcadia-raw-data-hub-{environment}`, where `environment` is `staging` or `production`.
+The S3 bucket name follows the template `arcadia-data-hub-raw-{environment}`, where `environment` is `staging` or `production`.
 
 ## Instrument IDs
 
@@ -63,8 +63,8 @@ Run `make check-all` before pushing. CI enforces the same checks.
 
 | Environment | API URL | S3 bucket |
 | --- | --- | --- |
-| Staging | `https://data-hub-env-staging-arcadia-science.vercel.app/api/v1` | `arcadia-raw-data-hub-staging` |
-| Production | `https://data-hub.arcadiascience.com/api/v1` | `arcadia-raw-data-hub-production` |
+| Staging | `https://data-hub-env-staging-arcadia-science.vercel.app/api/v1` | `arcadia-data-hub-raw-staging` |
+| Production | `https://data-hub.arcadiascience.com/api/v1` | `arcadia-data-hub-raw-production` |
 
 ## Testing
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,6 +11,7 @@ This guide walks through setting up the full Data Hub development environment.
 | Node.js | >= 22 | Web application |
 | PostgreSQL | >= 15 | Database (local development) |
 | Docker | latest | Lambda container builds |
+| [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) | latest | Infrastructure deployment (optional — only needed for deploying to AWS) |
 
 ## Clone and install
 

--- a/docs/guides/adding-an-instrument.md
+++ b/docs/guides/adding-an-instrument.md
@@ -113,7 +113,24 @@ Add unit tests in `lambda/tests/` for the new processor. Integration tests will 
 
 ### 5. Configure the S3 trigger
 
-The S3 bucket needs an event notification configured to trigger the Lambda function for the new instrument's file types. This is done in AWS outside this repository.
+Add an S3 event to the Lambda function in `infra/template.yaml` under the `Events` section of `DataHubFunction`. Each event specifies a prefix (the instrument ID) and a suffix (the file extension):
+
+```yaml
+BioRadCfx96:
+  Type: S3
+  Properties:
+    Bucket: !Ref RawDataBucket
+    Events: s3:ObjectCreated:*
+    Filter:
+      S3Key:
+        Rules:
+          - Name: prefix
+            Value: bio-rad-cfx96/
+          - Name: suffix
+            Value: .csv
+```
+
+The trigger is created automatically on the next `sam deploy` (or when the deploy workflow runs after merge).
 
 ## What you get without Lambda
 

--- a/docs/guides/adding-an-instrument.md
+++ b/docs/guides/adding-an-instrument.md
@@ -113,21 +113,18 @@ Add unit tests in `lambda/tests/` for the new processor. Integration tests will 
 
 ### 5. Configure the S3 trigger
 
-Add an S3 event to the Lambda function in `infra/template.yaml` under the `Events` section of `DataHubFunction`. Each event specifies a prefix (the instrument ID) and a suffix (the file extension):
+Add a `LambdaConfiguration` entry to the `RawDataBucket` resource's `NotificationConfiguration` in `infra/template.yaml`. Each entry specifies a prefix (the instrument ID) and a suffix (the file extension):
 
 ```yaml
-BioRadCfx96:
-  Type: S3
-  Properties:
-    Bucket: !Ref RawDataBucket
-    Events: s3:ObjectCreated:*
-    Filter:
-      S3Key:
-        Rules:
-          - Name: prefix
-            Value: bio-rad-cfx96/
-          - Name: suffix
-            Value: .csv
+- Event: s3:ObjectCreated:*
+  Filter:
+    S3Key:
+      Rules:
+        - Name: prefix
+          Value: bio-rad-cfx96/
+        - Name: suffix
+          Value: .csv
+  Function: !GetAtt DataHubFunction.Arn
 ```
 
 The trigger is created automatically on the next `sam deploy` (or when the deploy workflow runs after merge).

--- a/docs/lambda.md
+++ b/docs/lambda.md
@@ -48,8 +48,6 @@ The Lambda function is packaged as a container image:
 make docker-build
 ```
 
-This requires a `GH_PERSONAL_ACCESS_TOKEN` in your `.env` file (used for a private Git dependency during `uv export`).
-
 The Dockerfile is a multi-stage build:
 
 1. **Builder stage**: Uses `uv` to export and install third-party dependencies into the Lambda task root.

--- a/docs/lambda.md
+++ b/docs/lambda.md
@@ -45,7 +45,7 @@ Each processor module exposes a `process_file()` function that accepts the run I
 The Lambda function is packaged as a container image:
 
 ```sh
-make docker-build
+make docker-build-lambda
 ```
 
 The Dockerfile is a multi-stage build:

--- a/infra/bootstrap.yaml
+++ b/infra/bootstrap.yaml
@@ -25,6 +25,19 @@ Resources:
                 "action": {
                   "type": "expire"
                 }
+              },
+              {
+                "rulePriority": 2,
+                "description": "Keep only the 50 most recent tagged images",
+                "selection": {
+                  "tagStatus": "tagged",
+                  "tagPrefixList": ["staging-", "production-"],
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 50
+                },
+                "action": {
+                  "type": "expire"
+                }
               }
             ]
           }

--- a/infra/bootstrap.yaml
+++ b/infra/bootstrap.yaml
@@ -7,7 +7,7 @@ Resources:
   EcrRepository:
     Type: AWS::ECR::Repository
     Properties:
-      RepositoryName: arcadia-data-hub
+      RepositoryName: data-hub
       ImageTagMutability: MUTABLE
       LifecyclePolicy:
         LifecyclePolicyText: |

--- a/infra/bootstrap.yaml
+++ b/infra/bootstrap.yaml
@@ -1,0 +1,57 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  One-time shared resources for Data Hub: ECR repository and GitHub Actions
+  OIDC identity provider. Deploy this stack once, not per environment.
+
+Resources:
+  EcrRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: arcadia-data-hub
+      ImageTagMutability: MUTABLE
+      LifecyclePolicy:
+        LifecyclePolicyText: |
+          {
+            "rules": [
+              {
+                "rulePriority": 1,
+                "description": "Expire untagged images after 7 days",
+                "selection": {
+                  "tagStatus": "untagged",
+                  "countType": "sinceImagePushed",
+                  "countUnit": "days",
+                  "countNumber": 7
+                },
+                "action": {
+                  "type": "expire"
+                }
+              }
+            ]
+          }
+      Tags:
+        - Key: project
+          Value: arcadia-data-hub
+
+  GitHubOidcProvider:
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      Url: https://token.actions.githubusercontent.com
+      ClientIdList:
+        - sts.amazonaws.com
+      ThumbprintList:
+        # GitHub Actions OIDC thumbprint — AWS validates the provider certificate
+        # chain regardless, so the exact value here is not security-critical.
+        - 6938fd4d98bab03faadb97b34396831e3780aea1
+
+Outputs:
+  EcrRepositoryUri:
+    Description: ECR repository URI for container images
+    Value: !GetAtt EcrRepository.RepositoryUri
+    Export:
+      Name: !Sub "${AWS::StackName}-EcrRepositoryUri"
+
+  OidcProviderArn:
+    Description: ARN of the GitHub Actions OIDC identity provider
+    Value: !GetAtt GitHubOidcProvider.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-OidcProviderArn"

--- a/infra/samconfig.toml
+++ b/infra/samconfig.toml
@@ -1,11 +1,9 @@
 version = 0.1
 
-# Required parameters without defaults. For local deploys, either:
-#   1. Source a .env file before running (e.g., `source .env && make sam-deploy-staging`)
-#   2. Override on the command line: sam deploy --config-env staging --parameter-overrides "EcrImageUri=..."
-#
-# In CI (deploy-lambda.yml), these are passed via --parameter-overrides from
-# GitHub environment secrets, which take precedence over the values here.
+# Static deploy configuration per environment. Parameter overrides with
+# secret/dynamic values are passed via the Makefile (local) or the GitHub
+# Actions workflow (CI), where shell variable expansion works correctly.
+# SAM CLI does NOT expand environment variables inside samconfig.toml.
 
 [staging.deploy.parameters]
 stack_name = "data-hub-staging"
@@ -14,14 +12,7 @@ s3_prefix = "data-hub-staging"
 region = "us-west-1"
 capabilities = "CAPABILITY_NAMED_IAM"
 confirm_changeset = true
-parameter_overrides = [
-    "Environment=staging",
-    "EcrImageUri=${ECR_IMAGE_URI}",
-    "DataHubApiUrl=${DATA_HUB_API_URL}",
-    "DataHubApiKey=${DATA_HUB_API_KEY}",
-    "SlackWebhookUrl=${SLACK_WEBHOOK_URL}",
-    "OidcProviderArn=${OIDC_PROVIDER_ARN}",
-]
+resolve_image_repos = true
 
 [production.deploy.parameters]
 stack_name = "data-hub-production"
@@ -30,11 +21,4 @@ s3_prefix = "data-hub-production"
 region = "us-west-1"
 capabilities = "CAPABILITY_NAMED_IAM"
 confirm_changeset = true
-parameter_overrides = [
-    "Environment=production",
-    "EcrImageUri=${ECR_IMAGE_URI}",
-    "DataHubApiUrl=${DATA_HUB_API_URL}",
-    "DataHubApiKey=${DATA_HUB_API_KEY}",
-    "SlackWebhookUrl=${SLACK_WEBHOOK_URL}",
-    "OidcProviderArn=${OIDC_PROVIDER_ARN}",
-]
+resolve_image_repos = true

--- a/infra/samconfig.toml
+++ b/infra/samconfig.toml
@@ -20,7 +20,6 @@ parameter_overrides = [
     "DataHubApiUrl=${DATA_HUB_API_URL}",
     "DataHubApiKey=${DATA_HUB_API_KEY}",
     "SlackWebhookUrl=${SLACK_WEBHOOK_URL}",
-    "LambdaAuthToken=${LAMBDA_AUTH_TOKEN}",
     "OidcProviderArn=${OIDC_PROVIDER_ARN}",
 ]
 
@@ -37,6 +36,5 @@ parameter_overrides = [
     "DataHubApiUrl=${DATA_HUB_API_URL}",
     "DataHubApiKey=${DATA_HUB_API_KEY}",
     "SlackWebhookUrl=${SLACK_WEBHOOK_URL}",
-    "LambdaAuthToken=${LAMBDA_AUTH_TOKEN}",
     "OidcProviderArn=${OIDC_PROVIDER_ARN}",
 ]

--- a/infra/samconfig.toml
+++ b/infra/samconfig.toml
@@ -1,0 +1,42 @@
+version = 0.1
+
+# Required parameters without defaults. For local deploys, either:
+#   1. Source a .env file before running (e.g., `source .env && make sam-deploy-staging`)
+#   2. Override on the command line: sam deploy --config-env staging --parameter-overrides "EcrImageUri=..."
+#
+# In CI (deploy-lambda.yml), these are passed via --parameter-overrides from
+# GitHub environment secrets, which take precedence over the values here.
+
+[staging.deploy.parameters]
+stack_name = "data-hub-staging"
+resolve_s3 = true
+s3_prefix = "data-hub-staging"
+region = "us-west-1"
+capabilities = "CAPABILITY_NAMED_IAM"
+confirm_changeset = true
+parameter_overrides = [
+    "Environment=staging",
+    "EcrImageUri=${ECR_IMAGE_URI}",
+    "DataHubApiUrl=${DATA_HUB_API_URL}",
+    "DataHubApiKey=${DATA_HUB_API_KEY}",
+    "SlackWebhookUrl=${SLACK_WEBHOOK_URL}",
+    "LambdaAuthToken=${LAMBDA_AUTH_TOKEN}",
+    "OidcProviderArn=${OIDC_PROVIDER_ARN}",
+]
+
+[production.deploy.parameters]
+stack_name = "data-hub-production"
+resolve_s3 = true
+s3_prefix = "data-hub-production"
+region = "us-west-1"
+capabilities = "CAPABILITY_NAMED_IAM"
+confirm_changeset = true
+parameter_overrides = [
+    "Environment=production",
+    "EcrImageUri=${ECR_IMAGE_URI}",
+    "DataHubApiUrl=${DATA_HUB_API_URL}",
+    "DataHubApiKey=${DATA_HUB_API_KEY}",
+    "SlackWebhookUrl=${SLACK_WEBHOOK_URL}",
+    "LambdaAuthToken=${LAMBDA_AUTH_TOKEN}",
+    "OidcProviderArn=${OIDC_PROVIDER_ARN}",
+]

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -241,7 +241,7 @@ Resources:
                   - ecr:InitiateLayerUpload
                   - ecr:UploadLayerPart
                   - ecr:CompleteLayerUpload
-                Resource: !Sub "arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/arcadia-data-hub"
+                Resource: !Sub "arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/data-hub"
         - PolicyName: LambdaUpdate
           PolicyDocument:
             Version: "2012-10-17"

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -51,12 +51,69 @@ Resources:
 
   RawDataBucket:
     Type: AWS::S3::Bucket
+    DependsOn: S3InvokeLambdaPermission
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
       BucketName: !Sub "arcadia-data-hub-raw-${Environment}"
       VersioningConfiguration:
         Status: Enabled
+      NotificationConfiguration:
+        LambdaConfigurations:
+          - Event: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: agilent-4150-tapestation/
+                  - Name: suffix
+                    Value: .pdf
+            Function: !GetAtt DataHubFunction.Arn
+          - Event: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: akta-fplc/
+                  - Name: suffix
+                    Value: .pdf
+            Function: !GetAtt DataHubFunction.Arn
+          - Event: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: azure-600-gel-doc/
+                  - Name: suffix
+                    Value: .tif
+            Function: !GetAtt DataHubFunction.Arn
+          - Event: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: azure-cielo-qpcr/
+                  - Name: suffix
+                    Value: .csv
+            Function: !GetAtt DataHubFunction.Arn
+          - Event: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: spectramax-id3-plate-reader/
+                  - Name: suffix
+                    Value: .xls
+            Function: !GetAtt DataHubFunction.Arn
+          - Event: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: spectramax-id5-plate-reader/
+                  - Name: suffix
+                    Value: .xls
+            Function: !GetAtt DataHubFunction.Arn
       Tags:
         - Key: project
           Value: arcadia-data-hub
@@ -88,84 +145,24 @@ Resources:
         AuthType: NONE
       Environment:
         Variables:
-          AWS_S3_RAW_DATA_BUCKET: !Ref RawDataBucket
-          AWS_S3_PROCESSED_DATA_BUCKET: !Ref ProcessedDataBucket
+          AWS_S3_RAW_DATA_BUCKET: !Sub "arcadia-data-hub-raw-${Environment}"
+          AWS_S3_PROCESSED_DATA_BUCKET: !Sub "arcadia-data-hub-processed-${Environment}"
           DATA_HUB_API_URL: !Ref DataHubApiUrl
           DATA_HUB_API_KEY: !Ref DataHubApiKey
           SLACK_WEBHOOK_URL: !Ref SlackWebhookUrl
-      Events:
-        TapeStation:
-          Type: S3
-          Properties:
-            Bucket: !Ref RawDataBucket
-            Events: s3:ObjectCreated:*
-            Filter:
-              S3Key:
-                Rules:
-                  - Name: prefix
-                    Value: agilent-4150-tapestation/
-                  - Name: suffix
-                    Value: .pdf
-        AktaFplc:
-          Type: S3
-          Properties:
-            Bucket: !Ref RawDataBucket
-            Events: s3:ObjectCreated:*
-            Filter:
-              S3Key:
-                Rules:
-                  - Name: prefix
-                    Value: akta-fplc/
-                  - Name: suffix
-                    Value: .pdf
-        GelDoc:
-          Type: S3
-          Properties:
-            Bucket: !Ref RawDataBucket
-            Events: s3:ObjectCreated:*
-            Filter:
-              S3Key:
-                Rules:
-                  - Name: prefix
-                    Value: azure-600-gel-doc/
-                  - Name: suffix
-                    Value: .tif
-        CieloQpcr:
-          Type: S3
-          Properties:
-            Bucket: !Ref RawDataBucket
-            Events: s3:ObjectCreated:*
-            Filter:
-              S3Key:
-                Rules:
-                  - Name: prefix
-                    Value: azure-cielo-qpcr/
-                  - Name: suffix
-                    Value: .csv
-        SpectramaxId3:
-          Type: S3
-          Properties:
-            Bucket: !Ref RawDataBucket
-            Events: s3:ObjectCreated:*
-            Filter:
-              S3Key:
-                Rules:
-                  - Name: prefix
-                    Value: spectramax-id3-plate-reader/
-                  - Name: suffix
-                    Value: .xls
-        SpectramaxId5:
-          Type: S3
-          Properties:
-            Bucket: !Ref RawDataBucket
-            Events: s3:ObjectCreated:*
-            Filter:
-              S3Key:
-                Rules:
-                  - Name: prefix
-                    Value: spectramax-id5-plate-reader/
-                  - Name: suffix
-                    Value: .xls
+
+  # ---- S3 → Lambda event wiring ----
+  # Defined as explicit resources rather than SAM Events to avoid the circular
+  # dependency that occurs when the bucket and function are in the same template.
+
+  S3InvokeLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref DataHubFunction
+      Principal: s3.amazonaws.com
+      SourceArn: !Sub "arn:aws:s3:::arcadia-data-hub-raw-${Environment}"
+      SourceAccount: !Ref AWS::AccountId
 
   # ---- IAM: Lambda execution role ----
 
@@ -192,16 +189,16 @@ Resources:
                   - s3:GetObject
                   - s3:ListBucket
                 Resource:
-                  - !GetAtt RawDataBucket.Arn
-                  - !Sub "${RawDataBucket.Arn}/*"
+                  - !Sub "arn:aws:s3:::arcadia-data-hub-raw-${Environment}"
+                  - !Sub "arn:aws:s3:::arcadia-data-hub-raw-${Environment}/*"
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                   - s3:ListBucket
                 Resource:
-                  - !GetAtt ProcessedDataBucket.Arn
-                  - !Sub "${ProcessedDataBucket.Arn}/*"
+                  - !Sub "arn:aws:s3:::arcadia-data-hub-processed-${Environment}"
+                  - !Sub "arn:aws:s3:::arcadia-data-hub-processed-${Environment}/*"
 
   # ---- IAM: GitHub Actions deploy role ----
   # Scoped for routine image-update deploys only.  Initial stack creation and
@@ -254,7 +251,7 @@ Resources:
                   - lambda:UpdateFunctionCode
                   - lambda:UpdateFunctionConfiguration
                   - lambda:GetFunction
-                Resource: !GetAtt DataHubFunction.Arn
+                Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:data-hub-${Environment}"
         - PolicyName: SamDeploy
           PolicyDocument:
             Version: "2012-10-17"

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -37,11 +37,6 @@ Parameters:
     NoEcho: true
     Description: Slack incoming webhook URL for Lambda notifications
 
-  LambdaAuthToken:
-    Type: String
-    NoEcho: true
-    Description: Token for authenticating requests to the Lambda function URL
-
   OidcProviderArn:
     Type: String
     Description: ARN of the GitHub Actions OIDC provider (from bootstrap stack)
@@ -98,7 +93,6 @@ Resources:
           DATA_HUB_API_URL: !Ref DataHubApiUrl
           DATA_HUB_API_KEY: !Ref DataHubApiKey
           SLACK_WEBHOOK_URL: !Ref SlackWebhookUrl
-          AWS_LAMBDA_FUNCTION_URL_AUTH_TOKEN: !Ref LambdaAuthToken
       Events:
         TapeStation:
           Type: S3

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -56,8 +56,10 @@ Resources:
 
   RawDataBucket:
     Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
-      BucketName: !Sub "arcadia-raw-data-hub-${Environment}"
+      BucketName: !Sub "arcadia-data-hub-raw-${Environment}"
       VersioningConfiguration:
         Status: Enabled
       Tags:
@@ -66,8 +68,10 @@ Resources:
 
   ProcessedDataBucket:
     Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
-      BucketName: !Sub "arcadia-processed-data-hub-${Environment}"
+      BucketName: !Sub "arcadia-data-hub-processed-${Environment}"
       VersioningConfiguration:
         Status: Enabled
       Tags:
@@ -206,6 +210,9 @@ Resources:
                   - !Sub "${ProcessedDataBucket.Arn}/*"
 
   # ---- IAM: GitHub Actions deploy role ----
+  # Scoped for routine image-update deploys only.  Initial stack creation and
+  # infrastructure changes (new buckets, Lambda functions, S3 event triggers)
+  # require broader permissions — run those from an admin session.
 
   GitHubActionsDeployRole:
     Type: AWS::IAM::Role
@@ -286,8 +293,10 @@ Resources:
                   - iam:DeleteRolePolicy
                   - iam:DetachRolePolicy
                   - iam:TagRole
+                  # iam:DeleteRole is intentionally omitted — role replacement
+                  # requires an admin deploy (see ci-and-deployment.md).
                 Resource:
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/data-hub-*"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/data-hub-*-${Environment}"
 
 Outputs:
   DataHubFunctionArn:

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -1,0 +1,315 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: >-
+  Data Hub per-environment stack: S3 buckets, Lambda function with S3 triggers,
+  and IAM roles for Lambda execution and GitHub Actions deployment.
+
+Parameters:
+  Environment:
+    Type: String
+    AllowedValues:
+      - staging
+      - production
+
+  EcrImageUri:
+    Type: String
+    Description: Full ECR image URI including tag (e.g., 123456789.dkr.ecr.us-west-1.amazonaws.com/arcadia-data-hub:staging-abc123)
+
+  GitHubOrg:
+    Type: String
+    Default: Arcadia-Science
+
+  GitHubRepo:
+    Type: String
+    Default: data-hub
+
+  DataHubApiUrl:
+    Type: String
+    Description: Base URL of the Data Hub web API
+
+  DataHubApiKey:
+    Type: String
+    NoEcho: true
+    Description: API key for Lambda to authenticate with the Data Hub API
+
+  SlackWebhookUrl:
+    Type: String
+    NoEcho: true
+    Description: Slack incoming webhook URL for Lambda notifications
+
+  LambdaAuthToken:
+    Type: String
+    NoEcho: true
+    Description: Token for authenticating requests to the Lambda function URL
+
+  OidcProviderArn:
+    Type: String
+    Description: ARN of the GitHub Actions OIDC provider (from bootstrap stack)
+
+Globals:
+  Function:
+    Timeout: 300
+    MemorySize: 1024
+
+Resources:
+  # ---- S3 buckets ----
+
+  RawDataBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "arcadia-raw-data-hub-${Environment}"
+      VersioningConfiguration:
+        Status: Enabled
+      Tags:
+        - Key: project
+          Value: arcadia-data-hub
+
+  ProcessedDataBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "arcadia-processed-data-hub-${Environment}"
+      VersioningConfiguration:
+        Status: Enabled
+      Tags:
+        - Key: project
+          Value: arcadia-data-hub
+
+  # ---- Lambda function ----
+
+  DataHubFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "data-hub-${Environment}"
+      PackageType: Image
+      ImageUri: !Ref EcrImageUri
+      EphemeralStorage:
+        Size: 512
+      Role: !GetAtt LambdaExecutionRole.Arn
+      FunctionUrlConfig:
+        AuthType: NONE
+      Environment:
+        Variables:
+          AWS_S3_RAW_DATA_BUCKET: !Ref RawDataBucket
+          AWS_S3_PROCESSED_DATA_BUCKET: !Ref ProcessedDataBucket
+          DATA_HUB_API_URL: !Ref DataHubApiUrl
+          DATA_HUB_API_KEY: !Ref DataHubApiKey
+          SLACK_WEBHOOK_URL: !Ref SlackWebhookUrl
+          AWS_LAMBDA_FUNCTION_URL_AUTH_TOKEN: !Ref LambdaAuthToken
+      Events:
+        TapeStation:
+          Type: S3
+          Properties:
+            Bucket: !Ref RawDataBucket
+            Events: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: agilent-4150-tapestation/
+                  - Name: suffix
+                    Value: .pdf
+        AktaFplc:
+          Type: S3
+          Properties:
+            Bucket: !Ref RawDataBucket
+            Events: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: akta-fplc/
+                  - Name: suffix
+                    Value: .pdf
+        GelDoc:
+          Type: S3
+          Properties:
+            Bucket: !Ref RawDataBucket
+            Events: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: azure-600-gel-doc/
+                  - Name: suffix
+                    Value: .tif
+        CieloQpcr:
+          Type: S3
+          Properties:
+            Bucket: !Ref RawDataBucket
+            Events: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: azure-cielo-qpcr/
+                  - Name: suffix
+                    Value: .csv
+        SpectramaxId3:
+          Type: S3
+          Properties:
+            Bucket: !Ref RawDataBucket
+            Events: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: spectramax-id3-plate-reader/
+                  - Name: suffix
+                    Value: .xls
+        SpectramaxId5:
+          Type: S3
+          Properties:
+            Bucket: !Ref RawDataBucket
+            Events: s3:ObjectCreated:*
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: spectramax-id5-plate-reader/
+                  - Name: suffix
+                    Value: .xls
+
+  # ---- IAM: Lambda execution role ----
+
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "data-hub-lambda-${Environment}"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: S3Access
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:ListBucket
+                Resource:
+                  - !GetAtt RawDataBucket.Arn
+                  - !Sub "${RawDataBucket.Arn}/*"
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:ListBucket
+                Resource:
+                  - !GetAtt ProcessedDataBucket.Arn
+                  - !Sub "${ProcessedDataBucket.Arn}/*"
+
+  # ---- IAM: GitHub Actions deploy role ----
+
+  GitHubActionsDeployRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "data-hub-deploy-${Environment}"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Ref OidcProviderArn
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+              StringLike:
+                token.actions.githubusercontent.com:sub:
+                  - !Sub "repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/${Environment}"
+                  - !Sub "repo:${GitHubOrg}/${GitHubRepo}:environment:${Environment}"
+      Policies:
+        - PolicyName: EcrPush
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchGetImage
+                  - ecr:PutImage
+                  - ecr:InitiateLayerUpload
+                  - ecr:UploadLayerPart
+                  - ecr:CompleteLayerUpload
+                Resource: !Sub "arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/arcadia-data-hub"
+        - PolicyName: LambdaUpdate
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:UpdateFunctionCode
+                  - lambda:UpdateFunctionConfiguration
+                  - lambda:GetFunction
+                Resource: !GetAtt DataHubFunction.Arn
+        - PolicyName: SamDeploy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudformation:CreateChangeSet
+                  - cloudformation:DeleteChangeSet
+                  - cloudformation:DescribeChangeSet
+                  - cloudformation:DescribeStacks
+                  - cloudformation:ExecuteChangeSet
+                  - cloudformation:GetTemplateSummary
+                Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/data-hub-${Environment}/*"
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:GetBucketLocation
+                  - s3:ListBucket
+                Resource:
+                  - !Sub "arn:aws:s3:::aws-sam-cli-managed-default-samclisourcebucket-*"
+                  - !Sub "arn:aws:s3:::aws-sam-cli-managed-default-samclisourcebucket-*/*"
+              - Effect: Allow
+                Action:
+                  - iam:GetRole
+                  - iam:PassRole
+                  - iam:CreateRole
+                  - iam:AttachRolePolicy
+                  - iam:PutRolePolicy
+                  - iam:DeleteRolePolicy
+                  - iam:DetachRolePolicy
+                  - iam:TagRole
+                Resource:
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/data-hub-*"
+
+Outputs:
+  DataHubFunctionArn:
+    Description: Lambda function ARN
+    Value: !GetAtt DataHubFunction.Arn
+
+  DataHubFunctionName:
+    Description: Lambda function name
+    Value: !Ref DataHubFunction
+
+  DataHubFunctionUrl:
+    Description: Lambda function URL
+    Value: !GetAtt DataHubFunctionUrl.FunctionUrl
+
+  RawDataBucketName:
+    Description: Raw data S3 bucket name
+    Value: !Ref RawDataBucket
+
+  ProcessedDataBucketName:
+    Description: Processed data S3 bucket name
+    Value: !Ref ProcessedDataBucket
+
+  DeployRoleArn:
+    Description: GitHub Actions deploy role ARN
+    Value: !GetAtt GitHubActionsDeployRole.Arn

--- a/lambda/.env.example
+++ b/lambda/.env.example
@@ -15,9 +15,6 @@ AWS_S3_PROCESSED_DATA_BUCKET=
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
-# This token is used to authenticate requests to the publicly accessible Lambda function URL.
-AWS_LAMBDA_FUNCTION_URL_AUTH_TOKEN=
-
 # This is the Slack webhook URL for the channel to send messages to on workflow completion.
 # See: https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/.
 SLACK_WEBHOOK_URL=

--- a/lambda/Dockerfile
+++ b/lambda/Dockerfile
@@ -2,8 +2,6 @@ FROM ghcr.io/astral-sh/uv:0.8.12 AS uv
 
 FROM public.ecr.aws/lambda/python:3.12 AS builder
 
-RUN dnf install -y git
-
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_NO_INSTALLER_METADATA=1
 ENV UV_LINK_MODE=copy
@@ -11,17 +9,13 @@ ENV UV_LINK_MODE=copy
 # Resolve and install third-party deps into the Lambda task root. The
 # workspace root uv.lock is mounted for version pinning, but workspace
 # packages (shared, lambda) are excluded from the export — they're copied
-# as source in the final stage instead. GIT_AUTH_TOKEN is needed for the
-# private michaelis-menten-analysis git dependency.
+# as source in the final stage instead.
 RUN --mount=from=uv,source=/uv,target=/bin/uv \
     --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=lambda/pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=packages/shared/pyproject.toml,target=packages/shared/pyproject.toml \
     --mount=type=bind,source=packages/shared/src,target=packages/shared/src \
-    --mount=type=secret,id=GIT_AUTH_TOKEN \
-    export GIT_AUTH_TOKEN=$(cat /run/secrets/GIT_AUTH_TOKEN) && \
-    git config --global url."https://${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/" && \
     uv export --frozen --no-emit-workspace --no-dev --no-editable -o requirements.txt && \
     uv pip install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 

--- a/lambda/src/data_hub_lambda/agilent_4150_tapestation/process_file.py
+++ b/lambda/src/data_hub_lambda/agilent_4150_tapestation/process_file.py
@@ -27,7 +27,7 @@ def process_file(run_id: str, filename: str) -> str:
 
     client = get_client()
     s3_bucket = config.AWS_S3_RAW_DATA_BUCKET
-    s3_key = f"{INSTRUMENT_ID}/{filename}"
+    s3_key = f"{INSTRUMENT_ID}/{run_id}/{filename}"
 
     client.ensure_run(INSTRUMENT_ID, run_id)
 

--- a/lambda/src/data_hub_lambda/akta_fplc/process_file.py
+++ b/lambda/src/data_hub_lambda/akta_fplc/process_file.py
@@ -26,7 +26,7 @@ def process_file(run_id: str, filename: str) -> str:
 
     client = get_client()
     s3_bucket = config.AWS_S3_RAW_DATA_BUCKET
-    s3_key = f"{INSTRUMENT_ID}/{filename}"
+    s3_key = f"{INSTRUMENT_ID}/{run_id}/{filename}"
 
     client.ensure_run(INSTRUMENT_ID, run_id)
 

--- a/lambda/src/data_hub_lambda/azure_600_gel_doc/process_file.py
+++ b/lambda/src/data_hub_lambda/azure_600_gel_doc/process_file.py
@@ -32,7 +32,7 @@ def process_file(run_id: str, filename: str) -> str:
 
     client = get_client()
     s3_bucket = config.AWS_S3_RAW_DATA_BUCKET
-    s3_key = f"{INSTRUMENT_ID}/{filename}"
+    s3_key = f"{INSTRUMENT_ID}/{run_id}/{filename}"
 
     client.ensure_run(INSTRUMENT_ID, run_id)
 
@@ -58,7 +58,7 @@ def process_file(run_id: str, filename: str) -> str:
         png_file_path = tiff_processor.export_figure()
 
         processed_bucket = config.AWS_S3_PROCESSED_DATA_BUCKET
-        png_s3_key = f"{INSTRUMENT_ID}/{png_file_path.name}"
+        png_s3_key = f"{INSTRUMENT_ID}/{run_id}/{png_file_path.name}"
         s3_utils.upload_file(png_file_path, f"s3://{processed_bucket}/{png_s3_key}")
         logger.info("Uploaded processed image to s3://%s/%s", processed_bucket, png_s3_key)
 

--- a/lambda/src/data_hub_lambda/azure_cielo_qpcr/process_file.py
+++ b/lambda/src/data_hub_lambda/azure_cielo_qpcr/process_file.py
@@ -30,7 +30,7 @@ def process_file(run_id: str, filename: str) -> str:
 
     client = get_client()
     s3_bucket = config.AWS_S3_RAW_DATA_BUCKET
-    s3_key = f"{INSTRUMENT_ID}/{filename}"
+    s3_key = f"{INSTRUMENT_ID}/{run_id}/{filename}"
 
     client.ensure_run(INSTRUMENT_ID, run_id)
 

--- a/lambda/src/data_hub_lambda/config.py
+++ b/lambda/src/data_hub_lambda/config.py
@@ -6,10 +6,7 @@ class LambdaConfig:
     DATA_HUB_API_URL: str | None
     DATA_HUB_API_KEY: str | None
 
-    AWS_LAMBDA_FUNCTION_URL_AUTH_TOKEN: str | None
-
     def __init__(self) -> None:
-        self.AWS_LAMBDA_FUNCTION_URL_AUTH_TOKEN = os.getenv("AWS_LAMBDA_FUNCTION_URL_AUTH_TOKEN")
         self.DATA_HUB_API_URL = os.getenv("DATA_HUB_API_URL")
         self.DATA_HUB_API_KEY = os.getenv("DATA_HUB_API_KEY")
 

--- a/lambda/src/data_hub_lambda/spectramax_plate_reader/process_file.py
+++ b/lambda/src/data_hub_lambda/spectramax_plate_reader/process_file.py
@@ -28,7 +28,7 @@ def process_file(instrument_id: InstrumentType, run_id: str, filename: str) -> s
 
     client = get_client()
     s3_bucket = config.AWS_S3_RAW_DATA_BUCKET
-    s3_key = f"{instrument_id}/{filename}"
+    s3_key = f"{instrument_id}/{run_id}/{filename}"
 
     client.ensure_run(instrument_id, run_id)
 

--- a/lambda/tests/integration/conftest.py
+++ b/lambda/tests/integration/conftest.py
@@ -125,15 +125,18 @@ def make_s3_event() -> Callable[..., dict[str, Any]]:
     Usage::
 
         def test_example(make_s3_event):
-            event = make_s3_event("azure-cielo-qpcr", "Experiment_20260101_CqValues.csv")
+            event = make_s3_event(
+                "azure-cielo-qpcr", "Experiment_20260101", "CqValues.csv",
+            )
     """
 
     def _factory(
         instrument_id: str,
+        run_id: str,
         filename: str,
         bucket: str = "test-bucket",
     ) -> dict[str, Any]:
-        s3_key = f"{instrument_id}/{filename}"
+        s3_key = f"{instrument_id}/{run_id}/{filename}"
         return {
             "Records": [
                 {

--- a/lambda/tests/integration/test_lambda_api.py
+++ b/lambda/tests/integration/test_lambda_api.py
@@ -56,11 +56,13 @@ class TestQPCRHappyPath:
         mock_slack: MagicMock,
     ) -> None:
         # Register the real fixture CSV so the patched S3 download can find it.
-        s3_key = "azure-cielo-qpcr/Experiment_20260101_CqValues.csv"
+        run_id = "Experiment_20260101"
+        filename = f"{run_id}_CqValues.csv"
+        s3_key = f"azure-cielo-qpcr/{run_id}/{filename}"
         s3_fixture_files[s3_key] = _FIXTURES_DIR / "azure_cielo_qpcr_example.csv"
 
         # Fire the event to trigger the pipeline.
-        event = make_s3_event("azure-cielo-qpcr", "Experiment_20260101_CqValues.csv")
+        event = make_s3_event("azure-cielo-qpcr", run_id, filename)
         lambda_handler(event, mock_context)
 
         # Verify via the real API that the full pipeline wrote correct data.
@@ -150,11 +152,11 @@ class TestSpectraMaxHappyPath:
     ) -> None:
         # Register the real fixture CSV so the patched S3 download can find it.
         filename = f"{run_id}.xls"
-        s3_key = f"spectramax-id3-plate-reader/{filename}"
+        s3_key = f"spectramax-id3-plate-reader/{run_id}/{filename}"
         s3_fixture_files[s3_key] = _FIXTURES_DIR / fixture_file
 
         # Fire the event to trigger the pipeline.
-        event = make_s3_event("spectramax-id3-plate-reader", filename)
+        event = make_s3_event("spectramax-id3-plate-reader", run_id, filename)
         lambda_handler(event, mock_context)
 
         # Verify via the real API that the full pipeline wrote correct data.
@@ -220,11 +222,12 @@ class TestAzure600GelDocHappyPath:
     ) -> None:
         # Register the real fixture TIFF so the patched S3 download can find it.
         run_id = "26.04.01_16.51.59"
-        s3_key = f"azure-600-gel-doc/{run_id}.tif"
+        filename = f"{run_id}.tif"
+        s3_key = f"azure-600-gel-doc/{run_id}/{filename}"
         s3_fixture_files[s3_key] = _FIXTURES_DIR / "azure_600_gel_doc_example.tif"
 
         # Fire the event to trigger the pipeline.
-        event = make_s3_event("azure-600-gel-doc", f"{run_id}.tif")
+        event = make_s3_event("azure-600-gel-doc", run_id, filename)
         lambda_handler(event, mock_context)
 
         # Verify via the real API that the full pipeline wrote correct data.
@@ -263,7 +266,7 @@ class TestAzure600GelDocHappyPath:
         # The pipeline uploads the contrast-enhanced PNG to the processed bucket.
         mock_s3_upload.assert_called_once()
         upload_dest = mock_s3_upload.call_args[0][1]
-        assert upload_dest == f"s3://test-processed-bucket/azure-600-gel-doc/{run_id}.png"
+        assert upload_dest == f"s3://test-processed-bucket/azure-600-gel-doc/{run_id}/{run_id}.png"
 
         # Verify the Slack notification.
         mock_slack.assert_called_once()
@@ -294,11 +297,11 @@ class TestFailurePath:
 
         run_id = "Experiment_20260201"
         filename = f"{run_id}_CqValues.csv"
-        s3_key = f"azure-cielo-qpcr/{filename}"
+        s3_key = f"azure-cielo-qpcr/{run_id}/{filename}"
         s3_fixture_files[s3_key] = bad_csv
 
         # Fire the event to trigger the pipeline.
-        event = make_s3_event("azure-cielo-qpcr", filename)
+        event = make_s3_event("azure-cielo-qpcr", run_id, filename)
         lambda_handler(event, mock_context)
 
         # Verify via the real API that the full pipeline wrote correct data.
@@ -336,13 +339,14 @@ class TestIdempotentRunCreation:
         mock_slack: MagicMock,
     ) -> None:
         run_id = "Experiment_20260301"
-        s3_key = f"azure-cielo-qpcr/{run_id}_CqValues.csv"
+        filename = f"{run_id}_CqValues.csv"
+        s3_key = f"azure-cielo-qpcr/{run_id}/{filename}"
         s3_fixture_files[s3_key] = _FIXTURES_DIR / "azure_cielo_qpcr_example.csv"
 
         # Fire the same event twice to verify the upsert semantics of
         # ensure_run: the API returns 200 (existing) on the second call
         # rather than creating a duplicate.
-        event = make_s3_event("azure-cielo-qpcr", f"{run_id}_CqValues.csv")
+        event = make_s3_event("azure-cielo-qpcr", run_id, filename)
         lambda_handler(event, mock_context)
         lambda_handler(event, mock_context)
 
@@ -400,10 +404,11 @@ class TestFileReprocessing:
         file via completed → processing → completed.
         """
         run_id = "Experiment_20260301"
-        s3_key = f"azure-cielo-qpcr/{run_id}_CqValues.csv"
+        filename = f"{run_id}_CqValues.csv"
+        s3_key = f"azure-cielo-qpcr/{run_id}/{filename}"
         s3_fixture_files[s3_key] = _FIXTURES_DIR / "azure_cielo_qpcr_example.csv"
 
-        event = make_s3_event("azure-cielo-qpcr", f"{run_id}_CqValues.csv")
+        event = make_s3_event("azure-cielo-qpcr", run_id, filename)
         lambda_handler(event, mock_context)
         lambda_handler(event, mock_context)
 
@@ -447,12 +452,13 @@ class TestFileReprocessing:
         cleared.
         """
         run_id = "Experiment_20260301"
-        s3_key = f"azure-cielo-qpcr/{run_id}_CqValues.csv"
+        filename = f"{run_id}_CqValues.csv"
+        s3_key = f"azure-cielo-qpcr/{run_id}/{filename}"
         bad_csv = tmp_path / "bad.csv"
         bad_csv.write_text("Wrong,Headers,Only\nA,B,C\n")
         s3_fixture_files[s3_key] = bad_csv
 
-        event = make_s3_event("azure-cielo-qpcr", f"{run_id}_CqValues.csv")
+        event = make_s3_event("azure-cielo-qpcr", run_id, filename)
         lambda_handler(event, mock_context)
 
         run = _api_get(
@@ -496,11 +502,12 @@ class TestFileReprocessing:
         replaces rather than appends.
         """
         run_id = "033126_CM_Od750"
-        s3_key = f"spectramax-id3-plate-reader/{run_id}.xls"
+        filename = f"{run_id}.xls"
+        s3_key = f"spectramax-id3-plate-reader/{run_id}/{filename}"
         s3_fixture_files[s3_key] = _FIXTURES_DIR / "spectramax_plate_reader_endpoint.xls"
 
         # Fire the event twice.
-        event = make_s3_event("spectramax-id3-plate-reader", f"{run_id}.xls")
+        event = make_s3_event("spectramax-id3-plate-reader", run_id, filename)
         lambda_handler(event, mock_context)
         lambda_handler(event, mock_context)
 

--- a/watcher/src/data_hub_watcher/constants.py
+++ b/watcher/src/data_hub_watcher/constants.py
@@ -7,7 +7,7 @@ API_URLS: dict[str, str] = {
     "production": "https://data-hub.arcadiascience.com/api/v1",
 }
 
-S3_BUCKET_TEMPLATE = "arcadia-raw-data-hub-{environment}"
+S3_BUCKET_TEMPLATE = "arcadia-data-hub-raw-{environment}"
 
 DEFAULT_CONFIG_DIR = Path("~/.data-hub").expanduser()
 DEFAULT_CONFIG_FILENAME = "config.yaml"


### PR DESCRIPTION
## Summary

Introduces AWS SAM infrastructure-as-code for the Lambda stack, a GitHub Actions workflow for automated deployments via OIDC, and fixes the S3 key pattern to include `run_id` in the object path.

## Changes

- **SAM infrastructure** (`infra/template.yaml`): Defines the per-environment stack — S3 buckets (raw + processed), Lambda function with S3 event triggers for each instrument, IAM execution role, and a narrowly-scoped GitHub Actions deploy role using OIDC federation.
- **Bootstrap stack** (`infra/bootstrap.yaml`): One-time shared resources — ECR repository with lifecycle policy and the GitHub Actions OIDC identity provider.
- **SAM config** (`infra/samconfig.toml`): Per-environment deploy parameters for staging and production.
- **GitHub Actions workflow** (`.github/workflows/deploy-lambda.yml`): On pushes to `staging`/`production`, builds and pushes the Docker image to ECR, then runs `sam deploy` with environment-scoped secrets. Uses OIDC — no long-lived AWS keys.
- **S3 key pattern fix**: All `process_file` modules updated from `{instrument_id}/{filename}` to `{instrument_id}/{run_id}/{filename}` to match the actual S3 key structure produced by uploads.
- **S3 bucket naming**: Renamed from `arcadia-raw-data-hub-{env}` to `arcadia-data-hub-raw-{env}` across code, docs, and the watcher constant.
- **Makefile**: Added `sam-bootstrap`, `sam-deploy`, and `sam-teardown` targets.
- **Documentation**: Updated `ci-and-deployment.md` with deployment architecture, `getting-started.md` with SAM CLI prerequisite, `conventions.md` with corrected bucket names, and `adding-an-instrument.md` with SAM trigger instructions (replacing the previous "done outside this repo" note).

## Breaking changes

- **S3 key path** now includes `run_id`: `{instrument_id}/{run_id}/{filename}` instead of `{instrument_id}/{filename}`. Existing objects in S3 under the old key structure will not be found by the updated code without migration.
- **S3 bucket names** changed from `arcadia-raw-data-hub-{env}` to `arcadia-data-hub-raw-{env}`. Requires coordinated infrastructure update.
- **`make_s3_event` test fixture** now requires a `run_id` argument between `instrument_id` and `filename`.

## Driveby changes

None.

## Testing

- [x] Integration tests updated to use the new 3-argument `make_s3_event` factory and new S3 key paths — verify with `make check-all`.
- [x] Validate SAM template locally with `sam validate --template infra/template.yaml`.
- [x] Deploy bootstrap stack to a sandbox account with `make sam-bootstrap` and confirm ECR repo + OIDC provider are created.
- [x] Deploy the staging stack with `make sam-deploy-staging` and verify S3 triggers fire correctly with the new key pattern.
- [x] Verify the GitHub Actions workflow runs successfully on a push to `staging`.