### PR TITLE
Watcher: Fix slow restarts, duplicate run reports, and manual-mode uploads on Windows

### DIFF
--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -157,10 +157,13 @@ The watcher maintains a SQLite database at `~/.data-hub/watcher.db` to track whi
 
 ### Initial scan identity
 
-When the watcher starts it walks the watch directory to catch files that arrived while it was stopped. Identity for "have I already uploaded this?" is `(filename, size, mtime)` rather than a full-content hash — this keeps startup fast even on directories holding hundreds of GB of instrument output. Content integrity is still verified at upload time: the uploader computes a SHA-256 on every file it PUTs to S3 and records it alongside the upload.
+When the watcher starts it walks the watch directory to catch files that arrived while it was stopped. Identity for "have I already uploaded this?" is `(relative_path, size, mtime)` rather than a full-content hash — this keeps startup fast even on directories holding hundreds of GB of instrument output. Content integrity is still verified at upload time: the uploader computes a SHA-256 on every file it PUTs to S3 and records it alongside the upload.
+
+The relative path is the file's location relative to the watch directory (e.g. `run-2026-04-17/sample-a/output.nd2`), not just the basename. This matters in recursive watches where two runs might both emit files with the same name — they're disambiguated by subdirectory.
 
 Practical consequences:
 
 - Instrument output files are write-once, so the cheap stat-based check is effectively as strong as a hash in normal operation.
 - If an external tool (antivirus, OneDrive/Dropbox sync, backup restore) rewrites a file's mtime without changing its contents, the watcher will re-enqueue it. The server-side dedup (keyed on SHA-256) prevents a duplicate S3 object.
-- Upgrading from a pre-`size_bytes`/`mtime` state DB is a silent, self-healing migration: legacy rows miss the stat lookup, so files are re-enqueued once and then recorded with stat data on their next upload.
+- If a run's parent folder is renamed or moved, its files look "new" to the next scan and will be re-enqueued. The uploader's own SHA-based dedup prevents a redundant S3 PUT, but it will pay the cost of hashing each affected file once.
+- Upgrading from a pre-`relative_path`/`size_bytes`/`mtime` state DB is a silent, self-healing migration: legacy rows miss the stat lookup, so files are re-enqueued once and then recorded with full stat data on their next upload.

--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -50,7 +50,7 @@ Starts the file monitoring loop. Before entering the loop it:
 - Validates the config and checks that the instrument is active (not pending).
 - Syncs the config checksum with the API.
 - Initializes the local state database (`~/.data-hub/watcher.db`).
-- Retries any runs that were detected but not successfully reported (crash recovery).
+- Hydrates in-memory run state from the local DB so the initial scan skips files that were already reported in a previous session.
 
 While running:
 

--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -154,3 +154,13 @@ In YAML, prefer single-quoted strings for patterns so that backslash sequences l
 ## Local state
 
 The watcher maintains a SQLite database at `~/.data-hub/watcher.db` to track which files have been uploaded. Records older than 90 days are pruned automatically. Logs are written to `~/.data-hub/watcher.log` (10 MB rotating, 5 backups).
+
+### Initial scan identity
+
+When the watcher starts it walks the watch directory to catch files that arrived while it was stopped. Identity for "have I already uploaded this?" is `(filename, size, mtime)` rather than a full-content hash — this keeps startup fast even on directories holding hundreds of GB of instrument output. Content integrity is still verified at upload time: the uploader computes a SHA-256 on every file it PUTs to S3 and records it alongside the upload.
+
+Practical consequences:
+
+- Instrument output files are write-once, so the cheap stat-based check is effectively as strong as a hash in normal operation.
+- If an external tool (antivirus, OneDrive/Dropbox sync, backup restore) rewrites a file's mtime without changing its contents, the watcher will re-enqueue it. The server-side dedup (keyed on SHA-256) prevents a duplicate S3 object.
+- Upgrading from a pre-`size_bytes`/`mtime` state DB is a silent, self-healing migration: legacy rows miss the stat lookup, so files are re-enqueued once and then recorded with stat data on their next upload.

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -718,6 +718,7 @@ def watch(ctx: click.Context, dry_run: bool) -> None:
 
     # Step 8: Start everything
     heartbeat.start()
