### PR TITLE
Allow idempotent `processing` → `processing` file status transition

### DIFF
--- a/web-app/app/api/v1/files/[fileId]/route.ts
+++ b/web-app/app/api/v1/files/[fileId]/route.ts
@@ -23,7 +23,7 @@ const VALID_TRANSITIONS: Record<string, string[]> = {
   detected: ["uploaded"],
   upload_requested: ["uploaded"],
   uploaded: ["processing"],
-  processing: ["completed", "failed"],
+  processing: ["processing", "completed", "failed"],
   completed: ["processing"],
   failed: ["processing"],
 };


### PR DESCRIPTION
## Summary

Allow idempotent `processing → processing` file status transition to fix the reprocess flow, where both the reprocess endpoint and the Lambda independently set the file to "processing".

## Root cause

1. User clicks **Reprocess**. The `POST /api/v1/files/:fileId/reprocess` route transitions the file from `completed`/`failed` to `processing` (line 107 in `reprocess/route.ts`).
2. The route then invokes the Lambda Function URL.
3. The Lambda's `process_file` runs. But importantly, on line 45 of `spectramax_plate_reader/process_file.py`, **it also calls `client.update_file(file_id, status="processing")`** — which hits `PATCH /api/v1/files/:fileId`.
4. The PATCH endpoint checks the state machine in `VALID_TRANSITIONS`. The file is already in `processing` status, and `processing → processing` is not an allowed transition (only `processing → completed` and `processing → failed` are). So it returns the 409 Conflict error: **"Cannot transition from 'processing' to 'processing'"**.