### PR TITLE
Add manual file reprocessing and inline error display

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -68,4 +68,5 @@ jobs:
               "SlackWebhookUrl=${{ secrets.SLACK_WEBHOOK_URL }}" \
               "Environment=${{ github.ref_name }}" \
               "GitHubOidcProviderArn=${{ secrets.GH_OIDC_PROVIDER_ARN }}" \
-              "VercelOidcProviderArn=${{ secrets.VERCEL_OIDC_PROVIDER_ARN }}"
+              "VercelOidcProviderArn=${{ secrets.VERCEL_OIDC_PROVIDER_ARN }}" \
+              "LambdaInvokeToken=${{ secrets.LAMBDA_INVOKE_TOKEN }}"

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,8 @@ endif
 		"DataHubApiKey=$(DATA_HUB_API_KEY)" \
 		"SlackWebhookUrl=$(SLACK_WEBHOOK_URL)" \
 		"GitHubOidcProviderArn=$(GITHUB_OIDC_PROVIDER_ARN)" \
-		"VercelOidcProviderArn=$(VERCEL_OIDC_PROVIDER_ARN)"
+		"VercelOidcProviderArn=$(VERCEL_OIDC_PROVIDER_ARN)" \
+		"LambdaInvokeToken=$(LAMBDA_INVOKE_TOKEN)"
 
 # Usage: make sam-teardown ENV=staging
 .PHONY: sam-teardown

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -132,6 +132,7 @@ export DATA_HUB_API_KEY="<your-api-key>"
 export SLACK_WEBHOOK_URL="<your-slack-webhook>"
 export GITHUB_OIDC_PROVIDER_ARN="<github-oidc-arn-from-step-1>"
 export VERCEL_OIDC_PROVIDER_ARN="<vercel-oidc-arn-from-step-1>"