+    click.echo(f"Scanning {inst.watch_directory} for existing files…")
     monitor.start()
 
     click.echo(f"Watcher is running (instrument={inst.id}, dir={inst.watch_directory})…")

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -19,8 +19,6 @@ from data_hub_watcher.constants import (
     API_URLS,
     DEFAULT_CONFIG_DIR,
     DEFAULT_STABILITY_PERIOD_SECONDS,
-    HEARTBEAT_INTERVAL_SECONDS,
-    PRUNE_DAYS,
     RUN_DETECTION_PRESETS,
     STATE_DB_FILENAME,
     load_env,
@@ -28,14 +26,13 @@ from data_hub_watcher.constants import (
     save_api_key,
 )
 from data_hub_watcher.events import EventReporter, EventType, WatcherEvent
-from data_hub_watcher.heartbeat import HeartbeatLoop, WatcherCounters
+from data_hub_watcher.heartbeat import WatcherCounters
 from data_hub_watcher.models import (
     InstrumentConfig,
     RunDetectionConfig,
     WatcherConfig,
 )
-from data_hub_watcher.monitor import FileMonitor
-from data_hub_watcher.run_detector import RunDetector
+from data_hub_watcher.runtime import build_runtime, start_runtime, stop_runtime
 from data_hub_watcher.state import StateDB
 from data_hub_watcher.uploader import Uploader
 
@@ -641,101 +638,21 @@ def watch(ctx: click.Context, dry_run: bool) -> None:
     # Step 3: File logging
     _setup_file_logging()
 
-    # Step 4: State DB + pruning
+    # Step 4: Build the shared runtime (state DB, uploader, detector,
+    # monitor, heartbeat — all wired identically to the Windows-service
+    # path via data_hub_watcher.runtime).
     db_path = DEFAULT_CONFIG_DIR / STATE_DB_FILENAME
-    state_db = StateDB(db_path)
-    state_db.prune_uploaded_files(PRUNE_DAYS)
+    rt = build_runtime(client=client, cfg=cfg, db_path=db_path)
 
-    # Step 5: Core services
-    counters = WatcherCounters()
-    reporter = EventReporter(client, cfg.watcher_id)
-
-    is_auto = inst.upload_mode == "auto"
-
-    uploader = Uploader(
-        client=client,
-        state_db=state_db,
-        event_reporter=reporter,
-        counters=counters,
-        instrument_id=inst.id,
-        watcher_id=cfg.watcher_id,
-        watch_directory=inst.watch_directory,
-    )
-
-    detector = RunDetector(
-        pattern=inst.run_detection.pattern,
-        instrument_id=inst.id,
-        watcher_id=cfg.watcher_id,
-        client=client,
-        state_db=state_db,
-        event_reporter=reporter,
-        counters=counters,
-        upload_callback=uploader.upload_files if is_auto else None,
-        watch_directory=inst.watch_directory,
-    )
-
-    monitor = FileMonitor(
-        watch_directory=inst.watch_directory,
-        file_patterns=inst.file_patterns,
-        stability_period=inst.stability_period_seconds,
-        on_stable_file=detector.on_stable_file,
-        state_db=state_db,
-        recursive=inst.run_detection.recursive,
-    )
-
-    # In manual mode the server controls which files to upload. We piggyback
-    # on the heartbeat tick to poll the server's upload queue, so uploads
-    # happen at the same cadence as heartbeats without a separate timer.
-    def _poll_upload_queue() -> None:
-        try:
-            uploader.poll_upload_queue()
-        except Exception:
-            logger.exception("Upload queue poll failed")
-
-    heartbeat = HeartbeatLoop(
-        client=client,
-        watcher_id=cfg.watcher_id,
-        interval_seconds=HEARTBEAT_INTERVAL_SECONDS,
-        event_reporter=reporter,
-        instrument_id=inst.id,
-        watch_directory=str(inst.watch_directory),
-        upload_mode=inst.upload_mode,
-        counters=counters,
-        on_tick=_poll_upload_queue if not is_auto else None,
-    )
-
-    reporter.queue_event(
-        WatcherEvent(
-            event_type=EventType.WATCHER_STARTED,
-            message=f"Watcher started on {platform.node()}",
-        )
-    )
-
-    # If the watcher crashed mid-session, some runs may have been detected but
-    # never successfully POSTed to the API. Retry those before starting the
-    # normal event loop so they aren't silently lost.
-    detector.retry_unreported_runs()
-
-    # Step 8: Start everything
-    heartbeat.start()
     click.echo(f"Scanning {inst.watch_directory} for existing files…")
-    monitor.start()
+    start_runtime(rt, started_message=f"Watcher started on {platform.node()}")
 
     click.echo(f"Watcher is running (instrument={inst.id}, dir={inst.watch_directory})…")
     click.echo("Press Ctrl+C to stop.")
 
     def _shutdown(signum: int, frame: Any) -> None:
         click.echo("\nShutting down…")
-        monitor.stop()
-        reporter.queue_event(
-            WatcherEvent(
-                event_type=EventType.WATCHER_STOPPED,
-                message="Watcher stopped by user",
-            )
-        )
-        heartbeat.stop()
-        reporter.flush()
-        state_db.close()
+        stop_runtime(rt, stopped_message="Watcher stopped by user")
         raise SystemExit(0)
 
     signal.signal(signal.SIGINT, _shutdown)

--- a/watcher/src/data_hub_watcher/monitor.py
+++ b/watcher/src/data_hub_watcher/monitor.py
@@ -166,10 +166,12 @@ class FileMonitor:
         This catches files that appeared while the watcher was stopped (e.g.
         between a crash and restart, or overnight when running as a service).
 
-        Identity for "already uploaded" is `(filename, size, mtime)` — a cheap
-        `stat()` rather than a full-content SHA-256. For write-once instrument
-        output this is a safe and much faster heuristic. The uploader still
-        computes a real SHA-256 on its way out, so content integrity is not
+        Identity for "already uploaded" is `(relative_path, size, mtime)` —
+        a cheap `stat()` rather than a full-content SHA-256. The path is
+        relative to the watch directory, so same-named files in different
+        subdirectories don't collide. For write-once instrument output this
+        is a safe and much faster heuristic. The uploader still computes a
+        real SHA-256 on its way out, so content integrity is not
         compromised. See also: `StateDB.has_stat_match`.
         """
         logger.info(
@@ -192,7 +194,14 @@ class FileMonitor:
                 st = entry.stat()
             except OSError:
                 continue
-            if self._state_db.has_stat_match(entry.name, st.st_size, st.st_mtime):
+            try:
+                rel_path = entry.relative_to(self._watch_dir).as_posix()
+            except ValueError:
+                # Symlinks or oddities outside the watch dir: fall back to
+                # basename so the lookup degrades gracefully instead of
+                # raising.
+                rel_path = entry.name
+            if self._state_db.has_stat_match(rel_path, st.st_size, st.st_mtime):
                 skipped += 1
                 continue
             self._enqueue(entry)

--- a/watcher/src/data_hub_watcher/monitor.py
+++ b/watcher/src/data_hub_watcher/monitor.py
@@ -7,8 +7,8 @@ unchanged for the configured period), then invokes a callback.
 
 from __future__ import annotations
 import fnmatch
-import hashlib
 import logging
+import os
 import threading
 import time
 from collections.abc import Callable
@@ -27,15 +27,6 @@ from data_hub_watcher.constants import MAX_STABILITY_WAIT_SECONDS
 from data_hub_watcher.state import StateDB
 
 logger = logging.getLogger(__name__)
-
-
-def file_sha256(path: Path) -> str:
-    """Return the hex SHA-256 digest of *path*."""
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
-            h.update(chunk)
-    return h.hexdigest()
 
 
 @dataclass
@@ -213,7 +204,10 @@ class FileMonitor:
             ) or self._state_db.has_detected_stat_match(rel_path, st.st_size, st.st_mtime):
                 skipped += 1
                 continue
-            self._enqueue(entry)
+            # Pass `st` through so `_enqueue` doesn't issue a redundant
+            # stat() syscall — halves the stat cost on initial scans of
+            # large directories.
+            self._enqueue(entry, stat_result=st)
             queued += 1
             if total % 100 == 0:
                 logger.info(
@@ -234,22 +228,28 @@ class FileMonitor:
     # stability tracking
     # ------------------------------------------------------------------
 
-    def _enqueue(self, path: Path) -> None:
-        """Add or refresh a file in the pending-stability dict."""
-        try:
-            stat = path.stat()
-        except OSError:
-            return
+    def _enqueue(self, path: Path, *, stat_result: os.stat_result | None = None) -> None:
+        """Add or refresh a file in the pending-stability dict.
+
+        *stat_result* lets callers that already hold a fresh `stat()`
+        (notably `_initial_scan`) avoid a redundant syscall. Watchdog
+        event callbacks don't have one and pass `None`.
+        """
+        if stat_result is None:
+            try:
+                stat_result = path.stat()
+            except OSError:
+                return
         with self._lock:
             existing = self._pending.get(path)
             if existing is None:
                 self._pending[path] = _PendingFile(
-                    path=path, size=stat.st_size, mtime=stat.st_mtime
+                    path=path, size=stat_result.st_size, mtime=stat_result.st_mtime
                 )
             else:
-                if stat.st_size != existing.size or stat.st_mtime != existing.mtime:
-                    existing.size = stat.st_size
-                    existing.mtime = stat.st_mtime
+                if stat_result.st_size != existing.size or stat_result.st_mtime != existing.mtime:
+                    existing.size = stat_result.st_size
+                    existing.mtime = stat_result.st_mtime
                     existing.last_changed = time.monotonic()
 
     def _stability_loop(self) -> None:

--- a/watcher/src/data_hub_watcher/monitor.py
+++ b/watcher/src/data_hub_watcher/monitor.py
@@ -173,6 +173,13 @@ class FileMonitor:
         is a safe and much faster heuristic. The uploader still computes a
         real SHA-256 on its way out, so content integrity is not
         compromised. See also: `StateDB.has_stat_match`.
+
+        In addition to `uploaded_files`, files recorded in `detected_files`
+        (i.e. already part of a reported run's manifest) are also skipped.
+        This matters in manual mode where the uploader never runs locally
+        and `uploaded_files` stays empty — without this, every restart
+        would re-POST / PATCH the full manifest.
+        See also: `StateDB.has_detected_stat_match`.
         """
         logger.info(
             "Initial scan starting (dir=%s, patterns=%s, recursive=%s)…",
@@ -201,7 +208,9 @@ class FileMonitor:
                 # basename so the lookup degrades gracefully instead of
                 # raising.
                 rel_path = entry.name
-            if self._state_db.has_stat_match(rel_path, st.st_size, st.st_mtime):
+            if self._state_db.has_stat_match(
+                rel_path, st.st_size, st.st_mtime
+            ) or self._state_db.has_detected_stat_match(rel_path, st.st_size, st.st_mtime):
                 skipped += 1
                 continue
             self._enqueue(entry)

--- a/watcher/src/data_hub_watcher/monitor.py
+++ b/watcher/src/data_hub_watcher/monitor.py
@@ -165,22 +165,52 @@ class FileMonitor:
 
         This catches files that appeared while the watcher was stopped (e.g.
         between a crash and restart, or overnight when running as a service).
+
+        Identity for "already uploaded" is `(filename, size, mtime)` — a cheap
+        `stat()` rather than a full-content SHA-256. For write-once instrument
+        output this is a safe and much faster heuristic. The uploader still
+        computes a real SHA-256 on its way out, so content integrity is not
+        compromised. See also: `StateDB.has_stat_match`.
         """
+        logger.info(
+            "Initial scan starting (dir=%s, patterns=%s, recursive=%s)…",
+            self._watch_dir,
+            self._patterns,
+            self._recursive,
+        )
         iterator = self._watch_dir.rglob("*") if self._recursive else self._watch_dir.iterdir()
-        count = 0
+        total = 0
+        queued = 0
+        skipped = 0
         for entry in iterator:
             if not entry.is_file():
                 continue
             if not any(fnmatch.fnmatch(entry.name, pat) for pat in self._patterns):
                 continue
-            sha = file_sha256(entry)
-            if self._state_db.has_any_upload(entry.name, sha):
+            total += 1
+            try:
+                st = entry.stat()
+            except OSError:
+                continue
+            if self._state_db.has_stat_match(entry.name, st.st_size, st.st_mtime):
+                skipped += 1
                 continue
             self._enqueue(entry)
-            count += 1
+            queued += 1
+            if total % 100 == 0:
+                logger.info(
+                    "Initial scan progress: %d scanned, %d queued, %d skipped",
+                    total,
+                    queued,
+                    skipped,
+                )
 
-        if count:
-            logger.info("Initial scan queued %d file(s) for stability check", count)
+        logger.info(
+            "Initial scan complete: %d scanned, %d queued, %d skipped",
+            total,
+            queued,
+            skipped,
+        )
 
     # ------------------------------------------------------------------
     # stability tracking

--- a/watcher/src/data_hub_watcher/run_detector.py
+++ b/watcher/src/data_hub_watcher/run_detector.py
@@ -299,14 +299,3 @@ class RunDetector:
             count += 1
         if count:
             logger.info("Hydrated %d run(s) from state DB", count)
-
-    # ------------------------------------------------------------------
-    # crash recovery
-    # ------------------------------------------------------------------
-
-    def retry_unreported_runs(self) -> None:
-        """Attempt to re-report any runs that failed their initial POST."""
-        for run in self._runs.values():
-            if not run.reported and run.files:
-                logger.info("Retrying unreported run %s", run.run_id)
-                self._report_new_run(run)

--- a/watcher/src/data_hub_watcher/run_detector.py
+++ b/watcher/src/data_hub_watcher/run_detector.py
@@ -28,6 +28,10 @@ class FileInfo:
     path: Path
     filename: str
     size_bytes: int
+    # mtime at stability time. Persisted alongside the run manifest so a
+    # future restart's initial scan can cheaply stat-match against it
+    # (see `StateDB.has_detected_stat_match`) and skip re-reporting.
+    mtime: float = 0.0
 
 
 @dataclass
@@ -109,12 +113,12 @@ class RunDetector:
             return
 
         try:
-            size = path.stat().st_size
+            st = path.stat()
         except OSError:
             logger.warning("File disappeared before run detection: %s", path)
             return
 
-        info = FileInfo(path=path, filename=path.name, size_bytes=size)
+        info = FileInfo(path=path, filename=path.name, size_bytes=st.st_size, mtime=st.st_mtime)
 
         run = self._runs.get(run_id)
         if run is None:
@@ -163,6 +167,30 @@ class RunDetector:
             "size_bytes": info.size_bytes,
         }
 
+    def _relative_path(self, info: FileInfo) -> str:
+        try:
+            return info.path.relative_to(self._watch_dir).as_posix()
+        except ValueError:
+            return info.filename
+
+    def _persist_detected_files(self, run: RunState) -> None:
+        """Record the current `run.files` manifest in the state DB.
+
+        Called after every successful POST / PATCH so that on restart
+        the initial scan can skip these files and the run can be
+        hydrated back into `_runs` without re-reporting.
+        """
+        rows = [
+            (
+                self._relative_path(info),
+                info.filename,
+                info.size_bytes,
+                info.mtime,
+            )
+            for info in run.files
+        ]
+        self._state_db.record_detected_files(run.run_id, rows)
+
     def _report_new_run(self, run: RunState) -> None:
         payload = {
             "run_id": run.run_id,
@@ -175,13 +203,14 @@ class RunDetector:
             run.reported = True
             run.api_run_id = resp.id
             self._state_db.record_run_reported(run.run_id)
+            self._persist_detected_files(run)
             self._counters.runs_reported += 1
 
             self._reporter.queue_event(
                 WatcherEvent(
                     event_type=EventType.RUN_REPORTED,
-                    message=f"Run {run.run_id} reported with {len(run.files)} file(s)",
-                    details={"run_id": run.run_id, "file_count": len(run.files)},
+                    message=f"Run {run.run_id} reported",
+                    details={"run_id": run.run_id},
                 )
             )
             logger.info("Reported new run %s (%d files)", run.run_id, len(run.files))
@@ -208,6 +237,7 @@ class RunDetector:
         }
         try:
             self._client.update_run(self._instrument_id, run.run_id, payload)
+            self._persist_detected_files(run)
             logger.info("Updated run %s (now %d files)", run.run_id, len(run.files))
         except ApiError as exc:
             logger.warning("Failed to update run %s: %s", run.run_id, exc.message)
@@ -220,6 +250,55 @@ class RunDetector:
             run.uploaded_file_count += succeeded
         else:
             run.uploaded_file_count = len(run.files)
+
+    # ------------------------------------------------------------------
+    # hydration
+    # ------------------------------------------------------------------
+
+    def hydrate_from_state_db(self) -> None:
+        """Rebuild `_runs` from the `detected_files` table on startup.
+
+        Without this, every restart starts with `_runs = {}` and the
+        first stable file per previously-reported run triggers a
+        duplicate POST, with subsequent files triggering a storm of
+        PATCHes. After hydration, `_runs` already knows about every run
+        we've reported, and any genuinely-new file coming through the
+        initial scan + watcher correctly routes to `_update_run` (PATCH)
+        instead of `_report_new_run` (POST).
+
+        Only runs with a recorded manifest are hydrated. Legacy runs
+        that exist in the `runs` table but predate the `detected_files`
+        schema fall back to the pre-hydration path — they will
+        re-report once, after which their manifest will be persisted
+        and future restarts will skip them.
+        """
+        count = 0
+        for run_id in self._state_db.get_reported_run_ids_with_files():
+            records = self._state_db.get_detected_files_for_run(run_id)
+            if not records:
+                continue
+            files = [
+                FileInfo(
+                    path=self._watch_dir / rec.relative_path,
+                    filename=rec.filename,
+                    size_bytes=rec.size_bytes,
+                    mtime=rec.mtime,
+                )
+                for rec in records
+            ]
+            self._runs[run_id] = RunState(
+                run_id=run_id,
+                files=files,
+                reported=True,
+                # On restart every hydrated file is either already
+                # uploaded (auto mode, uploader-side dedup will skip it
+                # anyway if not) or server-driven (manual mode, where
+                # `_upload_cb` is None and this counter is unused).
+                uploaded_file_count=len(files),
+            )
+            count += 1
+        if count:
+            logger.info("Hydrated %d run(s) from state DB", count)
 
     # ------------------------------------------------------------------
     # crash recovery

--- a/watcher/src/data_hub_watcher/runtime.py
+++ b/watcher/src/data_hub_watcher/runtime.py
@@ -1,0 +1,168 @@
+"""Shared runtime wiring for the watcher's long-running loop.
+
+The CLI `watch` command and the Windows-service `SvcDoRun` entrypoint both
+need to assemble the same graph of objects (`StateDB`, `EventReporter`,
+`Uploader`, `RunDetector`, `FileMonitor`, `HeartbeatLoop`) and start /
+stop them in the same order. Keeping that wiring in one place prevents
+the two call sites from drifting — a historical source of bugs, notably
+the Windows-service path forgetting to pass `on_tick` to `HeartbeatLoop`
+and thereby silently skipping manual-mode upload-queue polling.
+"""
+
+from __future__ import annotations
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from data_hub_watcher.api_client import DataHubClient
+from data_hub_watcher.constants import HEARTBEAT_INTERVAL_SECONDS, PRUNE_DAYS
+from data_hub_watcher.events import EventReporter, EventType, WatcherEvent
+from data_hub_watcher.heartbeat import HeartbeatLoop, WatcherCounters
+from data_hub_watcher.models import WatcherConfig
+from data_hub_watcher.monitor import FileMonitor
+from data_hub_watcher.run_detector import RunDetector
+from data_hub_watcher.state import StateDB
+from data_hub_watcher.uploader import Uploader
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WatcherRuntime:
+    """Bundle of all long-lived objects for a running watcher session."""
+
+    state_db: StateDB
+    counters: WatcherCounters
+    reporter: EventReporter
+    uploader: Uploader
+    detector: RunDetector
+    monitor: FileMonitor
+    heartbeat: HeartbeatLoop
+
+
+def build_runtime(
+    *,
+    client: DataHubClient,
+    cfg: WatcherConfig,
+    db_path: Path,
+) -> WatcherRuntime:
+    """Construct the full runtime graph from a validated config.
+
+    The caller is responsible for ensuring `cfg.watcher_id` is set — the
+    CLI does this explicitly via a click error, and the service does it
+    via a registry lookup. We assert here as a safety net so a silent
+    misconfiguration becomes a loud crash.
+    """
+    if not cfg.watcher_id:
+        raise ValueError("cfg.watcher_id must be set before building the runtime")
+
+    inst = cfg.instrument
+    watcher_id = cfg.watcher_id
+
+    state_db = StateDB(db_path)
+    state_db.prune_uploaded_files(PRUNE_DAYS)
+
+    counters = WatcherCounters()
+    reporter = EventReporter(client, watcher_id)
+
+    is_auto = inst.upload_mode == "auto"
+
+    uploader = Uploader(
+        client=client,
+        state_db=state_db,
+        event_reporter=reporter,
+        counters=counters,
+        instrument_id=inst.id,
+        watcher_id=watcher_id,
+        watch_directory=inst.watch_directory,
+    )
+
+    detector = RunDetector(
+        pattern=inst.run_detection.pattern,
+        instrument_id=inst.id,
+        watcher_id=watcher_id,
+        client=client,
+        state_db=state_db,
+        event_reporter=reporter,
+        counters=counters,
+        upload_callback=uploader.upload_files if is_auto else None,
+        watch_directory=inst.watch_directory,
+    )
+
+    monitor = FileMonitor(
+        watch_directory=inst.watch_directory,
+        file_patterns=inst.file_patterns,
+        stability_period=inst.stability_period_seconds,
+        on_stable_file=detector.on_stable_file,
+        state_db=state_db,
+        recursive=inst.run_detection.recursive,
+    )
+
+    # In manual mode the server controls which files to upload. We
+    # piggyback on the heartbeat tick to poll the server's upload queue,
+    # so uploads happen at the same cadence as heartbeats without a
+    # separate timer.
+    def _poll_upload_queue() -> None:
+        try:
+            uploader.poll_upload_queue()
+        except Exception:
+            logger.exception("Upload queue poll failed")
+
+    heartbeat = HeartbeatLoop(
+        client=client,
+        watcher_id=watcher_id,
+        interval_seconds=HEARTBEAT_INTERVAL_SECONDS,
+        event_reporter=reporter,
+        instrument_id=inst.id,
+        watch_directory=str(inst.watch_directory),
+        upload_mode=inst.upload_mode,
+        counters=counters,
+        on_tick=_poll_upload_queue if not is_auto else None,
+    )
+
+    return WatcherRuntime(
+        state_db=state_db,
+        counters=counters,
+        reporter=reporter,
+        uploader=uploader,
+        detector=detector,
+        monitor=monitor,
+        heartbeat=heartbeat,
+    )
+
+
+def start_runtime(rt: WatcherRuntime, *, started_message: str) -> None:
+    """Queue the started event, recover unreported runs, then start threads.
+
+    The `started_message` varies by entry point (`"Watcher started on …"`
+    from the CLI vs `"Service started on …"` from the Windows service)
+    so operators can tell from the event log which code path launched.
+    """
+    rt.reporter.queue_event(
+        WatcherEvent(
+            event_type=EventType.WATCHER_STARTED,
+            message=started_message,
+        )
+    )
+
+    # If the watcher crashed mid-session, some runs may have been detected
+    # but never successfully POSTed to the API. Retry those before the
+    # normal event loop kicks in so they aren't silently lost.
+    rt.detector.retry_unreported_runs()
+
+    rt.heartbeat.start()
+    rt.monitor.start()
+
+
+def stop_runtime(rt: WatcherRuntime, *, stopped_message: str) -> None:
+    """Shut everything down in reverse order and flush pending events."""
+    rt.monitor.stop()
+    rt.reporter.queue_event(
+        WatcherEvent(
+            event_type=EventType.WATCHER_STOPPED,
+            message=stopped_message,
+        )
+    )
+    rt.heartbeat.stop()
+    rt.reporter.flush()
+    rt.state_db.close()

--- a/watcher/src/data_hub_watcher/runtime.py
+++ b/watcher/src/data_hub_watcher/runtime.py
@@ -145,6 +145,15 @@ def start_runtime(rt: WatcherRuntime, *, started_message: str) -> None:
         )
     )
 
+    # Rebuild in-memory run state from the local DB before any file
+    # events fire. Without this, every restart starts with an empty
+    # `_runs` dict and the initial scan would re-POST / re-PATCH runs
+    # that were already reported in a previous session. Must happen
+    # before `monitor.start()` (which runs the initial scan and may
+    # enqueue files) and before `retry_unreported_runs()` (which is
+    # unaffected by hydration but cheaper to call on a populated dict).
+    rt.detector.hydrate_from_state_db()
+
     # If the watcher crashed mid-session, some runs may have been detected
     # but never successfully POSTed to the API. Retry those before the
     # normal event loop kicks in so they aren't silently lost.

--- a/watcher/src/data_hub_watcher/runtime.py
+++ b/watcher/src/data_hub_watcher/runtime.py
@@ -149,15 +149,9 @@ def start_runtime(rt: WatcherRuntime, *, started_message: str) -> None:
     # events fire. Without this, every restart starts with an empty
     # `_runs` dict and the initial scan would re-POST / re-PATCH runs
     # that were already reported in a previous session. Must happen
-    # before `monitor.start()` (which runs the initial scan and may
-    # enqueue files) and before `retry_unreported_runs()` (which is
-    # unaffected by hydration but cheaper to call on a populated dict).
+    # before `monitor.start()`, which runs the initial scan and may
+    # route files through `_update_run` based on hydrated state.
     rt.detector.hydrate_from_state_db()
-
-    # If the watcher crashed mid-session, some runs may have been detected
-    # but never successfully POSTed to the API. Retry those before the
-    # normal event loop kicks in so they aren't silently lost.
-    rt.detector.retry_unreported_runs()
 
     rt.heartbeat.start()
     rt.monitor.start()

--- a/watcher/src/data_hub_watcher/service.py
+++ b/watcher/src/data_hub_watcher/service.py
@@ -272,16 +272,13 @@ def _create_service_class() -> type | None:
             from data_hub_watcher.config_io import config_checksum, load_config
             from data_hub_watcher.constants import (
                 API_URLS,
-                HEARTBEAT_INTERVAL_SECONDS,
-                PRUNE_DAYS,
                 STATE_DB_FILENAME,
             )
-            from data_hub_watcher.events import EventReporter, EventType, WatcherEvent
-            from data_hub_watcher.heartbeat import HeartbeatLoop, WatcherCounters
-            from data_hub_watcher.monitor import FileMonitor
-            from data_hub_watcher.run_detector import RunDetector
-            from data_hub_watcher.state import StateDB
-            from data_hub_watcher.uploader import Uploader
+            from data_hub_watcher.runtime import (
+                build_runtime,
+                start_runtime,
+                stop_runtime,
+            )
 
             servicemanager.LogInfoMsg(f"{SERVICE_DISPLAY_NAME} starting")
 
@@ -329,81 +326,25 @@ def _create_service_class() -> type | None:
                 except ApiError as exc:
                     servicemanager.LogWarningMsg(f"Could not sync config to API: {exc.message}")
 
-            db_path = path.parent / STATE_DB_FILENAME
-            state_db = StateDB(db_path)
-            state_db.prune_uploaded_files(PRUNE_DAYS)
-
-            counters = WatcherCounters()
-            reporter = EventReporter(client, cfg.watcher_id or "")
-
-            heartbeat = HeartbeatLoop(
-                client=client,
-                watcher_id=cfg.watcher_id or "",
-                interval_seconds=HEARTBEAT_INTERVAL_SECONDS,
-                event_reporter=reporter,
-                instrument_id=inst.id,
-                watch_directory=str(inst.watch_directory),
-                upload_mode=inst.upload_mode,
-                counters=counters,
-            )
-
-            is_auto = inst.upload_mode == "auto"
-
-            uploader = Uploader(
-                client=client,
-                state_db=state_db,
-                event_reporter=reporter,
-                counters=counters,
-                instrument_id=inst.id,
-                watcher_id=cfg.watcher_id or "",
-                watch_directory=inst.watch_directory,
-            )
-
-            detector = RunDetector(
-                pattern=inst.run_detection.pattern,
-                instrument_id=inst.id,
-                watcher_id=cfg.watcher_id or "",
-                client=client,
-                state_db=state_db,
-                event_reporter=reporter,
-                counters=counters,
-                upload_callback=uploader.upload_files if is_auto else None,
-                watch_directory=inst.watch_directory,
-            )
-
-            monitor = FileMonitor(
-                watch_directory=inst.watch_directory,
-                file_patterns=inst.file_patterns,
-                stability_period=inst.stability_period_seconds,
-                on_stable_file=detector.on_stable_file,
-                state_db=state_db,
-                recursive=inst.run_detection.recursive,
-            )
-
-            reporter.queue_event(
-                WatcherEvent(
-                    event_type=EventType.WATCHER_STARTED,
-                    message=f"Service started on {platform.node()}",
+            # build_runtime asserts cfg.watcher_id is set; surface that as
+            # a service-manager error rather than a hard crash so operators
+            # see a clear message in the Windows event log.
+            if not cfg.watcher_id:
+                servicemanager.LogErrorMsg(
+                    "No watcher_id in config. Run 'data-hub-watcher init' first."
                 )
-            )
+                return
 
-            heartbeat.start()
-            monitor.start()
+            db_path = path.parent / STATE_DB_FILENAME
+            rt = build_runtime(client=client, cfg=cfg, db_path=db_path)
+
+            start_runtime(rt, started_message=f"Service started on {platform.node()}")
 
             servicemanager.LogInfoMsg(f"{SERVICE_DISPLAY_NAME} is running")
 
             self._stop_event.wait()
 
-            monitor.stop()
-            reporter.queue_event(
-                WatcherEvent(
-                    event_type=EventType.WATCHER_STOPPED,
-                    message="Service stopped",
-                )
-            )
-            heartbeat.stop()
-            reporter.flush()
-            state_db.close()
+            stop_runtime(rt, stopped_message="Service stopped")
 
             servicemanager.LogInfoMsg(f"{SERVICE_DISPLAY_NAME} stopped")
 

--- a/watcher/src/data_hub_watcher/state.py
+++ b/watcher/src/data_hub_watcher/state.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 import threading
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -23,11 +24,25 @@ class RunRecord:
     uploaded_at: str | None
 
 
+@dataclass
+class DetectedFileRecord:
+    """A single file recorded as already-detected-and-reported for a run."""
+
+    relative_path: str
+    filename: str
+    size_bytes: int
+    mtime: float
+
+
 class StateDB:
-    """Thin wrapper around a SQLite database with two tables.
+    """Thin wrapper around a SQLite database with three tables.
 
     - `uploaded_files` — tracks files already sent to S3.
     - `runs` — tracks runs reported to and uploaded via the API.
+    - `detected_files` — tracks the file manifest for every run we have
+      reported to the API, so subsequent restarts can hydrate
+      `RunDetector._runs` and skip files in the initial scan even in
+      manual mode (where `uploaded_files` stays empty).
     """
 
     def __init__(self, db_path: Path) -> None:
@@ -58,6 +73,18 @@ class StateDB:
                 reported_at TEXT NOT NULL,
                 uploaded_at TEXT
             );
+
+            CREATE TABLE IF NOT EXISTS detected_files (
+                run_id        TEXT NOT NULL,
+                relative_path TEXT NOT NULL,
+                filename      TEXT NOT NULL,
+                size_bytes    INTEGER NOT NULL,
+                mtime         REAL NOT NULL,
+                PRIMARY KEY (run_id, relative_path)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_detected_files_stat
+                ON detected_files (relative_path, size_bytes, mtime);
             """
         )
         # Additive migration: older state DBs predate the stat-based initial
@@ -164,6 +191,89 @@ class StateDB:
                 (filename, sha256, now, s3_key, relative_path, size_bytes, mtime),
             )
             self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # detected_files
+    # ------------------------------------------------------------------
+
+    def record_detected_files(
+        self,
+        run_id: str,
+        files: Iterable[tuple[str, str, int, float]],
+    ) -> None:
+        """Persist the file manifest for a reported run.
+
+        *files* is an iterable of `(relative_path, filename, size_bytes,
+        mtime)` tuples. Rows are upserted so repeated calls for the same
+        run (e.g. as more files stabilise and PATCHes are issued) keep
+        the table consistent with the in-memory `RunState`.
+        """
+        rows = [
+            (run_id, rel_path, filename, size_bytes, mtime)
+            for rel_path, filename, size_bytes, mtime in files
+        ]
+        if not rows:
+            return
+        with self._lock:
+            self._conn.executemany(
+                "INSERT OR REPLACE INTO detected_files "
+                "(run_id, relative_path, filename, size_bytes, mtime) "
+                "VALUES (?, ?, ?, ?, ?)",
+                rows,
+            )
+            self._conn.commit()
+
+    def has_detected_stat_match(self, relative_path: str, size_bytes: int, mtime: float) -> bool:
+        """Return True if this file was already reported as part of some run.
+
+        Mirrors `has_stat_match` but targets the `detected_files` table
+        so the initial scan can skip files that are already represented
+        in a reported run's manifest — even when they haven't been
+        uploaded yet (manual mode).
+
+        Uses the same ~1s mtime tolerance as `has_stat_match` for
+        consistency across filesystem timestamp resolutions.
+        """
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT 1 FROM detected_files "
+                "WHERE relative_path = ? AND size_bytes = ? AND ABS(mtime - ?) < 1.0 "
+                "LIMIT 1",
+                (relative_path, size_bytes, mtime),
+            )
+            return cur.fetchone() is not None
+
+    def get_detected_files_for_run(self, run_id: str) -> list[DetectedFileRecord]:
+        """Return the persisted file manifest for *run_id*, ordered by path."""
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT relative_path, filename, size_bytes, mtime "
+                "FROM detected_files WHERE run_id = ? ORDER BY relative_path",
+                (run_id,),
+            )
+            rows = cur.fetchall()
+        return [
+            DetectedFileRecord(
+                relative_path=row[0],
+                filename=row[1],
+                size_bytes=row[2],
+                mtime=row[3],
+            )
+            for row in rows
+        ]
+
+    def get_reported_run_ids_with_files(self) -> list[str]:
+        """Return every run_id that has at least one recorded detected file.
+
+        Runs present in the legacy `runs` table but absent from
+        `detected_files` (pre-upgrade rows) are intentionally excluded:
+        they fall back to the pre-hydration code path and re-report once,
+        after which their manifest will be recorded and future restarts
+        will skip them.
+        """
+        with self._lock:
+            cur = self._conn.execute("SELECT DISTINCT run_id FROM detected_files ORDER BY run_id")
+            return [row[0] for row in cur.fetchall()]
 
     # ------------------------------------------------------------------
     # runs

--- a/watcher/src/data_hub_watcher/state.py
+++ b/watcher/src/data_hub_watcher/state.py
@@ -138,19 +138,6 @@ class StateDB:
             )
             return cur.fetchone() is not None
 
-    def has_any_upload(self, filename: str, sha256: str) -> bool:
-        """Check whether this file content has been uploaded to *any* destination.
-
-        Used by the file monitor's initial scan to skip files that have already
-        been processed, before the S3 key is known.
-        """
-        with self._lock:
-            cur = self._conn.execute(
-                "SELECT 1 FROM uploaded_files WHERE filename = ? AND sha256 = ?",
-                (filename, sha256),
-            )
-            return cur.fetchone() is not None
-
     def has_stat_match(self, relative_path: str, size_bytes: int, mtime: float) -> bool:
         """Cheap identity check for the initial scan.
 

--- a/watcher/src/data_hub_watcher/state.py
+++ b/watcher/src/data_hub_watcher/state.py
@@ -61,17 +61,24 @@ class StateDB:
             """
         )
         # Additive migration: older state DBs predate the stat-based initial
-        # scan and have no size/mtime columns. Add them as nullable so legacy
-        # rows remain valid; has_stat_match simply misses them and the scan
-        # falls back to enqueuing (uploader-side dedup prevents re-upload).
+        # scan and have no size/mtime/relative_path columns. Add them as
+        # nullable so legacy rows remain valid; has_stat_match simply misses
+        # them and the scan falls back to enqueuing (uploader-side dedup
+        # prevents re-upload).
+        #
+        # relative_path is keyed instead of just `filename` so same-named
+        # files in different subdirectories (common in recursive watches)
+        # don't collide on the cheap stat check.
         cols = {row[1] for row in self._conn.execute("PRAGMA table_info(uploaded_files)")}
         if "size_bytes" not in cols:
             self._conn.execute("ALTER TABLE uploaded_files ADD COLUMN size_bytes INTEGER")
         if "mtime" not in cols:
             self._conn.execute("ALTER TABLE uploaded_files ADD COLUMN mtime REAL")
+        if "relative_path" not in cols:
+            self._conn.execute("ALTER TABLE uploaded_files ADD COLUMN relative_path TEXT")
         self._conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_uploaded_files_stat "
-            "ON uploaded_files (filename, size_bytes, mtime)"
+            "ON uploaded_files (relative_path, size_bytes, mtime)"
         )
         self._conn.commit()
 
@@ -117,20 +124,24 @@ class StateDB:
             )
             return cur.fetchone() is not None
 
-    def has_stat_match(self, filename: str, size_bytes: int, mtime: float) -> bool:
+    def has_stat_match(self, relative_path: str, size_bytes: int, mtime: float) -> bool:
         """Cheap identity check for the initial scan.
 
-        Returns True if any prior upload record matches `(filename, size, mtime)`.
-        The mtime comparison uses a ~1s tolerance to absorb filesystem timestamp
-        resolution differences (FAT = 2s, NTFS = 100ns, ext4 = ns) and minor
-        float rounding between Python versions / platforms.
+        Returns True if any prior upload record matches
+        `(relative_path, size, mtime)`. We key on the watch-dir-relative
+        path rather than basename so same-named files in different
+        subdirectories (common in recursive watches) don't collide.
+
+        The mtime comparison uses a ~1s tolerance to absorb filesystem
+        timestamp resolution differences (FAT = 2s, NTFS = 100ns, ext4 = ns)
+        and minor float rounding between Python versions / platforms.
         """
         with self._lock:
             cur = self._conn.execute(
                 "SELECT 1 FROM uploaded_files "
-                "WHERE filename = ? AND size_bytes = ? AND ABS(mtime - ?) < 1.0 "
+                "WHERE relative_path = ? AND size_bytes = ? AND ABS(mtime - ?) < 1.0 "
                 "LIMIT 1",
-                (filename, size_bytes, mtime),
+                (relative_path, size_bytes, mtime),
             )
             return cur.fetchone() is not None
 
@@ -140,6 +151,7 @@ class StateDB:
         sha256: str,
         s3_key: str,
         *,
+        relative_path: str,
         size_bytes: int,
         mtime: float,
     ) -> None:
@@ -147,9 +159,9 @@ class StateDB:
         with self._lock:
             self._conn.execute(
                 "INSERT OR REPLACE INTO uploaded_files "
-                "(filename, sha256, uploaded_at, s3_key, size_bytes, mtime) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
-                (filename, sha256, now, s3_key, size_bytes, mtime),
+                "(filename, sha256, uploaded_at, s3_key, relative_path, size_bytes, mtime) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (filename, sha256, now, s3_key, relative_path, size_bytes, mtime),
             )
             self._conn.commit()
 

--- a/watcher/src/data_hub_watcher/state.py
+++ b/watcher/src/data_hub_watcher/state.py
@@ -60,6 +60,19 @@ class StateDB:
             );
             """
         )
+        # Additive migration: older state DBs predate the stat-based initial
+        # scan and have no size/mtime columns. Add them as nullable so legacy
+        # rows remain valid; has_stat_match simply misses them and the scan
+        # falls back to enqueuing (uploader-side dedup prevents re-upload).
+        cols = {row[1] for row in self._conn.execute("PRAGMA table_info(uploaded_files)")}
+        if "size_bytes" not in cols:
+            self._conn.execute("ALTER TABLE uploaded_files ADD COLUMN size_bytes INTEGER")
+        if "mtime" not in cols:
+            self._conn.execute("ALTER TABLE uploaded_files ADD COLUMN mtime REAL")
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_uploaded_files_stat "
+            "ON uploaded_files (filename, size_bytes, mtime)"
+        )
         self._conn.commit()
 
     # ------------------------------------------------------------------
