### PR TITLE
Fix Lambda ECR permissions, rename OIDC secret

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  deploy-lambda:
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name }}
     steps:
@@ -67,5 +67,5 @@ jobs:
               "DataHubApiKey=${{ secrets.DATA_HUB_API_KEY }}" \
               "SlackWebhookUrl=${{ secrets.SLACK_WEBHOOK_URL }}" \
               "Environment=${{ github.ref_name }}" \
-              "GitHubOidcProviderArn=${{ secrets.OIDC_PROVIDER_ARN }}" \
+              "GitHubOidcProviderArn=${{ secrets.GH_OIDC_PROVIDER_ARN }}" \
               "VercelOidcProviderArn=${{ secrets.VERCEL_OIDC_PROVIDER_ARN }}"

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -157,7 +157,7 @@ In your GitHub repo, go to **Settings → Environments**, create a `staging` env
 | Secret | Value |
 | --- | --- |
 | `AWS_DEPLOY_ROLE_ARN` | Deploy role ARN from the stack output |
-| `OIDC_PROVIDER_ARN` | GitHub OIDC provider ARN from the bootstrap stack |
+| `GH_OIDC_PROVIDER_ARN` | GitHub OIDC provider ARN from the bootstrap stack |
 | `VERCEL_OIDC_PROVIDER_ARN` | Vercel OIDC provider ARN from the bootstrap stack |
 | `SAM_S3_BUCKET` | SAM CLI managed S3 bucket name (see `sam deploy` output, e.g. `aws-sam-cli-managed-default-samclisourcebucket-*`) |
 | `DATA_HUB_API_URL` | Base API URL for the environment |

--- a/infra/bootstrap.yaml
+++ b/infra/bootstrap.yaml
@@ -10,6 +10,19 @@ Resources:
     Properties:
       RepositoryName: data-hub
       ImageTagMutability: MUTABLE
+      RepositoryPolicyText:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowLambdaImagePull
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action:
+              - ecr:BatchGetImage
+              - ecr:GetDownloadUrlForLayer
+            Condition:
+              StringLike:
+                "aws:sourceArn": !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*"
       LifecyclePolicy:
         LifecyclePolicyText: |
           {


### PR DESCRIPTION
## Summary

- Add an ECR repository policy in the bootstrap stack granting the Lambda service `ecr:BatchGetImage` and `ecr:GetDownloadUrlForLayer`, scoped to Lambda functions in the account. This fixes the `AccessDenied` error during `sam deploy` in [this run](https://github.com/Arcadia-Science/data-hub/actions/runs/24263319023/job/70852885155).
- Rename `OIDC_PROVIDER_ARN` secret to `GH_OIDC_PROVIDER_ARN` to distinguish it from the Vercel OIDC provider ARN.
- Rename the deploy job from `deploy` to `deploy-lambda` for clarity.

## Deploy steps
1. Recover the `data-hub-staging` stack from `UPDATE_ROLLBACK_FAILED`:
   ```sh
   aws cloudformation continue-update-rollback --stack-name data-hub-staging --region us-west-1
   ```
2. Deploy the bootstrap stack: `make sam-bootstrap`
3. Rename the GitHub environment secret from `OIDC_PROVIDER_ARN` to `GH_OIDC_PROVIDER_ARN` in both staging and production.
4. Re-run the deploy workflow.