### PR TITLE
Unify run detection into regex-based pattern matching on relative paths

### DIFF
--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -141,7 +141,7 @@ The `init` wizard offers the following presets (you can also supply a custom reg
 | Filename prefix | `^([^_]+)` | no | Run ID is everything before the first underscore. `RUN001_data.csv` → `RUN001`. |
 | Top subdirectory | `^([^/]+)/` | yes | Run ID is the top-level subdirectory name. `RUN001/data.csv` → `RUN001`. |
 | Deepest subdirectory | `([^/]+)/[^/]+$` | yes | Run ID is the immediate parent directory. `plate-a/well-b/data.csv` → `well-b`. |
-| Timestamp subdirectory | `(?:^│/)(\d{8}_\d{6}_\d{3})/` | yes | Run ID is a `YYYYMMDD_HHMMSS_fff`-shaped directory name anywhere in the path. |
+| Timestamp subdirectory | `(?:^\|/)(\d{8}_\d{6}_\d{3})/` | yes | Run ID is a `YYYYMMDD_HHMMSS_fff`-shaped directory name anywhere in the path. |
 | Filename stem | `^(?:.+/)?([^/]+?)\.[^/.]+$` | no | Each file is its own run. Run ID is the filename without its final extension. |
 
 In YAML, prefer single-quoted strings for patterns so that backslash sequences like `\d` don't need escaping.

--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -39,7 +39,7 @@ Interactive setup wizard that:
 1. Prompts for the environment (`staging`, `production`, or `preview`). Choosing `preview` also prompts for a custom API base URL.
 2. Prompts for an API key (or reads `DATA_HUB_API_KEY` from the environment). The key is saved to `~/.data-hub/.env`.
 3. Fetches existing instruments from the API or registers a new one.
-4. Prompts for the watch directory, file patterns, run detection method, stability period, and upload mode.
+4. Prompts for the watch directory, file patterns, run detection pattern, stability period, and upload mode.
 5. Registers the watcher with the API.
 6. Saves the config to `~/.data-hub/config.yaml`, the API key to `~/.data-hub/.env`, and syncs the config to the API.
 
@@ -55,7 +55,7 @@ Starts the file monitoring loop. Before entering the loop it:
 While running:
 
 - **File monitor** watches the directory for new/modified files using `watchdog` and waits for each file to stabilize (size + mtime unchanged for the configured stability period).
-- **Run detector** groups stable files into runs using the configured method (prefix regex or subdirectory).
+- **Run detector** groups stable files into runs by applying the configured regex to each file's relative path.
 - **Uploader** requests a presigned S3 URL from the API and uploads each file via HTTP PUT (auto mode), or polls the server's upload queue (manual mode). The watcher does not need AWS credentials.
 - **Heartbeat loop** sends periodic heartbeats (every 60 seconds) to the API. In manual mode, it also polls the upload queue on each tick.
 - **Event reporter** batches and flushes lifecycle events (started, stopped, file uploaded, errors) to the API.
@@ -124,14 +124,27 @@ instrument:
   upload_mode: auto              # "auto" or "manual"
   stability_period_seconds: 5    # 1–300
   run_detection:
-    method: prefix               # "prefix" or "directory"
-    prefix_pattern: "^([^_]+)"   # regex with one capture group (run ID)
+    pattern: '^([^/]+)/'         # regex with one capture group (run ID)
+    recursive: true
 ```
 
-### Run detection methods
+### Run detection
 
-- **`prefix`**: The run ID is extracted from each filename using a regex with one capture group. For example, `^([^_]+)` matches everything before the first underscore, so `RUN001_data.csv` yields run ID `RUN001`.
-- **`directory`**: Each subdirectory under the watch directory is treated as a separate run. The subdirectory name is the run ID.
+The `pattern` regex is applied (via `re.search`) to each file's path relative to `watch_directory`, with backslashes normalized to `/`. Capture group 1 is the run ID. The pattern must have exactly one capture group.
+
+When `recursive` is `true`, the watcher monitors subdirectories; when `false`, only files directly in the watch directory are considered.
+
+The `init` wizard offers the following presets (you can also supply a custom regex):
+
+| Preset | Pattern | Recursive | Description |
+| --- | --- | --- | --- |
+| Filename prefix | `^([^_]+)` | no | Run ID is everything before the first underscore. `RUN001_data.csv` → `RUN001`. |
+| Top subdirectory | `^([^/]+)/` | yes | Run ID is the top-level subdirectory name. `RUN001/data.csv` → `RUN001`. |
+| Deepest subdirectory | `([^/]+)/[^/]+$` | yes | Run ID is the immediate parent directory. `plate-a/well-b/data.csv` → `well-b`. |
+| Timestamp subdirectory | `(?:^│/)(\d{8}_\d{6}_\d{3})/` | yes | Run ID is a `YYYYMMDD_HHMMSS_fff`-shaped directory name anywhere in the path. |
+| Filename stem | `^(?:.+/)?([^/]+?)\.[^/.]+$` | no | Each file is its own run. Run ID is the filename without its final extension. |
+
+In YAML, prefer single-quoted strings for patterns so that backslash sequences like `\d` don't need escaping.
 
 ### Upload modes
 

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -18,10 +18,10 @@ from data_hub_watcher.config_io import config_checksum, load_config, save_config
 from data_hub_watcher.constants import (
     API_URLS,
     DEFAULT_CONFIG_DIR,
-    DEFAULT_PREFIX_PATTERN,
     DEFAULT_STABILITY_PERIOD_SECONDS,
     HEARTBEAT_INTERVAL_SECONDS,
     PRUNE_DAYS,
+    RUN_DETECTION_PRESETS,
     STATE_DB_FILENAME,
     load_env,
     resolve_config_path,
@@ -189,19 +189,7 @@ def init(ctx: click.Context) -> None:
     if not file_patterns:
         raise click.ClickException("At least one file pattern is required.")
 
-    # "prefix": run ID extracted from filename via regex
-    #   (e.g. "RUN001_data.csv" → "RUN001").
-    # "directory": each subdirectory under watch dir is its own run.
-    method = click.prompt(
-        "Run detection method",
-        type=click.Choice(["prefix", "directory"], case_sensitive=False),
-        default="prefix",
-    )
-
-    prefix_pattern: str | None = None
-    if method == "prefix":
-        prefix_pattern = click.prompt("Prefix pattern (regex)", default=DEFAULT_PREFIX_PATTERN)
-        _preview_prefix_pattern(prefix_pattern or DEFAULT_PREFIX_PATTERN, watch_dir)
+    run_pattern, run_recursive = _prompt_run_detection(watch_dir)
 
     # How long a file's size + mtime must remain unchanged before we consider
     # it fully written. Instruments that produce large files may need a longer
@@ -248,8 +236,8 @@ def init(ctx: click.Context) -> None:
             upload_mode=upload_mode,
             stability_period_seconds=stability,
             run_detection=RunDetectionConfig(
-                method=method,
-                prefix_pattern=prefix_pattern,
+                pattern=run_pattern,
+                recursive=run_recursive,
             ),
         ),
     )
@@ -276,8 +264,45 @@ def _register_new_instrument(client: DataHubClient) -> Any:
         raise click.ClickException(f"Failed to create instrument: {exc.message}") from exc
 
 
-def _preview_prefix_pattern(pattern: str, directory: Path) -> None:
-    """Show sample matches for the prefix pattern."""
+def _prompt_run_detection(
+    watch_dir: Path,
+    *,
+    current_pattern: str | None = None,
+    current_recursive: bool | None = None,
+) -> tuple[str, bool]:
+    """Prompt the operator for a run-detection pattern and recursive flag.
+
+    Returns ``(pattern, recursive)``.
+    """
+    click.echo("\nRun detection — how should the run ID be determined?")
+    for i, (_key, desc, _pat, _rec) in enumerate(RUN_DETECTION_PRESETS, 1):
+        click.echo(f"  {i}. {desc}")
+    custom_idx = len(RUN_DETECTION_PRESETS) + 1
+    click.echo(f"  {custom_idx}. Custom regex")
+
+    choice = click.prompt("Select", type=click.IntRange(1, custom_idx), default=1)
+
+    if choice == custom_idx:
+        pattern = click.prompt(
+            "Run detection pattern (regex with 1 capture group)",
+            default=current_pattern or RUN_DETECTION_PRESETS[0][2],
+        )
+        recursive_default = current_recursive if current_recursive is not None else True
+    else:
+        _key, _desc, pattern, recursive_default = RUN_DETECTION_PRESETS[choice - 1]
+        click.echo(f"  Pattern: {pattern}")
+
+    recursive = click.confirm(
+        "Watch subdirectories recursively?",
+        default=recursive_default if current_recursive is None else current_recursive,
+    )
+
+    _preview_run_pattern(pattern, watch_dir, recursive)
+    return pattern, recursive
+
+
+def _preview_run_pattern(pattern: str, directory: Path, recursive: bool) -> None:
+    """Show sample matches for the run detection pattern."""
     try:
         compiled = re.compile(pattern)
     except re.error:
@@ -286,17 +311,25 @@ def _preview_prefix_pattern(pattern: str, directory: Path) -> None:
 
     samples: list[str] = []
     try:
-        for entry in sorted(directory.iterdir())[:20]:
-            if entry.is_file():
-                m = compiled.match(entry.name)
-                if m and m.group(1):
-                    samples.append(f"    {entry.name} → run: {m.group(1)}")
+        iterator = sorted(directory.rglob("*")) if recursive else sorted(directory.iterdir())
+        for entry in iterator[:50]:
+            if not entry.is_file():
+                continue
+            try:
+                rel = entry.relative_to(directory).as_posix()
+            except ValueError:
+                continue
+            m = compiled.search(rel)
+            if m and m.group(1):
+                samples.append(f"    {rel} → run: {m.group(1)}")
+            if len(samples) >= 10:
+                break
     except PermissionError:
         pass
 
     if samples:
-        click.echo("  Prefix pattern preview:")
-        for s in samples[:10]:
+        click.echo("  Pattern preview:")
+        for s in samples:
             click.echo(s)
     else:
         click.echo("  (no matching files found for preview)")
@@ -334,12 +367,9 @@ def _dry_run_scan(cfg: WatcherConfig) -> None:
     """Scan the watch directory and log what `watch` would do, without side effects."""
     inst = cfg.instrument
     is_auto = inst.upload_mode == "auto"
-    is_recursive = inst.run_detection.method == "directory" and not is_auto
+    is_recursive = inst.run_detection.recursive
     watch_dir = inst.watch_directory
-
-    prefix_re: re.Pattern[str] | None = None
-    if inst.run_detection.method == "prefix" and inst.run_detection.prefix_pattern:
-        prefix_re = re.compile(inst.run_detection.prefix_pattern)
+    pattern_re = re.compile(inst.run_detection.pattern)
 
     iterator = watch_dir.rglob("*") if is_recursive else watch_dir.iterdir()
     matched: list[Path] = []
@@ -357,7 +387,7 @@ def _dry_run_scan(cfg: WatcherConfig) -> None:
     runs: dict[str, list[Path]] = {}
     unmatched: list[Path] = []
     for path in matched:
-        run_id = _extract_run_id_for_dry_run(path, inst.run_detection.method, prefix_re, watch_dir)
+        run_id = _extract_run_id_for_dry_run(path, pattern_re, watch_dir)
         if run_id is None:
             unmatched.append(path)
         else:
@@ -388,24 +418,17 @@ def _dry_run_scan(cfg: WatcherConfig) -> None:
 
 
 def _extract_run_id_for_dry_run(
-    path: Path, method: str, prefix_re: re.Pattern[str] | None, watch_dir: Path
+    path: Path, pattern_re: re.Pattern[str], watch_dir: Path
 ) -> str | None:
     """Extract a run ID from *path* using the same logic as `RunDetector`."""
-    if method == "prefix":
-        if prefix_re is None:
-            return None
-        m = prefix_re.match(path.name)
-        if m and m.group(1):
-            return m.group(1)
-        return None
     try:
-        rel = path.relative_to(watch_dir)
+        rel = path.relative_to(watch_dir).as_posix()
     except ValueError:
         return None
-    parts = rel.parts
-    if len(parts) < 2:
-        return None
-    return parts[0]
+    m = pattern_re.search(rel)
+    if m and m.group(1):
+        return m.group(1)
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -439,9 +462,8 @@ def config_show(ctx: click.Context) -> None:
     click.echo(f"    Enabled:         {inst.enabled}")
     click.echo(f"    Upload mode:     {inst.upload_mode}")
     click.echo(f"    Stability (s):   {inst.stability_period_seconds}")
-    click.echo(f"    Run detection:   {inst.run_detection.method}")
-    if inst.run_detection.prefix_pattern:
-        click.echo(f"    Prefix pattern:  {inst.run_detection.prefix_pattern}")
+    click.echo(f"    Run pattern:     {inst.run_detection.pattern}")
+    click.echo(f"    Recursive:       {inst.run_detection.recursive}")
 
 
 @config.command("validate")
@@ -472,18 +494,11 @@ def config_edit(ctx: click.Context) -> None:
     )
     file_patterns = [p.strip() for p in patterns_raw.split(",") if p.strip()]
 
-    method = click.prompt(
-        "Run detection method",
-        type=click.Choice(["prefix", "directory"], case_sensitive=False),
-        default=inst.run_detection.method,
+    run_pattern, run_recursive = _prompt_run_detection(
+        watch_dir,
+        current_pattern=inst.run_detection.pattern,
+        current_recursive=inst.run_detection.recursive,
     )
-
-    prefix_pattern: str | None = inst.run_detection.prefix_pattern
-    if method == "prefix":
-        prefix_pattern = click.prompt(
-            "Prefix pattern",
-            default=prefix_pattern or DEFAULT_PREFIX_PATTERN,
-        )
 
     stability = click.prompt(
         "Stability period (seconds)",
@@ -511,7 +526,7 @@ def config_edit(ctx: click.Context) -> None:
             enabled=enabled,
             upload_mode=upload_mode,
             stability_period_seconds=stability,
-            run_detection=RunDetectionConfig(method=method, prefix_pattern=prefix_pattern),
+            run_detection=RunDetectionConfig(pattern=run_pattern, recursive=run_recursive),
         ),
     )
 
@@ -629,8 +644,7 @@ def watch(ctx: click.Context, dry_run: bool) -> None:
     )
 
     detector = RunDetector(
-        method=inst.run_detection.method,
-        prefix_pattern=inst.run_detection.prefix_pattern,
+        pattern=inst.run_detection.pattern,
         instrument_id=inst.id,
         watcher_id=cfg.watcher_id,
         client=client,
@@ -641,17 +655,13 @@ def watch(ctx: click.Context, dry_run: bool) -> None:
         watch_directory=inst.watch_directory,
     )
 
-    # Directory-mode run detection needs recursive monitoring because each
-    # subdirectory represents a distinct run. Prefix mode only watches the
-    # top-level directory since run IDs are extracted from filenames.
-    is_recursive = inst.run_detection.method == "directory" and not is_auto
     monitor = FileMonitor(
         watch_directory=inst.watch_directory,
         file_patterns=inst.file_patterns,
         stability_period=inst.stability_period_seconds,
         on_stable_file=detector.on_stable_file,
         state_db=state_db,
-        recursive=is_recursive,
+        recursive=inst.run_detection.recursive,
     )
 
     # In manual mode the server controls which files to upload. We piggyback

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -283,18 +283,34 @@ def _prompt_run_detection(
     choice = click.prompt("Select", type=click.IntRange(1, custom_idx), default=1)
 
     if choice == custom_idx:
-        pattern = click.prompt(
-            "Run detection pattern (regex with 1 capture group)",
-            default=current_pattern or RUN_DETECTION_PRESETS[0][2],
-        )
-        recursive_default = current_recursive if current_recursive is not None else True
+        prompt_default = current_pattern or RUN_DETECTION_PRESETS[0][2]
+        while True:
+            pattern = click.prompt(
+                "Run detection pattern (regex with 1 capture group)",
+                default=prompt_default,
+            )
+            try:
+                compiled = re.compile(pattern)
+            except re.error as exc:
+                click.echo(click.style(f"  Invalid regex: {exc}", fg="red"))
+                continue
+            if compiled.groups != 1:
+                click.echo(
+                    click.style(
+                        f"  Pattern must have exactly 1 capture group, got {compiled.groups}",
+                        fg="red",
+                    )
+                )
+                continue
+            break
+        default_rec = current_recursive if current_recursive is not None else True
     else:
-        _key, _desc, pattern, recursive_default = RUN_DETECTION_PRESETS[choice - 1]
+        _key, _desc, pattern, default_rec = RUN_DETECTION_PRESETS[choice - 1]
         click.echo(f"  Pattern: {pattern}")
 
     recursive = click.confirm(
         "Watch subdirectories recursively?",
-        default=recursive_default if current_recursive is None else current_recursive,
+        default=default_rec,
     )
 
     _preview_run_pattern(pattern, watch_dir, recursive)

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -144,17 +144,20 @@ def init(ctx: click.Context) -> None:
     if not api_key:
         api_key = click.prompt("DATA_HUB_API_KEY", hide_input=True)
 
-    env_path = save_api_key(api_key)
-    click.echo(f"API key saved to {env_path}")
-
     client = _make_client(environment, api_key=api_key, api_base_url=api_base_url)
 
-    # 3. Instruments
+    # 3. Instruments (also validates the API key before we persist it)
     click.echo("\nFetching instruments…")
     try:
         instruments = client.list_instruments()
     except ApiError as exc:
-        raise click.ClickException(f"Failed to fetch instruments: {exc.message}") from exc
+        raise click.ClickException(
+            f"Failed to fetch instruments: {exc.message}\n"
+            "The API key was not saved. Please re-run init with a valid key."
+        ) from exc
+
+    env_path = save_api_key(api_key)
+    click.echo(f"API key saved to {env_path}")
 
     if instruments:
         click.echo("\nExisting instruments:")

--- a/watcher/src/data_hub_watcher/constants.py
+++ b/watcher/src/data_hub_watcher/constants.py
@@ -16,9 +16,43 @@ ENV_FILENAME = ".env"
 
 HEARTBEAT_INTERVAL_SECONDS = 60
 DEFAULT_STABILITY_PERIOD_SECONDS = 5
-# Captures everything before the first underscore as the run ID,
-# e.g. "RUN001_data.csv" → group(1) = "RUN001".
-DEFAULT_PREFIX_PATTERN = r"^([^_]+)"
+
+# Built-in presets for the ``init`` / ``config edit`` wizard.
+# Each entry: (key, description, pattern, recursive_default).
+# The stored config always uses a raw ``pattern`` + ``recursive``; these
+# presets exist purely as convenience shortcuts for operators.
+RUN_DETECTION_PRESETS: list[tuple[str, str, str, bool]] = [
+    (
+        "filename_prefix",
+        "Run ID is the filename prefix (before the first underscore)",
+        r"^([^_]+)",
+        False,
+    ),
+    (
+        "top_subdirectory",
+        "Each top-level subdirectory is a run",
+        r"^([^/]+)/",
+        True,
+    ),
+    (
+        "deepest_subdirectory",
+        "The deepest subdirectory (immediate parent of the file) is a run",
+        r"([^/]+)/[^/]+$",
+        True,
+    ),
+    (
+        "timestamp_subdirectory",
+        "Timestamp-named subdirectory (YYYYMMDD_HHMMSS_fff) is a run",
+        r"(?:^|/)(\d{8}_\d{6}_\d{3})/",
+        True,
+    ),
+    (
+        "filename_stem",
+        "Each file is its own run (run ID = filename without extension)",
+        r"^(?:.+/)?([^/]+?)\.[^/.]+$",
+        False,
+    ),
+]
 
 # If a file keeps changing for longer than this, give up and skip it
 # (likely being continuously appended to or locked by another process).

--- a/watcher/src/data_hub_watcher/models.py
+++ b/watcher/src/data_hub_watcher/models.py
@@ -17,30 +17,21 @@ logger = logging.getLogger(__name__)
 
 
 class RunDetectionConfig(BaseModel):
-    method: Literal["prefix", "directory"]
-    prefix_pattern: str | None = None
+    pattern: str
+    recursive: bool = True
 
-    @field_validator("prefix_pattern", mode="before")
+    @field_validator("pattern")
     @classmethod
-    def _default_prefix_pattern(cls, v: str | None, info: object) -> str | None:
+    def _one_capture_group(cls, v: str) -> str:
+        try:
+            compiled = re.compile(v)
+        except re.error as exc:
+            raise ValueError(f"Invalid run_detection.pattern regex: {exc}") from exc
+        if compiled.groups != 1:
+            raise ValueError(
+                f"run_detection.pattern must have exactly 1 capture group, got {compiled.groups}"
+            )
         return v
-
-    @model_validator(mode="after")
-    def _validate_prefix_pattern(self) -> RunDetectionConfig:
-        # Prefix mode requires exactly one capture group in the regex — that
-        # group is the run ID. This is validated eagerly at config load time
-        # so the user gets a clear error rather than a silent mismatch at runtime.
-        if self.method == "prefix":
-            pat = self.prefix_pattern or r"^([^_]+)"
-            try:
-                compiled = re.compile(pat)
-            except re.error as exc:
-                raise ValueError(f"Invalid prefix_pattern regex: {exc}") from exc
-            groups = compiled.groups
-            if groups != 1:
-                raise ValueError(f"prefix_pattern must have exactly 1 capture group, got {groups}")
-            self.prefix_pattern = pat
-        return self
 
 
 class InstrumentConfig(BaseModel):

--- a/watcher/src/data_hub_watcher/run_detector.py
+++ b/watcher/src/data_hub_watcher/run_detector.py
@@ -1,9 +1,9 @@
 """Run detection: group stable files into instrument runs and report them.
 
 `RunDetector` receives stable-file notifications from `FileMonitor`,
-groups them by run ID (extracted via prefix regex or parent directory),
-reports new / updated runs to the Data Hub API, and — in auto mode —
-hands them off to an upload callback immediately after reporting.
+groups them by run ID (extracted via a regex applied to the POSIX-normalized
+relative path), reports new / updated runs to the Data Hub API, and — in
+auto mode — hands them off to an upload callback immediately after reporting.
 """
 
 from __future__ import annotations
@@ -46,10 +46,10 @@ class RunDetector:
 
     Parameters
     ----------
-    method:
-        `"prefix"` or `"directory"`.
-    prefix_pattern:
-        Regex with one capture group (only used when *method* is `"prefix"`).
+    pattern:
+        Regex with exactly one capture group applied to the POSIX-normalized
+        relative path (relative to *watch_directory*). Capture group 1 is
+        the run ID.
     instrument_id:
         Instrument ID used in API paths.
     watcher_id:
@@ -72,8 +72,7 @@ class RunDetector:
     def __init__(
         self,
         *,
-        method: str,
-        prefix_pattern: str | None,
+        pattern: str,
         instrument_id: str,
         watcher_id: str,
         client: DataHubClient,
@@ -83,8 +82,7 @@ class RunDetector:
         upload_callback: Callable[[str, list[FileInfo]], int] | None = None,
         watch_directory: Path,
     ) -> None:
-        self._method = method
-        self._prefix_re = re.compile(prefix_pattern) if prefix_pattern else None
+        self._pattern = re.compile(pattern)
         self._instrument_id = instrument_id
         self._watcher_id = watcher_id
         self._client = client
@@ -139,39 +137,16 @@ class RunDetector:
     # ------------------------------------------------------------------
 
     def _extract_run_id(self, path: Path) -> str | None:
-        if self._method == "prefix":
-            return self._extract_prefix(path)
-        return self._extract_directory(path)
-
-    def _extract_prefix(self, path: Path) -> str | None:
-        if self._prefix_re is None:
-            logger.warning("No prefix pattern configured — cannot detect run for %s", path)
-            return None
-        m = self._prefix_re.match(path.name)
-        if not m or not m.group(1):
-            logger.warning("File %s does not match prefix pattern — skipping", path.name)
-            return None
-        return m.group(1)
-
-    def _extract_directory(self, path: Path) -> str | None:
-        """In directory mode, the first subdirectory name under the watch dir
-        is the run ID.  For example:
-            watch_dir/RUN001/data.csv  →  run_id = "RUN001"
-        Files sitting directly in the watch dir have no run context and are skipped.
-        """
         try:
-            rel = path.relative_to(self._watch_dir)
+            rel = path.relative_to(self._watch_dir).as_posix()
         except ValueError:
             logger.warning("File %s is not inside watch directory — skipping", path)
             return None
-        parts = rel.parts
-        if len(parts) < 2:
-            logger.warning(
-                "File %s is directly in watch directory (directory mode needs subdirs) — skipping",
-                path,
-            )
+        m = self._pattern.search(rel)
+        if not m or not m.group(1):
+            logger.warning("File %s did not match run_detection.pattern — skipping", rel)
             return None
-        return parts[0]
+        return m.group(1)
 
     # ------------------------------------------------------------------
     # API reporting

--- a/watcher/src/data_hub_watcher/service.py
+++ b/watcher/src/data_hub_watcher/service.py
@@ -360,8 +360,7 @@ def _create_service_class() -> type | None:
             )
 
             detector = RunDetector(
-                method=inst.run_detection.method,
-                prefix_pattern=inst.run_detection.prefix_pattern,
+                pattern=inst.run_detection.pattern,
                 instrument_id=inst.id,
                 watcher_id=cfg.watcher_id or "",
                 client=client,
@@ -372,14 +371,13 @@ def _create_service_class() -> type | None:
                 watch_directory=inst.watch_directory,
             )
 
-            is_recursive = inst.run_detection.method == "directory" and not is_auto
             monitor = FileMonitor(
                 watch_directory=inst.watch_directory,
                 file_patterns=inst.file_patterns,
                 stability_period=inst.stability_period_seconds,
                 on_stable_file=detector.on_stable_file,
                 state_db=state_db,
-                recursive=is_recursive,
+                recursive=inst.run_detection.recursive,
             )
 
             reporter.queue_event(

--- a/watcher/tests/test_preview_environment.py
+++ b/watcher/tests/test_preview_environment.py
@@ -28,7 +28,7 @@ def _make_instrument(tmp_path: Path) -> InstrumentConfig:
         id="test-instrument",
         watch_directory=watch_dir,
         file_patterns=["*.csv"],
-        run_detection=RunDetectionConfig(method="prefix"),
+        run_detection=RunDetectionConfig(pattern=r"^([^_]+)", recursive=False),
     )
 
 
@@ -109,7 +109,7 @@ class TestConfigRoundTrip:
                 "id": "test-instrument",
                 "watch_directory": str(watch_dir),
                 "file_patterns": ["*.csv"],
-                "run_detection": {"method": "prefix"},
+                "run_detection": {"pattern": "^([^_]+)", "recursive": False},
             },
         }
         path.write_text(yaml.dump(raw), encoding="utf-8")

--- a/watcher/tests/test_run_detection_config.py
+++ b/watcher/tests/test_run_detection_config.py
@@ -1,0 +1,42 @@
+"""Unit tests for ``RunDetectionConfig`` validation."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from data_hub_watcher.models import RunDetectionConfig
+
+
+class TestRunDetectionConfigValidation:
+    def test_valid_pattern_with_one_group(self) -> None:
+        cfg = RunDetectionConfig(pattern=r"^([^_]+)")
+        assert cfg.pattern == r"^([^_]+)"
+
+    def test_recursive_defaults_to_true(self) -> None:
+        cfg = RunDetectionConfig(pattern=r"^([^/]+)/")
+        assert cfg.recursive is True
+
+    def test_explicit_recursive_false(self) -> None:
+        cfg = RunDetectionConfig(pattern=r"^([^_]+)", recursive=False)
+        assert cfg.recursive is False
+
+    def test_zero_capture_groups_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="exactly 1 capture group, got 0"):
+            RunDetectionConfig(pattern=r"^[^_]+")
+
+    def test_two_capture_groups_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="exactly 1 capture group, got 2"):
+            RunDetectionConfig(pattern=r"^([^_]+)_(.+)")
+
+    def test_three_capture_groups_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="exactly 1 capture group, got 3"):
+            RunDetectionConfig(pattern=r"^(a)(b)(c)")
+
+    def test_invalid_regex_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid run_detection.pattern regex"):
+            RunDetectionConfig(pattern="[")
+
+    def test_non_capturing_groups_do_not_count(self) -> None:
+        cfg = RunDetectionConfig(pattern=r"(?:^|/)(\d{8}_\d{6}_\d{3})/")
+        assert cfg.pattern == r"(?:^|/)(\d{8}_\d{6}_\d{3})/"

--- a/watcher/tests/test_run_detector.py
+++ b/watcher/tests/test_run_detector.py
@@ -1,0 +1,241 @@
+"""Unit tests for run-ID extraction across all presets and path styles.
+
+Tests the core ``_extract_run_id`` logic by constructing a minimal
+``RunDetector`` with stubbed-out dependencies and calling
+``_extract_run_id`` directly.
+
+Cross-platform coverage is achieved by testing both forward-slash
+(POSIX) and backslash (Windows) relative paths. Since ``Path`` on a
+non-Windows host is always ``PosixPath``, the Windows tests verify
+the POSIX-normalization step in isolation using ``PureWindowsPath``.
+"""
+
+from __future__ import annotations
+import re
+from pathlib import Path, PureWindowsPath
+from unittest.mock import MagicMock
+
+import pytest
+
+from data_hub_watcher.constants import RUN_DETECTION_PRESETS
+from data_hub_watcher.run_detector import RunDetector
+
+
+def _make_detector(pattern: str, watch_directory: Path) -> RunDetector:
+    """Build a ``RunDetector`` with only the fields needed for run-ID extraction."""
+    return RunDetector(
+        pattern=pattern,
+        instrument_id="test-instrument",
+        watcher_id="w-test",
+        client=MagicMock(),
+        state_db=MagicMock(),
+        event_reporter=MagicMock(),
+        counters=MagicMock(),
+        watch_directory=watch_directory,
+    )
+
+
+def _preset_pattern(key: str) -> str:
+    """Look up a preset pattern by its key."""
+    for k, _desc, pat, _rec in RUN_DETECTION_PRESETS:
+        if k == key:
+            return pat
+    raise KeyError(key)
+
+
+# ------------------------------------------------------------------
+# Helper: simulate Windows-path normalization
+# ------------------------------------------------------------------
+
+
+def _extract_from_windows_path(pattern: str, watch_dir_str: str, file_path_str: str) -> str | None:
+    """Replicate ``_extract_run_id`` using ``PureWindowsPath`` to verify
+    that backslash normalization via ``.as_posix()`` works correctly.
+    """
+    watch_dir = PureWindowsPath(watch_dir_str)
+    file_path = PureWindowsPath(file_path_str)
+    rel = file_path.relative_to(watch_dir).as_posix()
+    m = re.compile(pattern).search(rel)
+    if m and m.group(1):
+        return m.group(1)
+    return None
+
+
+# ==================================================================
+# POSIX path tests (use real Path objects via tmp_path)
+# ==================================================================
+
+
+class TestRunIdExtractionPosix:
+    """Run-ID extraction on POSIX paths (real ``Path`` objects)."""
+
+    def test_filename_prefix(self, tmp_path: Path) -> None:
+        pat = _preset_pattern("filename_prefix")
+        d = _make_detector(pat, tmp_path)
+
+        assert d._extract_run_id(tmp_path / "RUN001_data.csv") == "RUN001"
+        assert d._extract_run_id(tmp_path / "BATCH-A_results.xlsx") == "BATCH-A"
+
+    def test_filename_prefix_no_underscore(self, tmp_path: Path) -> None:
+        pat = _preset_pattern("filename_prefix")
+        d = _make_detector(pat, tmp_path)
+        assert d._extract_run_id(tmp_path / "noprefix.csv") == "noprefix.csv"
+
+    def test_top_subdirectory(self, tmp_path: Path) -> None:
+        pat = _preset_pattern("top_subdirectory")
+        d = _make_detector(pat, tmp_path)
+
+        assert d._extract_run_id(tmp_path / "RUN001" / "data.csv") == "RUN001"
+        assert d._extract_run_id(tmp_path / "RUN001" / "sub" / "data.csv") == "RUN001"
+
+    def test_top_subdirectory_file_in_root(self, tmp_path: Path) -> None:
+        pat = _preset_pattern("top_subdirectory")
+        d = _make_detector(pat, tmp_path)
+        assert d._extract_run_id(tmp_path / "orphan.csv") is None
+
+    def test_deepest_subdirectory(self, tmp_path: Path) -> None:
+        pat = _preset_pattern("deepest_subdirectory")
+        d = _make_detector(pat, tmp_path)
+
+        assert d._extract_run_id(tmp_path / "plate-a" / "well-b" / "data.csv") == "well-b"
+        assert d._extract_run_id(tmp_path / "RUN001" / "data.csv") == "RUN001"
+
+    def test_deepest_subdirectory_file_in_root(self, tmp_path: Path) -> None:
+        pat = _preset_pattern("deepest_subdirectory")
+        d = _make_detector(pat, tmp_path)
+        assert d._extract_run_id(tmp_path / "orphan.csv") is None
+
+    def test_timestamp_subdirectory(self, tmp_path: Path) -> None:
+        pat = _preset_pattern("timestamp_subdirectory")
+        d = _make_detector(pat, tmp_path)
+
+        assert (
+            d._extract_run_id(tmp_path / "20260402_103919_624" / "file.png")
+            == "20260402_103919_624"
+        )
+
+    def test_timestamp_subdirectory_nested(self, tmp_path: Path) -> None:
+        pat = _preset_pattern("timestamp_subdirectory")
+        d = _make_detector(pat, tmp_path)
+
+        assert (
+            d._extract_run_id(tmp_path / "extra" / "nested" / "20260402_103919_624" / "file.png")
+            == "20260402_103919_624"
+        )
+
+    def test_timestamp_subdirectory_no_match(self, tmp_path: Path) -> None:
+        pat = _preset_pattern("timestamp_subdirectory")
+        d = _make_detector(pat, tmp_path)
+        assert d._extract_run_id(tmp_path / "not-a-timestamp" / "file.png") is None
+
+    def test_filename_stem(self, tmp_path: Path) -> None:
+        pat = _preset_pattern("filename_stem")
+        d = _make_detector(pat, tmp_path)
+
+        assert d._extract_run_id(tmp_path / "sample.csv") == "sample"
+        assert d._extract_run_id(tmp_path / "sample.ome.tiff") == "sample.ome"
+
+    def test_filename_stem_in_subdir(self, tmp_path: Path) -> None:
+        pat = _preset_pattern("filename_stem")
+        d = _make_detector(pat, tmp_path)
+        assert d._extract_run_id(tmp_path / "subdir" / "sample.csv") == "sample"
+
+    def test_file_outside_watch_dir(self, tmp_path: Path) -> None:
+        d = _make_detector(r"^([^_]+)", tmp_path / "watch")
+        assert d._extract_run_id(tmp_path / "elsewhere" / "file.csv") is None
+
+    def test_non_matching_file_returns_none(self, tmp_path: Path) -> None:
+        d = _make_detector(r"^(MAGIC_\d+)", tmp_path)
+        assert d._extract_run_id(tmp_path / "nomatch.csv") is None
+
+
+# ==================================================================
+# Windows path tests (use PureWindowsPath strings, no real FS)
+# ==================================================================
+
+
+class TestRunIdExtractionWindows:
+    """Verify that backslash paths are POSIX-normalized before matching."""
+
+    WATCH_DIR = r"D:\ArcadiaJOBS2023\JOBS_2023 Projects\Backup"
+
+    def test_filename_prefix(self) -> None:
+        pat = _preset_pattern("filename_prefix")
+        result = _extract_from_windows_path(
+            pat,
+            self.WATCH_DIR,
+            rf"{self.WATCH_DIR}\RUN001_data.csv",
+        )
+        assert result == "RUN001"
+
+    def test_top_subdirectory(self) -> None:
+        pat = _preset_pattern("top_subdirectory")
+        result = _extract_from_windows_path(
+            pat,
+            self.WATCH_DIR,
+            rf"{self.WATCH_DIR}\RUN001\data.csv",
+        )
+        assert result == "RUN001"
+
+    def test_top_subdirectory_file_in_root(self) -> None:
+        pat = _preset_pattern("top_subdirectory")
+        result = _extract_from_windows_path(
+            pat,
+            self.WATCH_DIR,
+            rf"{self.WATCH_DIR}\orphan.csv",
+        )
+        assert result is None
+
+    def test_deepest_subdirectory(self) -> None:
+        pat = _preset_pattern("deepest_subdirectory")
+        result = _extract_from_windows_path(
+            pat,
+            self.WATCH_DIR,
+            rf"{self.WATCH_DIR}\plate-a\well-b\data.csv",
+        )
+        assert result == "well-b"
+
+    def test_timestamp_subdirectory(self) -> None:
+        pat = _preset_pattern("timestamp_subdirectory")
+        result = _extract_from_windows_path(
+            pat,
+            self.WATCH_DIR,
+            rf"{self.WATCH_DIR}\20260402_103919_624\file.png",
+        )
+        assert result == "20260402_103919_624"
+
+    def test_timestamp_subdirectory_deeply_nested(self) -> None:
+        pat = _preset_pattern("timestamp_subdirectory")
+        result = _extract_from_windows_path(
+            pat,
+            self.WATCH_DIR,
+            rf"{self.WATCH_DIR}\yeast (1)\grid_w_AutoFocus\20260402_103919_624\file.png",
+        )
+        assert result == "20260402_103919_624"
+
+    def test_filename_stem(self) -> None:
+        pat = _preset_pattern("filename_stem")
+        result = _extract_from_windows_path(
+            pat,
+            self.WATCH_DIR,
+            rf"{self.WATCH_DIR}\sample.ome.tiff",
+        )
+        assert result == "sample.ome"
+
+    def test_filename_stem_in_subdir(self) -> None:
+        pat = _preset_pattern("filename_stem")
+        result = _extract_from_windows_path(
+            pat,
+            self.WATCH_DIR,
+            rf"{self.WATCH_DIR}\subdir\sample.csv",
+        )
+        assert result == "sample"
+
+    def test_file_outside_watch_dir(self) -> None:
+        pat = _preset_pattern("filename_prefix")
+        with pytest.raises(ValueError):
+            _extract_from_windows_path(
+                pat,
+                self.WATCH_DIR,
+                r"C:\Other\file.csv",
+            )


### PR DESCRIPTION
## Summary

Consolidates the watcher's two separate run detection methods (`prefix` and `directory`) into a single regex-based approach. The pattern is applied to each file's POSIX-normalized relative path, which is strictly more expressive than the old pair of methods while keeping the config simpler (one `pattern` field instead of `method` + `prefix_pattern`).

## Changes

- **`RunDetectionConfig` model** (`models.py`): Replaced `{ method, prefix_pattern }` with `{ pattern, recursive }`. The `pattern` field validator enforces exactly one capture group at config-load time.
- **`RunDetector`** (`run_detector.py`): Collapsed `_extract_prefix` and `_extract_directory` into a single `_extract_run_id` that computes `path.relative_to(watch_dir).as_posix()` and runs `re.search` against it. Constructor takes `pattern: str` instead of `method` + `prefix_pattern`.
- **CLI** (`cli.py`): Replaced the prefix/directory choice in `init` and `config edit` with a numbered preset picker (`_prompt_run_detection`) plus explicit `recursive` confirmation. Updated `config show`, dry-run scan, and `RunDetector` construction. The preview function now applies `re.search` against full relative paths instead of `re.match` against bare filenames.
- **Service** (`service.py`): Updated `RunDetector` construction and recursive flag to match the new config shape.
- **Presets** (`constants.py`): Replaced `DEFAULT_PREFIX_PATTERN` with `RUN_DETECTION_PRESETS` — five built-in options (`filename_prefix`, `top_subdirectory`, `deepest_subdirectory`, `timestamp_subdirectory`, `filename_stem`) used by the setup wizard.
- **Docs** (`watcher.md`): Updated config example, replaced "Run detection methods" section with a description of the unified regex approach and a presets reference table.

## Breaking changes

- **Config format**: `run_detection.method` and `run_detection.prefix_pattern` are replaced by `run_detection.pattern` and `run_detection.recursive`. Existing `config.yaml` files will fail validation and need to be updated (or re-generated via `init`).

## Driveby changes

- Fixed a latent bug where `recursive` monitoring was gated on `not is_auto` (`is_recursive = inst.run_detection.method == "directory" and not is_auto`), which would have prevented subdirectory watching in auto+directory mode. The recursive flag is now driven purely by `inst.run_detection.recursive`.

## Testing

- [x] `test_run_detection_config.py` — 8 tests: valid patterns, `recursive` defaults, 0/2/3 capture groups rejected, invalid regex rejected, non-capturing groups don't count
- [x] `test_run_detector.py` — 22 tests: every preset verified against POSIX paths (via `tmp_path`) and Windows paths (via `PureWindowsPath`), plus edge cases (file outside watch dir, non-matching file)
- [x] `test_preview_environment.py` — updated to use the new `RunDetectionConfig(pattern=..., recursive=...)` shape; all existing tests still pass
- [x] `make check-all` passes (ruff, pyright, eslint, tsc)