+export LAMBDA_INVOKE_TOKEN="<shared-secret-for-function-url-auth>"
 
 make sam-deploy ENV=staging
 ```
@@ -161,8 +162,15 @@ In your GitHub repo, go to **Settings → Environments**, create a `staging` env
 | `DATA_HUB_API_URL` | Base API URL for the environment |
 | `DATA_HUB_API_KEY` | API key for Lambda → Data Hub authentication |
 | `SLACK_WEBHOOK_URL` | Slack incoming webhook URL |
+| `LAMBDA_INVOKE_TOKEN` | Shared secret for web app → Lambda Function URL authentication |
 
-You'll also need the `WebAppRoleArn` stack output to configure the Vercel web app. Set `AWS_ROLE_ARN` in the Vercel dashboard (under the appropriate environment) to the role ARN so the web app can generate presigned S3 URLs via OIDC federation.
+You'll also need the `WebAppRoleArn` and `DataHubFunctionUrl` stack outputs to configure the Vercel web app. In the Vercel dashboard (under the appropriate environment), set:
+
+| Vercel env var | Value |
+| --- | --- |
+| `AWS_ROLE_ARN` | `WebAppRoleArn` stack output — lets the web app generate presigned S3 URLs via OIDC federation |
+| `LAMBDA_FUNCTION_URL` | `DataHubFunctionUrl` stack output — the Lambda Function URL for manual reprocessing |
+| `LAMBDA_INVOKE_TOKEN` | Same shared secret configured in the GitHub environment secret above |
 
 Once secrets are set, the CI workflow handles all subsequent deploys automatically.
 

--- a/docs/lambda.md
+++ b/docs/lambda.md
@@ -1,8 +1,12 @@
 # Lambda
 
-The Data Hub Lambda function preprocesses raw instrument data uploaded to S3. It is triggered by S3 events, runs an instrument-specific preprocessing pipeline, and reports results back through the API and Slack.
+The Data Hub Lambda function preprocesses raw instrument data uploaded to S3. It can be triggered automatically by S3 events or manually via the web app for reprocessing. It runs an instrument-specific preprocessing pipeline and reports results back through the API and Slack.
 
 ## How it works
+
+The Lambda has two invocation paths that converge on the same processing logic:
+
+### S3 trigger (automatic)
 
 1. An S3 `PutObject` event triggers the Lambda function.
 2. The handler parses the S3 key to extract the instrument ID, run ID, and filename. The expected key layout is `{instrument_id}/{run_id}/{filename}`.
@@ -10,6 +14,16 @@ The Data Hub Lambda function preprocesses raw instrument data uploaded to S3. It
 4. The processor downloads the raw file from S3, preprocesses it (e.g., extracting metadata), and creates/updates the run and files via the Data Hub API.
 5. On success, a Slack message is sent with a link to view the run in the web dashboard.
 6. On failure, a Slack message is sent with a link to the CloudWatch logs.
+
+### Function URL (manual reprocessing)
+
+When a file fails processing (or needs to be re-run), users can trigger reprocessing from the run detail page in the web app. This invokes the Lambda's Function URL instead of going through S3:
+
+1. The user clicks **Reprocess** on a failed or completed file in the web dashboard.
+2. The web app's `POST /api/v1/files/:fileId/reprocess` endpoint transitions the file to `processing` status, clears any previous error and report data, and sends a POST request to the Lambda Function URL.
+3. The request includes an `Authorization: Bearer <LAMBDA_INVOKE_TOKEN>` header and a JSON body containing a synthetic S3 event payload.
+4. The Lambda handler detects the Function URL invocation (via `requestContext` in the event), verifies the Bearer token against the `LAMBDA_INVOKE_TOKEN` environment variable using constant-time comparison, and parses the S3 event from the request body.
+5. From here, processing follows the same dispatch logic as the S3 trigger path (steps 2–6 above).
 
 ## Supported instruments
 

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -37,6 +37,11 @@ Parameters:
     NoEcho: true
     Description: Slack incoming webhook URL for Lambda notifications
 
+  LambdaInvokeToken:
+    Type: String
+    NoEcho: true
+    Description: Shared secret for authenticating manual Function URL invocations from the web app
+
   GitHubOidcProviderArn:
     Type: String
     Description: ARN of the GitHub Actions OIDC provider (from bootstrap stack)
@@ -154,6 +159,7 @@ Resources:
           DATA_HUB_API_URL: !Ref DataHubApiUrl
           DATA_HUB_API_KEY: !Ref DataHubApiKey
           SLACK_WEBHOOK_URL: !Ref SlackWebhookUrl
+          LAMBDA_INVOKE_TOKEN: !Ref LambdaInvokeToken
 
   # ---- S3 → Lambda event wiring ----
   # Defined as explicit resources rather than SAM Events to avoid the circular

--- a/lambda/src/data_hub_lambda/config.py
+++ b/lambda/src/data_hub_lambda/config.py
@@ -5,10 +5,12 @@ import os
 class LambdaConfig:
     DATA_HUB_API_URL: str | None
     DATA_HUB_API_KEY: str | None
+    LAMBDA_INVOKE_TOKEN: str | None
 
     def __init__(self) -> None:
         self.DATA_HUB_API_URL = os.getenv("DATA_HUB_API_URL")
         self.DATA_HUB_API_KEY = os.getenv("DATA_HUB_API_KEY")
+        self.LAMBDA_INVOKE_TOKEN = os.getenv("LAMBDA_INVOKE_TOKEN")
 
 
 lambda_config = LambdaConfig()

--- a/lambda/src/data_hub_lambda/handler.py
+++ b/lambda/src/data_hub_lambda/handler.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import hmac
+import json
 import re
 import warnings
 from dataclasses import dataclass
@@ -97,19 +99,72 @@ def get_cloudwatch_logs_url(context: Context) -> str:
 
 
 # ------------------------------------------------------------------
+# Function URL helpers
+# ------------------------------------------------------------------
+
+
+def _is_function_url_event(event: dict[str, Any]) -> bool:
+    return "requestContext" in event and "http" in event.get("requestContext", {})
+
+
+def _authenticate_function_url(event: dict[str, Any]) -> dict[str, Any] | None:
+    """Verify the Bearer token on a Function URL invocation.
+
+    Returns the parsed S3 event payload on success, or ``None`` if
+    authentication fails (the caller should return a 401 response).
+    """
+    from data_hub_lambda.config import lambda_config
+
+    expected = lambda_config.LAMBDA_INVOKE_TOKEN
+    if not expected:
+        logger.error("LAMBDA_INVOKE_TOKEN is not configured")
+        return None
+
+    headers: dict[str, str] = event.get("headers", {})
+    auth_header = headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return None
+
+    token = auth_header[len("Bearer ") :]
+    if not hmac.compare_digest(token, expected):
+        return None
+
+    body = event.get("body", "")
+    if event.get("isBase64Encoded"):
+        import base64
+
+        body = base64.b64decode(body).decode()
+
+    try:
+        return json.loads(body)  # type: ignore[no-any-return]
+    except (json.JSONDecodeError, TypeError):
+        logger.error("Function URL body is not valid JSON")
+        return None
+
+
+# ------------------------------------------------------------------
 # Main handler
 # ------------------------------------------------------------------
 
 
-def lambda_handler(event: dict[str, Any], context: Context) -> None:
+def lambda_handler(event: dict[str, Any], context: Context) -> dict[str, Any] | None:
     """Top-level Lambda handler dispatching to instrument workflows."""
     logger.info("Received event: %s", pformat(event))
+
+    # Function URL invocations carry a requestContext with an http key.
+    # Verify the Bearer token and unwrap the S3 event from the body.
+    if _is_function_url_event(event):
+        s3_event = _authenticate_function_url(event)
+        if s3_event is None:
+            logger.warning("Unauthorized Function URL invocation")
+            return {"statusCode": 401, "body": "Unauthorized"}
+        event = s3_event
 
     try:
         event_info = parse_s3_event(event)  # type: ignore[arg-type]
     except Exception:
         logger.exception("Error handling event.")
-        return
+        return None
 
     instrument_id = event_info.instrument_id
     run_id = event_info.run_id
@@ -156,7 +211,7 @@ def lambda_handler(event: dict[str, Any], context: Context) -> None:
 
         else:
             logger.error("Unsupported instrument: %s", instrument_id)
-            return
+            return None
 
         slack.send_message(
             f"*{instrument_name}*\n"

--- a/lambda/tests/integration/conftest.py
+++ b/lambda/tests/integration/conftest.py
@@ -6,6 +6,7 @@ full HTTP path with only S3 downloads and Slack mocked.
 """
 
 from __future__ import annotations
+import json
 import os
 import shutil
 from collections.abc import Callable, Generator
@@ -81,6 +82,7 @@ def integration_env(
         os.environ["AWS_S3_RAW_DATA_BUCKET"] = "test-bucket"
         os.environ["AWS_S3_PROCESSED_DATA_BUCKET"] = "test-processed-bucket"
         os.environ["LOCAL_DATA_DIRPATH"] = str(tmp_data)
+        os.environ["LAMBDA_INVOKE_TOKEN"] = "test-invoke-token"
 
         _reset_singletons()
 
@@ -93,6 +95,7 @@ def integration_env(
             "AWS_S3_RAW_DATA_BUCKET",
             "AWS_S3_PROCESSED_DATA_BUCKET",
             "LOCAL_DATA_DIRPATH",
+            "LAMBDA_INVOKE_TOKEN",
         ):
             os.environ.pop(key, None)
 
@@ -150,6 +153,58 @@ def make_s3_event() -> Callable[..., dict[str, Any]]:
                     },
                 }
             ]
+        }
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# Step 3a' — Function URL event factory
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def make_function_url_event(
+    make_s3_event: Callable[..., dict[str, Any]],
+) -> Callable[..., dict[str, Any]]:
+    """Factory fixture that wraps an S3 event inside a Function URL envelope.
+
+    Usage::
+
+        def test_example(make_function_url_event):
+            event = make_function_url_event(
+                "azure-cielo-qpcr", "Experiment_20260101", "CqValues.csv",
+                token="test-invoke-token",
+            )
+    """
+
+    def _factory(
+        instrument_id: str,
+        run_id: str,
+        filename: str,
+        bucket: str = "test-bucket",
+        token: str | None = "test-invoke-token",
+        body_override: str | None = None,
+    ) -> dict[str, Any]:
+        s3_event = make_s3_event(instrument_id, run_id, filename, bucket)
+
+        headers: dict[str, str] = {"content-type": "application/json"}
+        if token is not None:
+            headers["authorization"] = f"Bearer {token}"
+
+        return {
+            "version": "2.0",
+            "requestContext": {
+                "http": {
+                    "method": "POST",
+                    "path": "/",
+                    "sourceIp": "127.0.0.1",
+                },
+                "accountId": "123456789012",
+            },
+            "headers": headers,
+            "body": body_override if body_override is not None else json.dumps(s3_event),
+            "isBase64Encoded": False,
         }
 
     return _factory

--- a/lambda/tests/integration/test_lambda_api.py
+++ b/lambda/tests/integration/test_lambda_api.py
@@ -18,6 +18,8 @@ import requests
 from data_hub_lambda.handler import lambda_handler
 from data_hub_shared.testing import IntegrationEnv
 
+from .conftest import _reset_singletons
+
 _FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures"
 
 # Apply the `integration` marker to every test in this module so they can
@@ -528,3 +530,120 @@ class TestFileReprocessing:
             slack_msg = call[0][0]
             assert run_id in slack_msg
             assert "View in Data Hub" in slack_msg
+
+
+# ------------------------------------------------------------------
+# Test 4f: Function URL invocation
+# ------------------------------------------------------------------
+
+
+class TestFunctionUrlInvocation:
+    def test_happy_path_processes_file(
+        self,
+        integration_env: IntegrationEnv,
+        make_function_url_event: Callable[..., dict[str, Any]],
+        s3_fixture_files: dict[str, Path],
+        mock_context: MagicMock,
+        mock_slack: MagicMock,
+    ) -> None:
+        """A Function URL event with a valid token processes the file
+        identically to a direct S3 trigger."""
+        run_id = "Experiment_20260401"
+        filename = f"{run_id}_CqValues.csv"
+        s3_key = f"azure-cielo-qpcr/{run_id}/{filename}"
+        s3_fixture_files[s3_key] = _FIXTURES_DIR / "azure_cielo_qpcr_example.csv"
+
+        event = make_function_url_event("azure-cielo-qpcr", run_id, filename)
+        result = lambda_handler(event, mock_context)
+
+        # Function URL invocations should not return an error response.
+        assert result is None or result.get("statusCode", 200) == 200
+
+        run = _api_get(
+            integration_env.base_url,
+            integration_env.api_token,
+            f"/api/v1/instruments/azure-cielo-qpcr/runs/{run_id}",
+        )
+        assert run["run_id"] == run_id
+        assert len(run["files"]) == 1
+        assert run["files"][0]["status"] == "completed"
+
+        mock_slack.assert_called_once()
+        assert "View in Data Hub" in mock_slack.call_args[0][0]
+
+    def test_wrong_token_returns_401(
+        self,
+        make_function_url_event: Callable[..., dict[str, Any]],
+        mock_context: MagicMock,
+        mock_slack: MagicMock,
+    ) -> None:
+        """A Function URL event with an incorrect Bearer token is rejected."""
+        event = make_function_url_event(
+            "azure-cielo-qpcr",
+            "Experiment_20260401",
+            "Experiment_20260401_CqValues.csv",
+            token="wrong-token",
+        )
+        result = lambda_handler(event, mock_context)
+
+        assert result == {"statusCode": 401, "body": "Unauthorized"}
+        mock_slack.assert_not_called()
+
+    def test_missing_auth_header_returns_401(
+        self,
+        make_function_url_event: Callable[..., dict[str, Any]],
+        mock_context: MagicMock,
+        mock_slack: MagicMock,
+    ) -> None:
+        """A Function URL event with no Authorization header is rejected."""
+        event = make_function_url_event(
+            "azure-cielo-qpcr",
+            "Experiment_20260401",
+            "Experiment_20260401_CqValues.csv",
+            token=None,
+        )
+        result = lambda_handler(event, mock_context)
+
+        assert result == {"statusCode": 401, "body": "Unauthorized"}
+        mock_slack.assert_not_called()
+
+    def test_unconfigured_token_returns_401(
+        self,
+        make_function_url_event: Callable[..., dict[str, Any]],
+        mock_context: MagicMock,
+        mock_slack: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When LAMBDA_INVOKE_TOKEN is not set, all Function URL requests
+        are rejected even if the caller sends a valid-looking token."""
+        monkeypatch.delenv("LAMBDA_INVOKE_TOKEN", raising=False)
+        _reset_singletons()
+
+        event = make_function_url_event(
+            "azure-cielo-qpcr",
+            "Experiment_20260401",
+            "Experiment_20260401_CqValues.csv",
+        )
+        result = lambda_handler(event, mock_context)
+
+        assert result == {"statusCode": 401, "body": "Unauthorized"}
+        mock_slack.assert_not_called()
+
+    def test_invalid_json_body_returns_401(
+        self,
+        make_function_url_event: Callable[..., dict[str, Any]],
+        mock_context: MagicMock,
+        mock_slack: MagicMock,
+    ) -> None:
+        """A Function URL event with a valid token but non-JSON body is
+        rejected (the handler cannot parse the S3 event payload)."""
+        event = make_function_url_event(
+            "azure-cielo-qpcr",
+            "Experiment_20260401",
+            "Experiment_20260401_CqValues.csv",
+            body_override="this is not json",
+        )
+        result = lambda_handler(event, mock_context)
+
+        assert result == {"statusCode": 401, "body": "Unauthorized"}
+        mock_slack.assert_not_called()

--- a/web-app/app/api/v1/files/[fileId]/reprocess/route.ts
+++ b/web-app/app/api/v1/files/[fileId]/reprocess/route.ts
@@ -1,0 +1,139 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import {
+  apiError,
+  CONFLICT,
+  INTERNAL_ERROR,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
+import { db } from "@/lib/db";
+import { files, instrumentRuns, runReportData } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+type RouteContext = {
+  params: Promise<{ fileId: string }>;
+};
+
+const REPROCESSABLE_STATUSES = ["failed", "completed"];
+
+function getLambdaConfig() {
+  const url = process.env.LAMBDA_FUNCTION_URL;
+  const token = process.env.LAMBDA_INVOKE_TOKEN;
+  if (!url || !token) return null;
+  return { url, token };
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/files/:fileId/reprocess
+//
+// Transitions a failed or completed file back to "processing" and invokes
+// the Lambda Function URL to re-run the instrument's process_file workflow.
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { fileId } = await params;
+  const numericId = parseInt(fileId, 10);
+  if (isNaN(numericId)) {
+    return apiError(400, VALIDATION_ERROR, "Invalid file ID");
+  }
+
+  const [file] = await db
+    .select()
+    .from(files)
+    .where(eq(files.id, numericId))
+    .limit(1);
+
+  if (!file) {
+    return apiError(404, NOT_FOUND, `File '${fileId}' not found`);
+  }
+
+  if (file.deletedAt) {
+    return apiError(409, CONFLICT, "Cannot reprocess a soft-deleted file");
+  }
+
+  if (!REPROCESSABLE_STATUSES.includes(file.status)) {
+    return apiError(
+      409,
+      CONFLICT,
+      `Cannot reprocess a file in '${file.status}' status — only 'failed' or 'completed' files can be reprocessed`
+    );
+  }
+
+  if (!file.s3Bucket || !file.s3Key) {
+    return apiError(
+      409,
+      CONFLICT,
+      "File has no S3 location — it cannot be reprocessed"
+    );
+  }
+
+  // Verify parent run is not soft-deleted.
+  const [parentRun] = await db
+    .select({ deletedAt: instrumentRuns.deletedAt })
+    .from(instrumentRuns)
+    .where(eq(instrumentRuns.id, file.instrumentRunId))
+    .limit(1);
+
+  if (parentRun?.deletedAt) {
+    return apiError(
+      409,
+      CONFLICT,
+      "Cannot reprocess a file whose parent run is soft-deleted"
+    );
+  }
+
+  const lambda = getLambdaConfig();
+  if (!lambda) {
+    return apiError(
+      503,
+      INTERNAL_ERROR,
+      "Lambda reprocessing is not configured"
+    );
+  }
+
+  // Transition to "processing": clear previous error and report data.
+  await db.delete(runReportData).where(eq(runReportData.fileId, numericId));
+  await db
+    .update(files)
+    .set({
+      status: "processing",
+      processedAt: null,
+      errorMessage: null,
+    })
+    .where(eq(files.id, numericId));
+
+  // Build a synthetic S3 event matching the shape parse_s3_event expects.
+  const s3Event = {
+    Records: [
+      {
+        s3: {
+          bucket: { name: file.s3Bucket },
+          object: { key: file.s3Key },
+        },
+      },
+    ],
+  };
+
+  // Fire-and-forget: invoke the Lambda Function URL asynchronously.
+  // We don't await the Lambda's completion — it will call back via
+  // PATCH /api/v1/files/:fileId when processing finishes.
+  fetch(lambda.url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${lambda.token}`,
+    },
+    body: JSON.stringify(s3Event),
+  }).catch((err) => {
+    console.error(`Failed to invoke Lambda for file ${numericId}:`, err);
+  });
+
+  return Response.json({ status: "processing", file_id: numericId });
+}