@@ -104,13 +117,39 @@ class StateDB:
             )
             return cur.fetchone() is not None
 
-    def record_upload(self, filename: str, sha256: str, s3_key: str) -> None:
+    def has_stat_match(self, filename: str, size_bytes: int, mtime: float) -> bool:
+        """Cheap identity check for the initial scan.
+
+        Returns True if any prior upload record matches `(filename, size, mtime)`.
+        The mtime comparison uses a ~1s tolerance to absorb filesystem timestamp
+        resolution differences (FAT = 2s, NTFS = 100ns, ext4 = ns) and minor
+        float rounding between Python versions / platforms.
+        """
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT 1 FROM uploaded_files "
+                "WHERE filename = ? AND size_bytes = ? AND ABS(mtime - ?) < 1.0 "
+                "LIMIT 1",
+                (filename, size_bytes, mtime),
+            )
+            return cur.fetchone() is not None
+
+    def record_upload(
+        self,
+        filename: str,
+        sha256: str,
+        s3_key: str,
+        *,
+        size_bytes: int,
+        mtime: float,
+    ) -> None:
         now = datetime.now(timezone.utc).isoformat()
         with self._lock:
             self._conn.execute(
-                "INSERT OR REPLACE INTO uploaded_files (filename, sha256, uploaded_at, s3_key) "
-                "VALUES (?, ?, ?, ?)",
-                (filename, sha256, now, s3_key),
+                "INSERT OR REPLACE INTO uploaded_files "
+                "(filename, sha256, uploaded_at, s3_key, size_bytes, mtime) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (filename, sha256, now, s3_key, size_bytes, mtime),
             )
             self._conn.commit()
 

