### PR TITLE
Add self-service instrument run attribution

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -75,10 +75,20 @@ All tools return JSON encoded as a single text content block. Error cases set `i
 
 | Tool | Description |
 | --- | --- |
-| `search_runs` | Paginated search across runs with filtering, sorting, and date range. Supports plate-reader metadata filters (`wavelength`, `measurementMode`, `measurementType`). |
+| `search_runs` | Paginated search across runs with filtering, sorting, and date range. Supports plate-reader metadata filters (`wavelength`, `measurementMode`, `measurementType`) and attribution filtering via `ranBy` (a user id or the literal `"unattributed"`). |
 | `get_run` | Get a single run by its natural key (`instrumentId` + `runId`). |
 | `list_run_files` | List all files attached to a run, including processing status and metadata. Use `get_file_download_url` on processed CSV files to access experimental results. |
 | `get_run_archive_path` | Get the API path that streams a ZIP archive of all uploaded files for a run. Prepend the Data Hub origin and authenticate with the same Bearer token to download. |
+
+Both `get_run` and `search_runs` responses embed an `attributions` array on each run, listing the users who have claimed it (user id, display name, initials, avatar URL). No separate read tool is needed to inspect who ran a run.
+
+### Run attribution
+
+| Tool | Description |
+| --- | --- |
+| `claim_run` | **Write tool.** Mark a run as performed by the authenticated user. Idempotent. Only self-attribution is supported — the user id comes from the session token, never from an argument, so you cannot claim a run on behalf of another user. |
+| `unclaim_run` | **Write tool.** Remove the authenticated user's attribution from a run. Idempotent. Annotated `destructiveHint: true` because removing attribution is user-visible across the dashboard and runs tables. |
+| `list_run_attributors` | List distinct users who have claimed at least one run on a given instrument. Use the returned `userId` values to construct a `search_runs` call with `ranBy=<userId>`. |
 
 ### Files
 
@@ -125,6 +135,7 @@ Once installed, ask your client questions like:
 - *"Summarize the well data from run `2026-03-26_experiment` on the plate reader."* → `run_analysis` prompt, which chains `get_run`, `list_run_files`, and `get_file_download_url` for processed CSVs
 - *"The gel-doc in Lab 3 stopped uploading — what's wrong?"* → `troubleshoot_instrument` prompt, which inspects the watcher list and heartbeat history
 - *"Re-run processing for file 4217, we pushed a parser fix."* → `reprocess_file`. Clients typically confirm the destructive action with the user first.
+- *"Claim run `2026-03-26_experiment` on the SpectraMax — I ran it this morning."* → `claim_run`. To find runs you've already claimed, use `search_runs` with `ranBy` set to your user id (discoverable via `list_run_attributors`).
 
 ## Troubleshooting
 

--- a/lambda/src/data_hub_lambda/api_client.py
+++ b/lambda/src/data_hub_lambda/api_client.py
@@ -178,10 +178,15 @@ class DataHubClient:
         status: str | None = None,
         metadata: dict[str, Any] | None = None,
         error_message: str | None = None,
+        size_bytes: int | None = None,
+        content_type: str | None = None,
     ) -> FileResponse:
-        """Update a file record (status transition, metadata).
+        """Update a file record (status transition, metadata, S3 object properties).
 
         The API enforces a state machine: uploaded → processing → completed|failed.
+        `size_bytes` and `content_type` are objective properties of the S3 object
+        and may be PATCHed after the record is created (e.g. for processed
+        artifacts whose size is only known post-upload).
         """
         payload: dict[str, Any] = {}
         if status is not None:
@@ -190,6 +195,10 @@ class DataHubClient:
             payload["metadata"] = metadata
         if error_message is not None:
             payload["error_message"] = error_message
+        if size_bytes is not None:
+            payload["size_bytes"] = size_bytes
+        if content_type is not None:
+            payload["content_type"] = content_type
 
         resp = self._request("PATCH", f"/files/{file_id}", json=payload)
         return FileResponse.model_validate(resp.json())

--- a/lambda/src/data_hub_lambda/azure_600_gel_doc/process_file.py
+++ b/lambda/src/data_hub_lambda/azure_600_gel_doc/process_file.py
@@ -62,14 +62,18 @@ def process_file(run_id: str, filename: str) -> str:
         s3_utils.upload_file(png_file_path, f"s3://{processed_bucket}/{png_s3_key}")
         logger.info("Uploaded processed image to s3://%s/%s", processed_bucket, png_s3_key)
 
-        client.create_file(
+        processed_file = client.create_file(
             instrument_id=INSTRUMENT_ID,
             run_id=run_id,
             s3_bucket=processed_bucket or "",
             s3_key=png_s3_key,
             filename=png_file_path.name,
-            size_bytes=png_file_path.stat().st_size,
             category="processed",
+        )
+        client.update_file(
+            processed_file.id,
+            size_bytes=png_file_path.stat().st_size,
+            content_type="image/png",
         )
 
         metadata = parse_metadata(local_file_path)

--- a/lambda/src/data_hub_lambda/spectramax_plate_reader/process_file.py
+++ b/lambda/src/data_hub_lambda/spectramax_plate_reader/process_file.py
@@ -65,14 +65,18 @@ def process_file(instrument_id: InstrumentType, run_id: str, filename: str) -> s
         s3_utils.upload_file(csv_path, f"s3://{processed_bucket}/{csv_s3_key}")
         logger.info("Uploaded processed CSV to s3://%s/%s", processed_bucket, csv_s3_key)
 
-        client.create_file(
+        processed_file = client.create_file(
             instrument_id=instrument_id,
             run_id=run_id,
             s3_bucket=processed_bucket or "",
             s3_key=csv_s3_key,
             filename=csv_filename,
-            size_bytes=csv_path.stat().st_size,
             category="processed",
+        )
+        client.update_file(
+            processed_file.id,
+            size_bytes=csv_path.stat().st_size,
+            content_type="text/csv",
         )
 
         client.update_run(instrument_id, run_id, metadata=metadata)

--- a/web-app/app/api/v1/instrument-runs/route.ts
+++ b/web-app/app/api/v1/instrument-runs/route.ts
@@ -36,6 +36,7 @@ export async function GET(request: NextRequest) {
       max: 100,
     }),
     includeDeleted: searchParams.get("include_deleted") === "true",
+    ranBy: searchParams.get("ran_by") ?? undefined,
   });
 
   return Response.json(result);

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/attributions/me/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/attributions/me/route.ts
@@ -1,0 +1,91 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import { apiError, NOT_FOUND, UNAUTHORIZED } from "@/lib/api/errors";
+import {
+  getAttributionsByRunIds,
+  lookupRunByNaturalKey,
+} from "@/lib/api/instrument-runs";
+import { db } from "@/lib/db";
+import { runAttributions } from "@/lib/db/schema";
+import { and, eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+type RouteContext = {
+  params: Promise<{ instrumentId: string; runId: string }>;
+};
+
+// ---------------------------------------------------------------------------
+// PUT /api/v1/instruments/:instrumentId/runs/:runId/attributions/me
+//
+// Claim a run for the authenticated user. Idempotent: calling twice has the
+// same effect as calling once. The authenticated user id is the only user id
+// used — the URL carries no user id, so spoofing another user's attribution
+// is impossible.
+// ---------------------------------------------------------------------------
+
+export async function PUT(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { instrumentId, runId } = await params;
+  const run = await lookupRunByNaturalKey(instrumentId, runId);
+  if (!run) {
+    return apiError(
+      404,
+      NOT_FOUND,
+      `Run '${runId}' not found for instrument '${instrumentId}'`
+    );
+  }
+
+  await db
+    .insert(runAttributions)
+    .values({ runId: run.id, userId: authResult.userId })
+    .onConflictDoNothing();
+
+  const byRun = await getAttributionsByRunIds([run.id]);
+  return Response.json(
+    { attributions: byRun.get(run.id) ?? [] },
+    { status: 200 }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/instruments/:instrumentId/runs/:runId/attributions/me
+//
+// Remove the authenticated user's attribution from this run. Idempotent:
+// deleting when no attribution exists is a no-op. Server-side enforcement of
+// "self only" — the query always uses session.user.id.
+// ---------------------------------------------------------------------------
+
+export async function DELETE(request: NextRequest, { params }: RouteContext) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { instrumentId, runId } = await params;
+  const run = await lookupRunByNaturalKey(instrumentId, runId);
+  if (!run) {
+    return apiError(
+      404,
+      NOT_FOUND,
+      `Run '${runId}' not found for instrument '${instrumentId}'`
+    );
+  }
+
+  await db
+    .delete(runAttributions)
+    .where(
+      and(
+        eq(runAttributions.runId, run.id),
+        eq(runAttributions.userId, authResult.userId)
+      )
+    );
+
+  const byRun = await getAttributionsByRunIds([run.id]);
+  return Response.json(
+    { attributions: byRun.get(run.id) ?? [] },
+    { status: 200 }
+  );
+}

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/route.ts
@@ -84,6 +84,7 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
     updated_at: run.updatedAt,
     deleted_at: run.deletedAt,
     metadata: run.metadata,
+    attributions: run.attributions,
     files: filesWithUrls,
   });
 }

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/route.ts
@@ -210,6 +210,7 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
       max: 100,
     }),
     includeDeleted: searchParams.get("include_deleted") === "true",
+    ranBy: searchParams.get("ran_by") ?? undefined,
   });
 
   return Response.json(result);

--- a/web-app/app/instruments/[instrumentId]/page.tsx
+++ b/web-app/app/instruments/[instrumentId]/page.tsx
@@ -13,6 +13,7 @@ import {
   getGelDocFilterOptions,
   getPlateReaderFilterOptions,
   getQpcrFilterOptions,
+  getRanByFilterOptions,
 } from "@/lib/api/instrument-runs";
 import { getInstrumentById } from "@/lib/api/instruments";
 import { auth } from "@/lib/auth";
@@ -63,6 +64,7 @@ export default async function InstrumentDetailPage({
       gelWavelength: filters.gel_wavelength ?? undefined,
       gelColor: filters.gel_color ?? undefined,
       dyeChannel: filters.dye_channel ?? undefined,
+      ranBy: filters.ran_by ?? undefined,
     }),
   ]);
 
@@ -73,11 +75,13 @@ export default async function InstrumentDetailPage({
   const isQpcr = instrument.instrumentType === "qpcr";
 
   // Fetch distinct metadata values for instrument-specific column filter dropdowns.
-  const [filterOptions, gelDocFilterOptions, qpcrFilterOptions] =
+  // `ranByOptions` applies to every instrument type.
+  const [filterOptions, gelDocFilterOptions, qpcrFilterOptions, ranByUsers] =
     await Promise.all([
       isPlateReader ? getPlateReaderFilterOptions(instrumentId) : undefined,
       isGelDoc ? getGelDocFilterOptions(instrumentId) : undefined,
       isQpcr ? getQpcrFilterOptions(instrumentId) : undefined,
+      getRanByFilterOptions(instrumentId),
     ]);
 
   const hasFilters =
@@ -92,7 +96,8 @@ export default async function InstrumentDetailPage({
     filters.imaging_mode !== null ||
     filters.gel_wavelength !== null ||
     filters.gel_color !== null ||
-    filters.dye_channel !== null;
+    filters.dye_channel !== null ||
+    filters.ran_by !== null;
 
   const currentUserId = session.user?.id ?? null;
   const unattributedCount = runResult.data.filter(
@@ -103,6 +108,20 @@ export default async function InstrumentDetailPage({
         row.attributions.some((a) => a.userId === currentUserId)
       ).length
     : 0;
+
+  // Build the "Ran by" dropdown options: the current user (labelled "You"),
+  // pinned to the top if they've attributed anything here, followed by other
+  // attributors by display name, then the "Unattributed" sentinel.
+  const meOption = currentUserId
+    ? ranByUsers.find((u) => u.userId === currentUserId)
+    : undefined;
+  const ranByOptions = [
+    ...(meOption ? [{ value: meOption.userId, label: "You" }] : []),
+    ...ranByUsers
+      .filter((u) => u.userId !== currentUserId)
+      .map((u) => ({ value: u.userId, label: u.displayName })),
+    { value: "unattributed", label: "Unattributed" },
+  ];
 
   return (
     <div className="mx-auto flex max-w-7xl flex-col gap-6 p-6">
@@ -120,6 +139,10 @@ export default async function InstrumentDetailPage({
               filterOptions={filterOptions}
               gelDocFilterOptions={gelDocFilterOptions}
               qpcrFilterOptions={qpcrFilterOptions}
+              ranByOptions={ranByOptions}
+              totalCount={runResult.pagination.total}
+              unattributedCount={unattributedCount}
+              ranByYouCount={ranByYouCount}
             />
           </TablePendingBoundary>
           <PaginationNav
@@ -127,19 +150,6 @@ export default async function InstrumentDetailPage({
             totalPages={runResult.pagination.total_pages}
             pageParam="page"
           />
-          {runResult.data.length > 0 ? (
-            <div className="flex items-center justify-between text-xs text-muted-foreground">
-              <p>
-                Hover any row to reveal &ldquo;I ran this&rdquo;. Check multiple
-                rows to attribute them together.
-              </p>
-              <p>
-                <span className="tabular-nums">{unattributedCount}</span>{" "}
-                unattributed ·{" "}
-                <span className="tabular-nums">{ranByYouCount}</span> ran by you
-              </p>
-            </div>
-          ) : null}
         </TablePendingProvider>
       </RunSelectionProvider>
     </div>

--- a/web-app/app/instruments/[instrumentId]/page.tsx
+++ b/web-app/app/instruments/[instrumentId]/page.tsx
@@ -1,6 +1,8 @@
 import { InstrumentHeader } from "@/components/instruments/instrument-header";
 import { InstrumentRunsToolbar } from "@/components/instruments/instrument-runs-toolbar";
 import { InstrumentRunsTable } from "@/components/instruments/runs-table";
+import { BulkAttributionBar } from "@/components/instruments/runs-table/bulk-attribution-bar";
+import { RunSelectionProvider } from "@/components/instruments/runs-table/run-selection-provider";
 import { PaginationNav } from "@/components/pagination-nav";
 import {
   TablePendingBoundary,
@@ -92,28 +94,54 @@ export default async function InstrumentDetailPage({
     filters.gel_color !== null ||
     filters.dye_channel !== null;
 
+  const currentUserId = session.user?.id ?? null;
+  const unattributedCount = runResult.data.filter(
+    (row) => row.attributions.length === 0
+  ).length;
+  const ranByYouCount = currentUserId
+    ? runResult.data.filter((row) =>
+        row.attributions.some((a) => a.userId === currentUserId)
+      ).length
+    : 0;
+
   return (
     <div className="mx-auto flex max-w-7xl flex-col gap-6 p-6">
       <InstrumentHeader instrument={instrument} />
-      <TablePendingProvider>
-        <InstrumentRunsToolbar />
-        <TablePendingBoundary>
-          <InstrumentRunsTable
-            data={runResult.data}
-            instrumentId={instrumentId}
-            instrumentType={instrument.instrumentType}
-            hasFilters={hasFilters}
-            filterOptions={filterOptions}
-            gelDocFilterOptions={gelDocFilterOptions}
-            qpcrFilterOptions={qpcrFilterOptions}
+      <RunSelectionProvider>
+        <TablePendingProvider>
+          <InstrumentRunsToolbar />
+          <BulkAttributionBar />
+          <TablePendingBoundary>
+            <InstrumentRunsTable
+              data={runResult.data}
+              instrumentId={instrumentId}
+              instrumentType={instrument.instrumentType}
+              hasFilters={hasFilters}
+              filterOptions={filterOptions}
+              gelDocFilterOptions={gelDocFilterOptions}
+              qpcrFilterOptions={qpcrFilterOptions}
+            />
+          </TablePendingBoundary>
+          <PaginationNav
+            page={runResult.pagination.page}
+            totalPages={runResult.pagination.total_pages}
+            pageParam="page"
           />
-        </TablePendingBoundary>
-        <PaginationNav
-          page={runResult.pagination.page}
-          totalPages={runResult.pagination.total_pages}
-          pageParam="page"
-        />
-      </TablePendingProvider>
+          {runResult.data.length > 0 ? (
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <p>
+                Hover any row to reveal &ldquo;I ran this&rdquo;. Check multiple
+                rows to attribute them together.
+              </p>
+              <p>
+                <span className="tabular-nums">{unattributedCount}</span>{" "}
+                unattributed ·{" "}
+                <span className="tabular-nums">{ranByYouCount}</span> ran by you
+              </p>
+            </div>
+          ) : null}
+        </TablePendingProvider>
+      </RunSelectionProvider>
     </div>
   );
 }

--- a/web-app/app/instruments/[instrumentId]/runs/[runId]/page.tsx
+++ b/web-app/app/instruments/[instrumentId]/runs/[runId]/page.tsx
@@ -1,3 +1,4 @@
+import { RunAttributionsSection } from "@/components/runs/run-attributions-section";
 import { RunDetailVariant } from "@/components/runs/variants";
 import {
   getProcessedCsvData,
@@ -41,6 +42,13 @@ export default async function RunDetailPage({ params }: Props) {
         wellData={wellData}
         instrumentId={instrumentId}
         runId={runId}
+        attributionsSlot={
+          <RunAttributionsSection
+            instrumentId={run.instrumentId}
+            runId={run.runId}
+            attributions={run.attributions}
+          />
+        }
       />
     </div>
   );

--- a/web-app/app/layout.tsx
+++ b/web-app/app/layout.tsx
@@ -44,7 +44,7 @@ export default async function RootLayout({
       )}
     >
       <body>
-        <SessionProvider>
+        <SessionProvider session={session}>
           <ThemeProvider>
             <NuqsAdapter>
               <TooltipProvider>

--- a/web-app/app/page.tsx
+++ b/web-app/app/page.tsx
@@ -4,6 +4,8 @@ import {
 } from "@/components/dashboard/instrument-cards";
 import { RunsTable } from "@/components/dashboard/runs-table";
 import { RunsToolbar } from "@/components/dashboard/runs-toolbar";
+import { BulkAttributionBar } from "@/components/instruments/runs-table/bulk-attribution-bar";
+import { RunSelectionProvider } from "@/components/instruments/runs-table/run-selection-provider";
 import { PaginationNav } from "@/components/pagination-nav";
 import {
   TablePendingBoundary,
@@ -62,6 +64,15 @@ export default async function DashboardPage({
   ]);
 
   const hasFilters = hasActiveFilters(params);
+  const currentUserId = session.user?.id ?? null;
+  const unattributedCount = runResult.data.filter(
+    (row) => row.attributions.length === 0
+  ).length;
+  const ranByYouCount = currentUserId
+    ? runResult.data.filter((row) =>
+        row.attributions.some((a) => a.userId === currentUserId)
+      ).length
+    : 0;
 
   return (
     <div className="mx-auto flex max-w-7xl flex-col gap-6 p-6">
@@ -69,18 +80,33 @@ export default async function DashboardPage({
         <InstrumentCards />
       </Suspense>
 
-      <TablePendingProvider>
-        <RunsToolbar instruments={instruments} />
-
-        <TablePendingBoundary>
-          <RunsTable data={runResult.data} hasFilters={hasFilters} />
-        </TablePendingBoundary>
-        <PaginationNav
-          page={runResult.pagination.page}
-          totalPages={runResult.pagination.total_pages}
-          pageParam="page"
-        />
-      </TablePendingProvider>
+      <RunSelectionProvider>
+        <TablePendingProvider>
+          <RunsToolbar instruments={instruments} />
+          <BulkAttributionBar />
+          <TablePendingBoundary>
+            <RunsTable data={runResult.data} hasFilters={hasFilters} />
+          </TablePendingBoundary>
+          <PaginationNav
+            page={runResult.pagination.page}
+            totalPages={runResult.pagination.total_pages}
+            pageParam="page"
+          />
+          {runResult.data.length > 0 ? (
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <p>
+                Hover any row to reveal &ldquo;I ran this&rdquo;. Check multiple
+                rows to attribute them together.
+              </p>
+              <p>
+                <span className="tabular-nums">{unattributedCount}</span>{" "}
+                unattributed ·{" "}
+                <span className="tabular-nums">{ranByYouCount}</span> ran by you
+              </p>
+            </div>
+          ) : null}
+        </TablePendingProvider>
+      </RunSelectionProvider>
     </div>
   );
 }

--- a/web-app/components/dashboard/runs-table.tsx
+++ b/web-app/components/dashboard/runs-table.tsx
@@ -1,4 +1,11 @@
 import { RelativeTime } from "@/components/dashboard/relative-time";
+import { ClickableRow } from "@/components/instruments/runs-table/clickable-row";
+import { RanByCell } from "@/components/instruments/runs-table/ran-by-cell";
+import {
+  RunSelectAllCheckbox,
+  RunSelectCheckbox,
+} from "@/components/instruments/runs-table/run-select-checkbox";
+import type { RunRef } from "@/components/instruments/runs-table/run-selection-provider";
 import { RunStatusIcon } from "@/components/instruments/runs-table/run-status-icon";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -10,9 +17,9 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import type { RunAttribution } from "@/lib/api/instrument-runs";
 import { cn, formatBytes } from "@/lib/utils";
 import { FlaskConical, SearchX } from "lucide-react";
-import Link from "next/link";
 
 type RunRow = {
   id: string;
@@ -30,6 +37,7 @@ type RunRow = {
   files_pending_upload: number;
   total_size_bytes: number;
   error_messages: string[];
+  attributions: RunAttribution[];
 };
 
 export function RunsTable({
@@ -52,15 +60,25 @@ export function RunsTable({
     );
   }
 
+  const runRefs: RunRef[] = data.map((row) => ({
+    id: row.id,
+    instrumentId: row.instrument_id,
+    runId: row.run_id,
+  }));
+
   return (
     <div className="rounded-lg border">
       <Table>
         <TableHeader>
           <TableRow>
+            <TableHead className="w-10">
+              <RunSelectAllCheckbox refs={runRefs} />
+            </TableHead>
             <TableHead>Instrument</TableHead>
             <TableHead>Run ID</TableHead>
             <TableHead>Files</TableHead>
             <TableHead className="text-right">Total Size</TableHead>
+            <TableHead>Ran by</TableHead>
             <TableHead className="text-right">Created</TableHead>
           </TableRow>
         </TableHeader>
@@ -69,14 +87,21 @@ export function RunsTable({
             const isDeleted = row.deleted_at !== null;
             const href = `/instruments/${row.instrument_id}/runs/${encodeURIComponent(row.run_id)}`;
             return (
-              <TableRow
+              <ClickableRow
                 key={row.id}
-                className={cn("group relative", isDeleted && "opacity-50")}
+                href={href}
+                className={cn(isDeleted && "opacity-50")}
               >
                 <TableCell>
-                  <Link href={href} className="absolute inset-0" tabIndex={-1}>
-                    <span className="sr-only">View run {row.run_id}</span>
-                  </Link>
+                  <RunSelectCheckbox
+                    runRef={{
+                      id: row.id,
+                      instrumentId: row.instrument_id,
+                      runId: row.run_id,
+                    }}
+                  />
+                </TableCell>
+                <TableCell>
                   <div className="flex items-center gap-1.5">
                     <FlaskConical className="size-3.5 shrink-0 text-muted-foreground" />
                     <span className="text-sm font-medium">
@@ -98,14 +123,14 @@ export function RunsTable({
                     >
                       {row.run_id}
                     </span>
-                    {isDeleted && (
+                    {isDeleted ? (
                       <Badge
                         variant="outline"
                         className="ml-1.5 text-[10px] font-normal"
                       >
                         deleted
                       </Badge>
-                    )}
+                    ) : null}
                   </div>
                 </TableCell>
                 <TableCell className="text-sm tabular-nums">
@@ -114,10 +139,17 @@ export function RunsTable({
                 <TableCell className="text-right text-sm tabular-nums">
                   {formatBytes(row.total_size_bytes)}
                 </TableCell>
+                <TableCell>
+                  <RanByCell
+                    instrumentId={row.instrument_id}
+                    runId={row.run_id}
+                    attributions={row.attributions}
+                  />
+                </TableCell>
                 <TableCell className="text-right">
                   <RelativeTime date={new Date(row.created_at).toISOString()} />
                 </TableCell>
-              </TableRow>
+              </ClickableRow>
             );
           })}
         </TableBody>
@@ -132,16 +164,21 @@ export function RunsTableSkeleton() {
       <Table>
         <TableHeader>
           <TableRow>
+            <TableHead className="w-10" />
             <TableHead>Instrument</TableHead>
             <TableHead>Run ID</TableHead>
             <TableHead>Files</TableHead>
             <TableHead className="text-right">Total Size</TableHead>
+            <TableHead>Ran by</TableHead>
             <TableHead className="text-right">Created</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {Array.from({ length: 5 }).map((_, i) => (
             <TableRow key={i}>
+              <TableCell>
+                <Skeleton className="size-4" />
+              </TableCell>
               <TableCell>
                 <Skeleton className="h-4 w-28" />
               </TableCell>
@@ -153,6 +190,9 @@ export function RunsTableSkeleton() {
               </TableCell>
               <TableCell className="text-right">
                 <Skeleton className="ml-auto h-4 w-16" />
+              </TableCell>
+              <TableCell>
+                <Skeleton className="h-6 w-16" />
               </TableCell>
               <TableCell className="text-right">
                 <Skeleton className="ml-auto h-4 w-20" />

--- a/web-app/components/dashboard/runs-table.tsx
+++ b/web-app/components/dashboard/runs-table.tsx
@@ -78,7 +78,7 @@ export function RunsTable({
             <TableHead>Run ID</TableHead>
             <TableHead>Files</TableHead>
             <TableHead className="text-right">Total Size</TableHead>
-            <TableHead>Ran by</TableHead>
+            <TableHead>Ran By</TableHead>
             <TableHead className="text-right">Created</TableHead>
           </TableRow>
         </TableHeader>
@@ -169,7 +169,7 @@ export function RunsTableSkeleton() {
             <TableHead>Run ID</TableHead>
             <TableHead>Files</TableHead>
             <TableHead className="text-right">Total Size</TableHead>
-            <TableHead>Ran by</TableHead>
+            <TableHead>Ran By</TableHead>
             <TableHead className="text-right">Created</TableHead>
           </TableRow>
         </TableHeader>

--- a/web-app/components/instruments/instrument-header.tsx
+++ b/web-app/components/instruments/instrument-header.tsx
@@ -1,6 +1,14 @@
 import { Badge } from "@/components/ui/badge";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
 import type { InstrumentDetail } from "@/lib/api/instruments";
-import { Activity, ArrowLeft, Radio, WifiOff } from "lucide-react";
+import { Activity, Radio, WifiOff } from "lucide-react";
 import Link from "next/link";
 
 type WatcherVariant = "online" | "offline" | "no_watcher";
@@ -36,13 +44,19 @@ export function InstrumentHeader({
 
   return (
     <div className="flex flex-col gap-2">
-      <Link
-        href="/instruments"
-        className="mb-2 flex w-fit items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <ArrowLeft className="size-3.5" />
-        Back to instruments
-      </Link>
+      <Breadcrumb className="mb-2">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href="/instruments">Instruments</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>{instrument.displayName}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
 
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">

--- a/web-app/components/instruments/runs-table/bulk-attribution-bar.tsx
+++ b/web-app/components/instruments/runs-table/bulk-attribution-bar.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import { toast } from "sonner";
+
+import { useRunSelection, type RunRef } from "./run-selection-provider";
+
+async function fanOut(
+  method: "PUT" | "DELETE",
+  refs: RunRef[]
+): Promise<{ ok: number; failed: number }> {
+  const results = await Promise.all(
+    refs.map(async (ref) => {
+      const url = `/api/v1/instruments/${ref.instrumentId}/runs/${encodeURIComponent(
+        ref.runId
+      )}/attributions/me`;
+      try {
+        const res = await fetch(url, { method });
+        return res.ok;
+      } catch {
+        return false;
+      }
+    })
+  );
+  const ok = results.filter(Boolean).length;
+  return { ok, failed: results.length - ok };
+}
+
+export function BulkAttributionBar() {
+  const { state, actions, meta } = useRunSelection();
+  const router = useRouter();
+  const [isPending, startMutation] = useTransition();
+
+  if (meta.count === 0) return null;
+
+  const refs = Array.from(state.selected.values());
+
+  function runAction(method: "PUT" | "DELETE", label: string) {
+    startMutation(async () => {
+      const { ok, failed } = await fanOut(method, refs);
+      if (failed === 0) {
+        toast.success(`${label} ${ok} ${ok === 1 ? "run" : "runs"}.`);
+      } else if (ok === 0) {
+        toast.error(
+          `Failed to update ${failed} ${failed === 1 ? "run" : "runs"}.`
+        );
+      } else {
+        toast.warning(
+          `${label} ${ok} ${ok === 1 ? "run" : "runs"}, ${failed} failed.`
+        );
+      }
+      actions.clear();
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="flex items-center justify-between rounded-lg border bg-muted/40 px-4 py-2">
+      <div className="text-sm">
+        <span className="font-medium">{meta.count}</span>{" "}
+        <span className="text-muted-foreground">
+          {meta.count === 1 ? "run" : "runs"} selected
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="default"
+          size="sm"
+          disabled={isPending}
+          onClick={() => runAction("PUT", "Claimed")}
+        >
+          I ran these
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={isPending}
+          onClick={() => runAction("DELETE", "Removed attribution from")}
+        >
+          Remove my attribution
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={isPending}
+          onClick={() => actions.clear()}
+        >
+          Clear
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web-app/components/instruments/runs-table/clickable-row.tsx
+++ b/web-app/components/instruments/runs-table/clickable-row.tsx
@@ -16,7 +16,7 @@ export function ClickableRow({
 
   return (
     <TableRow
-      className={`cursor-pointer ${className ?? ""}`}
+      className={`group cursor-pointer ${className ?? ""}`}
       onClick={() => router.push(href)}
     >
       {children}

--- a/web-app/components/instruments/runs-table/default-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/default-runs-table.tsx
@@ -12,17 +12,30 @@ import { cn, formatBytes } from "@/lib/utils";
 
 import type { RunsTableProps } from ".";
 import { ClickableRow } from "./clickable-row";
+import { RanByCell } from "./ran-by-cell";
+import { RunSelectAllCheckbox, RunSelectCheckbox } from "./run-select-checkbox";
+import type { RunRef } from "./run-selection-provider";
 import { RunStatusIcon } from "./run-status-icon";
 
 export function DefaultRunsTable({ data, instrumentId }: RunsTableProps) {
+  const runRefs: RunRef[] = data.map((row) => ({
+    id: row.id,
+    instrumentId: row.instrument_id,
+    runId: row.run_id,
+  }));
+
   return (
     <div className="rounded-lg border">
       <Table>
         <TableHeader>
           <TableRow>
+            <TableHead className="w-10">
+              <RunSelectAllCheckbox refs={runRefs} />
+            </TableHead>
             <TableHead>Run ID</TableHead>
             <TableHead>Files</TableHead>
             <TableHead className="text-right">Total Size</TableHead>
+            <TableHead>Ran by</TableHead>
             <TableHead className="text-right">Created</TableHead>
           </TableRow>
         </TableHeader>
@@ -35,6 +48,15 @@ export function DefaultRunsTable({ data, instrumentId }: RunsTableProps) {
                 href={`/instruments/${instrumentId}/runs/${encodeURIComponent(row.run_id)}`}
                 className={cn(isDeleted && "opacity-50")}
               >
+                <TableCell>
+                  <RunSelectCheckbox
+                    runRef={{
+                      id: row.id,
+                      instrumentId: row.instrument_id,
+                      runId: row.run_id,
+                    }}
+                  />
+                </TableCell>
                 <TableCell>
                   <div className="flex items-center gap-2.5">
                     <RunStatusIcon
@@ -58,6 +80,13 @@ export function DefaultRunsTable({ data, instrumentId }: RunsTableProps) {
                 </TableCell>
                 <TableCell className="text-right text-sm tabular-nums">
                   {formatBytes(row.total_size_bytes)}
+                </TableCell>
+                <TableCell>
+                  <RanByCell
+                    instrumentId={row.instrument_id}
+                    runId={row.run_id}
+                    attributions={row.attributions}
+                  />
                 </TableCell>
                 <TableCell className="text-right">
                   <RelativeTime date={row.created_at.toISOString()} />

--- a/web-app/components/instruments/runs-table/default-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/default-runs-table.tsx
@@ -12,12 +12,17 @@ import { cn, formatBytes } from "@/lib/utils";
 
 import type { RunsTableProps } from ".";
 import { ClickableRow } from "./clickable-row";
+import { FilterableColumnHeader } from "./filterable-column-header";
 import { RanByCell } from "./ran-by-cell";
 import { RunSelectAllCheckbox, RunSelectCheckbox } from "./run-select-checkbox";
 import type { RunRef } from "./run-selection-provider";
 import { RunStatusIcon } from "./run-status-icon";
 
-export function DefaultRunsTable({ data, instrumentId }: RunsTableProps) {
+export function DefaultRunsTable({
+  data,
+  instrumentId,
+  ranByOptions,
+}: RunsTableProps) {
   const runRefs: RunRef[] = data.map((row) => ({
     id: row.id,
     instrumentId: row.instrument_id,
@@ -25,77 +30,81 @@ export function DefaultRunsTable({ data, instrumentId }: RunsTableProps) {
   }));
 
   return (
-    <div className="rounded-lg border">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-10">
-              <RunSelectAllCheckbox refs={runRefs} />
-            </TableHead>
-            <TableHead>Run ID</TableHead>
-            <TableHead>Files</TableHead>
-            <TableHead className="text-right">Total Size</TableHead>
-            <TableHead>Ran by</TableHead>
-            <TableHead className="text-right">Created</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {data.map((row) => {
-            const isDeleted = row.deleted_at !== null;
-            return (
-              <ClickableRow
-                key={row.id}
-                href={`/instruments/${instrumentId}/runs/${encodeURIComponent(row.run_id)}`}
-                className={cn(isDeleted && "opacity-50")}
-              >
-                <TableCell>
-                  <RunSelectCheckbox
-                    runRef={{
-                      id: row.id,
-                      instrumentId: row.instrument_id,
-                      runId: row.run_id,
-                    }}
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-10">
+            <RunSelectAllCheckbox refs={runRefs} />
+          </TableHead>
+          <TableHead>Run ID</TableHead>
+          <TableHead>Files</TableHead>
+          <TableHead className="text-right">Total Size</TableHead>
+          <TableHead>
+            <FilterableColumnHeader
+              label="Ran by"
+              paramKey="ran_by"
+              options={ranByOptions}
+            />
+          </TableHead>
+          <TableHead className="text-right">Created</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {data.map((row) => {
+          const isDeleted = row.deleted_at !== null;
+          return (
+            <ClickableRow
+              key={row.id}
+              href={`/instruments/${instrumentId}/runs/${encodeURIComponent(row.run_id)}`}
+              className={cn(isDeleted && "opacity-50")}
+            >
+              <TableCell>
+                <RunSelectCheckbox
+                  runRef={{
+                    id: row.id,
+                    instrumentId: row.instrument_id,
+                    runId: row.run_id,
+                  }}
+                />
+              </TableCell>
+              <TableCell>
+                <div className="flex items-center gap-2.5">
+                  <RunStatusIcon
+                    filesFailed={row.files_failed}
+                    errorMessages={row.error_messages}
                   />
-                </TableCell>
-                <TableCell>
-                  <div className="flex items-center gap-2.5">
-                    <RunStatusIcon
-                      filesFailed={row.files_failed}
-                      errorMessages={row.error_messages}
-                    />
-                    <span
-                      className={cn("font-mono", isDeleted && "line-through")}
-                    >
-                      {row.run_id}
-                    </span>
-                    {isDeleted && (
-                      <Badge variant="outline" className="ml-1.5 font-normal">
-                        deleted
-                      </Badge>
-                    )}
-                  </div>
-                </TableCell>
-                <TableCell className="text-sm tabular-nums">
-                  {row.file_count}
-                </TableCell>
-                <TableCell className="text-right text-sm tabular-nums">
-                  {formatBytes(row.total_size_bytes)}
-                </TableCell>
-                <TableCell>
-                  <RanByCell
-                    instrumentId={row.instrument_id}
-                    runId={row.run_id}
-                    attributions={row.attributions}
-                  />
-                </TableCell>
-                <TableCell className="text-right">
-                  <RelativeTime date={row.created_at.toISOString()} />
-                </TableCell>
-              </ClickableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
+                  <span
+                    className={cn("font-mono", isDeleted && "line-through")}
+                  >
+                    {row.run_id}
+                  </span>
+                  {isDeleted && (
+                    <Badge variant="outline" className="ml-1.5 font-normal">
+                      deleted
+                    </Badge>
+                  )}
+                </div>
+              </TableCell>
+              <TableCell className="text-sm tabular-nums">
+                {row.file_count}
+              </TableCell>
+              <TableCell className="text-right text-sm tabular-nums">
+                {formatBytes(row.total_size_bytes)}
+              </TableCell>
+              <TableCell>
+                <RanByCell
+                  instrumentId={row.instrument_id}
+                  runId={row.run_id}
+                  attributions={row.attributions}
+                />
+              </TableCell>
+              <TableCell className="text-right">
+                <RelativeTime date={row.created_at.toISOString()} />
+              </TableCell>
+            </ClickableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
   );
 }

--- a/web-app/components/instruments/runs-table/filterable-column-header.tsx
+++ b/web-app/components/instruments/runs-table/filterable-column-header.tsx
@@ -23,7 +23,20 @@ type FilterParamKey =
   | "imaging_mode"
   | "gel_wavelength"
   | "gel_color"
-  | "dye_channel";
+  | "dye_channel"
+  | "ran_by";
+
+// Options accept either plain strings (value == label) or { value, label }
+// pairs for cases where the URL-stable value and the display label differ
+// (e.g., `ran_by` stores a userId but renders the user's display name).
+export type FilterOption = string | { value: string; label: string };
+
+function normalizeOption(option: FilterOption): {
+  value: string;
+  label: string;
+} {
+  return typeof option === "string" ? { value: option, label: option } : option;
+}
 
 export function FilterableColumnHeader({
   label,
@@ -32,7 +45,7 @@ export function FilterableColumnHeader({
 }: {
   label: string;
   paramKey: FilterParamKey;
-  options: string[];
+  options: FilterOption[];
 }) {
   const { startTransition } = useTablePending();
   const [filters, setFilters] = useQueryStates(instrumentDetailSearchParams, {
@@ -71,11 +84,14 @@ export function FilterableColumnHeader({
         >
           <DropdownMenuRadioItem value="">All</DropdownMenuRadioItem>
           <DropdownMenuSeparator />
-          {options.map((option) => (
-            <DropdownMenuRadioItem key={option} value={option}>
-              {option}
-            </DropdownMenuRadioItem>
-          ))}
+          {options.map((option) => {
+            const { value, label } = normalizeOption(option);
+            return (
+              <DropdownMenuRadioItem key={value} value={value}>
+                {label}
+              </DropdownMenuRadioItem>
+            );
+          })}
         </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/web-app/components/instruments/runs-table/gel-doc-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/gel-doc-runs-table.tsx
@@ -35,10 +35,12 @@ export function GelDocRunsTable({
   data,
   instrumentId,
   filterOptions,
+  ranByOptions,
 }: {
   data: RunRow[];
   instrumentId: string;
   filterOptions: GelDocFilterOptions;
+  ranByOptions: { value: string; label: string }[];
 }) {
   const allWavelengths = data.flatMap((row) =>
     getMetadataArray(row.metadata, "wavelengths")
@@ -51,140 +53,144 @@ export function GelDocRunsTable({
   }));
 
   return (
-    <div className="rounded-lg border">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-10">
-              <RunSelectAllCheckbox refs={runRefs} />
-            </TableHead>
-            <TableHead>Run ID</TableHead>
-            <TableHead>Files</TableHead>
-            <TableHead className="text-right">Total Size</TableHead>
-            <TableHead>
-              <FilterableColumnHeader
-                label="Capture Type"
-                paramKey="capture_type"
-                options={filterOptions.captureTypes}
-              />
-            </TableHead>
-            <TableHead>
-              <FilterableColumnHeader
-                label="Imaging Mode"
-                paramKey="imaging_mode"
-                options={filterOptions.imagingModes}
-              />
-            </TableHead>
-            <TableHead>
-              <FilterableColumnHeader
-                label="Wavelengths"
-                paramKey="gel_wavelength"
-                options={filterOptions.wavelengths}
-              />
-            </TableHead>
-            <TableHead>
-              <FilterableColumnHeader
-                label="Wavelength Colors"
-                paramKey="gel_color"
-                options={filterOptions.colors}
-              />
-            </TableHead>
-            <TableHead>Ran by</TableHead>
-            <TableHead className="text-right">Created</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {data.map((row) => {
-            const isDeleted = row.deleted_at !== null;
-            const captureType = getMetadataField(row.metadata, "capture_type");
-            const imagingMode = getMetadataField(row.metadata, "imaging_mode");
-            const wavelengths = getMetadataArray(row.metadata, "wavelengths");
-            const wavelengthColorLabels = getMetadataArray(
-              row.metadata,
-              "colors"
-            );
-            return (
-              <ClickableRow
-                key={row.id}
-                href={`/instruments/${instrumentId}/runs/${encodeURIComponent(row.run_id)}`}
-                className={cn(isDeleted && "opacity-50")}
-              >
-                <TableCell>
-                  <RunSelectCheckbox
-                    runRef={{
-                      id: row.id,
-                      instrumentId: row.instrument_id,
-                      runId: row.run_id,
-                    }}
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-10">
+            <RunSelectAllCheckbox refs={runRefs} />
+          </TableHead>
+          <TableHead>Run ID</TableHead>
+          <TableHead>Files</TableHead>
+          <TableHead className="text-right">Total Size</TableHead>
+          <TableHead>
+            <FilterableColumnHeader
+              label="Capture Type"
+              paramKey="capture_type"
+              options={filterOptions.captureTypes}
+            />
+          </TableHead>
+          <TableHead>
+            <FilterableColumnHeader
+              label="Imaging Mode"
+              paramKey="imaging_mode"
+              options={filterOptions.imagingModes}
+            />
+          </TableHead>
+          <TableHead>
+            <FilterableColumnHeader
+              label="Wavelengths"
+              paramKey="gel_wavelength"
+              options={filterOptions.wavelengths}
+            />
+          </TableHead>
+          <TableHead>
+            <FilterableColumnHeader
+              label="Wavelength Colors"
+              paramKey="gel_color"
+              options={filterOptions.colors}
+            />
+          </TableHead>
+          <TableHead>
+            <FilterableColumnHeader
+              label="Ran by"
+              paramKey="ran_by"
+              options={ranByOptions}
+            />
+          </TableHead>
+          <TableHead className="text-right">Created</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {data.map((row) => {
+          const isDeleted = row.deleted_at !== null;
+          const captureType = getMetadataField(row.metadata, "capture_type");
+          const imagingMode = getMetadataField(row.metadata, "imaging_mode");
+          const wavelengths = getMetadataArray(row.metadata, "wavelengths");
+          const wavelengthColorLabels = getMetadataArray(
+            row.metadata,
+            "colors"
+          );
+          return (
+            <ClickableRow
+              key={row.id}
+              href={`/instruments/${instrumentId}/runs/${encodeURIComponent(row.run_id)}`}
+              className={cn(isDeleted && "opacity-50")}
+            >
+              <TableCell>
+                <RunSelectCheckbox
+                  runRef={{
+                    id: row.id,
+                    instrumentId: row.instrument_id,
+                    runId: row.run_id,
+                  }}
+                />
+              </TableCell>
+              <TableCell>
+                <div className="flex items-center gap-2.5">
+                  <RunStatusIcon
+                    filesFailed={row.files_failed}
+                    errorMessages={row.error_messages}
                   />
-                </TableCell>
-                <TableCell>
-                  <div className="flex items-center gap-2.5">
-                    <RunStatusIcon
-                      filesFailed={row.files_failed}
-                      errorMessages={row.error_messages}
-                    />
-                    <span
-                      className={cn("font-mono", isDeleted && "line-through")}
-                    >
-                      {row.run_id}
-                    </span>
-                    {isDeleted && (
-                      <Badge variant="outline" className="ml-1.5 font-normal">
-                        deleted
-                      </Badge>
-                    )}
-                  </div>
-                </TableCell>
-                <TableCell className="text-sm tabular-nums">
-                  {row.file_count}
-                </TableCell>
-                <TableCell className="text-right text-sm tabular-nums">
-                  {formatBytes(row.total_size_bytes)}
-                </TableCell>
-                <TableCell>
-                  <MetadataFieldBadge
-                    value={captureType}
-                    colorClass={
-                      captureType ? CAPTURE_TYPE_COLORS[captureType] : undefined
-                    }
-                  />
-                </TableCell>
-                <TableCell>
-                  <MetadataFieldBadge
-                    value={imagingMode}
-                    colorClass={
-                      imagingMode ? IMAGING_MODE_COLORS[imagingMode] : undefined
-                    }
-                  />
-                </TableCell>
-                <TableCell>
-                  <MetadataArrayBadges
-                    values={wavelengths}
-                    colorMap={wavelengthColors}
-                  />
-                </TableCell>
-                <TableCell>
-                  <MetadataArrayBadges
-                    values={wavelengthColorLabels}
-                    colorMap={CHANNEL_COLOR_STYLES}
-                  />
-                </TableCell>
-                <TableCell>
-                  <RanByCell
-                    instrumentId={row.instrument_id}
-                    runId={row.run_id}
-                    attributions={row.attributions}
-                  />
-                </TableCell>
-                <TableCell className="text-right">
-                  <RelativeTime date={row.created_at.toISOString()} />
-                </TableCell>
-              </ClickableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
+                  <span
+                    className={cn("font-mono", isDeleted && "line-through")}
+                  >
+                    {row.run_id}
+                  </span>
+                  {isDeleted && (
+                    <Badge variant="outline" className="ml-1.5 font-normal">
+                      deleted
+                    </Badge>
+                  )}
+                </div>
+              </TableCell>
+              <TableCell className="text-sm tabular-nums">
+                {row.file_count}
+              </TableCell>
+              <TableCell className="text-right text-sm tabular-nums">
+                {formatBytes(row.total_size_bytes)}
+              </TableCell>
+              <TableCell>
+                <MetadataFieldBadge
+                  value={captureType}
+                  colorClass={
+                    captureType ? CAPTURE_TYPE_COLORS[captureType] : undefined
+                  }
+                />
+              </TableCell>
+              <TableCell>
+                <MetadataFieldBadge
+                  value={imagingMode}
+                  colorClass={
+                    imagingMode ? IMAGING_MODE_COLORS[imagingMode] : undefined
+                  }
+                />
+              </TableCell>
+              <TableCell>
+                <MetadataArrayBadges
+                  values={wavelengths}
+                  colorMap={wavelengthColors}
+                />
+              </TableCell>
+              <TableCell>
+                <MetadataArrayBadges
+                  values={wavelengthColorLabels}
+                  colorMap={CHANNEL_COLOR_STYLES}
+                />
+              </TableCell>
+              <TableCell>
+                <RanByCell
+                  instrumentId={row.instrument_id}
+                  runId={row.run_id}
+                  attributions={row.attributions}
+                />
+              </TableCell>
+              <TableCell className="text-right">
+                <RelativeTime date={row.created_at.toISOString()} />
+              </TableCell>
+            </ClickableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
   );
 }

--- a/web-app/components/instruments/runs-table/gel-doc-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/gel-doc-runs-table.tsx
@@ -26,6 +26,9 @@ import {
   getMetadataArray,
   getMetadataField,
 } from "./metadata-utils";
+import { RanByCell } from "./ran-by-cell";
+import { RunSelectAllCheckbox, RunSelectCheckbox } from "./run-select-checkbox";
+import type { RunRef } from "./run-selection-provider";
 import { RunStatusIcon } from "./run-status-icon";
 
 export function GelDocRunsTable({
@@ -41,12 +44,20 @@ export function GelDocRunsTable({
     getMetadataArray(row.metadata, "wavelengths")
   );
   const wavelengthColors = buildWavelengthColorMap(allWavelengths);
+  const runRefs: RunRef[] = data.map((row) => ({
+    id: row.id,
+    instrumentId: row.instrument_id,
+    runId: row.run_id,
+  }));
 
   return (
     <div className="rounded-lg border">
       <Table>
         <TableHeader>
           <TableRow>
+            <TableHead className="w-10">
+              <RunSelectAllCheckbox refs={runRefs} />
+            </TableHead>
             <TableHead>Run ID</TableHead>
             <TableHead>Files</TableHead>
             <TableHead className="text-right">Total Size</TableHead>
@@ -78,6 +89,7 @@ export function GelDocRunsTable({
                 options={filterOptions.colors}
               />
             </TableHead>
+            <TableHead>Ran by</TableHead>
             <TableHead className="text-right">Created</TableHead>
           </TableRow>
         </TableHeader>
@@ -97,6 +109,15 @@ export function GelDocRunsTable({
                 href={`/instruments/${instrumentId}/runs/${encodeURIComponent(row.run_id)}`}
                 className={cn(isDeleted && "opacity-50")}
               >
+                <TableCell>
+                  <RunSelectCheckbox
+                    runRef={{
+                      id: row.id,
+                      instrumentId: row.instrument_id,
+                      runId: row.run_id,
+                    }}
+                  />
+                </TableCell>
                 <TableCell>
                   <div className="flex items-center gap-2.5">
                     <RunStatusIcon
@@ -147,6 +168,13 @@ export function GelDocRunsTable({
                   <MetadataArrayBadges
                     values={wavelengthColorLabels}
                     colorMap={CHANNEL_COLOR_STYLES}
+                  />
+                </TableCell>
+                <TableCell>
+                  <RanByCell
+                    instrumentId={row.instrument_id}
+                    runId={row.run_id}
+                    attributions={row.attributions}
                   />
                 </TableCell>
                 <TableCell className="text-right">

--- a/web-app/components/instruments/runs-table/index.tsx
+++ b/web-app/components/instruments/runs-table/index.tsx
@@ -11,6 +11,7 @@ import { DefaultRunsTable } from "./default-runs-table";
 import { GelDocRunsTable } from "./gel-doc-runs-table";
 import { PlateReaderRunsTable } from "./plate-reader-runs-table";
 import { QpcrRunsTable } from "./qpcr-runs-table";
+import { RunsTableFooter } from "./runs-table-footer";
 
 export type RunRow = {
   id: string;
@@ -31,9 +32,12 @@ export type RunRow = {
   attributions: RunAttribution[];
 };
 
+export type RanByOption = { value: string; label: string };
+
 export type RunsTableProps = {
   data: RunRow[];
   instrumentId: string;
+  ranByOptions: RanByOption[];
 };
 
 export function InstrumentRunsTable({
@@ -44,6 +48,10 @@ export function InstrumentRunsTable({
   filterOptions,
   gelDocFilterOptions,
   qpcrFilterOptions,
+  ranByOptions,
+  totalCount,
+  unattributedCount,
+  ranByYouCount,
 }: {
   data: RunRow[];
   instrumentId: string;
@@ -52,6 +60,10 @@ export function InstrumentRunsTable({
   filterOptions?: PlateReaderFilterOptions;
   gelDocFilterOptions?: GelDocFilterOptions;
   qpcrFilterOptions?: QpcrFilterOptions;
+  ranByOptions: RanByOption[];
+  totalCount: number;
+  unattributedCount: number;
+  ranByYouCount: number;
 }) {
   if (data.length === 0) {
     return (
@@ -66,32 +78,57 @@ export function InstrumentRunsTable({
     );
   }
 
+  let table;
   switch (instrumentType) {
     case "plate_reader":
-      return (
+      table = (
         <PlateReaderRunsTable
           data={data}
           instrumentId={instrumentId}
           filterOptions={filterOptions!}
+          ranByOptions={ranByOptions}
         />
       );
+      break;
     case "gel_doc":
-      return (
+      table = (
         <GelDocRunsTable
           data={data}
           instrumentId={instrumentId}
           filterOptions={gelDocFilterOptions!}
+          ranByOptions={ranByOptions}
         />
       );
+      break;
     case "qpcr":
-      return (
+      table = (
         <QpcrRunsTable
           data={data}
           instrumentId={instrumentId}
           filterOptions={qpcrFilterOptions!}
+          ranByOptions={ranByOptions}
         />
       );
+      break;
     default:
-      return <DefaultRunsTable data={data} instrumentId={instrumentId} />;
+      table = (
+        <DefaultRunsTable
+          data={data}
+          instrumentId={instrumentId}
+          ranByOptions={ranByOptions}
+        />
+      );
   }
+
+  return (
+    <div className="rounded-lg border">
+      {table}
+      <RunsTableFooter
+        shownCount={data.length}
+        totalCount={totalCount}
+        unattributedCount={unattributedCount}
+        ranByYouCount={ranByYouCount}
+      />
+    </div>
+  );
 }

--- a/web-app/components/instruments/runs-table/index.tsx
+++ b/web-app/components/instruments/runs-table/index.tsx
@@ -2,6 +2,7 @@ import type {
   GelDocFilterOptions,
   PlateReaderFilterOptions,
   QpcrFilterOptions,
+  RunAttribution,
 } from "@/lib/api/instrument-runs";
 import type { InstrumentType } from "@/lib/db/schema";
 import { SearchX } from "lucide-react";
@@ -27,6 +28,7 @@ export type RunRow = {
   files_pending_upload: number;
   total_size_bytes: number;
   error_messages: string[];
+  attributions: RunAttribution[];
 };
 
 export type RunsTableProps = {

--- a/web-app/components/instruments/runs-table/plate-reader-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/plate-reader-runs-table.tsx
@@ -20,6 +20,9 @@ import type { RunRow } from ".";
 import { ClickableRow } from "./clickable-row";
 import { FilterableColumnHeader } from "./filterable-column-header";
 import { MetadataFieldBadge, getMetadataField } from "./metadata-utils";
+import { RanByCell } from "./ran-by-cell";
+import { RunSelectAllCheckbox, RunSelectCheckbox } from "./run-select-checkbox";
+import type { RunRef } from "./run-selection-provider";
 import { RunStatusIcon } from "./run-status-icon";
 
 export function PlateReaderRunsTable({
@@ -32,12 +35,20 @@ export function PlateReaderRunsTable({
   filterOptions: PlateReaderFilterOptions;
 }) {
   const wavelengthColors = buildWavelengthColorMap(filterOptions.wavelengths);
+  const runRefs: RunRef[] = data.map((row) => ({
+    id: row.id,
+    instrumentId: row.instrument_id,
+    runId: row.run_id,
+  }));
 
   return (
     <div className="rounded-lg border">
       <Table>
         <TableHeader>
           <TableRow>
+            <TableHead className="w-10">
+              <RunSelectAllCheckbox refs={runRefs} />
+            </TableHead>
             <TableHead>Run ID</TableHead>
             <TableHead>Files</TableHead>
             <TableHead className="text-right">Total Size</TableHead>
@@ -62,6 +73,7 @@ export function PlateReaderRunsTable({
                 options={filterOptions.measurementTypes}
               />
             </TableHead>
+            <TableHead>Ran by</TableHead>
             <TableHead className="text-right">Created</TableHead>
           </TableRow>
         </TableHeader>
@@ -77,6 +89,15 @@ export function PlateReaderRunsTable({
                 href={`/instruments/${instrumentId}/runs/${encodeURIComponent(row.run_id)}`}
                 className={cn(isDeleted && "opacity-50")}
               >
+                <TableCell>
+                  <RunSelectCheckbox
+                    runRef={{
+                      id: row.id,
+                      instrumentId: row.instrument_id,
+                      runId: row.run_id,
+                    }}
+                  />
+                </TableCell>
                 <TableCell>
                   <div className="flex items-center gap-2.5">
                     <RunStatusIcon
@@ -123,6 +144,13 @@ export function PlateReaderRunsTable({
                     colorClass={
                       type ? MEASUREMENT_TYPE_COLORS[type] : undefined
                     }
+                  />
+                </TableCell>
+                <TableCell>
+                  <RanByCell
+                    instrumentId={row.instrument_id}
+                    runId={row.run_id}
+                    attributions={row.attributions}
                   />
                 </TableCell>
                 <TableCell className="text-right">

--- a/web-app/components/instruments/runs-table/plate-reader-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/plate-reader-runs-table.tsx
@@ -29,10 +29,12 @@ export function PlateReaderRunsTable({
   data,
   instrumentId,
   filterOptions,
+  ranByOptions,
 }: {
   data: RunRow[];
   instrumentId: string;
   filterOptions: PlateReaderFilterOptions;
+  ranByOptions: { value: string; label: string }[];
 }) {
   const wavelengthColors = buildWavelengthColorMap(filterOptions.wavelengths);
   const runRefs: RunRef[] = data.map((row) => ({
@@ -42,125 +44,125 @@ export function PlateReaderRunsTable({
   }));
 
   return (
-    <div className="rounded-lg border">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-10">
-              <RunSelectAllCheckbox refs={runRefs} />
-            </TableHead>
-            <TableHead>Run ID</TableHead>
-            <TableHead>Files</TableHead>
-            <TableHead className="text-right">Total Size</TableHead>
-            <TableHead>
-              <FilterableColumnHeader
-                label="Wavelength"
-                paramKey="wavelength"
-                options={filterOptions.wavelengths}
-              />
-            </TableHead>
-            <TableHead>
-              <FilterableColumnHeader
-                label="Measurement Mode"
-                paramKey="measurement_mode"
-                options={filterOptions.measurementModes}
-              />
-            </TableHead>
-            <TableHead>
-              <FilterableColumnHeader
-                label="Measurement Type"
-                paramKey="measurement_type"
-                options={filterOptions.measurementTypes}
-              />
-            </TableHead>
-            <TableHead>Ran by</TableHead>
-            <TableHead className="text-right">Created</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {data.map((row) => {
-            const isDeleted = row.deleted_at !== null;
-            const wavelength = getMetadataField(row.metadata, "wavelength");
-            const mode = getMetadataField(row.metadata, "measurement_mode");
-            const type = getMetadataField(row.metadata, "measurement_type");
-            return (
-              <ClickableRow
-                key={row.id}
-                href={`/instruments/${instrumentId}/runs/${encodeURIComponent(row.run_id)}`}
-                className={cn(isDeleted && "opacity-50")}
-              >
-                <TableCell>
-                  <RunSelectCheckbox
-                    runRef={{
-                      id: row.id,
-                      instrumentId: row.instrument_id,
-                      runId: row.run_id,
-                    }}
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-10">
+            <RunSelectAllCheckbox refs={runRefs} />
+          </TableHead>
+          <TableHead>Run ID</TableHead>
+          <TableHead>Files</TableHead>
+          <TableHead className="text-right">Total Size</TableHead>
+          <TableHead>
+            <FilterableColumnHeader
+              label="Wavelength"
+              paramKey="wavelength"
+              options={filterOptions.wavelengths}
+            />
+          </TableHead>
+          <TableHead>
+            <FilterableColumnHeader
+              label="Measurement Mode"
+              paramKey="measurement_mode"
+              options={filterOptions.measurementModes}
+            />
+          </TableHead>
+          <TableHead>
+            <FilterableColumnHeader
+              label="Measurement Type"
+              paramKey="measurement_type"
+              options={filterOptions.measurementTypes}
+            />
+          </TableHead>
+          <TableHead>
+            <FilterableColumnHeader
+              label="Ran by"
+              paramKey="ran_by"
+              options={ranByOptions}
+            />
+          </TableHead>
+          <TableHead className="text-right">Created</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {data.map((row) => {
+          const isDeleted = row.deleted_at !== null;
+          const wavelength = getMetadataField(row.metadata, "wavelength");
+          const mode = getMetadataField(row.metadata, "measurement_mode");
+          const type = getMetadataField(row.metadata, "measurement_type");
+          return (
+            <ClickableRow
+              key={row.id}
+              href={`/instruments/${instrumentId}/runs/${encodeURIComponent(row.run_id)}`}
+              className={cn(isDeleted && "opacity-50")}
+            >
+              <TableCell>
+                <RunSelectCheckbox
+                  runRef={{
+                    id: row.id,
+                    instrumentId: row.instrument_id,
+                    runId: row.run_id,
+                  }}
+                />
+              </TableCell>
+              <TableCell>
+                <div className="flex items-center gap-2.5">
+                  <RunStatusIcon
+                    filesFailed={row.files_failed}
+                    errorMessages={row.error_messages}
                   />
-                </TableCell>
-                <TableCell>
-                  <div className="flex items-center gap-2.5">
-                    <RunStatusIcon
-                      filesFailed={row.files_failed}
-                      errorMessages={row.error_messages}
-                    />
-                    <span
-                      className={cn("font-mono", isDeleted && "line-through")}
-                    >
-                      {row.run_id}
-                    </span>
-                    {isDeleted && (
-                      <Badge variant="outline" className="ml-1.5 font-normal">
-                        deleted
-                      </Badge>
-                    )}
-                  </div>
-                </TableCell>
-                <TableCell className="text-sm tabular-nums">
-                  {row.file_count}
-                </TableCell>
-                <TableCell className="text-right text-sm tabular-nums">
-                  {formatBytes(row.total_size_bytes)}
-                </TableCell>
-                <TableCell>
-                  <MetadataFieldBadge
-                    value={wavelength}
-                    colorClass={
-                      wavelength ? wavelengthColors[wavelength] : undefined
-                    }
-                  />
-                </TableCell>
-                <TableCell>
-                  <MetadataFieldBadge
-                    value={mode}
-                    colorClass={
-                      mode ? MEASUREMENT_MODE_COLORS[mode] : undefined
-                    }
-                  />
-                </TableCell>
-                <TableCell>
-                  <MetadataFieldBadge
-                    value={type}
-                    colorClass={
-                      type ? MEASUREMENT_TYPE_COLORS[type] : undefined
-                    }
-                  />
-                </TableCell>
-                <TableCell>
-                  <RanByCell
-                    instrumentId={row.instrument_id}
-                    runId={row.run_id}
-                    attributions={row.attributions}
-                  />
-                </TableCell>
-                <TableCell className="text-right">
-                  <RelativeTime date={row.created_at.toISOString()} />
-                </TableCell>
-              </ClickableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
+                  <span
+                    className={cn("font-mono", isDeleted && "line-through")}
+                  >
+                    {row.run_id}
+                  </span>
+                  {isDeleted && (
+                    <Badge variant="outline" className="ml-1.5 font-normal">
+                      deleted
+                    </Badge>
+                  )}
+                </div>
+              </TableCell>
+              <TableCell className="text-sm tabular-nums">
+                {row.file_count}
+              </TableCell>
+              <TableCell className="text-right text-sm tabular-nums">
+                {formatBytes(row.total_size_bytes)}
+              </TableCell>
+              <TableCell>
+                <MetadataFieldBadge
+                  value={wavelength}
+                  colorClass={
+                    wavelength ? wavelengthColors[wavelength] : undefined
+                  }
+                />
+              </TableCell>
+              <TableCell>
+                <MetadataFieldBadge
+                  value={mode}
+                  colorClass={mode ? MEASUREMENT_MODE_COLORS[mode] : undefined}
+                />
+              </TableCell>
+              <TableCell>
+                <MetadataFieldBadge
+                  value={type}
+                  colorClass={type ? MEASUREMENT_TYPE_COLORS[type] : undefined}
+                />
+              </TableCell>
+              <TableCell>
+                <RanByCell
+                  instrumentId={row.instrument_id}
+                  runId={row.run_id}
+                  attributions={row.attributions}
+                />
+              </TableCell>
+              <TableCell className="text-right">
+                <RelativeTime date={row.created_at.toISOString()} />
+              </TableCell>
+            </ClickableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
   );
 }

--- a/web-app/components/instruments/runs-table/qpcr-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/qpcr-runs-table.tsx
@@ -16,6 +16,9 @@ import type { RunRow } from ".";
 import { ClickableRow } from "./clickable-row";
 import { FilterableColumnHeader } from "./filterable-column-header";
 import { MetadataArrayBadges, getMetadataArray } from "./metadata-utils";
+import { RanByCell } from "./ran-by-cell";
+import { RunSelectAllCheckbox, RunSelectCheckbox } from "./run-select-checkbox";
+import type { RunRef } from "./run-selection-provider";
 import { RunStatusIcon } from "./run-status-icon";
 
 export function QpcrRunsTable({
@@ -27,11 +30,20 @@ export function QpcrRunsTable({
   instrumentId: string;
   filterOptions: QpcrFilterOptions;
 }) {
+  const runRefs: RunRef[] = data.map((row) => ({
+    id: row.id,
+    instrumentId: row.instrument_id,
+    runId: row.run_id,
+  }));
+
   return (
     <div className="rounded-lg border">
       <Table>
         <TableHeader>
           <TableRow>
+            <TableHead className="w-10">
+              <RunSelectAllCheckbox refs={runRefs} />
+            </TableHead>
             <TableHead>Run ID</TableHead>
             <TableHead>Files</TableHead>
             <TableHead className="text-right">Total Size</TableHead>
@@ -42,6 +54,7 @@ export function QpcrRunsTable({
                 options={filterOptions.dyeChannels}
               />
             </TableHead>
+            <TableHead>Ran by</TableHead>
             <TableHead className="text-right">Created</TableHead>
           </TableRow>
         </TableHeader>
@@ -58,6 +71,15 @@ export function QpcrRunsTable({
                 href={`/instruments/${instrumentId}/runs/${encodeURIComponent(row.run_id)}`}
                 className={cn(isDeleted && "opacity-50")}
               >
+                <TableCell>
+                  <RunSelectCheckbox
+                    runRef={{
+                      id: row.id,
+                      instrumentId: row.instrument_id,
+                      runId: row.run_id,
+                    }}
+                  />
+                </TableCell>
                 <TableCell>
                   <div className="flex items-center gap-2.5">
                     <RunStatusIcon
@@ -86,6 +108,13 @@ export function QpcrRunsTable({
                   <MetadataArrayBadges
                     values={dyeChannels}
                     colorMap={dyeChannelColors}
+                  />
+                </TableCell>
+                <TableCell>
+                  <RanByCell
+                    instrumentId={row.instrument_id}
+                    runId={row.run_id}
+                    attributions={row.attributions}
                   />
                 </TableCell>
                 <TableCell className="text-right">

--- a/web-app/components/instruments/runs-table/qpcr-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/qpcr-runs-table.tsx
@@ -25,10 +25,12 @@ export function QpcrRunsTable({
   data,
   instrumentId,
   filterOptions,
+  ranByOptions,
 }: {
   data: RunRow[];
   instrumentId: string;
   filterOptions: QpcrFilterOptions;
+  ranByOptions: { value: string; label: string }[];
 }) {
   const runRefs: RunRef[] = data.map((row) => ({
     id: row.id,
@@ -37,94 +39,98 @@ export function QpcrRunsTable({
   }));
 
   return (
-    <div className="rounded-lg border">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-10">
-              <RunSelectAllCheckbox refs={runRefs} />
-            </TableHead>
-            <TableHead>Run ID</TableHead>
-            <TableHead>Files</TableHead>
-            <TableHead className="text-right">Total Size</TableHead>
-            <TableHead>
-              <FilterableColumnHeader
-                label="Dye Channels"
-                paramKey="dye_channel"
-                options={filterOptions.dyeChannels}
-              />
-            </TableHead>
-            <TableHead>Ran by</TableHead>
-            <TableHead className="text-right">Created</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {data.map((row) => {
-            const isDeleted = row.deleted_at !== null;
-            const dyeChannels = getMetadataArray(row.metadata, "dye_channels");
-            const dyeChannelColors = Object.fromEntries(
-              dyeChannels.map((ch) => [ch, getDyeChannelColor(ch)])
-            );
-            return (
-              <ClickableRow
-                key={row.id}
-                href={`/instruments/${instrumentId}/runs/${encodeURIComponent(row.run_id)}`}
-                className={cn(isDeleted && "opacity-50")}
-              >
-                <TableCell>
-                  <RunSelectCheckbox
-                    runRef={{
-                      id: row.id,
-                      instrumentId: row.instrument_id,
-                      runId: row.run_id,
-                    }}
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-10">
+            <RunSelectAllCheckbox refs={runRefs} />
+          </TableHead>
+          <TableHead>Run ID</TableHead>
+          <TableHead>Files</TableHead>
+          <TableHead className="text-right">Total Size</TableHead>
+          <TableHead>
+            <FilterableColumnHeader
+              label="Dye Channels"
+              paramKey="dye_channel"
+              options={filterOptions.dyeChannels}
+            />
+          </TableHead>
+          <TableHead>
+            <FilterableColumnHeader
+              label="Ran by"
+              paramKey="ran_by"
+              options={ranByOptions}
+            />
+          </TableHead>
+          <TableHead className="text-right">Created</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {data.map((row) => {
+          const isDeleted = row.deleted_at !== null;
+          const dyeChannels = getMetadataArray(row.metadata, "dye_channels");
+          const dyeChannelColors = Object.fromEntries(
+            dyeChannels.map((ch) => [ch, getDyeChannelColor(ch)])
+          );
+          return (
+            <ClickableRow
+              key={row.id}
+              href={`/instruments/${instrumentId}/runs/${encodeURIComponent(row.run_id)}`}
+              className={cn(isDeleted && "opacity-50")}
+            >
+              <TableCell>
+                <RunSelectCheckbox
+                  runRef={{
+                    id: row.id,
+                    instrumentId: row.instrument_id,
+                    runId: row.run_id,
+                  }}
+                />
+              </TableCell>
+              <TableCell>
+                <div className="flex items-center gap-2.5">
+                  <RunStatusIcon
+                    filesFailed={row.files_failed}
+                    errorMessages={row.error_messages}
                   />
-                </TableCell>
-                <TableCell>
-                  <div className="flex items-center gap-2.5">
-                    <RunStatusIcon
-                      filesFailed={row.files_failed}
-                      errorMessages={row.error_messages}
-                    />
-                    <span
-                      className={cn("font-mono", isDeleted && "line-through")}
-                    >
-                      {row.run_id}
-                    </span>
-                    {isDeleted && (
-                      <Badge variant="outline" className="ml-1.5 font-normal">
-                        deleted
-                      </Badge>
-                    )}
-                  </div>
-                </TableCell>
-                <TableCell className="text-sm tabular-nums">
-                  {row.file_count}
-                </TableCell>
-                <TableCell className="text-right text-sm tabular-nums">
-                  {formatBytes(row.total_size_bytes)}
-                </TableCell>
-                <TableCell>
-                  <MetadataArrayBadges
-                    values={dyeChannels}
-                    colorMap={dyeChannelColors}
-                  />
-                </TableCell>
-                <TableCell>
-                  <RanByCell
-                    instrumentId={row.instrument_id}
-                    runId={row.run_id}
-                    attributions={row.attributions}
-                  />
-                </TableCell>
-                <TableCell className="text-right">
-                  <RelativeTime date={row.created_at.toISOString()} />
-                </TableCell>
-              </ClickableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
+                  <span
+                    className={cn("font-mono", isDeleted && "line-through")}
+                  >
+                    {row.run_id}
+                  </span>
+                  {isDeleted && (
+                    <Badge variant="outline" className="ml-1.5 font-normal">
+                      deleted
+                    </Badge>
+                  )}
+                </div>
+              </TableCell>
+              <TableCell className="text-sm tabular-nums">
+                {row.file_count}
+              </TableCell>
+              <TableCell className="text-right text-sm tabular-nums">
+                {formatBytes(row.total_size_bytes)}
+              </TableCell>
+              <TableCell>
+                <MetadataArrayBadges
+                  values={dyeChannels}
+                  colorMap={dyeChannelColors}
+                />
+              </TableCell>
+              <TableCell>
+                <RanByCell
+                  instrumentId={row.instrument_id}
+                  runId={row.run_id}
+                  attributions={row.attributions}
+                />
+              </TableCell>
+              <TableCell className="text-right">
+                <RelativeTime date={row.created_at.toISOString()} />
+              </TableCell>
+            </ClickableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
   );
 }

--- a/web-app/components/instruments/runs-table/ran-by-cell.tsx
+++ b/web-app/components/instruments/runs-table/ran-by-cell.tsx
@@ -12,12 +12,7 @@ import { cn } from "@/lib/utils";
 import { UserPlus, X } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import {
-  startTransition,
-  useOptimistic,
-  useTransition,
-  type MouseEvent,
-} from "react";
+import { useOptimistic, useTransition, type MouseEvent } from "react";
 import { toast } from "sonner";
 
 // A small, deterministic palette keyed by userId hash so the same user always
@@ -40,6 +35,16 @@ function avatarColor(userId: string): string {
     hash = (hash * 31 + userId.charCodeAt(i)) | 0;
   }
   return AVATAR_PALETTE[Math.abs(hash) % AVATAR_PALETTE.length];
+}
+
+// Mirrors the server-side helper in lib/api/instrument-runs.ts so optimistic
+// attributions render with the same initials the server will echo back,
+// avoiding a fallback flip on reconcile.
+function toInitials(displayName: string): string {
+  const parts = displayName.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
 type Action =
@@ -84,22 +89,24 @@ export function RanByCell({
   function handleClaim(event: MouseEvent) {
     event.stopPropagation();
     if (!currentUserId) return;
-    // Optimistically add "me" using a placeholder shape; the server response
-    // via router.refresh() will reconcile the real display name / avatar.
+    // Optimistic shape mirrors what the server will send back so the avatar
+    // bubble doesn't flip from a colored "YO" fallback to the real photo on
+    // reconcile. Pulls displayName / image straight from the session.
+    const displayName = session?.user?.name ?? session?.user?.email ?? "You";
     const me: RunAttribution = {
       userId: currentUserId,
-      displayName: "You",
-      initials: "YO",
-      avatarUrl: null,
+      displayName,
+      initials: toInitials(displayName),
+      avatarUrl: session?.user?.image ?? null,
     };
-    startTransition(() => dispatch({ kind: "claim", user: me }));
     startMutation(async () => {
+      dispatch({ kind: "claim", user: me });
       try {
         const res = await fetch(baseUrl, { method: "PUT" });
         if (!res.ok) throw new Error(await res.text());
-        router.refresh();
       } catch {
         toast.error("Couldn't claim this run. Try again?");
+      } finally {
         router.refresh();
       }
     });
@@ -108,14 +115,14 @@ export function RanByCell({
   function handleRemove(event: MouseEvent) {
     event.stopPropagation();
     if (!currentUserId) return;
-    startTransition(() => dispatch({ kind: "remove", userId: currentUserId }));
     startMutation(async () => {
+      dispatch({ kind: "remove", userId: currentUserId });
       try {
         const res = await fetch(baseUrl, { method: "DELETE" });
         if (!res.ok) throw new Error(await res.text());
-        router.refresh();
       } catch {
         toast.error("Couldn't remove attribution. Try again?");
+      } finally {
         router.refresh();
       }
     });

--- a/web-app/components/instruments/runs-table/ran-by-cell.tsx
+++ b/web-app/components/instruments/runs-table/ran-by-cell.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { RunAttribution } from "@/lib/api/instrument-runs";
+import { cn } from "@/lib/utils";
+import { UserPlus, X } from "lucide-react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import {
+  startTransition,
+  useOptimistic,
+  useTransition,
+  type MouseEvent,
+} from "react";
+import { toast } from "sonner";
+
+// A small, deterministic palette keyed by userId hash so the same user always
+// gets the same color across rows. Tailwind tokens are baked in (we can't
+// interpolate class names safely).
+const AVATAR_PALETTE = [
+  "bg-blue-200 text-blue-900 dark:bg-blue-800 dark:text-blue-100",
+  "bg-emerald-200 text-emerald-900 dark:bg-emerald-800 dark:text-emerald-100",
+  "bg-violet-200 text-violet-900 dark:bg-violet-800 dark:text-violet-100",
+  "bg-amber-200 text-amber-900 dark:bg-amber-800 dark:text-amber-100",
+  "bg-rose-200 text-rose-900 dark:bg-rose-800 dark:text-rose-100",
+  "bg-teal-200 text-teal-900 dark:bg-teal-800 dark:text-teal-100",
+  "bg-fuchsia-200 text-fuchsia-900 dark:bg-fuchsia-800 dark:text-fuchsia-100",
+  "bg-orange-200 text-orange-900 dark:bg-orange-800 dark:text-orange-100",
+];
+
+function avatarColor(userId: string): string {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) | 0;
+  }
+  return AVATAR_PALETTE[Math.abs(hash) % AVATAR_PALETTE.length];
+}
+
+type Action =
+  | { kind: "claim"; user: RunAttribution }
+  | { kind: "remove"; userId: string };
+
+function applyOptimistic(
+  current: RunAttribution[],
+  action: Action
+): RunAttribution[] {
+  if (action.kind === "claim") {
+    if (current.some((a) => a.userId === action.user.userId)) return current;
+    return [...current, action.user];
+  }
+  return current.filter((a) => a.userId !== action.userId);
+}
+
+export function RanByCell({
+  instrumentId,
+  runId,
+  attributions,
+}: {
+  instrumentId: string;
+  runId: string;
+  attributions: RunAttribution[];
+}) {
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id ?? null;
+  const router = useRouter();
+  const [isPending, startMutation] = useTransition();
+  const [optimistic, dispatch] = useOptimistic(attributions, applyOptimistic);
+
+  const selfAttribution = currentUserId
+    ? (optimistic.find((a) => a.userId === currentUserId) ?? null)
+    : null;
+  const isSelfAttributed = selfAttribution !== null;
+
+  const baseUrl = `/api/v1/instruments/${instrumentId}/runs/${encodeURIComponent(
+    runId
+  )}/attributions/me`;
+
+  function handleClaim(event: MouseEvent) {
+    event.stopPropagation();
+    if (!currentUserId) return;
+    // Optimistically add "me" using a placeholder shape; the server response
+    // via router.refresh() will reconcile the real display name / avatar.
+    const me: RunAttribution = {
+      userId: currentUserId,
+      displayName: "You",
+      initials: "YO",
+      avatarUrl: null,
+    };
+    startTransition(() => dispatch({ kind: "claim", user: me }));
+    startMutation(async () => {
+      try {
+        const res = await fetch(baseUrl, { method: "PUT" });
+        if (!res.ok) throw new Error(await res.text());
+        router.refresh();
+      } catch {
+        toast.error("Couldn't claim this run. Try again?");
+        router.refresh();
+      }
+    });
+  }
+
+  function handleRemove(event: MouseEvent) {
+    event.stopPropagation();
+    if (!currentUserId) return;
+    startTransition(() => dispatch({ kind: "remove", userId: currentUserId }));
+    startMutation(async () => {
+      try {
+        const res = await fetch(baseUrl, { method: "DELETE" });
+        if (!res.ok) throw new Error(await res.text());
+        router.refresh();
+      } catch {
+        toast.error("Couldn't remove attribution. Try again?");
+        router.refresh();
+      }
+    });
+  }
+
+  // Unattributed state: muted UserPlus icon normally; ghost "I ran this"
+  // button on row hover. Pure CSS group-hover: no React hover state needed.
+  return optimistic.length === 0 ? (
+    <div className="flex items-center">
+      {currentUserId ? (
+        <>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                aria-hidden="true"
+                className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground/60 group-hover:hidden"
+              >
+                <UserPlus className="size-4" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>Unattributed</TooltipContent>
+          </Tooltip>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={isPending}
+            onClick={handleClaim}
+            className="hidden h-7 px-2 text-xs font-medium group-hover:inline-flex"
+          >
+            I ran this
+          </Button>
+        </>
+      ) : (
+        <span className="inline-flex size-7 items-center justify-center text-muted-foreground/60">
+          <UserPlus className="size-4" />
+        </span>
+      )}
+    </div>
+  ) : (
+    <div className="flex items-center gap-2">
+      <div className="flex -space-x-1.5">
+        {optimistic.map((attribution) => (
+          <Tooltip key={attribution.userId}>
+            <TooltipTrigger asChild>
+              <Avatar
+                size="sm"
+                className={cn(
+                  "ring-2 ring-background",
+                  attribution.userId === currentUserId && "ring-primary/30"
+                )}
+              >
+                {attribution.avatarUrl ? (
+                  <AvatarImage
+                    src={attribution.avatarUrl}
+                    alt={attribution.displayName}
+                  />
+                ) : null}
+                <AvatarFallback className={avatarColor(attribution.userId)}>
+                  {attribution.initials}
+                </AvatarFallback>
+              </Avatar>
+            </TooltipTrigger>
+            <TooltipContent>{attribution.displayName}</TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+      {isSelfAttributed ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={isPending}
+          onClick={handleRemove}
+          className="hidden h-6 gap-1 px-2 text-xs font-medium group-hover:inline-flex"
+        >
+          <X className="size-3" />
+          Remove
+        </Button>
+      ) : currentUserId ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={isPending}
+          onClick={handleClaim}
+          className="hidden h-6 px-2 text-xs font-medium group-hover:inline-flex"
+        >
+          I ran this too
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/web-app/components/instruments/runs-table/ran-by-cell.tsx
+++ b/web-app/components/instruments/runs-table/ran-by-cell.tsx
@@ -121,38 +121,37 @@ export function RanByCell({
     });
   }
 
-  // Unattributed state: muted UserPlus icon normally; ghost "I ran this"
-  // button on row hover. Pure CSS group-hover: no React hover state needed.
+  // Each action is an icon-only button; its label lives in a tooltip so the
+  // cell width is naturally fixed.
   return optimistic.length === 0 ? (
     <div className="flex items-center">
       {currentUserId ? (
-        <>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span
-                aria-hidden="true"
-                className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground/60 group-hover:hidden"
-              >
-                <UserPlus className="size-4" />
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>Unattributed</TooltipContent>
-          </Tooltip>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            disabled={isPending}
-            onClick={handleClaim}
-            className="hidden h-7 px-2 text-xs font-medium group-hover:inline-flex"
-          >
-            I ran this
-          </Button>
-        </>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              disabled={isPending}
+              onClick={handleClaim}
+              aria-label="I ran this"
+              className="size-7 text-muted-foreground/70 hover:text-foreground"
+            >
+              <UserPlus className="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>I ran this</TooltipContent>
+        </Tooltip>
       ) : (
-        <span className="inline-flex size-7 items-center justify-center text-muted-foreground/60">
-          <UserPlus className="size-4" />
-        </span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex size-7 items-center justify-center text-muted-foreground/60">
+              <UserPlus className="size-4" aria-hidden="true" />
+              <span className="sr-only">Unattributed</span>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>Unattributed</TooltipContent>
+        </Tooltip>
       )}
     </div>
   ) : (
@@ -184,28 +183,39 @@ export function RanByCell({
         ))}
       </div>
       {isSelfAttributed ? (
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={isPending}
-          onClick={handleRemove}
-          className="hidden h-6 gap-1 px-2 text-xs font-medium group-hover:inline-flex"
-        >
-          <X className="size-3" />
-          Remove
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              disabled={isPending}
+              onClick={handleRemove}
+              aria-label="Remove"
+              className="size-6 text-muted-foreground/70 hover:text-foreground"
+            >
+              <X className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Remove</TooltipContent>
+        </Tooltip>
       ) : currentUserId ? (
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          disabled={isPending}
-          onClick={handleClaim}
-          className="hidden h-6 px-2 text-xs font-medium group-hover:inline-flex"
-        >
-          I ran this too
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              disabled={isPending}
+              onClick={handleClaim}
+              aria-label="I ran this too"
+              className="size-6 text-muted-foreground/70 hover:text-foreground"
+            >
+              <UserPlus className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>I ran this too</TooltipContent>
+        </Tooltip>
       ) : null}
     </div>
   );

--- a/web-app/components/instruments/runs-table/run-select-checkbox.tsx
+++ b/web-app/components/instruments/runs-table/run-select-checkbox.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import type { MouseEvent } from "react";
+
+import { useRunSelection, type RunRef } from "./run-selection-provider";
+
+// Stops row-click navigation when interacting with the checkbox.
+function swallow(event: MouseEvent) {
+  event.stopPropagation();
+}
+
+export function RunSelectCheckbox({ runRef }: { runRef: RunRef }) {
+  const { actions, meta } = useRunSelection();
+  return (
+    <div onClick={swallow} className="flex items-center">
+      <Checkbox
+        aria-label={`Select run ${runRef.runId}`}
+        checked={meta.isSelected(runRef.id)}
+        onCheckedChange={() => actions.toggle(runRef)}
+      />
+    </div>
+  );
+}
+
+export function RunSelectAllCheckbox({ refs }: { refs: RunRef[] }) {
+  const { actions, meta } = useRunSelection();
+  return (
+    <div onClick={swallow} className="flex items-center">
+      <Checkbox
+        aria-label="Select all runs on this page"
+        checked={refs.length > 0 && meta.allSelected(refs)}
+        disabled={refs.length === 0}
+        onCheckedChange={() => actions.selectMany(refs)}
+      />
+    </div>
+  );
+}

--- a/web-app/components/instruments/runs-table/run-selection-provider.tsx
+++ b/web-app/components/instruments/runs-table/run-selection-provider.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { createContext, use, useCallback, useMemo, useState } from "react";
+
+export type RunRef = {
+  id: string;
+  instrumentId: string;
+  runId: string;
+};
+
+// Explicit context interface: state / actions / meta. Consumers never touch
+// the underlying useState — we can swap implementations (e.g. move to URL
+// state, redux, etc.) without changing any consumer.
+type RunSelectionContextValue = {
+  state: { selected: ReadonlyMap<string, RunRef> };
+  actions: {
+    toggle: (ref: RunRef) => void;
+    selectMany: (refs: RunRef[]) => void;
+    clear: () => void;
+  };
+  meta: {
+    count: number;
+    isSelected: (runInternalId: string) => boolean;
+    allSelected: (refs: RunRef[]) => boolean;
+  };
+};
+
+const RunSelectionContext = createContext<RunSelectionContextValue | null>(
+  null
+);
+
+export function RunSelectionProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [selected, setSelected] = useState<Map<string, RunRef>>(
+    () => new Map()
+  );
+
+  const toggle = useCallback((ref: RunRef) => {
+    setSelected((prev) => {
+      const next = new Map(prev);
+      if (next.has(ref.id)) {
+        next.delete(ref.id);
+      } else {
+        next.set(ref.id, ref);
+      }
+      return next;
+    });
+  }, []);
+
+  const selectMany = useCallback((refs: RunRef[]) => {
+    setSelected((prev) => {
+      const next = new Map(prev);
+      const alreadyAll = refs.every((r) => next.has(r.id));
+      if (alreadyAll) {
+        for (const r of refs) next.delete(r.id);
+      } else {
+        for (const r of refs) next.set(r.id, r);
+      }
+      return next;
+    });
+  }, []);
+
+  const clear = useCallback(() => {
+    setSelected(new Map());
+  }, []);
+
+  const value = useMemo<RunSelectionContextValue>(
+    () => ({
+      state: { selected },
+      actions: { toggle, selectMany, clear },
+      meta: {
+        count: selected.size,
+        isSelected: (id) => selected.has(id),
+        allSelected: (refs) =>
+          refs.length > 0 && refs.every((r) => selected.has(r.id)),
+      },
+    }),
+    [selected, toggle, selectMany, clear]
+  );
+
+  return (
+    <RunSelectionContext.Provider value={value}>
+      {children}
+    </RunSelectionContext.Provider>
+  );
+}
+
+export function useRunSelection(): RunSelectionContextValue {
+  const ctx = use(RunSelectionContext);
+  if (!ctx) {
+    throw new Error(
+      "useRunSelection must be used within a RunSelectionProvider"
+    );
+  }
+  return ctx;
+}

--- a/web-app/components/instruments/runs-table/runs-table-footer.tsx
+++ b/web-app/components/instruments/runs-table/runs-table-footer.tsx
@@ -1,0 +1,24 @@
+export function RunsTableFooter({
+  shownCount,
+  totalCount,
+  unattributedCount,
+  ranByYouCount,
+}: {
+  shownCount: number;
+  totalCount: number;
+  unattributedCount: number;
+  ranByYouCount: number;
+}) {
+  return (
+    <div className="flex items-center justify-between border-t px-4 py-2.5 text-xs text-muted-foreground">
+      <p>
+        Showing <span className="tabular-nums">{shownCount}</span> of{" "}
+        <span className="tabular-nums">{totalCount}</span>
+      </p>
+      <p>
+        <span className="tabular-nums">{unattributedCount}</span> unattributed ·{" "}
+        <span className="tabular-nums">{ranByYouCount}</span> ran by you
+      </p>
+    </div>
+  );
+}

--- a/web-app/components/runs/run-attributions-section.tsx
+++ b/web-app/components/runs/run-attributions-section.tsx
@@ -1,0 +1,27 @@
+import { RanByCell } from "@/components/instruments/runs-table/ran-by-cell";
+import type { RunAttribution } from "@/lib/api/instrument-runs";
+
+// Used on the run detail page to show (and mutate) attributions next to the
+// run header. We reuse RanByCell so the claim/remove UX matches the list.
+// Wrapped in a `group` so the cell's hover-only affordances reveal correctly
+// whether the user hovers the label area or the avatars.
+export function RunAttributionsSection({
+  instrumentId,
+  runId,
+  attributions,
+}: {
+  instrumentId: string;
+  runId: string;
+  attributions: RunAttribution[];
+}) {
+  return (
+    <div className="group flex items-center gap-3 rounded-lg border bg-card/50 px-4 py-2.5">
+      <span className="text-xs font-medium text-muted-foreground">Ran by</span>
+      <RanByCell
+        instrumentId={instrumentId}
+        runId={runId}
+        attributions={attributions}
+      />
+    </div>
+  );
+}

--- a/web-app/components/runs/run-attributions-section.tsx
+++ b/web-app/components/runs/run-attributions-section.tsx
@@ -1,10 +1,9 @@
 import { RanByCell } from "@/components/instruments/runs-table/ran-by-cell";
 import type { RunAttribution } from "@/lib/api/instrument-runs";
 
-// Used on the run detail page to show (and mutate) attributions next to the
-// run header. We reuse RanByCell so the claim/remove UX matches the list.
-// Wrapped in a `group` so the cell's hover-only affordances reveal correctly
-// whether the user hovers the label area or the avatars.
+// Used inline in the run header's metadata row (alongside Created/Updated
+// timestamps) to show and mutate attributions. Reuses RanByCell so the
+// claim/remove UX matches the list.
 export function RunAttributionsSection({
   instrumentId,
   runId,
@@ -15,8 +14,8 @@ export function RunAttributionsSection({
   attributions: RunAttribution[];
 }) {
   return (
-    <div className="group flex items-center gap-3 rounded-lg border bg-card/50 px-4 py-2.5">
-      <span className="text-xs font-medium text-muted-foreground">Ran by</span>
+    <div className="flex items-center gap-2">
+      <span>Ran By</span>
       <RanByCell
         instrumentId={instrumentId}
         runId={runId}

--- a/web-app/components/runs/run-detail.ts
+++ b/web-app/components/runs/run-detail.ts
@@ -25,4 +25,7 @@ export type RunDetailProps = {
   wellData: RawWellRow[];
   instrumentId: string;
   runId: string;
+  // Rendered below the header on every variant. Parent composes the
+  // attribution UI so server-only user/session wiring stays at the page.
+  attributionsSlot: React.ReactNode;
 };

--- a/web-app/components/runs/run-header.tsx
+++ b/web-app/components/runs/run-header.tsx
@@ -1,6 +1,14 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
 import type { RunDetail } from "@/lib/api/instrument-runs";
 import { formatDateTime } from "@/lib/date";
-import { ArrowLeft, Trash2 } from "lucide-react";
+import { Trash2 } from "lucide-react";
 import Link from "next/link";
 
 export function RunHeader({
@@ -14,13 +22,27 @@ export function RunHeader({
 }) {
   return (
     <div className="flex flex-col gap-4">
-      <Link
-        href={`/instruments/${run.instrumentId}`}
-        className="flex w-fit items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <ArrowLeft className="size-3.5" />
-        {run.instrumentDisplayName}
-      </Link>
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href="/instruments">Instruments</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href={`/instruments/${run.instrumentId}`}>
+                {run.instrumentDisplayName}
+              </Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage className="font-mono">{run.runId}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
 
       {run.deletedAt && (
         <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-2.5 text-sm text-destructive">

--- a/web-app/components/runs/run-header.tsx
+++ b/web-app/components/runs/run-header.tsx
@@ -6,9 +6,11 @@ import Link from "next/link";
 export function RunHeader({
   run,
   children,
+  attributionsSlot,
 }: {
   run: RunDetail;
   children?: React.ReactNode;
+  attributionsSlot?: React.ReactNode;
 }) {
   return (
     <div className="flex flex-col gap-4">
@@ -44,6 +46,12 @@ export function RunHeader({
         <span>Created {formatDateTime(run.createdAt)}</span>
         <span className="text-muted-foreground/40">&middot;</span>
         <span>Updated {formatDateTime(run.updatedAt)}</span>
+        {attributionsSlot && (
+          <>
+            <span className="text-muted-foreground/40">&middot;</span>
+            {attributionsSlot}
+          </>
+        )}
       </div>
     </div>
   );

--- a/web-app/components/runs/variants/default-run-detail.tsx
+++ b/web-app/components/runs/variants/default-run-detail.tsx
@@ -12,6 +12,7 @@ export function DefaultRunDetail({
   files,
   instrumentId,
   runId,
+  attributionsSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
   const canRestore = isDeleted && run.filesPurgedAt === null;
@@ -35,6 +36,8 @@ export function DefaultRunDetail({
           <RestoreRunButton instrumentId={instrumentId} runId={runId} />
         )}
       </RunDetail.Header>
+
+      {attributionsSlot}
 
       <RunDetail.FilesMetadataLayout>
         {hasDefaultMetadata(run.metadata as Record<string, unknown>) && (

--- a/web-app/components/runs/variants/default-run-detail.tsx
+++ b/web-app/components/runs/variants/default-run-detail.tsx
@@ -23,7 +23,7 @@ export function DefaultRunDetail({
 
   return (
     <>
-      <RunDetail.Header run={run}>
+      <RunDetail.Header run={run} attributionsSlot={attributionsSlot}>
         {!isDeleted && (
           <DeleteRunDialog
             instrumentId={instrumentId}
@@ -36,8 +36,6 @@ export function DefaultRunDetail({
           <RestoreRunButton instrumentId={instrumentId} runId={runId} />
         )}
       </RunDetail.Header>
-
-      {attributionsSlot}
 
       <RunDetail.FilesMetadataLayout>
         {hasDefaultMetadata(run.metadata as Record<string, unknown>) && (

--- a/web-app/components/runs/variants/gel-doc-run-detail.tsx
+++ b/web-app/components/runs/variants/gel-doc-run-detail.tsx
@@ -23,7 +23,7 @@ export function GelDocRunDetail({
 
   return (
     <>
-      <RunDetail.Header run={run}>
+      <RunDetail.Header run={run} attributionsSlot={attributionsSlot}>
         {!isDeleted && (
           <DeleteRunDialog
             instrumentId={instrumentId}
@@ -36,8 +36,6 @@ export function GelDocRunDetail({
           <RestoreRunButton instrumentId={instrumentId} runId={runId} />
         )}
       </RunDetail.Header>
-
-      {attributionsSlot}
 
       <RunDetail.FilesMetadataLayout>
         {hasGelDocMetadata(run.metadata as Record<string, unknown>) && (

--- a/web-app/components/runs/variants/gel-doc-run-detail.tsx
+++ b/web-app/components/runs/variants/gel-doc-run-detail.tsx
@@ -12,6 +12,7 @@ export function GelDocRunDetail({
   files,
   instrumentId,
   runId,
+  attributionsSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
   const canRestore = isDeleted && run.filesPurgedAt === null;
@@ -35,6 +36,8 @@ export function GelDocRunDetail({
           <RestoreRunButton instrumentId={instrumentId} runId={runId} />
         )}
       </RunDetail.Header>
+
+      {attributionsSlot}
 
       <RunDetail.FilesMetadataLayout>
         {hasGelDocMetadata(run.metadata as Record<string, unknown>) && (

--- a/web-app/components/runs/variants/plate-reader-run-detail.tsx
+++ b/web-app/components/runs/variants/plate-reader-run-detail.tsx
@@ -263,6 +263,7 @@ export function PlateReaderRunDetail({
   wellData,
   instrumentId,
   runId,
+  attributionsSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
   const canRestore = isDeleted && run.filesPurgedAt === null;
@@ -298,6 +299,8 @@ export function PlateReaderRunDetail({
           <RestoreRunButton instrumentId={instrumentId} runId={runId} />
         )}
       </RunDetail.Header>
+
+      {attributionsSlot}
 
       <RunDetail.FilesMetadataLayout>
         {hasPlateReaderMetadata(run.metadata as Record<string, unknown>) && (

--- a/web-app/components/runs/variants/plate-reader-run-detail.tsx
+++ b/web-app/components/runs/variants/plate-reader-run-detail.tsx
@@ -286,7 +286,7 @@ export function PlateReaderRunDetail({
 
   return (
     <>
-      <RunDetail.Header run={run}>
+      <RunDetail.Header run={run} attributionsSlot={attributionsSlot}>
         {!isDeleted && (
           <DeleteRunDialog
             instrumentId={instrumentId}
@@ -299,8 +299,6 @@ export function PlateReaderRunDetail({
           <RestoreRunButton instrumentId={instrumentId} runId={runId} />
         )}
       </RunDetail.Header>
-
-      {attributionsSlot}
 
       <RunDetail.FilesMetadataLayout>
         {hasPlateReaderMetadata(run.metadata as Record<string, unknown>) && (

--- a/web-app/components/runs/variants/qpcr-run-detail.tsx
+++ b/web-app/components/runs/variants/qpcr-run-detail.tsx
@@ -23,7 +23,7 @@ export function QpcrRunDetail({
 
   return (
     <>
-      <RunDetail.Header run={run}>
+      <RunDetail.Header run={run} attributionsSlot={attributionsSlot}>
         {!isDeleted && (
           <DeleteRunDialog
             instrumentId={instrumentId}
@@ -36,8 +36,6 @@ export function QpcrRunDetail({
           <RestoreRunButton instrumentId={instrumentId} runId={runId} />
         )}
       </RunDetail.Header>
-
-      {attributionsSlot}
 
       <RunDetail.FilesMetadataLayout>
         {hasQpcrMetadata(run.metadata as Record<string, unknown>) && (

--- a/web-app/components/runs/variants/qpcr-run-detail.tsx
+++ b/web-app/components/runs/variants/qpcr-run-detail.tsx
@@ -12,6 +12,7 @@ export function QpcrRunDetail({
   files,
   instrumentId,
   runId,
+  attributionsSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
   const canRestore = isDeleted && run.filesPurgedAt === null;
@@ -35,6 +36,8 @@ export function QpcrRunDetail({
           <RestoreRunButton instrumentId={instrumentId} runId={runId} />
         )}
       </RunDetail.Header>
+
+      {attributionsSlot}
 
       <RunDetail.FilesMetadataLayout>
         {hasQpcrMetadata(run.metadata as Record<string, unknown>) && (

--- a/web-app/components/runs/variants/tape-station-run-detail.tsx
+++ b/web-app/components/runs/variants/tape-station-run-detail.tsx
@@ -12,6 +12,7 @@ export function TapeStationRunDetail({
   files,
   instrumentId,
   runId,
+  attributionsSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
   const canRestore = isDeleted && run.filesPurgedAt === null;
@@ -35,6 +36,8 @@ export function TapeStationRunDetail({
           <RestoreRunButton instrumentId={instrumentId} runId={runId} />
         )}
       </RunDetail.Header>
+
+      {attributionsSlot}
 
       <RunDetail.FilesMetadataLayout>
         {hasTapeStationMetadata(run.metadata as Record<string, unknown>) && (

--- a/web-app/components/runs/variants/tape-station-run-detail.tsx
+++ b/web-app/components/runs/variants/tape-station-run-detail.tsx
@@ -23,7 +23,7 @@ export function TapeStationRunDetail({
 
   return (
     <>
-      <RunDetail.Header run={run}>
+      <RunDetail.Header run={run} attributionsSlot={attributionsSlot}>
         {!isDeleted && (
           <DeleteRunDialog
             instrumentId={instrumentId}
@@ -36,8 +36,6 @@ export function TapeStationRunDetail({
           <RestoreRunButton instrumentId={instrumentId} runId={runId} />
         )}
       </RunDetail.Header>
-
-      {attributionsSlot}
 
       <RunDetail.FilesMetadataLayout>
         {hasTapeStationMetadata(run.metadata as Record<string, unknown>) && (

--- a/web-app/components/ui/breadcrumb.tsx
+++ b/web-app/components/ui/breadcrumb.tsx
@@ -1,0 +1,119 @@
+import { Slot } from "radix-ui";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { ChevronRightIcon, MoreHorizontalIcon } from "lucide-react";
+
+function Breadcrumb({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      aria-label="breadcrumb"
+      data-slot="breadcrumb"
+      className={cn(className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground sm:gap-2.5",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1.5", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbLink({
+  asChild,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean;
+}) {
+  const Comp = asChild ? Slot.Root : "a";
+
+  return (
+    <Comp
+      data-slot="breadcrumb-link"
+      className={cn("transition-colors hover:text-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("font-normal text-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5", className)}
+      {...props}
+    >
+      {children ?? <ChevronRightIcon />}
+    </li>
+  );
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn(
+        "flex size-5 items-center justify-center [&>svg]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <MoreHorizontalIcon />
+      <span className="sr-only">More</span>
+    </span>
+  );
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+};

--- a/web-app/components/watchers/watcher-header.tsx
+++ b/web-app/components/watchers/watcher-header.tsx
@@ -1,10 +1,17 @@
 import { Badge } from "@/components/ui/badge";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
 import { DeregisterDialog } from "@/components/watchers/deregister-dialog";
 import { statusBadge } from "@/components/watchers/status-badge";
 import type { WatcherDetail } from "@/lib/api/watchers";
 import { formatDate } from "@/lib/date";
 import { formatRelativeTime } from "@/lib/utils";
-import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 
 export function WatcherHeader({ watcher }: { watcher: WatcherDetail }) {
@@ -13,13 +20,21 @@ export function WatcherHeader({ watcher }: { watcher: WatcherDetail }) {
 
   return (
     <div className="flex flex-col gap-4">
-      <Link
-        href="/watchers"
-        className="flex w-fit items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <ArrowLeft className="size-3.5" />
-        Back to watchers
-      </Link>
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href="/watchers">Watchers</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>
+              {watcher.hostname ?? "Unnamed Watcher"}
+            </BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
 
       {/* Deregistered watchers get a muted, dashed-border treatment to
           visually signal that this is historical data. The deregister action

--- a/web-app/drizzle/0007_dazzling_hercules.sql
+++ b/web-app/drizzle/0007_dazzling_hercules.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "run_attributions" (
+	"run_id" uuid NOT NULL,
+	"user_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "run_attributions_run_id_user_id_pk" PRIMARY KEY("run_id","user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "run_attributions" ADD CONSTRAINT "run_attributions_run_id_instrument_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."instrument_runs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "run_attributions" ADD CONSTRAINT "run_attributions_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_run_attributions_run_id" ON "run_attributions" USING btree ("run_id");--> statement-breakpoint
+CREATE INDEX "idx_run_attributions_user_id" ON "run_attributions" USING btree ("user_id");

--- a/web-app/drizzle/meta/0007_snapshot.json
+++ b/web-app/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1361 @@
+{
+  "id": "5ed571bb-c4c1-4f0b-a8fa-7f1a16e2c57b",
+  "prevId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "file_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raw'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_requested_at": {
+          "name": "upload_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_files_instrument_run_id_relative_path": {
+          "name": "uq_files_instrument_run_id_relative_path",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"relative_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_s3_key": {
+          "name": "uq_files_s3_key",
+          "columns": [
+            {
+              "expression": "s3_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"s3_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_instrument_run_id": {
+          "name": "idx_files_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_status_instrument_run_id": {
+          "name": "idx_files_status_instrument_run_id",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_active": {
+          "name": "idx_files_active",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_upload_queue": {
+          "name": "idx_files_upload_queue",
+          "columns": [
+            {
+              "expression": "upload_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"upload_requested_at\" is not null and \"files\".\"uploaded_at\" is null and \"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_metadata_gin": {
+          "name": "idx_files_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_instrument_run_id_instrument_runs_id_fk": {
+          "name": "files_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_runs": {
+      "name": "instrument_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "instrument_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lambda'"
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_purged_at": {
+          "name": "files_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instrument_runs_instrument_id_created_at": {
+          "name": "idx_instrument_runs_instrument_id_created_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active": {
+          "name": "idx_instrument_runs_active",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_metadata_gin": {
+          "name": "idx_instrument_runs_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_runs_instrument_id_instruments_id_fk": {
+          "name": "instrument_runs_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_watcher_id_watchers_id_fk": {
+          "name": "instrument_runs_watcher_id_watchers_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_instrument_runs_instrument_id_run_id": {
+          "name": "uq_instrument_runs_instrument_id_run_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instrument_id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instruments": {
+      "name": "instruments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instrument_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instrument_type": {
+          "name": "instrument_type",
+          "type": "instrument_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_personal_access_tokens_user_id": {
+          "name": "idx_personal_access_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_user_id_fk": {
+          "name": "personal_access_tokens_user_id_user_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_attributions": {
+      "name": "run_attributions",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_attributions_run_id": {
+          "name": "idx_run_attributions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_attributions_user_id": {
+          "name": "idx_run_attributions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_attributions_run_id_instrument_runs_id_fk": {
+          "name": "run_attributions_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_attributions_user_id_user_id_fk": {
+          "name": "run_attributions_user_id_user_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_attributions_run_id_user_id_pk": {
+          "name": "run_attributions_run_id_user_id_pk",
+          "columns": [
+            "run_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_events": {
+      "name": "watcher_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "watcher_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_events_watcher_id_timestamp": {
+          "name": "idx_watcher_events_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_watcher_events_watcher_id_event_type": {
+          "name": "idx_watcher_events_watcher_id_event_type",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_events_watcher_id_watchers_id_fk": {
+          "name": "watcher_events_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_events",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_heartbeats": {
+      "name": "watcher_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_mode": {
+          "name": "upload_mode",
+          "type": "upload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_uploaded_since_last": {
+          "name": "files_uploaded_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "runs_reported_since_last": {
+          "name": "runs_reported_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_since_last": {
+          "name": "errors_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_heartbeats_watcher_id_timestamp": {
+          "name": "idx_watcher_heartbeats_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_heartbeats_watcher_id_watchers_id_fk": {
+          "name": "watcher_heartbeats_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_heartbeats",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watchers": {
+      "name": "watchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_info": {
+          "name": "os_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_checksum": {
+          "name": "config_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_yaml": {
+          "name": "config_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "watcher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_watchers_instrument_id": {
+          "name": "idx_watchers_instrument_id",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"watchers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchers_instrument_id_instruments_id_fk": {
+          "name": "watchers_instrument_id_instruments_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.file_category": {
+      "name": "file_category",
+      "schema": "public",
+      "values": [
+        "raw",
+        "processed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "detected",
+        "upload_requested",
+        "uploaded",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.instrument_run_source": {
+      "name": "instrument_run_source",
+      "schema": "public",
+      "values": [
+        "lambda",
+        "watcher"
+      ]
+    },
+    "public.instrument_status": {
+      "name": "instrument_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "inactive"
+      ]
+    },
+    "public.instrument_type": {
+      "name": "instrument_type",
+      "schema": "public",
+      "values": [
+        "generic",
+        "plate_reader",
+        "gel_doc",
+        "qpcr",
+        "tape_station"
+      ]
+    },
+    "public.upload_mode": {
+      "name": "upload_mode",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual"
+      ]
+    },
+    "public.watcher_event_type": {
+      "name": "watcher_event_type",
+      "schema": "public",
+      "values": [
+        "watcher_started",
+        "watcher_stopped",
+        "file_uploaded",
+        "upload_failed",
+        "run_reported",
+        "config_synced",
+        "error"
+      ]
+    },
+    "public.watcher_status": {
+      "name": "watcher_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "watching",
+        "stopped"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web-app/drizzle/meta/_journal.json
+++ b/web-app/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1776988800000,
       "tag": "0006_qpcr_tape_station",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1776804297734,
+      "tag": "0007_dazzling_hercules",
+      "breakpoints": true
     }
   ]
 }

--- a/web-app/lib/api/instrument-runs.ts
+++ b/web-app/lib/api/instrument-runs.ts
@@ -1,7 +1,13 @@
 import { parse } from "csv-parse/sync";
 
 import { db } from "@/lib/db";
-import { files, instrumentRuns, instruments } from "@/lib/db/schema";
+import {
+  files,
+  instrumentRuns,
+  instruments,
+  runAttributions,
+  users,
+} from "@/lib/db/schema";
 import { getS3ObjectStream } from "@/lib/s3";
 import type { SQL } from "drizzle-orm";
 import {
@@ -16,6 +22,59 @@ import {
   lte,
   sql,
 } from "drizzle-orm";
+
+// ---------------------------------------------------------------------------
+// Run attributions: users who claimed they ran a given run. Wire shape is
+// deliberately minimal to keep RSC -> client payloads small; `initials` is
+// computed server-side so the client doesn't recompute per render.
+// ---------------------------------------------------------------------------
+
+export type RunAttribution = {
+  userId: string;
+  displayName: string;
+  initials: string;
+  avatarUrl: string | null;
+};
+
+function toInitials(displayName: string): string {
+  const parts = displayName.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+export async function getAttributionsByRunIds(
+  runIds: string[]
+): Promise<Map<string, RunAttribution[]>> {
+  const byRun = new Map<string, RunAttribution[]>();
+  if (runIds.length === 0) return byRun;
+
+  const rows = await db
+    .select({
+      runId: runAttributions.runId,
+      userId: users.id,
+      name: users.name,
+      email: users.email,
+      image: users.image,
+    })
+    .from(runAttributions)
+    .innerJoin(users, eq(users.id, runAttributions.userId))
+    .where(inArray(runAttributions.runId, runIds))
+    .orderBy(runAttributions.createdAt);
+
+  for (const row of rows) {
+    const displayName = row.name ?? row.email ?? "Unknown";
+    const list = byRun.get(row.runId) ?? [];
+    list.push({
+      userId: row.userId,
+      displayName,
+      initials: toInitials(displayName),
+      avatarUrl: row.image,
+    });
+    byRun.set(row.runId, list);
+  }
+  return byRun;
+}
 
 // ---------------------------------------------------------------------------
 // Run lookup by natural key (instrumentId, runId) — shared across detail,
@@ -55,7 +114,10 @@ export async function lookupRunByNaturalKey(
     )
     .limit(1);
 
-  return row ?? null;
+  if (!row) return null;
+
+  const byRun = await getAttributionsByRunIds([row.id]);
+  return { ...row, attributions: byRun.get(row.id) ?? [] };
 }
 
 // ---------------------------------------------------------------------------
@@ -259,8 +321,18 @@ export async function buildRunListQuery(filters: RunListFilters) {
     .limit(perPage)
     .offset(offset);
 
+  // Fetch attributions in a separate query so the join doesn't cross-multiply
+  // with the files left-join and break the aggregate counts above.
+  const attributionsByRun = await getAttributionsByRunIds(
+    rows.map((r) => r.id)
+  );
+  const data = rows.map((row) => ({
+    ...row,
+    attributions: attributionsByRun.get(row.id) ?? [],
+  }));
+
   return {
-    data: rows,
+    data,
     pagination: {
       page: filters.page,
       per_page: perPage,

--- a/web-app/lib/api/instrument-runs.ts
+++ b/web-app/lib/api/instrument-runs.ts
@@ -144,7 +144,12 @@ type RunListFilters = {
   gelWavelength?: string;
   gelColor?: string;
   dyeChannel?: string;
+  // Either a userId (match runs attributed to that user) or the reserved
+  // sentinel "unattributed" (match runs with no attributions).
+  ranBy?: string;
 };
+
+const UNATTRIBUTED_SENTINEL = "unattributed";
 
 const MAX_PER_PAGE = 100;
 
@@ -243,6 +248,17 @@ export async function buildRunListQuery(filters: RunListFilters) {
   if (filters.dyeChannel) {
     conditions.push(
       sql`${instrumentRuns.metadata}->'dye_channels' @> ${JSON.stringify([filters.dyeChannel])}::jsonb`
+    );
+  }
+
+  // Attribution filter — correlated (NOT) EXISTS against run_attributions.
+  if (filters.ranBy === UNATTRIBUTED_SENTINEL) {
+    conditions.push(
+      sql`not exists (select 1 from ${runAttributions} where ${runAttributions.runId} = ${instrumentRuns.id})`
+    );
+  } else if (filters.ranBy) {
+    conditions.push(
+      sql`exists (select 1 from ${runAttributions} where ${runAttributions.runId} = ${instrumentRuns.id} and ${runAttributions.userId} = ${filters.ranBy})`
     );
   }
 
@@ -534,4 +550,40 @@ export async function getQpcrFilterOptions(
     "dye_channels"
   );
   return { dyeChannels };
+}
+
+// ---------------------------------------------------------------------------
+// Distinct users who have attributed any (non-deleted) run for this
+// instrument — used to populate the "Ran by" column filter dropdown.
+// ---------------------------------------------------------------------------
+
+export type RanByFilterOption = {
+  userId: string;
+  displayName: string;
+};
+
+export async function getRanByFilterOptions(
+  instrumentId: string
+): Promise<RanByFilterOption[]> {
+  const rows = await db
+    .selectDistinct({
+      userId: users.id,
+      name: users.name,
+      email: users.email,
+    })
+    .from(runAttributions)
+    .innerJoin(users, eq(users.id, runAttributions.userId))
+    .innerJoin(instrumentRuns, eq(instrumentRuns.id, runAttributions.runId))
+    .where(
+      and(
+        eq(instrumentRuns.instrumentId, instrumentId),
+        isNull(instrumentRuns.deletedAt)
+      )
+    )
+    .orderBy(users.name);
+
+  return rows.map((r) => ({
+    userId: r.userId,
+    displayName: r.name ?? r.email ?? "Unknown",
+  }));
 }

--- a/web-app/lib/db/schema.ts
+++ b/web-app/lib/db/schema.ts
@@ -475,3 +475,29 @@ export const files = pgTable(
     index("idx_files_metadata_gin").using("gin", file.metadata),
   ]
 );
+
+// Many-to-many link between users and runs: a user "claims" a run they
+// personally performed. Attribution is self-service — users create and remove
+// only their own row. Composite PK enforces one row per (run, user).
+export const runAttributions = pgTable(
+  "run_attributions",
+  {
+    runId: uuid("run_id")
+      .notNull()
+      .references(() => instrumentRuns.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "date",
+    })
+      .notNull()
+      .defaultNow(),
+  },
+  (attribution) => [
+    primaryKey({ columns: [attribution.runId, attribution.userId] }),
+    index("idx_run_attributions_run_id").on(attribution.runId),
+    index("idx_run_attributions_user_id").on(attribution.userId),
+  ]
+);

--- a/web-app/lib/mcp/tools.ts
+++ b/web-app/lib/mcp/tools.ts
@@ -7,6 +7,8 @@ import {
 } from "@/lib/api/files";
 import {
   buildRunListQuery,
+  getAttributionsByRunIds,
+  getRanByFilterOptions,
   getRunFiles,
   lookupRunByNaturalKey,
 } from "@/lib/api/instrument-runs";
@@ -15,8 +17,12 @@ import {
   getInstrumentListWithCounts,
 } from "@/lib/api/instruments";
 import { getWatcherHeartbeats, getWatcherList } from "@/lib/api/watchers";
+import { db } from "@/lib/db";
+import { runAttributions } from "@/lib/db/schema";
 import { getPresignedDownloadUrl } from "@/lib/s3";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 // Pre-signed URLs issued via the MCP server use the same default window as
@@ -35,6 +41,38 @@ function errorResult(message: string) {
     content: [{ type: "text" as const, text: message }],
     isError: true,
   };
+}
+
+type AttributionResolution =
+  | { ok: true; userId: string; runUuid: string }
+  | { ok: false; error: ReturnType<typeof errorResult> };
+
+// Shared resolution step for claim_run / unclaim_run. The authenticated user
+// id is pulled only from authInfo — never from an argument — to preserve the
+// "no spoofable user id" invariant the REST route at
+// /api/v1/instruments/:instrumentId/runs/:runId/attributions/me enforces.
+async function resolveAttributionTarget(
+  authInfo: AuthInfo | undefined,
+  instrumentId: string,
+  runId: string
+): Promise<AttributionResolution> {
+  const userId = authInfo?.extra?.userId as string | undefined;
+  if (!userId) {
+    return {
+      ok: false,
+      error: errorResult("Authenticated user not available on this session."),
+    };
+  }
+  const run = await lookupRunByNaturalKey(instrumentId, runId);
+  if (!run) {
+    return {
+      ok: false,
+      error: errorResult(
+        `Run '${runId}' not found for instrument '${instrumentId}'.`
+      ),
+    };
+  }
+  return { ok: true, userId, runUuid: run.id };
 }
 
 export function registerTools(server: McpServer) {
@@ -149,6 +187,12 @@ export function registerTools(server: McpServer) {
           .string()
           .optional()
           .describe("Plate reader: filter by measurement type"),
+        ranBy: z
+          .string()
+          .optional()
+          .describe(
+            'Filter by attributor. Pass a user id to match runs attributed to that user, or the literal "unattributed" to match runs with no attributions. Use list_run_attributors to discover valid user ids.'
+          ),
       },
       annotations: { readOnlyHint: true },
     },
@@ -167,6 +211,7 @@ export function registerTools(server: McpServer) {
         wavelength: args.wavelength,
         measurementMode: args.measurementMode,
         measurementType: args.measurementType,
+        ranBy: args.ranBy,
       });
       return textResult(result);
     }
@@ -412,6 +457,105 @@ export function registerTools(server: McpServer) {
         total,
         heartbeats: rows,
       });
+    }
+  );
+
+  server.registerTool(
+    "claim_run",
+    {
+      title: "Claim Run",
+      description:
+        "Mark a run as performed by the authenticated user. Idempotent — claiming a run you already claimed is a no-op. Only self-attribution is supported; you cannot claim a run on behalf of another user.",
+      inputSchema: {
+        instrumentId: z.string().describe("Instrument identifier"),
+        runId: z.string().describe("Run identifier within the instrument"),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async ({ instrumentId, runId }, { authInfo }) => {
+      const resolved = await resolveAttributionTarget(
+        authInfo,
+        instrumentId,
+        runId
+      );
+      if (!resolved.ok) return resolved.error;
+
+      await db
+        .insert(runAttributions)
+        .values({ runId: resolved.runUuid, userId: resolved.userId })
+        .onConflictDoNothing();
+
+      const byRun = await getAttributionsByRunIds([resolved.runUuid]);
+      return textResult({
+        instrumentId,
+        runId,
+        attributions: byRun.get(resolved.runUuid) ?? [],
+      });
+    }
+  );
+
+  server.registerTool(
+    "unclaim_run",
+    {
+      title: "Unclaim Run",
+      description:
+        "Remove the authenticated user's attribution from a run. Idempotent — unclaiming a run you don't currently claim is a no-op. Only self-attribution is supported; you cannot remove another user's attribution.",
+      inputSchema: {
+        instrumentId: z.string().describe("Instrument identifier"),
+        runId: z.string().describe("Run identifier within the instrument"),
+      },
+      // destructiveHint because removing an attribution is user-visible across
+      // dashboards and the runs table; clients should confirm before calling.
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+      },
+    },
+    async ({ instrumentId, runId }, { authInfo }) => {
+      const resolved = await resolveAttributionTarget(
+        authInfo,
+        instrumentId,
+        runId
+      );
+      if (!resolved.ok) return resolved.error;
+
+      await db
+        .delete(runAttributions)
+        .where(
+          and(
+            eq(runAttributions.runId, resolved.runUuid),
+            eq(runAttributions.userId, resolved.userId)
+          )
+        );
+
+      const byRun = await getAttributionsByRunIds([resolved.runUuid]);
+      return textResult({
+        instrumentId,
+        runId,
+        attributions: byRun.get(resolved.runUuid) ?? [],
+      });
+    }
+  );
+
+  server.registerTool(
+    "list_run_attributors",
+    {
+      title: "List Run Attributors",
+      description:
+        "List distinct users who have claimed at least one run on a given instrument. Use the returned userId with search_runs ranBy=<userId>.",
+      inputSchema: {
+        instrumentId: z.string().describe("Instrument identifier"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ instrumentId }) => {
+      const attributors = await getRanByFilterOptions(instrumentId);
+      return textResult(attributors);
     }
   );
 }

--- a/web-app/lib/search-params.ts
+++ b/web-app/lib/search-params.ts
@@ -43,6 +43,8 @@ export const instrumentDetailSearchParams = {
   gel_color: parseAsString,
   // qPCR metadata column filters.
   dye_channel: parseAsString,
+  // Attribution filter: either a userId or the reserved sentinel "unattributed".
+  ran_by: parseAsString,
 };
 
 export const instrumentDetailParamsCache = createSearchParamsCache(

--- a/web-app/tests/integration/helpers.ts
+++ b/web-app/tests/integration/helpers.ts
@@ -36,6 +36,7 @@ export async function closeTestDb() {
 // Quoted names match Drizzle-generated tables that use camelCase identifiers.
 const TRUNCATE_ORDER = [
   "files",
+  "run_attributions",
   "instrument_runs",
   "watcher_events",
   "watcher_heartbeats",

--- a/web-app/tests/integration/mcp.test.ts
+++ b/web-app/tests/integration/mcp.test.ts
@@ -6,7 +6,7 @@ import {
   resetDb,
   seedTestUser,
 } from "@/tests/integration/helpers";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 function jsonRpc(method: string, params: unknown = {}, id: number = 1) {
   return {
@@ -37,23 +37,63 @@ async function parseSseResponse(res: Response) {
 
 describe("MCP Server (HTTP)", () => {
   let token: string;
+  let userId: string;
+  let tokenB: string;
+
+  const instrumentId = "mcp-test-instrument";
+  const runId = "mcp-test-run";
 
   beforeAll(async () => {
     await resetDb();
-    ({ token } = await seedTestUser());
+    ({ token, userId } = await seedTestUser());
+    ({ token: tokenB } = await seedTestUser());
 
     const db = getTestDb();
     await db.insert(schema.instruments).values({
-      id: "mcp-test-instrument",
+      id: instrumentId,
       displayName: "MCP Test Instrument",
       status: "active",
       instrumentType: "plate_reader",
     });
+
+    await db.insert(schema.instrumentRuns).values({
+      instrumentId,
+      runId,
+      source: "lambda",
+    });
+  });
+
+  // Wipe attributions between tool-call tests so each one controls the state
+  // it asserts against. The seeded run cascades from `instrument_runs` and
+  // survives the delete.
+  beforeEach(async () => {
+    const db = getTestDb();
+    await db.delete(schema.runAttributions);
   });
 
   afterAll(async () => {
     await closeTestDb();
   });
+
+  // Helper — POST a tools/call request and return the parsed JSON-RPC result.
+  async function callTool(
+    name: string,
+    args: Record<string, unknown>,
+    bearer: string = token
+  ): Promise<{
+    isError?: boolean;
+    content: Array<{ type: string; text: string }>;
+  }> {
+    const res = await api("/api/v1/mcp", {
+      method: "POST",
+      token: bearer,
+      headers: MCP_HEADERS,
+      body: jsonRpc("tools/call", { name, arguments: args }),
+    });
+    expect(res.status).toBe(200);
+    const data = await parseSseResponse(res);
+    return data.result;
+  }
 
   // ---- Auth ----------------------------------------------------------------
 
@@ -116,7 +156,10 @@ describe("MCP Server (HTTP)", () => {
     expect(toolNames).toContain("list_watchers");
     expect(toolNames).toContain("get_watcher_heartbeats");
     expect(toolNames).toContain("reprocess_file");
-    expect(toolNames).toHaveLength(12);
+    expect(toolNames).toContain("claim_run");
+    expect(toolNames).toContain("unclaim_run");
+    expect(toolNames).toContain("list_run_attributors");
+    expect(toolNames).toHaveLength(15);
   });
 
   // ---- Tool execution (end-to-end) -----------------------------------------
@@ -137,9 +180,119 @@ describe("MCP Server (HTTP)", () => {
     const text = data.result.content[0].text;
     const instruments = JSON.parse(text);
     expect(instruments).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ id: "mcp-test-instrument" }),
-      ])
+      expect.arrayContaining([expect.objectContaining({ id: instrumentId })])
     );
+  });
+
+  // ---- Attribution tools (end-to-end) --------------------------------------
+
+  // These tests exercise the auth wiring: `authInfo.extra.userId` is the only
+  // user id ever written, regardless of what the client sneaks into
+  // arguments. They also cover idempotency and the `ranBy` filter that
+  // `search_runs` now accepts.
+
+  it("claim_run attributes the run to the token's user and is idempotent", async () => {
+    const first = await callTool("claim_run", {
+      instrumentId,
+      runId,
+    });
+    expect(first.isError).toBeFalsy();
+    const firstParsed = JSON.parse(first.content[0].text);
+    expect(firstParsed.attributions).toHaveLength(1);
+    expect(firstParsed.attributions[0].userId).toBe(userId);
+
+    const second = await callTool("claim_run", { instrumentId, runId });
+    expect(second.isError).toBeFalsy();
+    const secondParsed = JSON.parse(second.content[0].text);
+    expect(secondParsed.attributions).toHaveLength(1);
+    expect(secondParsed.attributions[0].userId).toBe(userId);
+  });
+
+  it("claim_run ignores a spoofed userId argument — the token's user is the attributor", async () => {
+    const result = await callTool("claim_run", {
+      instrumentId,
+      runId,
+      userId: "some-other-user",
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.attributions).toHaveLength(1);
+    expect(parsed.attributions[0].userId).toBe(userId);
+    expect(parsed.attributions[0].userId).not.toBe("some-other-user");
+  });
+
+  it("claim_run on a nonexistent run returns an error", async () => {
+    const result = await callTool("claim_run", {
+      instrumentId,
+      runId: "nonexistent-run",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text.toLowerCase()).toContain("not found");
+  });
+
+  it("unclaim_run removes attribution and is idempotent", async () => {
+    await callTool("claim_run", { instrumentId, runId });
+
+    const first = await callTool("unclaim_run", { instrumentId, runId });
+    expect(first.isError).toBeFalsy();
+    const firstParsed = JSON.parse(first.content[0].text);
+    expect(firstParsed.attributions).toEqual([]);
+
+    const second = await callTool("unclaim_run", { instrumentId, runId });
+    expect(second.isError).toBeFalsy();
+    const secondParsed = JSON.parse(second.content[0].text);
+    expect(secondParsed.attributions).toEqual([]);
+  });
+
+  it("search_runs ranBy=<userId> filters runs to that user's attributions", async () => {
+    // User A claims the seeded run, then user B searches by user A's id.
+    await callTool("claim_run", { instrumentId, runId });
+
+    const ranByA = await callTool(
+      "search_runs",
+      { instrumentId, ranBy: userId },
+      tokenB
+    );
+    expect(ranByA.isError).toBeFalsy();
+    const ranByAParsed = JSON.parse(ranByA.content[0].text);
+    const ranByARunIds = ranByAParsed.data.map(
+      (r: { run_id: string }) => r.run_id
+    );
+    expect(ranByARunIds).toContain(runId);
+
+    const unattributed = await callTool(
+      "search_runs",
+      { instrumentId, ranBy: "unattributed" },
+      tokenB
+    );
+    expect(unattributed.isError).toBeFalsy();
+    const unattributedParsed = JSON.parse(unattributed.content[0].text);
+    const unattributedRunIds = unattributedParsed.data.map(
+      (r: { run_id: string }) => r.run_id
+    );
+    expect(unattributedRunIds).not.toContain(runId);
+  });
+
+  it("list_run_attributors returns the set of attributors for an instrument", async () => {
+    await callTool("claim_run", { instrumentId, runId });
+
+    const result = await callTool("list_run_attributors", { instrumentId });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content[0].text) as Array<{
+      userId: string;
+      displayName: string;
+    }>;
+    expect(parsed.map((p) => p.userId)).toContain(userId);
+  });
+
+  it("get_run response includes the attributions array", async () => {
+    await callTool("claim_run", { instrumentId, runId });
+
+    const result = await callTool("get_run", { instrumentId, runId });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content[0].text);
+    expect(Array.isArray(parsed.attributions)).toBe(true);
+    expect(parsed.attributions).toHaveLength(1);
+    expect(parsed.attributions[0].userId).toBe(userId);
   });
 });

--- a/web-app/tests/integration/run-attributions.test.ts
+++ b/web-app/tests/integration/run-attributions.test.ts
@@ -1,0 +1,255 @@
+import { instruments } from "@/lib/db/schema";
+import {
+  api,
+  closeTestDb,
+  getTestDb,
+  resetDb,
+  seedTestUser,
+} from "@/tests/integration/helpers";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// End-to-end tests for the self-service run attribution surface:
+//
+//   - PUT/DELETE /api/v1/instruments/:instrumentId/runs/:runId/attributions/me
+//   - The `ran_by` query-param filter on the runs list endpoints
+//   - The `attributions` field embedded in run detail responses
+//
+// Attribution is strictly self-scoped: the URL and body carry no user id, so
+// these tests prove the authenticated token's user is the only user ever
+// written and that idempotency holds across duplicate PUT/DELETE calls.
+describe("Run Attributions API", () => {
+  let tokenA: string;
+  let userIdA: string;
+  let tokenB: string;
+  let userIdB: string;
+
+  const instrumentId = "attributions-test-instrument";
+
+  beforeAll(async () => {
+    await resetDb();
+
+    ({ token: tokenA, userId: userIdA } = await seedTestUser());
+    ({ token: tokenB, userId: userIdB } = await seedTestUser());
+
+    const db = getTestDb();
+    await db.insert(instruments).values({
+      id: instrumentId,
+      displayName: "Attributions Test Instrument",
+      status: "active",
+    });
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  // -------------------------------------------------------------------------
+  // Helpers — create a fresh run per test that needs isolated state.
+  // -------------------------------------------------------------------------
+
+  async function createRun(runId: string): Promise<void> {
+    const res = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token: tokenA,
+      body: { run_id: runId, source: "lambda" },
+    });
+    expect([200, 201]).toContain(res.status);
+  }
+
+  function attributionPath(runId: string): string {
+    return `/api/v1/instruments/${instrumentId}/runs/${runId}/attributions/me`;
+  }
+
+  // -------------------------------------------------------------------------
+  // PUT /attributions/me
+  // -------------------------------------------------------------------------
+
+  it("PUT without a token returns 401", async () => {
+    const res = await api(attributionPath("run-no-auth"), { method: "PUT" });
+    expect(res.status).toBe(401);
+  });
+
+  it("PUT on an unknown run returns 404 with NOT_FOUND", async () => {
+    const res = await api(attributionPath("does-not-exist"), {
+      method: "PUT",
+      token: tokenA,
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("PUT claims the run for the authenticated user", async () => {
+    const runId = "run-claim-single";
+    await createRun(runId);
+
+    const res = await api(attributionPath(runId), {
+      method: "PUT",
+      token: tokenA,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.attributions).toHaveLength(1);
+    expect(body.attributions[0].userId).toBe(userIdA);
+    expect(body.attributions[0].displayName).toBeTruthy();
+    expect(body.attributions[0].initials).toBeTruthy();
+  });
+
+  it("PUT is idempotent — claiming twice still yields one entry", async () => {
+    const runId = "run-claim-idempotent";
+    await createRun(runId);
+
+    await api(attributionPath(runId), { method: "PUT", token: tokenA });
+    const res = await api(attributionPath(runId), {
+      method: "PUT",
+      token: tokenA,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.attributions).toHaveLength(1);
+    expect(body.attributions[0].userId).toBe(userIdA);
+  });
+
+  // -------------------------------------------------------------------------
+  // DELETE /attributions/me
+  // -------------------------------------------------------------------------
+
+  it("DELETE without a token returns 401", async () => {
+    const res = await api(attributionPath("run-no-auth"), { method: "DELETE" });
+    expect(res.status).toBe(401);
+  });
+
+  it("DELETE on an unknown run returns 404 with NOT_FOUND", async () => {
+    const res = await api(attributionPath("does-not-exist"), {
+      method: "DELETE",
+      token: tokenA,
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("DELETE removes the attribution", async () => {
+    const runId = "run-delete-single";
+    await createRun(runId);
+    await api(attributionPath(runId), { method: "PUT", token: tokenA });
+
+    const res = await api(attributionPath(runId), {
+      method: "DELETE",
+      token: tokenA,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.attributions).toEqual([]);
+  });
+
+  it("DELETE is idempotent — deleting when no attribution exists is a no-op", async () => {
+    const runId = "run-delete-noop";
+    await createRun(runId);
+
+    const res = await api(attributionPath(runId), {
+      method: "DELETE",
+      token: tokenA,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.attributions).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Two-user ordering
+  // -------------------------------------------------------------------------
+
+  it("two users claim the same run — both are attributed, ordered by createdAt", async () => {
+    const runId = "run-two-users";
+    await createRun(runId);
+
+    const first = await api(attributionPath(runId), {
+      method: "PUT",
+      token: tokenA,
+    });
+    expect(first.status).toBe(200);
+
+    const second = await api(attributionPath(runId), {
+      method: "PUT",
+      token: tokenB,
+    });
+    expect(second.status).toBe(200);
+    const body = await second.json();
+    expect(body.attributions).toHaveLength(2);
+    expect(body.attributions[0].userId).toBe(userIdA);
+    expect(body.attributions[1].userId).toBe(userIdB);
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /runs?ran_by=...
+  // -------------------------------------------------------------------------
+
+  it("GET runs?ran_by=<userId> returns only runs that user claimed", async () => {
+    const claimedRunId = "run-filter-claimed";
+    const otherRunId = "run-filter-unclaimed";
+    await createRun(claimedRunId);
+    await createRun(otherRunId);
+    await api(attributionPath(claimedRunId), {
+      method: "PUT",
+      token: tokenA,
+    });
+
+    const res = await api(
+      `/api/v1/instruments/${instrumentId}/runs?ran_by=${userIdA}&per_page=100`,
+      { token: tokenA }
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const runIds = body.data.map((r: { run_id: string }) => r.run_id);
+    expect(runIds).toContain(claimedRunId);
+    expect(runIds).not.toContain(otherRunId);
+  });
+
+  it("GET runs?ran_by=unattributed returns only runs with no attributions", async () => {
+    // These runs are created fresh for this test, then only one is claimed —
+    // the other must show up under the unattributed sentinel. The prior
+    // suite-level runs get filtered by the attributions list to stay stable
+    // across run order.
+    const claimedRunId = "run-unattributed-claimed";
+    const unattributedRunId = "run-unattributed-bare";
+    await createRun(claimedRunId);
+    await createRun(unattributedRunId);
+    await api(attributionPath(claimedRunId), {
+      method: "PUT",
+      token: tokenA,
+    });
+
+    const res = await api(
+      `/api/v1/instruments/${instrumentId}/runs?ran_by=unattributed&per_page=100`,
+      { token: tokenA }
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const runIds = body.data.map((r: { run_id: string }) => r.run_id);
+    expect(runIds).toContain(unattributedRunId);
+    expect(runIds).not.toContain(claimedRunId);
+    for (const run of body.data) {
+      expect(run.attributions).toEqual([]);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /runs/:runId — embedded attributions
+  // -------------------------------------------------------------------------
+
+  it("GET run detail includes the attributions array", async () => {
+    const runId = "run-detail-attributions";
+    await createRun(runId);
+    await api(attributionPath(runId), { method: "PUT", token: tokenA });
+
+    const res = await api(`/api/v1/instruments/${instrumentId}/runs/${runId}`, {
+      token: tokenA,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.attributions)).toBe(true);
+    expect(body.attributions).toHaveLength(1);
+    expect(body.attributions[0].userId).toBe(userIdA);
+  });
+});

--- a/web-app/tests/mcp/mcp-protocol.test.ts
+++ b/web-app/tests/mcp/mcp-protocol.test.ts
@@ -105,6 +105,27 @@ vi.mock("@/lib/api/instrument-runs", () => ({
     wavelengths: ["520"],
     colors: ["Green"],
   }),
+  getAttributionsByRunIds: vi.fn().mockResolvedValue(new Map()),
+  getRanByFilterOptions: vi
+    .fn()
+    .mockResolvedValue([{ userId: "u-1", displayName: "Alice" }]),
+}));
+
+// The write-tool happy path goes through the raw Drizzle client. Stub out
+// the chainable methods that `claim_run` / `unclaim_run` use so the tools
+// can be invoked without a real database. A real end-to-end write test
+// lives in the HTTP integration suite.
+vi.mock("@/lib/db", () => ({
+  db: {
+    insert: () => ({
+      values: () => ({
+        onConflictDoNothing: () => Promise.resolve(),
+      }),
+    }),
+    delete: () => ({
+      where: () => Promise.resolve(),
+    }),
+  },
 }));
 
 vi.mock("@/lib/api/dashboard", () => ({
@@ -230,9 +251,12 @@ describe("MCP Protocol (in-memory)", () => {
     "get_run_archive_path",
     "reprocess_file",
     "get_watcher_heartbeats",
+    "claim_run",
+    "unclaim_run",
+    "list_run_attributors",
   ] as const;
 
-  const WRITE_TOOLS = new Set(["reprocess_file"]);
+  const WRITE_TOOLS = new Set(["reprocess_file", "claim_run", "unclaim_run"]);
 
   it("registers all expected tools", async () => {
     const { tools } = await client.listTools();
@@ -282,6 +306,46 @@ describe("MCP Protocol (in-memory)", () => {
 
     const heartbeats = tools.find((t) => t.name === "get_watcher_heartbeats")!;
     expect(heartbeats.inputSchema.properties).toHaveProperty("watcherId");
+
+    // Attribution tools intentionally do NOT expose a `userId` argument — the
+    // authenticated user is pulled from `authInfo.extra.userId` on the server
+    // so the wire API has no spoofable slot.
+    const claimRun = tools.find((t) => t.name === "claim_run")!;
+    expect(claimRun.inputSchema.properties).toHaveProperty("instrumentId");
+    expect(claimRun.inputSchema.properties).toHaveProperty("runId");
+    expect(claimRun.inputSchema.properties).not.toHaveProperty("userId");
+
+    const unclaimRun = tools.find((t) => t.name === "unclaim_run")!;
+    expect(unclaimRun.inputSchema.properties).toHaveProperty("instrumentId");
+    expect(unclaimRun.inputSchema.properties).toHaveProperty("runId");
+    expect(unclaimRun.inputSchema.properties).not.toHaveProperty("userId");
+
+    const listAttributors = tools.find(
+      (t) => t.name === "list_run_attributors"
+    )!;
+    expect(listAttributors.inputSchema.properties).toHaveProperty(
+      "instrumentId"
+    );
+
+    // search_runs gained a `ranBy` filter alongside the new attribution tools.
+    const searchRuns = tools.find((t) => t.name === "search_runs")!;
+    expect(searchRuns.inputSchema.properties).toHaveProperty("ranBy");
+  });
+
+  it("claim_run is annotated as write / non-destructive / idempotent", async () => {
+    const { tools } = await client.listTools();
+    const tool = tools.find((t) => t.name === "claim_run")!;
+    expect(tool.annotations?.readOnlyHint).toBe(false);
+    expect(tool.annotations?.destructiveHint).toBe(false);
+    expect(tool.annotations?.idempotentHint).toBe(true);
+  });
+
+  it("unclaim_run is annotated as write / destructive / idempotent", async () => {
+    const { tools } = await client.listTools();
+    const tool = tools.find((t) => t.name === "unclaim_run")!;
+    expect(tool.annotations?.readOnlyHint).toBe(false);
+    expect(tool.annotations?.destructiveHint).toBe(true);
+    expect(tool.annotations?.idempotentHint).toBe(true);
   });
 
   // ---- Tool execution (happy path) ----------------------------------------
@@ -488,6 +552,44 @@ describe("MCP Protocol (in-memory)", () => {
     const tool = tools.find((t) => t.name === "reprocess_file")!;
     expect(tool.annotations?.readOnlyHint).toBe(false);
     expect(tool.annotations?.destructiveHint).toBe(true);
+  });
+
+  it("list_run_attributors returns the mocked list", async () => {
+    const result = await client.callTool({
+      name: "list_run_attributors",
+      arguments: { instrumentId: "test-plate-reader" },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = parseText(result.content) as Array<{
+      userId: string;
+      displayName: string;
+    }>;
+    expect(parsed).toEqual([{ userId: "u-1", displayName: "Alice" }]);
+  });
+
+  // The in-memory transport does not supply `authInfo`, so the tool must
+  // refuse to attribute anything. The happy path lives in the HTTP suite
+  // where a real Bearer token resolves `authInfo.extra.userId`.
+  it("claim_run without authInfo reports an authenticated-user error", async () => {
+    const result = await client.callTool({
+      name: "claim_run",
+      arguments: { instrumentId: "test-plate-reader", runId: "run-1" },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("Authenticated user not available");
+  });
+
+  it("unclaim_run without authInfo reports an authenticated-user error", async () => {
+    const result = await client.callTool({
+      name: "unclaim_run",
+      arguments: { instrumentId: "test-plate-reader", runId: "run-1" },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("Authenticated user not available");
   });
 
   // ---- Resources -----------------------------------------------------------


### PR DESCRIPTION
## Summary

Lab members can now mark the runs they personally performed. Attribution is self-service — each user claims/unclaims their own rows, there is no admin assignment flow and no way to attribute a run to someone else. The new UI surfaces "Ran by" avatars on the dashboard runs table, per-instrument runs tables, and the run detail header, with per-row hover actions and a bulk selection bar for multi-claim. Attribution is also exposed as a filter (`ran_by=<userId>` or `ran_by=unattributed`) and as three new MCP tools (`claim_run`, `unclaim_run`, `list_run_attributors`).

## Changes

**Data model**

- New `run_attributions` join table with composite PK `(run_id, user_id)`, cascade deletes on both sides, and per-column indexes for the two access patterns (fetch-by-run, fetch-by-user). Migration `drizzle/0007_dazzling_hercules.sql`.

**REST API**

- `PUT /api/v1/instruments/:instrumentId/runs/:runId/attributions/me` and matching `DELETE` — idempotent, self-scoped; the user id comes from `session.user.id`, never from the URL or body.
- `ran_by` query parameter added to both list endpoints (`GET /api/v1/instruments/:id/runs`, `GET /api/v1/instrument-runs`). Accepts a `userId` or the literal `"unattributed"`.
- `GET /api/v1/instruments/:id/runs/:runId` now embeds an `attributions` array.

**MCP**

- `claim_run` (idempotent), `unclaim_run` (idempotent + `destructiveHint`), `list_run_attributors` (read-only, instrument-scoped).
- `search_runs` gains a `ranBy` arg; `get_run` / `search_runs` responses include `attributions`.
- `resolveAttributionTarget` centralizes the "authInfo → userId → run UUID" step so claim/unclaim cannot be spoofed via arguments.

**Web UI**

- `RanByCell` — avatar stack + per-row "I ran this" / "Remove" hover affordances, with `useOptimistic` for instant feedback and `router.refresh()` to reconcile. Deterministic color-per-user via userId hash.
- `RunSelectionProvider` + `BulkAttributionBar` — header checkbox, per-row checkboxes, and a sticky bar that fans out parallel `PUT`/`DELETE` for bulk claim.
- "Ran by" column on all four runs-table variants (default, plate reader, gel doc, qPCR) with a `FilterableColumnHeader` dropdown.
- Run detail page shows attributors inline beside Created/Updated via a new `attributionsSlot` prop on `RunHeader`.
- Footer summary — "N unattributed · N ran by you" — on both list pages.

**Tests (`a8d014b`)**

- REST: new `tests/integration/run-attributions.test.ts` covering PUT/DELETE auth, 404, idempotency, two-user ordering, `ran_by` filters, and the embedded `attributions` array on run detail.
- MCP protocol: `tests/mcp/mcp-protocol.test.ts` extended with the three new tools, write-tool annotations, the `ranBy` inputSchema, and a unit-level guard that claim/unclaim refuse to run without `authInfo.extra.userId`.
- MCP HTTP: `tests/integration/mcp.test.ts` extended with end-to-end claim/unclaim idempotency, a no-spoof invariant (sneaking a `userId` into args is ignored), `search_runs` with `ranBy`, `list_run_attributors`, and `get_run.attributions`.

## Breaking changes

None for end users or existing clients. One schema migration (`0007_dazzling_hercules.sql`) must run before deploy.

## Driveby changes

- **Lambda — populate `size_bytes` / `content_type` on processed files** (`da7e65a`). Processed file records (Gel Doc PNG, Spectramax CSV) were being created with NULL `size_bytes`, so the UI rendered "—" for size. Because `POST /files` is idempotent on `s3_key` and returns the existing row unchanged on reprocess, the Lambda now PATCHes the record after creation. `DataHubClient.update_file` gained `size_bytes` and `content_type` kwargs to support this.
- **Breadcrumbs** (`bd3d9aa`). Replaced the ad-hoc "Back to instruments" / "Back to watchers" links on `InstrumentHeader`, `WatcherHeader`, and `RunHeader` with the shadcn `Breadcrumb` component for consistency across detail pages. Ships `components/ui/breadcrumb.tsx`.
- **Seed `SessionProvider` with RSC session**. `app/layout.tsx` passes `session={await auth()}` so `useSession()` is hydrated synchronously on first render — needed for optimistic attribution UI, also removes a loading flicker on other client components that read the session.

## Testing

- [x] Run `pnpm --filter web-app test` — all integration and MCP protocol tests pass
- [x] Apply `drizzle/0007_dazzling_hercules.sql` on a dev database and confirm the `run_attributions` table, constraints, and indexes
- [x] As user A, claim a run from the instrument runs table; confirm avatar appears immediately (optimistic) and persists after reload
- [x] As user A, unclaim the same run; confirm the "I ran this" affordance returns
- [x] Multi-select several rows via checkboxes and use the bulk bar to claim + unclaim; confirm success toast count matches selection
- [x] As user B, claim a run already claimed by user A; confirm both avatars render stacked on refresh
- [x] Filter the runs table by "Ran by → You", then "Unattributed"; confirm URL updates (`?ran_by=...`) and counts line up
- [x] Claim a run from the run detail page header (`RunAttributionsSection`); confirm it also appears in the list
- [x] Trigger a Lambda reprocess on a Spectramax run and confirm the processed CSV row now shows a non-zero size in the UI
- [x] Exercise the MCP tools against a local server: `claim_run`, `unclaim_run`, `search_runs { ranBy }`, `list_run_attributors`, `get_run` (verify `attributions` is present)
- [x] Confirm sneaking `{ userId: "someone-else" }` into `claim_run` arguments is ignored and the caller's user id is used
- [x] Smoke test breadcrumbs on instrument detail, watcher detail, and run detail pages