--- a/web-app/app/api/v1/files/[fileId]/reprocess/route.ts
+++ b/web-app/app/api/v1/files/[fileId]/reprocess/route.ts
@@ -99,15 +99,17 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   }
 
   // Transition to "processing": clear previous error and report data.
-  await db.delete(runReportData).where(eq(runReportData.fileId, numericId));
-  await db
-    .update(files)
-    .set({
-      status: "processing",
-      processedAt: null,
-      errorMessage: null,
-    })
-    .where(eq(files.id, numericId));
+  await db.transaction(async (tx) => {
+    await tx.delete(runReportData).where(eq(runReportData.fileId, numericId));
+    await tx
+      .update(files)
+      .set({
+        status: "processing",
+        processedAt: null,
+        errorMessage: null,
+      })
+      .where(eq(files.id, numericId));
+  });
 
   // Build a synthetic S3 event matching the shape parse_s3_event expects.
   const s3Event = {
@@ -121,19 +123,36 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
     ],
   };
 
-  // Fire-and-forget: invoke the Lambda Function URL asynchronously.
-  // We don't await the Lambda's completion — it will call back via
-  // PATCH /api/v1/files/:fileId when processing finishes.
-  fetch(lambda.url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${lambda.token}`,
-    },
-    body: JSON.stringify(s3Event),
-  }).catch((err) => {
+  // Invoke the Lambda Function URL. We await the HTTP response (not the
+  // Lambda's processing) so we can roll back if the invocation itself fails.
+  // The Lambda will call back via PATCH /api/v1/files/:fileId when done.
+  let lambdaRes: Response;
+  try {
+    lambdaRes = await fetch(lambda.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${lambda.token}`,
+      },
+      body: JSON.stringify(s3Event),
+    });
+  } catch (err) {
     console.error(`Failed to invoke Lambda for file ${numericId}:`, err);
-  });
+    await db
+      .update(files)
+      .set({ status: file.status, errorMessage: file.errorMessage })
+      .where(eq(files.id, numericId));
+    return apiError(502, INTERNAL_ERROR, "Failed to reach the Lambda function");
+  }
+
+  if (!lambdaRes.ok) {
+    console.error(`Lambda returned ${lambdaRes.status} for file ${numericId}`);
+    await db
+      .update(files)
+      .set({ status: file.status, errorMessage: file.errorMessage })
+      .where(eq(files.id, numericId));
+    return apiError(502, INTERNAL_ERROR, "Lambda invocation failed");
+  }
 
   return Response.json({ status: "processing", file_id: numericId });
 }