--- a/watcher/src/data_hub_watcher/uploader.py
+++ b/watcher/src/data_hub_watcher/uploader.py
@@ -22,9 +22,9 @@ from data_hub_watcher.constants import (
 )
 from data_hub_watcher.events import EventReporter, EventType, WatcherEvent
 from data_hub_watcher.heartbeat import WatcherCounters
-from data_hub_watcher.monitor import file_sha256
 from data_hub_watcher.run_detector import FileInfo
 from data_hub_watcher.state import StateDB
+from data_hub_watcher.util import file_sha256
 
 logger = logging.getLogger(__name__)
 

--- a/watcher/src/data_hub_watcher/uploader.py
+++ b/watcher/src/data_hub_watcher/uploader.py
@@ -163,6 +163,7 @@ class Uploader:
         """
         content_type = _guess_content_type(path)
         sha = file_sha256(path)
+        stat = path.stat()
 
         # Request a presigned upload URL from the API. This also creates or
         # locates the server-side file record.
@@ -172,7 +173,7 @@ class Uploader:
                 run_id,
                 path.name,
                 content_type=content_type,
-                size_bytes=path.stat().st_size,
+                size_bytes=stat.st_size,
             )
         except ApiError as exc:
             logger.error("Failed to get presigned URL for %s: %s", path.name, exc.message)
@@ -192,7 +193,9 @@ class Uploader:
 
         if presigned.already_uploaded:
             logger.debug("Server says already uploaded, skipping: %s", path.name)
-            self._state_db.record_upload(path.name, sha, s3_key)
+            self._state_db.record_upload(
+                path.name, sha, s3_key, size_bytes=stat.st_size, mtime=stat.st_mtime
+            )
             return True
 
         if self._state_db.is_uploaded(path.name, sha, s3_key):
@@ -256,7 +259,9 @@ class Uploader:
             )
             return False
 
-        self._state_db.record_upload(path.name, sha, s3_key)
+        self._state_db.record_upload(
+            path.name, sha, s3_key, size_bytes=stat.st_size, mtime=stat.st_mtime
+        )
         self._counters.files_uploaded += 1
         self._reporter.queue_event(
             WatcherEvent(

--- a/watcher/src/data_hub_watcher/uploader.py
+++ b/watcher/src/data_hub_watcher/uploader.py
@@ -34,6 +34,19 @@ def _guess_content_type(path: Path) -> str | None:
     return content_type
 
 
+def _relative_path(path: Path, watch_dir: Path) -> str:
+    """Return *path* as a forward-slash relative to *watch_dir*.
+
+    Falls back to the basename for paths outside the watch directory
+    (e.g. one-shot `upload --file /abs/path`) so we never raise during
+    upload recording.
+    """
+    try:
+        return path.relative_to(watch_dir).as_posix()
+    except ValueError:
+        return path.name
+
+
 class Uploader:
     """Uploads files via presigned S3 PUT URLs and notifies the Data Hub API.
 
