### PR TITLE
Fix CI workflow for Lambda deployment by passing SAM S3 bucket explicitly

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -56,6 +56,9 @@ jobs:
             --config-env "${{ github.ref_name }}" \
             --no-confirm-changeset \
             --no-fail-on-empty-changeset \
+            --s3-bucket "${{ secrets.SAM_S3_BUCKET }}" \
+            --s3-prefix "data-hub-${{ github.ref_name }}" \
+            --no-resolve-s3 \
             --parameter-overrides \
               "EcrImageUri=${IMAGE_URI}" \
               "DataHubApiUrl=${{ secrets.DATA_HUB_API_URL }}" \

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -157,6 +157,7 @@ In your GitHub repo, go to **Settings → Environments**, create a `staging` env
 | --- | --- |
 | `AWS_DEPLOY_ROLE_ARN` | Deploy role ARN from the stack output |
 | `OIDC_PROVIDER_ARN` | OIDC provider ARN from the bootstrap stack |
+| `SAM_S3_BUCKET` | SAM CLI managed S3 bucket name (see `sam deploy` output, e.g. `aws-sam-cli-managed-default-samclisourcebucket-*`) |
 | `DATA_HUB_API_URL` | Base API URL for the environment |
 | `DATA_HUB_API_KEY` | API key for Lambda → Data Hub authentication |
 | `SLACK_WEBHOOK_URL` | Slack incoming webhook URL |


### PR DESCRIPTION
## Summary

The CI Lambda deploy role's CloudFormation permissions are scoped to `data-hub-{env}/*` stacks, but SAM CLI's `resolve_s3` option tries to create/manage its own `aws-sam-cli-managed-default` bootstrap stack, which the role isn't authorized for. This passes the S3 bucket explicitly so SAM skips the managed stack check entirely.

## Changes

- Added `--s3-bucket`, `--s3-prefix`, and `--no-resolve-s3` flags to the `sam deploy` command in the deploy workflow, sourcing the bucket name from a new `SAM_S3_BUCKET` environment secret.
- Documented the new `SAM_S3_BUCKET` secret in the GitHub environment secrets table in `ci-and-deployment.md`.

## Breaking changes

Requires a new `SAM_S3_BUCKET` secret in both the `staging` and `production` GitHub environments before the next deploy. Set it to the SAM CLI managed bucket name.

## Driveby changes

None.

## Testing

- [x] Add `SAM_S3_BUCKET` secret to the `staging` GitHub environment
- [x] Re-run the deploy workflow on `staging` and confirm `sam deploy` succeeds
- [x] Add `SAM_S3_BUCKET` secret to the `production` GitHub environment