--- a/web-app/app/settings/layout.tsx
+++ b/web-app/app/settings/layout.tsx
@@ -21,7 +21,7 @@ export default async function SettingsLayout({
   }
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-10 sm:px-6 lg:px-8">
+    <div className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8">
       <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
       <div className="mt-6 flex gap-8">
         <SettingsNav />

--- a/web-app/components/instruments/edit-instrument-dialog.tsx
+++ b/web-app/components/instruments/edit-instrument-dialog.tsx
@@ -87,7 +87,7 @@ export function EditInstrumentDialog({
       }}
     >
       <DialogTrigger asChild>
-        <Button variant="ghost" size="sm" className="flex gap-2 text-sm">
+        <Button variant="ghost" size="sm" className="flex gap-2 text-xs">
           <Pencil className="size-3.5" />
           <span>Edit</span>
         </Button>

--- a/web-app/components/instruments/instruments-table.tsx
+++ b/web-app/components/instruments/instruments-table.tsx
@@ -66,7 +66,7 @@ export function InstrumentsTable({ data }: { data: InstrumentListItem[] }) {
                   {row.watcherCount > 0 ? (
                     <Badge
                       variant={isOnline ? "default" : "destructive"}
-                      className="gap-1 text-sm"
+                      className="gap-1 text-xs"
                     >
                       {isOnline ? (
                         <Radio className="size-3" />
@@ -76,7 +76,7 @@ export function InstrumentsTable({ data }: { data: InstrumentListItem[] }) {
                       {isOnline ? "Online" : "Offline"}
                     </Badge>
                   ) : (
-                    <Badge variant="outline" className="gap-1 text-sm">
+                    <Badge variant="outline" className="gap-1 text-xs">
                       <WifiOff className="size-3" />
                       No Watcher
                     </Badge>
@@ -89,7 +89,7 @@ export function InstrumentsTable({ data }: { data: InstrumentListItem[] }) {
                         <Badge
                           key={p}
                           variant="outline"
-                          className="font-mono text-sm font-normal"
+                          className="font-mono text-xs font-normal"
                         >
                           {p}
                         </Badge>

--- a/web-app/components/runs/file-card.tsx
+++ b/web-app/components/runs/file-card.tsx
@@ -15,7 +15,16 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import type { RunFile } from "@/lib/api/instrument-runs";
-import { Download, Eye, FileText, Loader2, Upload, X } from "lucide-react";
+import {
+  AlertCircle,
+  Download,
+  Eye,
+  FileText,
+  Loader2,
+  RotateCw,
+  Upload,
+  X,
+} from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTransition } from "react";
 import { toast } from "sonner";
@@ -65,6 +74,10 @@ export function FileCard({
     "completed",
     "failed",
   ].includes(file.status);
+  const isReprocessable =
+    !isDismissed &&
+    (file.status === "failed" || file.status === "completed") &&
+    file.s3Key !== null;
 
   // Signals the watcher agent on the instrument PC to transfer this file to S3.
   // The file transitions from "detected" → "upload_requested" until the watcher
@@ -100,6 +113,21 @@ export function FileCard({
         return;
       }
       toast.success(`Dismissed ${file.filename}`);
+      router.refresh();
+    });
+  }
+
+  function handleReprocess() {
+    startTransition(async () => {
+      const res = await fetch(`/api/v1/files/${file.id}/reprocess`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        toast.error(body?.error?.message ?? "Failed to start reprocessing");
+        return;
+      }
+      toast.success("Reprocessing started");
       router.refresh();
     });
   }
@@ -152,6 +180,13 @@ export function FileCard({
                 {Array.isArray(v) ? v.join(", ") : String(v)}
               </span>
             ))}
+          </div>
+        )}
+
+        {file.status === "failed" && file.errorMessage && (
+          <div className="mt-1 flex items-start gap-1.5 rounded-md bg-destructive/10 px-2 py-1.5 text-xs text-destructive">
+            <AlertCircle className="mt-0.5 size-3 shrink-0" />
+            <span className="wrap-break-word">{file.errorMessage}</span>
           </div>
         )}
       </div>
@@ -212,29 +247,71 @@ export function FileCard({
         )}
 
         {isDownloadable && (
-          <div className="flex items-center gap-1">
-            {file.contentType?.startsWith("image/") && (
-              <Button variant="ghost" size="sm" className="h-7 text-xs" asChild>
-                <a
-                  href={`/api/v1/files/${file.id}/download`}
-                  target="_blank"
-                  rel="noopener noreferrer"
+          <div className="flex flex-col items-end gap-1">
+            <div className="flex items-center gap-1">
+              {file.contentType?.startsWith("image/") && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 text-xs"
+                  asChild
                 >
-                  <Eye className="size-3" />
+                  <a
+                    href={`/api/v1/files/${file.id}/download`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Eye className="size-3" />
+                  </a>
+                </Button>
+              )}
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1 text-xs"
+                asChild
+              >
+                <a href={`/api/v1/files/${file.id}/download`}>
+                  <Download className="size-3" />
+                  Download
                 </a>
               </Button>
+            </div>
+            {isReprocessable && (
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 gap-1 text-xs"
+                    disabled={isPending}
+                  >
+                    {isPending ? (
+                      <Loader2 className="size-3 animate-spin" />
+                    ) : (
+                      <RotateCw className="size-3" />
+                    )}
+                    Reprocess
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Reprocess file?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      <strong className="font-mono">{file.filename}</strong>{" "}
+                      will be sent to the Lambda function for reprocessing. Any
+                      existing report data for this file will be cleared.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction onClick={handleReprocess}>
+                      Reprocess
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
             )}
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 gap-1 text-xs"
-              asChild
-            >
-              <a href={`/api/v1/files/${file.id}/download`}>
-                <Download className="size-3" />
-                Download
-              </a>
-            </Button>
           </div>
         )}
       </div>

--- a/web-app/components/runs/run-report-section.tsx
+++ b/web-app/components/runs/run-report-section.tsx
@@ -1,34 +1,8 @@
 import { PlateMapGrid } from "@/components/runs/plate-map-grid";
 import { ReportDataTable } from "@/components/runs/report-data-table";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { RunFile, RunReportEntry } from "@/lib/api/instrument-runs";
-import { AlertCircle } from "lucide-react";
-
-export function FileProcessingErrors({ files }: { files: RunFile[] }) {
-  const failedFiles = files.filter(
-    (f) => f.status === "failed" && f.errorMessage
-  );
-  if (failedFiles.length === 0) return null;
-
-  return (
-    <Card size="sm">
-      <CardHeader>
-        <CardTitle>Processing Errors</CardTitle>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-3">
-        {failedFiles.map((file) => (
-          <Alert key={file.id} variant="destructive">
-            <AlertCircle className="size-4" />
-            <AlertTitle>{file.filename}</AlertTitle>
-            <AlertDescription>{file.errorMessage}</AlertDescription>
-          </Alert>
-        ))}
-      </CardContent>
-    </Card>
-  );
-}
 
 // Dispatches to a specialised renderer based on dataType. Plate maps get a
 // visual grid; everything else falls through to a generic key/value table.
@@ -46,11 +20,7 @@ export function RunReportSection({
   reportData: RunReportEntry[];
   files: RunFile[];
 }) {
-  const hasFailedFiles = files.some(
-    (f) => f.status === "failed" && f.errorMessage
-  );
-
-  if (reportData.length === 0 && !hasFailedFiles) {
+  if (reportData.length === 0) {
     return (
       <Card size="sm">
         <CardHeader>
@@ -77,44 +47,38 @@ export function RunReportSection({
   }
 
   return (
-    <>
-      <FileProcessingErrors files={files} />
-
-      {reportData.length > 0 && (
-        <Card size="sm">
-          <CardHeader>
-            <CardTitle>
-              Report Data{" "}
-              <span className="ml-1 font-mono text-xs font-normal text-muted-foreground">
-                {reportData.length} dataset(s)
-              </span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-6">
-            {Array.from(byFile.entries()).map(([fileId, entries]) => {
-              const file = fileMap.get(fileId);
-              return (
-                <div key={fileId} className="flex flex-col gap-3">
-                  <h3 className="text-sm font-medium">
-                    {file?.filename ?? `File #${fileId}`}
-                  </h3>
-                  {entries.map((entry) => (
-                    <div key={entry.id} className="flex flex-col gap-1.5">
-                      <Badge
-                        variant="outline"
-                        className="w-fit font-mono text-[10px]"
-                      >
-                        {entry.dataType}
-                      </Badge>
-                      <ReportEntryRenderer entry={entry} />
-                    </div>
-                  ))}
+    <Card size="sm">
+      <CardHeader>
+        <CardTitle>
+          Report Data{" "}
+          <span className="ml-1 font-mono text-xs font-normal text-muted-foreground">
+            {reportData.length} dataset(s)
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        {Array.from(byFile.entries()).map(([fileId, entries]) => {
+          const file = fileMap.get(fileId);
+          return (
+            <div key={fileId} className="flex flex-col gap-3">
+              <h3 className="text-sm font-medium">
+                {file?.filename ?? `File #${fileId}`}
+              </h3>
+              {entries.map((entry) => (
+                <div key={entry.id} className="flex flex-col gap-1.5">
+                  <Badge
+                    variant="outline"
+                    className="w-fit font-mono text-[10px]"
+                  >
+                    {entry.dataType}
+                  </Badge>
+                  <ReportEntryRenderer entry={entry} />
                 </div>
-              );
-            })}
-          </CardContent>
-        </Card>
-      )}
-    </>
+              ))}
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
   );
 }

--- a/web-app/components/runs/variants/plate-reader-run-detail.tsx
+++ b/web-app/components/runs/variants/plate-reader-run-detail.tsx
@@ -8,7 +8,6 @@ import { ReportDataTable } from "@/components/runs/report-data-table";
 import { RestoreRunButton } from "@/components/runs/restore-run-button";
 import type { RunDetailProps } from "@/components/runs/run-detail";
 import { RunDetail } from "@/components/runs/run-detail";
-import { FileProcessingErrors } from "@/components/runs/run-report-section";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { RunReportEntry } from "@/lib/api/instrument-runs";
@@ -345,8 +344,6 @@ export function PlateReaderRunDetail({
           metadata={run.metadata as Record<string, unknown>}
         />
       </RunDetail.FilesMetadataLayout>
-
-      <FileProcessingErrors files={files} />
 
       <PlateMapSection
         entries={plateMapEntries}

--- a/web-app/tests/integration/files.test.ts
+++ b/web-app/tests/integration/files.test.ts
@@ -24,6 +24,8 @@ describe("Files API", () => {
   const instrumentId = "files-test-instrument";
   const runId = "files-test-run";
   let fileId: number;
+  let secondFileId: number;
+  let thirdFileId: number;
   let lambdaFileId: number;
 
   beforeAll(async () => {
@@ -55,17 +57,27 @@ describe("Files API", () => {
             filename: "sample2.csv",
             size_bytes: 1024,
           },
+          {
+            relative_path: "sample3.csv",
+            filename: "sample3.csv",
+            size_bytes: 256,
+          },
         ],
       },
     });
 
-    // Fetch the run to get file IDs
+    // Fetch the run and store file IDs by filename for targeted assertions.
     const detail = await api(
       `/api/v1/instruments/${instrumentId}/runs/${runId}`,
       { token }
     );
     const detailData = await detail.json();
-    fileId = detailData.files[0].id;
+    const byName = (name: string) =>
+      detailData.files.find((f: { filename: string }) => f.filename === name)!
+        .id;
+    fileId = byName("sample.csv");
+    secondFileId = byName("sample2.csv");
+    thirdFileId = byName("sample3.csv");
   });
 
   afterAll(async () => {
@@ -264,19 +276,7 @@ describe("Files API", () => {
   // -------------------------------------------------------------------------
 
   it("DELETE soft-deletes a detected file", async () => {
-    // Use the second detected file (sample2.csv) which is still in detected status
-    const detail = await api(
-      `/api/v1/instruments/${instrumentId}/runs/${runId}`,
-      { token }
-    );
-    const detailData = await detail.json();
-    const detectedFile = detailData.files.find(
-      (f: { status: string; relative_path: string }) =>
-        f.status === "detected" && f.relative_path === "sample2.csv"
-    );
-    expect(detectedFile).toBeTruthy();
-
-    const res = await api(`/api/v1/files/${detectedFile.id}`, {
+    const res = await api(`/api/v1/files/${secondFileId}`, {
       method: "DELETE",
       token,
     });
@@ -302,5 +302,132 @@ describe("Files API", () => {
       token,
     });
     expect(res.status).toBe(404);
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /api/v1/files/:fileId/reprocess
+  //
+  // At this point in the test lifecycle:
+  //   fileId (sample.csv)             → completed, has S3 info
+  //   secondFileId (sample2.csv)      → detected, soft-deleted
+  //   thirdFileId (sample3.csv)       → detected, not deleted
+  //   lambdaFileId (processed_output) → failed, has S3 info
+  // -------------------------------------------------------------------------
+
+  it("REPROCESS returns 401 without auth", async () => {
+    const res = await api(`/api/v1/files/${lambdaFileId}/reprocess`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("REPROCESS returns 400 for invalid file ID", async () => {
+    const res = await api("/api/v1/files/abc/reprocess", {
+      method: "POST",
+      token,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("REPROCESS returns 404 for nonexistent file", async () => {
+    const res = await api("/api/v1/files/999999/reprocess", {
+      method: "POST",
+      token,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("REPROCESS returns 409 for non-reprocessable status (detected)", async () => {
+    const res = await api(`/api/v1/files/${thirdFileId}/reprocess`, {
+      method: "POST",
+      token,
+    });
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.error.message).toContain("detected");
+  });
+
+  it("REPROCESS returns 409 for soft-deleted file", async () => {
+    const res = await api(`/api/v1/files/${secondFileId}/reprocess`, {
+      method: "POST",
+      token,
+    });
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.error.message).toContain("soft-deleted");
+  });
+
+  // Create a dedicated run, add a failed file, then soft-delete the run
+  // to verify the parent-run guard without affecting other tests.
+  it("REPROCESS returns 409 when parent run is soft-deleted", async () => {
+    // Create a run and a file via the Lambda path.
+    const deletedRunId = "reprocess-deleted-run";
+    await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: { run_id: deletedRunId, source: "lambda" },
+    });
+    const createFileRes = await api(
+      `/api/v1/instruments/${instrumentId}/runs/${deletedRunId}/files`,
+      {
+        method: "POST",
+        token,
+        body: {
+          s3_bucket: "test-bucket",
+          s3_key: `${instrumentId}/${deletedRunId}/data.csv`,
+          filename: "data.csv",
+        },
+      }
+    );
+    const createdFile = await createFileRes.json();
+
+    // Transition the file to "failed" so it would normally be reprocessable.
+    await api(`/api/v1/files/${createdFile.id}`, {
+      method: "PATCH",
+      token,
+      body: { status: "processing" },
+    });
+    await api(`/api/v1/files/${createdFile.id}`, {
+      method: "PATCH",
+      token,
+      body: { status: "failed", error_message: "intentional failure" },
+    });
+
+    // Soft-delete the parent run.
+    await api(`/api/v1/instruments/${instrumentId}/runs/${deletedRunId}`, {
+      method: "DELETE",
+      token,
+    });
+
+    const res = await api(`/api/v1/files/${createdFile.id}/reprocess`, {
+      method: "POST",
+      token,
+    });
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.error.message).toContain("parent run");
+  });
+
+  // These two tests verify that both reprocessable statuses (failed and
+  // completed) pass all validation guards. They return 503 because the
+  // test server has no LAMBDA_FUNCTION_URL / LAMBDA_INVOKE_TOKEN configured.
+  it("REPROCESS returns 503 for failed file when Lambda is not configured", async () => {
+    const res = await api(`/api/v1/files/${lambdaFileId}/reprocess`, {
+      method: "POST",
+      token,
+    });
+    expect(res.status).toBe(503);
+    const data = await res.json();
+    expect(data.error.message).toContain("not configured");
+  });
+
+  it("REPROCESS returns 503 for completed file when Lambda is not configured", async () => {
+    const res = await api(`/api/v1/files/${fileId}/reprocess`, {
+      method: "POST",
+      token,
+    });
+    expect(res.status).toBe(503);
+    const data = await res.json();
+    expect(data.error.message).toContain("not configured");
   });
 });


### PR DESCRIPTION
## Summary

When Lambda processing fails, users can now see the error message directly on the file card and manually trigger reprocessing from the web app. The Lambda Function URL is used for manual invocations, authenticated with a shared Bearer token (`LAMBDA_INVOKE_TOKEN`).

## Changes

- **Inline error display:** The `FileCard` component now shows the `errorMessage` inline when a file is in `failed` status, with a destructive-styled banner below the file metadata.
- **Reprocess API route:** New `POST /api/v1/files/:fileId/reprocess` endpoint that validates the file is in `failed` or `completed` status, transitions it to `processing` (clearing previous error and report data), and invokes the Lambda Function URL with a synthetic S3 event payload.
- **Reprocess button:** Failed and completed files show a "Reprocess" button below the Download button. Clicking it opens a confirmation dialog before triggering the reprocess flow.
- **Lambda Function URL auth:** The Lambda handler now detects Function URL invocations (via `requestContext` in the event), verifies a `Bearer` token against `LAMBDA_INVOKE_TOKEN` using constant-time comparison, and parses the JSON body as the S3 event payload. S3-triggered invocations are unaffected.
- **Infrastructure:** Added `LambdaInvokeToken` as a SAM parameter, passed it to the Lambda environment variables, and added it to the deploy workflow and Makefile.
- **Removed duplicate error display:** The `FileProcessingErrors` card in the report section has been removed since errors are now shown inline on each file card.
- **Documentation:** Updated `docs/lambda.md` with the new Function URL invocation path and `docs/ci-and-deployment.md` with the new `LAMBDA_INVOKE_TOKEN` secret and Vercel env vars.

## Breaking changes

None. Existing S3-triggered invocations are unaffected. The `LAMBDA_INVOKE_TOKEN` env var must be configured on both the Lambda (SAM) and web app (Vercel) sides for reprocessing to work, but the feature degrades gracefully (returns 503) if not set.

## Driveby changes

- `web-app/app/settings/layout.tsx`: Widened settings page container from `max-w-4xl` to `max-w-5xl`.
- `web-app/components/instruments/edit-instrument-dialog.tsx`: Changed edit button text from `text-sm` to `text-xs`.
- `web-app/components/instruments/instruments-table.tsx`: Changed badge text from `text-sm` to `text-xs` across watcher status and file pattern badges.