@@ -164,6 +177,7 @@ class Uploader:
         content_type = _guess_content_type(path)
         sha = file_sha256(path)
         stat = path.stat()
+        rel_path = _relative_path(path, self._watch_dir)
 
         # Request a presigned upload URL from the API. This also creates or
         # locates the server-side file record.
@@ -194,7 +208,12 @@ class Uploader:
         if presigned.already_uploaded:
             logger.debug("Server says already uploaded, skipping: %s", path.name)
             self._state_db.record_upload(
-                path.name, sha, s3_key, size_bytes=stat.st_size, mtime=stat.st_mtime
+                path.name,
+                sha,
+                s3_key,
+                relative_path=rel_path,
+                size_bytes=stat.st_size,
+                mtime=stat.st_mtime,
             )
             return True
 
@@ -260,7 +279,12 @@ class Uploader:
             return False
 
         self._state_db.record_upload(
-            path.name, sha, s3_key, size_bytes=stat.st_size, mtime=stat.st_mtime
+            path.name,
+            sha,
+            s3_key,
+            relative_path=rel_path,
+            size_bytes=stat.st_size,
+            mtime=stat.st_mtime,
         )
         self._counters.files_uploaded += 1
         self._reporter.queue_event(

--- a/watcher/src/data_hub_watcher/util.py
+++ b/watcher/src/data_hub_watcher/util.py
@@ -1,0 +1,25 @@
+"""Small, dependency-free helpers shared across the watcher.
+
+Keep this module lightweight — it is imported by both the monitor and
+the uploader, so introducing heavy imports here would pull them into
+every startup path.
+"""
+
+from __future__ import annotations
+import hashlib
+from pathlib import Path
+
+
+def file_sha256(path: Path) -> str:
+    """Return the hex SHA-256 digest of *path*.
+
+    Streams the file in 8 KiB chunks so we don't load multi-GiB
+    instrument outputs into memory. Lives here rather than next to the
+    uploader so callers don't have to import the full upload module
+    just to hash a file.
+    """
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()

--- a/watcher/tests/test_monitor_initial_scan.py
+++ b/watcher/tests/test_monitor_initial_scan.py
@@ -1,0 +1,176 @@
+"""Unit tests for FileMonitor._initial_scan and StateDB.has_stat_match."""
+
+from __future__ import annotations
+import os
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from data_hub_watcher.monitor import FileMonitor
+from data_hub_watcher.state import StateDB
+
+
+@pytest.fixture()
+def state_db(tmp_path: Path) -> Generator[StateDB, None, None]:
+    db = StateDB(tmp_path / "test.db")
+    yield db
+    db.close()
+
+
+@pytest.fixture()
+def watch_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "watch"
+    d.mkdir()
+    return d
+
+
+def _make_monitor(watch_dir: Path, state_db: StateDB) -> FileMonitor:
+    return FileMonitor(
+        watch_directory=watch_dir,
+        file_patterns=["*.nd2"],
+        stability_period=1,
+        on_stable_file=MagicMock(),
+        state_db=state_db,
+        recursive=False,
+    )
+
+
+class TestHasStatMatch:
+    def test_match_on_exact_stat(self, state_db: StateDB) -> None:
+        state_db.record_upload(
+            "sample.nd2", "sha-a", "s3/sample.nd2", size_bytes=1024, mtime=1_700_000_000.0
+        )
+
+        assert state_db.has_stat_match("sample.nd2", 1024, 1_700_000_000.0) is True
+
+    def test_miss_on_different_size(self, state_db: StateDB) -> None:
+        state_db.record_upload(
+            "sample.nd2", "sha-a", "s3/sample.nd2", size_bytes=1024, mtime=1_700_000_000.0
+        )
+
+        assert state_db.has_stat_match("sample.nd2", 2048, 1_700_000_000.0) is False
+
+    def test_miss_on_different_filename(self, state_db: StateDB) -> None:
+        state_db.record_upload(
+            "sample.nd2", "sha-a", "s3/sample.nd2", size_bytes=1024, mtime=1_700_000_000.0
+        )
+
+        assert state_db.has_stat_match("other.nd2", 1024, 1_700_000_000.0) is False
+
+    def test_mtime_within_tolerance_matches(self, state_db: StateDB) -> None:
+        state_db.record_upload(
+            "sample.nd2", "sha-a", "s3/sample.nd2", size_bytes=1024, mtime=1_700_000_000.0
+        )
+
+        assert state_db.has_stat_match("sample.nd2", 1024, 1_700_000_000.5) is True
+
+    def test_mtime_outside_tolerance_misses(self, state_db: StateDB) -> None:
+        state_db.record_upload(
+            "sample.nd2", "sha-a", "s3/sample.nd2", size_bytes=1024, mtime=1_700_000_000.0
+        )
+
+        assert state_db.has_stat_match("sample.nd2", 1024, 1_700_000_100.0) is False
+
+    def test_legacy_row_without_stat_misses(self, state_db: StateDB) -> None:
+        state_db._conn.execute(
+            "INSERT INTO uploaded_files (filename, sha256, uploaded_at, s3_key) "
+            "VALUES (?, ?, ?, ?)",
+            ("legacy.nd2", "sha-legacy", "2025-01-01T00:00:00+00:00", "s3/legacy.nd2"),
+        )
+        state_db._conn.commit()
+
+        assert state_db.has_stat_match("legacy.nd2", 512, 1_600_000_000.0) is False
+
+
+class TestInitialScan:
+    def test_skips_file_with_matching_stat(self, state_db: StateDB, watch_dir: Path) -> None:
+        f = watch_dir / "seen.nd2"
+        f.write_bytes(b"x" * 2048)
+        st = f.stat()
+        state_db.record_upload(
+            "seen.nd2", "sha-seen", "s3/seen.nd2", size_bytes=st.st_size, mtime=st.st_mtime
+        )
+
+        monitor = _make_monitor(watch_dir, state_db)
+        monitor._initial_scan()
+
+        assert f not in monitor._pending
+
+    def test_enqueues_file_with_different_size(self, state_db: StateDB, watch_dir: Path) -> None:
+        f = watch_dir / "grew.nd2"
+        f.write_bytes(b"x" * 2048)
+        st = f.stat()
+        state_db.record_upload(
+            "grew.nd2",
+            "sha-old",
+            "s3/grew.nd2",
+            size_bytes=st.st_size - 1,
+            mtime=st.st_mtime,
+        )
+
+        monitor = _make_monitor(watch_dir, state_db)
+        monitor._initial_scan()
+
+        assert f in monitor._pending
+
+    def test_enqueues_file_with_different_mtime(self, state_db: StateDB, watch_dir: Path) -> None:
+        f = watch_dir / "touched.nd2"
+        f.write_bytes(b"x" * 2048)
+        st = f.stat()
+        state_db.record_upload(
+            "touched.nd2",
+            "sha-old",
+            "s3/touched.nd2",
+            size_bytes=st.st_size,
+            mtime=st.st_mtime - 10.0,
+        )
+
+        monitor = _make_monitor(watch_dir, state_db)
+        monitor._initial_scan()
+
+        assert f in monitor._pending
+
+    def test_enqueues_legacy_record(self, state_db: StateDB, watch_dir: Path) -> None:
+        f = watch_dir / "legacy.nd2"
+        f.write_bytes(b"x" * 2048)
+        state_db._conn.execute(
+            "INSERT INTO uploaded_files (filename, sha256, uploaded_at, s3_key) "
+            "VALUES (?, ?, ?, ?)",
+            ("legacy.nd2", "sha-legacy", "2025-01-01T00:00:00+00:00", "s3/legacy.nd2"),
+        )
+        state_db._conn.commit()
+
+        monitor = _make_monitor(watch_dir, state_db)
+        monitor._initial_scan()
+
+        assert f in monitor._pending
+
+    def test_skips_unmatched_patterns(self, state_db: StateDB, watch_dir: Path) -> None:
+        (watch_dir / "readme.txt").write_text("ignore me")
+        (watch_dir / "sample.nd2").write_bytes(b"x" * 1024)
+
+        monitor = _make_monitor(watch_dir, state_db)
+        monitor._initial_scan()
+
+        assert watch_dir / "sample.nd2" in monitor._pending
+        assert watch_dir / "readme.txt" not in monitor._pending
+
+    def test_does_not_read_file_contents(self, state_db: StateDB, watch_dir: Path) -> None:
+        """Regression guard: the scan must not open file bodies.
+
+        Chmod a file to 0o000 so any read would fail, then assert the scan
+        still enqueues it. Proves the scan is stat-only.
+        """
+        f = watch_dir / "unreadable.nd2"
+        f.write_bytes(b"x" * 1024)
+        original_mode = f.stat().st_mode
+        os.chmod(f, 0o000)
+        try:
+            monitor = _make_monitor(watch_dir, state_db)
+            monitor._initial_scan()
+        finally:
+            os.chmod(f, original_mode)
+
+        assert f in monitor._pending

--- a/watcher/tests/test_monitor_initial_scan.py
+++ b/watcher/tests/test_monitor_initial_scan.py
@@ -1,4 +1,11 @@
-"""Unit tests for FileMonitor._initial_scan and StateDB.has_stat_match."""
+"""Unit tests for FileMonitor._initial_scan and StateDB stat-match helpers.
+
+Covers both `StateDB.has_stat_match` (uploaded_files) and
+`StateDB.has_detected_stat_match` / `record_detected_files` /
+`get_detected_files_for_run` / `get_reported_run_ids_with_files`
+(detected_files) — the two tables feed the same initial-scan skip
+path.
+"""
 
 from __future__ import annotations
 import os
@@ -218,6 +225,57 @@ class TestInitialScan:
 
         assert f in monitor._pending
 
+    def test_skips_file_recorded_in_detected_files(
+        self, state_db: StateDB, watch_dir: Path
+    ) -> None:
+        """Initial scan must also honor `detected_files` records.
+
+        In manual mode `uploaded_files` is never populated locally, so
+        without this skip path every restart would re-POST / re-PATCH
+        the full manifest.
+        """
+        f = watch_dir / "run-42.nd2"
+        f.write_bytes(b"x" * 4096)
+        st = f.stat()
+        state_db.record_detected_files(
+            "run-42",
+            [("run-42.nd2", "run-42.nd2", st.st_size, st.st_mtime)],
+        )
+
+        monitor = _make_monitor(watch_dir, state_db)
+        monitor._initial_scan()
+
+        assert f not in monitor._pending
+
+    def test_skips_union_of_uploaded_and_detected(self, state_db: StateDB, watch_dir: Path) -> None:
+        uploaded = watch_dir / "uploaded.nd2"
+        detected = watch_dir / "detected.nd2"
+        fresh = watch_dir / "fresh.nd2"
+        for p in (uploaded, detected, fresh):
+            p.write_bytes(b"x" * 1024)
+
+        st_up = uploaded.stat()
+        state_db.record_upload(
+            "uploaded.nd2",
+            "sha-up",
+            "s3/uploaded.nd2",
+            relative_path="uploaded.nd2",
+            size_bytes=st_up.st_size,
+            mtime=st_up.st_mtime,
+        )
+        st_det = detected.stat()
+        state_db.record_detected_files(
+            "run-1",
+            [("detected.nd2", "detected.nd2", st_det.st_size, st_det.st_mtime)],
+        )
+
+        monitor = _make_monitor(watch_dir, state_db)
+        monitor._initial_scan()
+
+        assert uploaded not in monitor._pending
+        assert detected not in monitor._pending
+        assert fresh in monitor._pending
+
     def test_same_basename_in_different_subdirs_both_enqueued(
         self, state_db: StateDB, watch_dir: Path
     ) -> None:
@@ -250,3 +308,68 @@ class TestInitialScan:
 
         assert a not in monitor._pending
         assert b in monitor._pending
+
+
+class TestDetectedFilesApi:
+    """Unit tests for the `detected_files` table helpers on `StateDB`."""
+
+    def test_record_and_lookup_roundtrip(self, state_db: StateDB) -> None:
+        state_db.record_detected_files(
+            "run-1",
+            [
+                ("a/one.nd2", "one.nd2", 1024, 1_700_000_000.0),
+                ("a/two.nd2", "two.nd2", 2048, 1_700_000_001.0),
+            ],
+        )
+
+        records = state_db.get_detected_files_for_run("run-1")
+        assert [(r.relative_path, r.filename, r.size_bytes, r.mtime) for r in records] == [
+            ("a/one.nd2", "one.nd2", 1024, 1_700_000_000.0),
+            ("a/two.nd2", "two.nd2", 2048, 1_700_000_001.0),
+        ]
+
+    def test_record_is_idempotent_upsert(self, state_db: StateDB) -> None:
+        """Re-recording the same (run_id, relative_path) must upsert, not dup."""
+        state_db.record_detected_files("run-1", [("a.nd2", "a.nd2", 1024, 1_700_000_000.0)])
+        state_db.record_detected_files("run-1", [("a.nd2", "a.nd2", 2048, 1_700_000_050.0)])
+
+        records = state_db.get_detected_files_for_run("run-1")
+        assert len(records) == 1
+        assert records[0].size_bytes == 2048
+        assert records[0].mtime == pytest.approx(1_700_000_050.0)
+
+    def test_record_empty_iterable_is_noop(self, state_db: StateDB) -> None:
+        state_db.record_detected_files("run-empty", [])
+        assert state_db.get_detected_files_for_run("run-empty") == []
+        assert state_db.get_reported_run_ids_with_files() == []
+
+    def test_has_detected_stat_match_hit(self, state_db: StateDB) -> None:
+        state_db.record_detected_files("run-1", [("x.nd2", "x.nd2", 1024, 1_700_000_000.0)])
+        assert state_db.has_detected_stat_match("x.nd2", 1024, 1_700_000_000.0) is True
+
+    def test_has_detected_stat_match_respects_mtime_tolerance(self, state_db: StateDB) -> None:
+        state_db.record_detected_files("run-1", [("x.nd2", "x.nd2", 1024, 1_700_000_000.0)])
+        assert state_db.has_detected_stat_match("x.nd2", 1024, 1_700_000_000.5) is True
+        assert state_db.has_detected_stat_match("x.nd2", 1024, 1_700_000_100.0) is False
+
+    def test_has_detected_stat_match_miss_on_different_path(self, state_db: StateDB) -> None:
+        state_db.record_detected_files(
+            "run-a", [("run-a/out.nd2", "out.nd2", 1024, 1_700_000_000.0)]
+        )
+        assert state_db.has_detected_stat_match("run-b/out.nd2", 1024, 1_700_000_000.0) is False
+
+    def test_get_reported_run_ids_with_files_distinct_and_scoped(self, state_db: StateDB) -> None:
+        state_db.record_detected_files(
+            "run-1",
+            [
+                ("run-1/a.nd2", "a.nd2", 1, 1_700_000_000.0),
+                ("run-1/b.nd2", "b.nd2", 2, 1_700_000_001.0),
+            ],
+        )
+        state_db.record_detected_files("run-2", [("run-2/a.nd2", "a.nd2", 3, 1_700_000_002.0)])
+        state_db.record_run_reported("run-legacy")
+
+        ids = state_db.get_reported_run_ids_with_files()
+
+        assert ids == ["run-1", "run-2"]
+        assert "run-legacy" not in ids

--- a/watcher/tests/test_monitor_initial_scan.py
+++ b/watcher/tests/test_monitor_initial_scan.py
@@ -26,49 +26,85 @@ def watch_dir(tmp_path: Path) -> Path:
     return d
 
 
-def _make_monitor(watch_dir: Path, state_db: StateDB) -> FileMonitor:
+def _make_monitor(
+    watch_dir: Path,
+    state_db: StateDB,
+    *,
+    recursive: bool = False,
+) -> FileMonitor:
     return FileMonitor(
         watch_directory=watch_dir,
         file_patterns=["*.nd2"],
         stability_period=1,
         on_stable_file=MagicMock(),
         state_db=state_db,
-        recursive=False,
+        recursive=recursive,
     )
 
 
 class TestHasStatMatch:
     def test_match_on_exact_stat(self, state_db: StateDB) -> None:
         state_db.record_upload(
-            "sample.nd2", "sha-a", "s3/sample.nd2", size_bytes=1024, mtime=1_700_000_000.0
+            "sample.nd2",
+            "sha-a",
+            "s3/sample.nd2",
+            relative_path="sample.nd2",
+            size_bytes=1024,
+            mtime=1_700_000_000.0,
         )
 
         assert state_db.has_stat_match("sample.nd2", 1024, 1_700_000_000.0) is True
 
     def test_miss_on_different_size(self, state_db: StateDB) -> None:
         state_db.record_upload(
-            "sample.nd2", "sha-a", "s3/sample.nd2", size_bytes=1024, mtime=1_700_000_000.0
+            "sample.nd2",
+            "sha-a",
+            "s3/sample.nd2",
+            relative_path="sample.nd2",
+            size_bytes=1024,
+            mtime=1_700_000_000.0,
         )
 
         assert state_db.has_stat_match("sample.nd2", 2048, 1_700_000_000.0) is False
 
-    def test_miss_on_different_filename(self, state_db: StateDB) -> None:
+    def test_miss_on_different_relative_path(self, state_db: StateDB) -> None:
+        """Same basename in a different subfolder must NOT match.
+
+        This is the main reason has_stat_match keys on relative path rather
+        than basename: two runs that both emit `output.nd2` must each be
+        uploaded.
+        """
         state_db.record_upload(
-            "sample.nd2", "sha-a", "s3/sample.nd2", size_bytes=1024, mtime=1_700_000_000.0
+            "output.nd2",
+            "sha-a",
+            "s3/run-a/output.nd2",
+            relative_path="run-a/output.nd2",
+            size_bytes=1024,
+            mtime=1_700_000_000.0,
         )
 
-        assert state_db.has_stat_match("other.nd2", 1024, 1_700_000_000.0) is False
+        assert state_db.has_stat_match("run-b/output.nd2", 1024, 1_700_000_000.0) is False
 
     def test_mtime_within_tolerance_matches(self, state_db: StateDB) -> None:
         state_db.record_upload(
-            "sample.nd2", "sha-a", "s3/sample.nd2", size_bytes=1024, mtime=1_700_000_000.0
+            "sample.nd2",
+            "sha-a",
+            "s3/sample.nd2",
+            relative_path="sample.nd2",
+            size_bytes=1024,
+            mtime=1_700_000_000.0,
         )
 
         assert state_db.has_stat_match("sample.nd2", 1024, 1_700_000_000.5) is True
 
     def test_mtime_outside_tolerance_misses(self, state_db: StateDB) -> None:
         state_db.record_upload(
-            "sample.nd2", "sha-a", "s3/sample.nd2", size_bytes=1024, mtime=1_700_000_000.0
+            "sample.nd2",
+            "sha-a",
+            "s3/sample.nd2",
+            relative_path="sample.nd2",
+            size_bytes=1024,
+            mtime=1_700_000_000.0,
         )
 
         assert state_db.has_stat_match("sample.nd2", 1024, 1_700_000_100.0) is False
@@ -90,7 +126,12 @@ class TestInitialScan:
         f.write_bytes(b"x" * 2048)
         st = f.stat()
         state_db.record_upload(
-            "seen.nd2", "sha-seen", "s3/seen.nd2", size_bytes=st.st_size, mtime=st.st_mtime
+            "seen.nd2",
+            "sha-seen",
+            "s3/seen.nd2",
+            relative_path="seen.nd2",
+            size_bytes=st.st_size,
+            mtime=st.st_mtime,
         )
 
         monitor = _make_monitor(watch_dir, state_db)
@@ -106,6 +147,7 @@ class TestInitialScan:
             "grew.nd2",
             "sha-old",
             "s3/grew.nd2",
+            relative_path="grew.nd2",
             size_bytes=st.st_size - 1,
             mtime=st.st_mtime,
         )
@@ -123,6 +165,7 @@ class TestInitialScan:
             "touched.nd2",
             "sha-old",
             "s3/touched.nd2",
+            relative_path="touched.nd2",
             size_bytes=st.st_size,
             mtime=st.st_mtime - 10.0,
         )
@@ -174,3 +217,36 @@ class TestInitialScan:
             os.chmod(f, original_mode)
 
         assert f in monitor._pending
+
+    def test_same_basename_in_different_subdirs_both_enqueued(
+        self, state_db: StateDB, watch_dir: Path
+    ) -> None:
+        """Regression guard for basename collisions in recursive watches.
+
+        Two runs both emit `output.nd2` with identical size and mtime (think
+        `cp -p` from one run folder into another). Run-a has been uploaded;
+        run-b must still be enqueued because its relative path differs.
+        """
+        (watch_dir / "run-a").mkdir()
+        (watch_dir / "run-b").mkdir()
+        a = watch_dir / "run-a" / "output.nd2"
+        b = watch_dir / "run-b" / "output.nd2"
+        a.write_bytes(b"x" * 2048)
+        b.write_bytes(b"x" * 2048)
+        os.utime(b, (a.stat().st_atime, a.stat().st_mtime))
+
+        st_a = a.stat()
+        state_db.record_upload(
+            "output.nd2",
+            "sha-a",
+            "s3/run-a/output.nd2",
+            relative_path="run-a/output.nd2",
+            size_bytes=st_a.st_size,
+            mtime=st_a.st_mtime,
+        )
+
+        monitor = _make_monitor(watch_dir, state_db, recursive=True)
+        monitor._initial_scan()
+
+        assert a not in monitor._pending
+        assert b in monitor._pending

--- a/watcher/tests/test_run_detector_hydration.py
+++ b/watcher/tests/test_run_detector_hydration.py
@@ -1,0 +1,202 @@
+"""Unit tests for `RunDetector.hydrate_from_state_db` and downstream PATCH behavior.
+
+These tests pin down the core guarantee of the "skip reported files"
+change: on watcher restart, a previously-reported run must be
+reconstructed in memory from the local state DB so that any
+subsequently-stabilised file for that run triggers a PATCH
+(`_update_run`) rather than a duplicate POST (`_report_new_run`).
+"""
+
+from __future__ import annotations
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from data_hub_watcher.run_detector import RunDetector
+from data_hub_watcher.state import StateDB
+
+
+@pytest.fixture()
+def state_db(tmp_path: Path) -> Generator[StateDB, None, None]:
+    db = StateDB(tmp_path / "state.db")
+    yield db
+    db.close()
+
+
+@pytest.fixture()
+def watch_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "watch"
+    d.mkdir()
+    return d
+
+
+def _make_detector(
+    watch_dir: Path,
+    state_db: StateDB,
+    *,
+    client: MagicMock | None = None,
+) -> RunDetector:
+    return RunDetector(
+        pattern=r"^([^/]+)/",
+        instrument_id="inst-1",
+        watcher_id="watcher-1",
+        client=client or MagicMock(),
+        state_db=state_db,
+        event_reporter=MagicMock(),
+        counters=MagicMock(runs_reported=0, errors=0),
+        watch_directory=watch_dir,
+    )
+
+
+class TestHydrateFromStateDb:
+    def test_populates_runs_with_reported_true(self, state_db: StateDB, watch_dir: Path) -> None:
+        state_db.record_detected_files(
+            "run-alpha",
+            [
+                ("run-alpha/a.nd2", "a.nd2", 1024, 1_700_000_000.0),
+                ("run-alpha/b.nd2", "b.nd2", 2048, 1_700_000_001.0),
+            ],
+        )
+
+        detector = _make_detector(watch_dir, state_db)
+        detector.hydrate_from_state_db()
+
+        assert "run-alpha" in detector._runs
+        run = detector._runs["run-alpha"]
+        assert run.reported is True
+        assert run.uploaded_file_count == 2
+        paths = [f.path for f in run.files]
+        assert paths == [
+            watch_dir / "run-alpha/a.nd2",
+            watch_dir / "run-alpha/b.nd2",
+        ]
+        assert run.files[0].size_bytes == 1024
+        assert run.files[0].mtime == pytest.approx(1_700_000_000.0)
+
+    def test_skips_runs_without_detected_files(self, state_db: StateDB, watch_dir: Path) -> None:
+        """Legacy runs (in `runs` but not `detected_files`) must not hydrate.
+
+        The upgrade path is: such runs fall through to the pre-hydration
+        code path exactly once, re-report, record their manifest, and
+        future restarts will skip them.
+        """
+        state_db.record_run_reported("run-legacy")
+
+        detector = _make_detector(watch_dir, state_db)
+        detector.hydrate_from_state_db()
+
+        assert detector._runs == {}
+
+    def test_hydration_is_idempotent(self, state_db: StateDB, watch_dir: Path) -> None:
+        state_db.record_detected_files("run-1", [("run-1/a.nd2", "a.nd2", 10, 1_700_000_000.0)])
+
+        detector = _make_detector(watch_dir, state_db)
+        detector.hydrate_from_state_db()
+        detector.hydrate_from_state_db()
+
+        assert list(detector._runs.keys()) == ["run-1"]
+        assert len(detector._runs["run-1"].files) == 1
+
+    def test_retry_unreported_runs_skips_hydrated_runs(
+        self, state_db: StateDB, watch_dir: Path
+    ) -> None:
+        state_db.record_detected_files("run-1", [("run-1/a.nd2", "a.nd2", 10, 1_700_000_000.0)])
+
+        client = MagicMock()
+        detector = _make_detector(watch_dir, state_db, client=client)
+        detector.hydrate_from_state_db()
+        detector.retry_unreported_runs()
+
+        client.report_run.assert_not_called()
+
+
+class TestNewFileAfterHydrationTriggersPatch:
+    def test_new_file_patches_instead_of_posting(self, state_db: StateDB, watch_dir: Path) -> None:
+        """Regression guard for the "re-POST on restart" bug.
+
+        Pre-fix, `_runs` was empty on restart so a newly-stabilised file
+        for an already-reported run triggered a POST. Post-fix, the
+        hydrated `RunState` routes it through `_update_run` (PATCH).
+        """
+        (watch_dir / "run-42").mkdir()
+        existing = watch_dir / "run-42" / "existing.nd2"
+        existing.write_bytes(b"x" * 1024)
+        st = existing.stat()
+        state_db.record_detected_files(
+            "run-42",
+            [("run-42/existing.nd2", "existing.nd2", st.st_size, st.st_mtime)],
+        )
+
+        client = MagicMock()
+        client.update_run.return_value = MagicMock(id="api-run-42")
+        detector = _make_detector(watch_dir, state_db, client=client)
+        detector.hydrate_from_state_db()
+
+        new_file = watch_dir / "run-42" / "new.nd2"
+        new_file.write_bytes(b"y" * 2048)
+        detector.on_stable_file(new_file)
+
+        client.report_run.assert_not_called()
+        client.update_run.assert_called_once()
+        args, _kwargs = client.update_run.call_args
+        assert args[0] == "inst-1"
+        assert args[1] == "run-42"
+        payload = args[2]
+        rel_paths = [f["relative_path"] for f in payload["detected_files"]]
+        assert "run-42/existing.nd2" in rel_paths
+        assert "run-42/new.nd2" in rel_paths
+
+    def test_update_run_persists_new_manifest(self, state_db: StateDB, watch_dir: Path) -> None:
+        """After a successful PATCH the new file is recorded in `detected_files`."""
+        (watch_dir / "run-7").mkdir()
+        existing = watch_dir / "run-7" / "a.nd2"
+        existing.write_bytes(b"x" * 1024)
+        st = existing.stat()
+        state_db.record_detected_files("run-7", [("run-7/a.nd2", "a.nd2", st.st_size, st.st_mtime)])
+
+        client = MagicMock()
+        detector = _make_detector(watch_dir, state_db, client=client)
+        detector.hydrate_from_state_db()
+
+        new_file = watch_dir / "run-7" / "b.nd2"
+        new_file.write_bytes(b"y" * 512)
+        detector.on_stable_file(new_file)
+
+        rel_paths = {r.relative_path for r in state_db.get_detected_files_for_run("run-7")}
+        assert rel_paths == {"run-7/a.nd2", "run-7/b.nd2"}
+
+
+class TestReportNewRunPersistsManifest:
+    def test_successful_post_records_detected_files(
+        self, state_db: StateDB, watch_dir: Path
+    ) -> None:
+        client = MagicMock()
+        client.report_run.return_value = MagicMock(id="api-run-id")
+        detector = _make_detector(watch_dir, state_db, client=client)
+
+        (watch_dir / "run-new").mkdir()
+        f = watch_dir / "run-new" / "first.nd2"
+        f.write_bytes(b"z" * 42)
+        detector.on_stable_file(f)
+
+        records = state_db.get_detected_files_for_run("run-new")
+        assert [r.relative_path for r in records] == ["run-new/first.nd2"]
+        assert records[0].filename == "first.nd2"
+        assert records[0].size_bytes == 42
+
+    def test_manifest_not_recorded_if_post_fails(self, state_db: StateDB, watch_dir: Path) -> None:
+        from data_hub_watcher.api_client import ApiError
+
+        client = MagicMock()
+        client.report_run.side_effect = ApiError("boom", 500)
+        detector = _make_detector(watch_dir, state_db, client=client)
+
+        (watch_dir / "run-fail").mkdir()
+        f = watch_dir / "run-fail" / "first.nd2"
+        f.write_bytes(b"z" * 42)
+        detector.on_stable_file(f)
+
+        assert state_db.get_detected_files_for_run("run-fail") == []
+        assert state_db.get_reported_run_ids_with_files() == []

--- a/watcher/tests/test_run_detector_hydration.py
+++ b/watcher/tests/test_run_detector_hydration.py
@@ -99,18 +99,6 @@ class TestHydrateFromStateDb:
         assert list(detector._runs.keys()) == ["run-1"]
         assert len(detector._runs["run-1"].files) == 1
 
-    def test_retry_unreported_runs_skips_hydrated_runs(
-        self, state_db: StateDB, watch_dir: Path
-    ) -> None:
-        state_db.record_detected_files("run-1", [("run-1/a.nd2", "a.nd2", 10, 1_700_000_000.0)])
-
-        client = MagicMock()
-        detector = _make_detector(watch_dir, state_db, client=client)
-        detector.hydrate_from_state_db()
-        detector.retry_unreported_runs()
-
-        client.report_run.assert_not_called()
-
 
 class TestNewFileAfterHydrationTriggersPatch:
     def test_new_file_patches_instead_of_posting(self, state_db: StateDB, watch_dir: Path) -> None:

--- a/watcher/tests/test_runtime.py
+++ b/watcher/tests/test_runtime.py
@@ -1,0 +1,201 @@
+"""Unit tests for `data_hub_watcher.runtime.build_runtime` wiring invariants.
+
+The CLI `watch` command and the Windows-service entrypoint both delegate
+to `build_runtime` to assemble the long-lived object graph. A silent
+regression previously broke manual-mode uploads because the service path
+forgot to wire `on_tick` on the `HeartbeatLoop`. These tests lock in the
+wiring contract per `upload_mode` so any future drift fails loudly:
+
+* auto mode    -> `detector._upload_cb` is `uploader.upload_files`
+                  and `heartbeat._on_tick` is `None`
+* manual mode  -> `detector._upload_cb` is `None`
+                  and `heartbeat._on_tick` polls `uploader.poll_upload_queue`
+"""
+
+from __future__ import annotations
+from pathlib import Path
+from typing import Literal
+from unittest.mock import MagicMock
+
+import pytest
+
+from data_hub_watcher.constants import HEARTBEAT_INTERVAL_SECONDS
+from data_hub_watcher.heartbeat import HeartbeatLoop, WatcherCounters
+from data_hub_watcher.models import InstrumentConfig, RunDetectionConfig, WatcherConfig
+from data_hub_watcher.monitor import FileMonitor
+from data_hub_watcher.run_detector import RunDetector
+from data_hub_watcher.runtime import build_runtime
+from data_hub_watcher.state import StateDB
+from data_hub_watcher.uploader import Uploader
+
+
+def _make_config(
+    tmp_path: Path,
+    *,
+    upload_mode: Literal["auto", "manual"],
+    watcher_id: str | None = "w-test",
+) -> WatcherConfig:
+    """Build a minimal valid `WatcherConfig` rooted in *tmp_path*."""
+    watch_dir = tmp_path / "data"
+    watch_dir.mkdir()
+    # Give the watch dir one matching file so `WatcherConfig` doesn't
+    # emit the "no files match" warning during validation.
+    (watch_dir / "RUN001_sample.csv").write_text("a,b\n1,2\n")
+    instrument = InstrumentConfig(
+        id="test-instrument",
+        watch_directory=watch_dir,
+        file_patterns=["*.csv"],
+        upload_mode=upload_mode,
+        run_detection=RunDetectionConfig(pattern=r"^([^_]+)", recursive=False),
+    )
+    return WatcherConfig(
+        version=1,
+        environment="staging",
+        watcher_id=watcher_id,
+        instrument=instrument,
+    )
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "state.sqlite"
+
+
+class TestBuildRuntimeAutoMode:
+    """Auto mode: detector drives uploads, heartbeat does not poll."""
+
+    def test_detector_upload_callback_is_uploader_upload_files(
+        self, tmp_path: Path, db_path: Path
+    ) -> None:
+        cfg = _make_config(tmp_path, upload_mode="auto")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+
+        try:
+            # The detector must call Uploader.upload_files (bound method)
+            # after reporting a run so auto-mode uploads actually fire.
+            # Bound-method identity (`is`) fails because Python synthesizes
+            # a fresh bound-method object on each attribute access, so
+            # compare the underlying function and bound instance instead.
+            cb = rt.detector._upload_cb
+            assert cb is not None
+            assert cb.__func__ is Uploader.upload_files  # type: ignore[union-attr]
+            assert cb.__self__ is rt.uploader  # type: ignore[union-attr]
+        finally:
+            rt.state_db.close()
+
+    def test_heartbeat_on_tick_is_none(self, tmp_path: Path, db_path: Path) -> None:
+        cfg = _make_config(tmp_path, upload_mode="auto")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+
+        try:
+            # Auto mode has no server-driven upload queue to poll, so the
+            # heartbeat tick must not invoke any extra callback.
+            assert rt.heartbeat._on_tick is None
+        finally:
+            rt.state_db.close()
+
+
+class TestBuildRuntimeManualMode:
+    """Manual mode: heartbeat polls the upload queue, detector does not upload."""
+
+    def test_detector_upload_callback_is_none(self, tmp_path: Path, db_path: Path) -> None:
+        cfg = _make_config(tmp_path, upload_mode="manual")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+
+        try:
+            # In manual mode the server decides what to upload, so the
+            # detector must not eagerly hand files to the uploader.
+            assert rt.detector._upload_cb is None
+        finally:
+            rt.state_db.close()
+
+    def test_heartbeat_on_tick_polls_upload_queue(self, tmp_path: Path, db_path: Path) -> None:
+        cfg = _make_config(tmp_path, upload_mode="manual")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+
+        try:
+            # The heartbeat must call `uploader.poll_upload_queue` on every
+            # tick — this is the bug the runtime extraction was fixing.
+            assert rt.heartbeat._on_tick is not None
+
+            rt.uploader.poll_upload_queue = MagicMock()  # type: ignore[method-assign]
+            rt.heartbeat._on_tick()
+            rt.uploader.poll_upload_queue.assert_called_once_with()
+        finally:
+            rt.state_db.close()
+
+    def test_on_tick_swallows_poll_exceptions(self, tmp_path: Path, db_path: Path) -> None:
+        """Polling errors must not propagate out of the heartbeat tick,
+        otherwise one transient server blip kills the heartbeat thread
+        and the watcher goes silent until restart."""
+        cfg = _make_config(tmp_path, upload_mode="manual")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+
+        try:
+            rt.uploader.poll_upload_queue = MagicMock(  # type: ignore[method-assign]
+                side_effect=RuntimeError("boom")
+            )
+            assert rt.heartbeat._on_tick is not None
+            rt.heartbeat._on_tick()
+            rt.uploader.poll_upload_queue.assert_called_once_with()
+        finally:
+            rt.state_db.close()
+
+
+class TestBuildRuntimeSharedDependencies:
+    """Cross-object wiring invariants that apply to both upload modes."""
+
+    @pytest.mark.parametrize("upload_mode", ["auto", "manual"])
+    def test_runtime_fields_have_expected_types(
+        self, tmp_path: Path, db_path: Path, upload_mode: Literal["auto", "manual"]
+    ) -> None:
+        cfg = _make_config(tmp_path, upload_mode=upload_mode)
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+
+        try:
+            assert isinstance(rt.state_db, StateDB)
+            assert isinstance(rt.counters, WatcherCounters)
+            assert isinstance(rt.uploader, Uploader)
+            assert isinstance(rt.detector, RunDetector)
+            assert isinstance(rt.monitor, FileMonitor)
+            assert isinstance(rt.heartbeat, HeartbeatLoop)
+        finally:
+            rt.state_db.close()
+
+    @pytest.mark.parametrize("upload_mode", ["auto", "manual"])
+    def test_counters_are_shared_across_components(
+        self, tmp_path: Path, db_path: Path, upload_mode: Literal["auto", "manual"]
+    ) -> None:
+        """Uploader, detector, and heartbeat must share a single
+        `WatcherCounters` so the heartbeat actually sees increments."""
+        cfg = _make_config(tmp_path, upload_mode=upload_mode)
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+
+        try:
+            assert rt.uploader._counters is rt.counters
+            assert rt.detector._counters is rt.counters
+            assert rt.heartbeat.counters is rt.counters
+        finally:
+            rt.state_db.close()
+
+    @pytest.mark.parametrize("upload_mode", ["auto", "manual"])
+    def test_heartbeat_reflects_upload_mode(
+        self, tmp_path: Path, db_path: Path, upload_mode: Literal["auto", "manual"]
+    ) -> None:
+        cfg = _make_config(tmp_path, upload_mode=upload_mode)
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+
+        try:
+            assert rt.heartbeat._upload_mode == upload_mode
+            assert rt.heartbeat._interval == HEARTBEAT_INTERVAL_SECONDS
+            assert rt.heartbeat._watcher_id == "w-test"
+            assert rt.heartbeat._instrument_id == cfg.instrument.id
+        finally:
+            rt.state_db.close()
+
+
+class TestBuildRuntimeErrors:
+    def test_missing_watcher_id_raises(self, tmp_path: Path, db_path: Path) -> None:
+        cfg = _make_config(tmp_path, upload_mode="auto", watcher_id=None)
+        with pytest.raises(ValueError, match="watcher_id"):
+            build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)

--- a/watcher/tests/test_uploader.py
+++ b/watcher/tests/test_uploader.py
@@ -53,6 +53,7 @@ class TestUploadSingle:
         uploader: Uploader,
         mock_client: MagicMock,
         tmp_file: Path,
+        state_db: StateDB,
     ) -> None:
         mock_client.request_upload_url.return_value = PresignedUploadResponse(
             upload_url="https://s3.example.com/presigned",
@@ -79,6 +80,11 @@ class TestUploadSingle:
             },
         )
         assert uploader._counters.files_uploaded == 1
+
+        # Stat columns must be populated so subsequent initial scans can
+        # skip this file without re-hashing its contents.
+        st = tmp_file.stat()
+        assert state_db.has_stat_match(tmp_file.name, st.st_size, st.st_mtime) is True
 
     def test_already_uploaded_skips(
         self,

--- a/watcher/tests/test_uploader.py
+++ b/watcher/tests/test_uploader.py
@@ -81,10 +81,12 @@ class TestUploadSingle:
         )
         assert uploader._counters.files_uploaded == 1
 
-        # Stat columns must be populated so subsequent initial scans can
-        # skip this file without re-hashing its contents.
+        # Stat columns must be populated (keyed on the watch-dir-relative
+        # path) so subsequent initial scans can skip this file without
+        # re-hashing its contents.
         st = tmp_file.stat()
-        assert state_db.has_stat_match(tmp_file.name, st.st_size, st.st_mtime) is True
+        rel_path = tmp_file.relative_to(uploader._watch_dir).as_posix()
+        assert state_db.has_stat_match(rel_path, st.st_size, st.st_mtime) is True
 
     def test_already_uploaded_skips(
         self,

--- a/web-app/app/instruments/[instrumentId]/page.tsx
+++ b/web-app/app/instruments/[instrumentId]/page.tsx
@@ -109,7 +109,7 @@ export default async function InstrumentDetailPage({
       ).length
     : 0;
 
-  // Build the "Ran by" dropdown options: the current user (labelled "You"),
+  // Build the "Ran By" dropdown options: the current user (labelled "You"),
   // pinned to the top if they've attributed anything here, followed by other
   // attributors by display name, then the "Unattributed" sentinel.
   const meOption = currentUserId

--- a/web-app/components/instruments/runs-table/default-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/default-runs-table.tsx
@@ -41,7 +41,7 @@ export function DefaultRunsTable({
           <TableHead className="text-right">Total Size</TableHead>
           <TableHead>
             <FilterableColumnHeader
-              label="Ran by"
+              label="Ran By"
               paramKey="ran_by"
               options={ranByOptions}
             />

--- a/web-app/components/instruments/runs-table/gel-doc-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/gel-doc-runs-table.tsx
@@ -92,7 +92,7 @@ export function GelDocRunsTable({
           </TableHead>
           <TableHead>
             <FilterableColumnHeader
-              label="Ran by"
+              label="Ran By"
               paramKey="ran_by"
               options={ranByOptions}
             />

--- a/web-app/components/instruments/runs-table/plate-reader-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/plate-reader-runs-table.tsx
@@ -76,7 +76,7 @@ export function PlateReaderRunsTable({
           </TableHead>
           <TableHead>
             <FilterableColumnHeader
-              label="Ran by"
+              label="Ran By"
               paramKey="ran_by"
               options={ranByOptions}
             />

--- a/web-app/components/instruments/runs-table/qpcr-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/qpcr-runs-table.tsx
@@ -57,7 +57,7 @@ export function QpcrRunsTable({
           </TableHead>
           <TableHead>
             <FilterableColumnHeader
-              label="Ran by"
+              label="Ran By"
               paramKey="ran_by"
               options={ranByOptions}
             />

--- a/web-app/lib/api/instrument-runs.ts
+++ b/web-app/lib/api/instrument-runs.ts
@@ -554,7 +554,7 @@ export async function getQpcrFilterOptions(
 
 // ---------------------------------------------------------------------------
 // Distinct users who have attributed any (non-deleted) run for this
-// instrument — used to populate the "Ran by" column filter dropdown.
+// instrument — used to populate the "Ran By" column filter dropdown.
 // ---------------------------------------------------------------------------
 
 export type RanByFilterOption = {


### PR DESCRIPTION
## Summary

Four watcher fixes that together make restarts fast, correct, and identical between the CLI (`data-hub-watcher watch`) and Windows service code paths:

- **Startup is O(stat) instead of O(bytes hashed).** The initial scan no longer SHA-256s every file in the watch directory — a multi-hour cost on instruments that hold hundreds of GB — and instead uses a cheap `(relative_path, size, mtime)` check. Content integrity is still verified: the uploader computes a real SHA-256 on its way out.
- **No duplicate runs on restart.** A new `detected_files` table persists the file manifest for every reported run. On startup the `RunDetector` hydrates its in-memory state from this table, so subsequently-stabilised files route through PATCH (`_update_run`) instead of POST (`_report_new_run`). Previously, every restart re-POSTed runs in auto mode and re-PATCHed the full manifest in manual mode.
- **Manual-mode uploads work under the Windows service.** The service path was silently missing `on_tick=uploader.poll_upload_queue` on `HeartbeatLoop`, so manual-mode watchers installed as a service never pulled their upload queue. The fix extracts the CLI and service wiring into a shared `data_hub_watcher.runtime` module so they can't drift again.
- **Recursive watches don't collide on basename.** The stat check keys on watch-dir-relative path rather than filename, so two runs that both emit `output.nd2` are disambiguated by subdirectory.

## Changes

Watcher:

- `watcher/src/data_hub_watcher/state.py`
  - New `detected_files` table + `DetectedFileRecord` dataclass.
  - Additive migration on `uploaded_files` adds nullable `relative_path`, `size_bytes`, `mtime` columns and an index on `(relative_path, size_bytes, mtime)`.
  - New helpers: `has_stat_match`, `has_detected_stat_match`, `record_detected_files`, `get_detected_files_for_run`, `get_reported_run_ids_with_files`.
  - `record_upload` now requires stat metadata so every upload contributes to the stat-match index.
  - Removed unused `has_any_upload`.
- `watcher/src/data_hub_watcher/monitor.py`
  - `_initial_scan` replaces the SHA-based check with a stat check against both `uploaded_files` and `detected_files`, and emits progress logs for large directories.
  - `_enqueue` accepts an optional pre-fetched `stat_result` to avoid a redundant syscall from the initial scan.
  - Moved `file_sha256` to a new `util.py` now that the monitor no longer hashes anything.
- `watcher/src/data_hub_watcher/run_detector.py`
  - `FileInfo` gains `mtime`.
  - `_persist_detected_files` records the manifest after every successful POST/PATCH.
  - New `hydrate_from_state_db()` rebuilds `_runs` on startup. Legacy runs without a recorded manifest fall through and re-report once, which self-heals on the next start.
  - Removed `retry_unreported_runs` — it was unreachable on a fresh process because nothing populates `_runs` before it runs.
- `watcher/src/data_hub_watcher/runtime.py` (new)
  - `WatcherRuntime` dataclass and `build_runtime` / `start_runtime` / `stop_runtime` helpers that the CLI and Windows service both delegate to.
- `watcher/src/data_hub_watcher/cli.py` + `watcher/src/data_hub_watcher/service.py`
  - Both entry points now assemble their object graph via `build_runtime` and start/stop via the shared helpers.
- `watcher/src/data_hub_watcher/uploader.py`
  - Captures `stat()` + relative path once per upload and passes them through to `StateDB.record_upload` so the stat index stays populated.

Docs:

- `docs/watcher.md` — new "Initial scan identity" section explaining the stat-based identity check, why it's safe for write-once instrument output, and the edge cases (mtime-touching sync tools, parent folder renames, upgrade path).

## Breaking changes

None. Schema migration is additive and self-healing:

- Legacy `uploaded_files` rows without stat columns miss the stat match and fall through to enqueue; uploader-side SHA dedup prevents re-upload to S3.
- Legacy `runs` rows without a `detected_files` manifest fall through to the pre-hydration path and re-report exactly once, after which their manifest is recorded and future restarts skip them. `report_run` is idempotent server-side.

## Driveby changes

- `0b712bd` — title-case the "Ran By" column label across the instrument run tables in `web-app`. Not related to the watcher work, picked up from the same branch.

## Testing

- [x] `test_monitor_initial_scan.py` — unit tests for `StateDB.has_stat_match` / `has_detected_stat_match` and `FileMonitor._initial_scan` (matching stat, size/mtime deltas, legacy rows, unreadable file via chmod 000 proving the scan is stat-only, union of `uploaded_files` and `detected_files`, same-basename-in-different-subdirs regression guard, and `record_detected_files` / `get_detected_files_for_run` / `get_reported_run_ids_with_files` round-trips).
- [x] `test_run_detector_hydration.py` — hydration populates `_runs` with `reported=True`, is idempotent, skips legacy runs without a manifest; post-hydration new files PATCH instead of POST; manifest is not recorded when POST fails.
- [x] `test_runtime.py` — locks in the CLI/service wiring contract per `upload_mode`:
  - auto: `detector._upload_cb is uploader.upload_files`, `heartbeat._on_tick is None`
  - manual: `detector._upload_cb is None`, `heartbeat._on_tick` invokes `uploader.poll_upload_queue` and swallows exceptions
  - shared: `WatcherCounters` is the same instance across uploader/detector/heartbeat; missing `watcher_id` raises.
- [x] Existing `test_uploader.py` updated for the new `record_upload` signature.
- [ ] Manual smoke: restart watcher against a large (>100 GB) instrument directory on macOS — verify the initial scan completes in seconds and queues no already-uploaded files.
- [ ] Manual smoke: restart watcher on Windows installed as a service in manual mode — verify the upload queue is drained on heartbeat ticks.
- [ ] Manual smoke: upgrade a pre-migration `watcher.db` — first run re-reports legacy runs once (no duplicates after), subsequent restart re-reports nothing.