### PR TITLE
SpectraMax: Parse wavelengths as an array; truncate wavelength badges with hover tooltip

### DIFF
--- a/lambda/src/data_hub_lambda/spectramax_plate_reader/utils.py
+++ b/lambda/src/data_hub_lambda/spectramax_plate_reader/utils.py
@@ -183,17 +183,20 @@ def _parse_column_layout(col_header_line: str) -> _ColumnLayout:
     raise ValueError("Could not determine column layout from header row")
 
 
-def parse_metadata(file_path: Path) -> dict[str, str]:
+def parse_metadata(file_path: Path) -> dict[str, object]:
     """Extract measurement metadata from a SpectraMax `.xls` file.
 
     Returns:
         A dict with keys `measurement_mode`, `measurement_type`, and
-        `wavelength`.  Example::
+        `wavelengths`.  Wavelengths are returned as a list of numeric
+        strings (without the ``nm`` suffix) to mirror the shape used by
+        other multi-wavelength instruments (e.g. Azure 600 Gel Doc) and
+        let the UI layer own display formatting.  Example::
 
             {
                 "measurement_mode": "Absorbance",
                 "measurement_type": "Endpoint",
-                "wavelength": "750 nm",
+                "wavelengths": ["750", "700", "650", "600"],
             }
 
     Raises:
@@ -223,7 +226,7 @@ def parse_metadata(file_path: Path) -> dict[str, str]:
         return {
             "measurement_mode": header.measurement_mode,
             "measurement_type": header.measurement_type,
-            "wavelength": ", ".join(f"{w} nm" for w in wavelengths),
+            "wavelengths": [str(w) for w in wavelengths],
         }
 
     raise ValueError(f"No 'Plate:' header line found in {file_path}")

--- a/lambda/tests/integration/test_lambda_api.py
+++ b/lambda/tests/integration/test_lambda_api.py
@@ -111,7 +111,7 @@ class TestSpectraMaxHappyPath:
                 {
                     "measurement_mode": "Absorbance",
                     "measurement_type": "Endpoint",
-                    "wavelength": "750 nm",
+                    "wavelengths": ["750"],
                 },
                 id="endpoint",
             ),
@@ -121,7 +121,7 @@ class TestSpectraMaxHappyPath:
                 {
                     "measurement_mode": "Absorbance",
                     "measurement_type": "Well Scan",
-                    "wavelength": "595 nm",
+                    "wavelengths": ["595"],
                 },
                 id="well-scan",
             ),
@@ -131,7 +131,7 @@ class TestSpectraMaxHappyPath:
                 {
                     "measurement_mode": "Absorbance",
                     "measurement_type": "Kinetic",
-                    "wavelength": "595 nm",
+                    "wavelengths": ["595"],
                 },
                 id="kinetic",
             ),
@@ -147,7 +147,7 @@ class TestSpectraMaxHappyPath:
         mock_s3_upload: MagicMock,
         fixture_file: str,
         run_id: str,
-        expected_metadata: dict[str, str],
+        expected_metadata: dict[str, object],
     ) -> None:
         filename = f"{run_id}.xls"
         s3_key = f"spectramax-id3-plate-reader/{run_id}/{filename}"

--- a/lambda/tests/spectramax_plate_reader/test_parse_metadata.py
+++ b/lambda/tests/spectramax_plate_reader/test_parse_metadata.py
@@ -77,7 +77,7 @@ class TestRealFixtures:
         assert result == {
             "measurement_mode": "Absorbance",
             "measurement_type": "Endpoint",
-            "wavelength": "750 nm",
+            "wavelengths": ["750"],
         }
 
     def test_well_scan_absorbance(self) -> None:
@@ -85,7 +85,7 @@ class TestRealFixtures:
         assert result == {
             "measurement_mode": "Absorbance",
             "measurement_type": "Well Scan",
-            "wavelength": "595 nm",
+            "wavelengths": ["595"],
         }
 
     def test_endpoint_fluorescence(self) -> None:
@@ -93,7 +93,7 @@ class TestRealFixtures:
         assert result == {
             "measurement_mode": "Fluorescence",
             "measurement_type": "Endpoint",
-            "wavelength": "512 nm",
+            "wavelengths": ["512"],
         }
 
     def test_endpoint_sparse_absorbance(self) -> None:
@@ -101,7 +101,7 @@ class TestRealFixtures:
         assert result == {
             "measurement_mode": "Absorbance",
             "measurement_type": "Endpoint",
-            "wavelength": "600 nm",
+            "wavelengths": ["600"],
         }
 
     def test_kinetic_absorbance(self) -> None:
@@ -109,7 +109,7 @@ class TestRealFixtures:
         assert result == {
             "measurement_mode": "Absorbance",
             "measurement_type": "Kinetic",
-            "wavelength": "595 nm",
+            "wavelengths": ["595"],
         }
 
     def test_endpoint_flat(self) -> None:
@@ -117,7 +117,7 @@ class TestRealFixtures:
         assert result == {
             "measurement_mode": "Absorbance",
             "measurement_type": "Endpoint",
-            "wavelength": "595 nm",
+            "wavelengths": ["595"],
         }
 
 
@@ -138,7 +138,7 @@ class TestParseMetadataHappyPath:
         assert result == {
             "measurement_mode": "Absorbance",
             "measurement_type": "Endpoint",
-            "wavelength": "750 nm",
+            "wavelengths": ["750"],
         }
 
     def test_fluorescence_kinetic(self, tmp_path: Path) -> None:
@@ -152,7 +152,7 @@ class TestParseMetadataHappyPath:
         assert result == {
             "measurement_mode": "Fluorescence",
             "measurement_type": "Kinetic",
-            "wavelength": "488 nm",
+            "wavelengths": ["488"],
         }
 
     def test_reduced_anchor(self, tmp_path: Path) -> None:
@@ -167,7 +167,7 @@ class TestParseMetadataHappyPath:
         assert result == {
             "measurement_mode": "Absorbance",
             "measurement_type": "Endpoint",
-            "wavelength": "600 nm",
+            "wavelengths": ["600"],
         }
 
 
@@ -198,7 +198,16 @@ class TestParseMetadataValidation:
         assert result == {
             "measurement_mode": "Absorbance",
             "measurement_type": "Endpoint",
-            "wavelength": "750 nm, 600 nm",
+            "wavelengths": ["750", "600"],
+        }
+
+    def test_four_wavelengths(self, tmp_path: Path) -> None:
+        path = _build_xls(tmp_path, wavelength="750 700 650 600")
+        result = parse_metadata(path)
+        assert result == {
+            "measurement_mode": "Absorbance",
+            "measurement_type": "Endpoint",
+            "wavelengths": ["750", "700", "650", "600"],
         }
 
     def test_missing_plate_header(self, tmp_path: Path) -> None:

--- a/web-app/components/instruments/runs-table/gel-doc-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/gel-doc-runs-table.tsx
@@ -21,7 +21,6 @@ import type { RunRow } from ".";
 import { ClickableRow } from "./clickable-row";
 import { FilterableColumnHeader } from "./filterable-column-header";
 import {
-  MetadataArrayBadges,
   MetadataFieldBadge,
   TruncatedBadges,
   getMetadataArray,
@@ -178,9 +177,10 @@ export function GelDocRunsTable({
                 />
               </TableCell>
               <TableCell>
-                <MetadataArrayBadges
+                <TruncatedBadges
                   values={wavelengthColorLabels}
                   colorMap={CHANNEL_COLOR_STYLES}
+                  maxVisible={2}
                 />
               </TableCell>
               <TableCell>

--- a/web-app/components/instruments/runs-table/gel-doc-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/gel-doc-runs-table.tsx
@@ -23,8 +23,10 @@ import { FilterableColumnHeader } from "./filterable-column-header";
 import {
   MetadataArrayBadges,
   MetadataFieldBadge,
+  TruncatedBadges,
   getMetadataArray,
   getMetadataField,
+  sortWavelengths,
 } from "./metadata-utils";
 import { RanByCell } from "./ran-by-cell";
 import { RunSelectAllCheckbox, RunSelectCheckbox } from "./run-select-checkbox";
@@ -46,6 +48,7 @@ export function GelDocRunsTable({
     getMetadataArray(row.metadata, "wavelengths")
   );
   const wavelengthColors = buildWavelengthColorMap(allWavelengths);
+  const sortedWavelengthOptions = sortWavelengths(filterOptions.wavelengths);
   const runRefs: RunRef[] = data.map((row) => ({
     id: row.id,
     instrumentId: row.instrument_id,
@@ -80,7 +83,7 @@ export function GelDocRunsTable({
             <FilterableColumnHeader
               label="Wavelengths"
               paramKey="gel_wavelength"
-              options={filterOptions.wavelengths}
+              options={sortedWavelengthOptions}
             />
           </TableHead>
           <TableHead>
@@ -105,7 +108,9 @@ export function GelDocRunsTable({
           const isDeleted = row.deleted_at !== null;
           const captureType = getMetadataField(row.metadata, "capture_type");
           const imagingMode = getMetadataField(row.metadata, "imaging_mode");
-          const wavelengths = getMetadataArray(row.metadata, "wavelengths");
+          const wavelengths = sortWavelengths(
+            getMetadataArray(row.metadata, "wavelengths")
+          );
           const wavelengthColorLabels = getMetadataArray(
             row.metadata,
             "colors"
@@ -166,9 +171,10 @@ export function GelDocRunsTable({
                 />
               </TableCell>
               <TableCell>
-                <MetadataArrayBadges
+                <TruncatedBadges
                   values={wavelengths}
                   colorMap={wavelengthColors}
+                  maxVisible={1}
                 />
               </TableCell>
               <TableCell>

--- a/web-app/components/instruments/runs-table/metadata-utils.tsx
+++ b/web-app/components/instruments/runs-table/metadata-utils.tsx
@@ -1,6 +1,8 @@
 export {
   MetadataArrayBadges,
   MetadataFieldBadge,
+  TruncatedBadges,
   getMetadataArray,
   getMetadataField,
+  sortWavelengths,
 } from "@/components/runs/metadata-badges";

--- a/web-app/components/instruments/runs-table/plate-reader-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/plate-reader-runs-table.tsx
@@ -20,10 +20,11 @@ import type { RunRow } from ".";
 import { ClickableRow } from "./clickable-row";
 import { FilterableColumnHeader } from "./filterable-column-header";
 import {
-  MetadataArrayBadges,
   MetadataFieldBadge,
+  TruncatedBadges,
   getMetadataArray,
   getMetadataField,
+  sortWavelengths,
 } from "./metadata-utils";
 import { RanByCell } from "./ran-by-cell";
 import { RunSelectAllCheckbox, RunSelectCheckbox } from "./run-select-checkbox";
@@ -41,13 +42,8 @@ export function PlateReaderRunsTable({
   filterOptions: PlateReaderFilterOptions;
   ranByOptions: { value: string; label: string }[];
 }) {
-  const allWavelengths = data.flatMap((row) =>
-    getMetadataArray(row.metadata, "wavelengths")
-  );
-  const wavelengthColors = buildWavelengthColorMap([
-    ...filterOptions.wavelengths,
-    ...allWavelengths,
-  ]);
+  const wavelengthColors = buildWavelengthColorMap(filterOptions.wavelengths);
+  const sortedWavelengthOptions = sortWavelengths(filterOptions.wavelengths);
   const runRefs: RunRef[] = data.map((row) => ({
     id: row.id,
     instrumentId: row.instrument_id,
@@ -68,7 +64,7 @@ export function PlateReaderRunsTable({
             <FilterableColumnHeader
               label="Wavelengths"
               paramKey="wavelength"
-              options={filterOptions.wavelengths}
+              options={sortedWavelengthOptions}
             />
           </TableHead>
           <TableHead>
@@ -98,7 +94,9 @@ export function PlateReaderRunsTable({
       <TableBody>
         {data.map((row) => {
           const isDeleted = row.deleted_at !== null;
-          const wavelengths = getMetadataArray(row.metadata, "wavelengths");
+          const wavelengths = sortWavelengths(
+            getMetadataArray(row.metadata, "wavelengths")
+          );
           const mode = getMetadataField(row.metadata, "measurement_mode");
           const type = getMetadataField(row.metadata, "measurement_type");
           return (
@@ -141,9 +139,10 @@ export function PlateReaderRunsTable({
                 {formatBytes(row.total_size_bytes)}
               </TableCell>
               <TableCell>
-                <MetadataArrayBadges
+                <TruncatedBadges
                   values={wavelengths}
                   colorMap={wavelengthColors}
+                  maxVisible={1}
                 />
               </TableCell>
               <TableCell>

--- a/web-app/components/instruments/runs-table/plate-reader-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/plate-reader-runs-table.tsx
@@ -19,7 +19,12 @@ import { cn, formatBytes } from "@/lib/utils";
 import type { RunRow } from ".";
 import { ClickableRow } from "./clickable-row";
 import { FilterableColumnHeader } from "./filterable-column-header";
-import { MetadataFieldBadge, getMetadataField } from "./metadata-utils";
+import {
+  MetadataArrayBadges,
+  MetadataFieldBadge,
+  getMetadataArray,
+  getMetadataField,
+} from "./metadata-utils";
 import { RanByCell } from "./ran-by-cell";
 import { RunSelectAllCheckbox, RunSelectCheckbox } from "./run-select-checkbox";
 import type { RunRef } from "./run-selection-provider";
@@ -36,7 +41,13 @@ export function PlateReaderRunsTable({
   filterOptions: PlateReaderFilterOptions;
   ranByOptions: { value: string; label: string }[];
 }) {
-  const wavelengthColors = buildWavelengthColorMap(filterOptions.wavelengths);
+  const allWavelengths = data.flatMap((row) =>
+    getMetadataArray(row.metadata, "wavelengths")
+  );
+  const wavelengthColors = buildWavelengthColorMap([
+    ...filterOptions.wavelengths,
+    ...allWavelengths,
+  ]);
   const runRefs: RunRef[] = data.map((row) => ({
     id: row.id,
     instrumentId: row.instrument_id,
@@ -55,7 +66,7 @@ export function PlateReaderRunsTable({
           <TableHead className="text-right">Total Size</TableHead>
           <TableHead>
             <FilterableColumnHeader
-              label="Wavelength"
+              label="Wavelengths"
               paramKey="wavelength"
               options={filterOptions.wavelengths}
             />
@@ -87,7 +98,7 @@ export function PlateReaderRunsTable({
       <TableBody>
         {data.map((row) => {
           const isDeleted = row.deleted_at !== null;
-          const wavelength = getMetadataField(row.metadata, "wavelength");
+          const wavelengths = getMetadataArray(row.metadata, "wavelengths");
           const mode = getMetadataField(row.metadata, "measurement_mode");
           const type = getMetadataField(row.metadata, "measurement_type");
           return (
@@ -130,11 +141,9 @@ export function PlateReaderRunsTable({
                 {formatBytes(row.total_size_bytes)}
               </TableCell>
               <TableCell>
-                <MetadataFieldBadge
-                  value={wavelength}
-                  colorClass={
-                    wavelength ? wavelengthColors[wavelength] : undefined
-                  }
+                <MetadataArrayBadges
+                  values={wavelengths}
+                  colorMap={wavelengthColors}
                 />
               </TableCell>
               <TableCell>

--- a/web-app/components/runs/metadata-badges.tsx
+++ b/web-app/components/runs/metadata-badges.tsx
@@ -1,4 +1,9 @@
 import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 export function getMetadataField(
@@ -18,6 +23,24 @@ export function getMetadataArray(metadata: unknown, key: string): string[] {
   return [];
 }
 
+/**
+ * Sort a list of wavelength strings (e.g. `"750"`) in ascending numerical
+ * order. Non-numeric entries are pushed to the end, preserving their
+ * relative order, so mixed inputs still render predictably.
+ */
+export function sortWavelengths(wavelengths: string[]): string[] {
+  return [...wavelengths].sort((a, b) => {
+    const na = Number(a);
+    const nb = Number(b);
+    const aNum = Number.isFinite(na);
+    const bNum = Number.isFinite(nb);
+    if (aNum && bNum) return na - nb;
+    if (aNum) return -1;
+    if (bNum) return 1;
+    return a.localeCompare(b);
+  });
+}
+
 export function MetadataFieldBadge({
   value,
   colorClass,
@@ -33,17 +56,17 @@ export function MetadataFieldBadge({
   );
 }
 
-export function MetadataArrayBadges({
+function BadgeRow({
   values,
   colorMap,
+  className,
 }: {
   values: string[];
   colorMap?: Record<string, string>;
+  className?: string;
 }) {
-  if (values.length === 0)
-    return <span className="text-muted-foreground">&mdash;</span>;
   return (
-    <div className="flex flex-wrap gap-1">
+    <div className={cn("flex flex-wrap gap-1", className)}>
       {values.map((v) => (
         <Badge
           key={v}
@@ -54,5 +77,71 @@ export function MetadataArrayBadges({
         </Badge>
       ))}
     </div>
+  );
+}
+
+export function MetadataArrayBadges({
+  values,
+  colorMap,
+}: {
+  values: string[];
+  colorMap?: Record<string, string>;
+}) {
+  if (values.length === 0)
+    return <span className="text-muted-foreground">&mdash;</span>;
+  return <BadgeRow values={values} colorMap={colorMap} />;
+}
+
+/**
+ * Renders up to `maxVisible` badges followed by a `+N` overflow badge when
+ * the array exceeds the limit. Hovering the cell surfaces a tooltip listing
+ * every badge on a single row (no wrapping) so the collapsed values remain
+ * discoverable. When the array fits within `maxVisible` no tooltip is shown.
+ */
+export function TruncatedBadges({
+  values,
+  colorMap,
+  maxVisible = 2,
+}: {
+  values: string[];
+  colorMap?: Record<string, string>;
+  maxVisible?: number;
+}) {
+  if (values.length === 0)
+    return <span className="text-muted-foreground">&mdash;</span>;
+
+  if (values.length <= maxVisible) {
+    return <BadgeRow values={values} colorMap={colorMap} />;
+  }
+
+  const visible = values.slice(0, maxVisible);
+  const hiddenCount = values.length - maxVisible;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="flex flex-wrap gap-1">
+          {visible.map((v) => (
+            <Badge
+              key={v}
+              variant="outline"
+              className={cn("font-mono", colorMap?.[v])}
+            >
+              {v}
+            </Badge>
+          ))}
+          <Badge
+            variant="outline"
+            className="font-mono text-muted-foreground"
+            aria-label={`${hiddenCount} more`}
+          >
+            +{hiddenCount}
+          </Badge>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-none">
+        <BadgeRow values={values} colorMap={colorMap} className="flex-nowrap" />
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/web-app/components/runs/run-metadata-badges.tsx
+++ b/web-app/components/runs/run-metadata-badges.tsx
@@ -54,7 +54,7 @@ function ColorBadge({
 
 export function hasPlateReaderMetadata(metadata: Record<string, unknown>) {
   return Boolean(
-    getMetadataField(metadata, "wavelength") ||
+    getMetadataArray(metadata, "wavelengths").length ||
     getMetadataField(metadata, "measurement_mode") ||
     getMetadataField(metadata, "measurement_type")
   );
@@ -65,11 +65,13 @@ export function PlateReaderRunBadges({
 }: {
   metadata: Record<string, unknown>;
 }) {
-  const wavelength = getMetadataField(metadata, "wavelength");
+  const wavelengths = getMetadataArray(metadata, "wavelengths");
   const mode = getMetadataField(metadata, "measurement_mode");
   const type = getMetadataField(metadata, "measurement_type");
 
-  if (!wavelength && !mode && !type) return null;
+  if (!wavelengths.length && !mode && !type) return null;
+
+  const wavelengthColors = buildWavelengthColorMap(wavelengths);
 
   return (
     <>
@@ -83,9 +85,13 @@ export function PlateReaderRunBadges({
           <ColorBadge value={mode} colorClass={MEASUREMENT_MODE_COLORS[mode]} />
         </MetadataRow>
       )}
-      {wavelength && (
-        <MetadataRow label="Wavelength">
-          <ColorBadge value={wavelength} />
+      {wavelengths.length > 0 && (
+        <MetadataRow
+          label={wavelengths.length === 1 ? "Wavelength" : "Wavelengths"}
+        >
+          {wavelengths.map((w) => (
+            <ColorBadge key={w} value={w} colorClass={wavelengthColors[w]} />
+          ))}
         </MetadataRow>
       )}
     </>

--- a/web-app/components/runs/run-metadata-badges.tsx
+++ b/web-app/components/runs/run-metadata-badges.tsx
@@ -13,6 +13,7 @@ import { cn } from "@/lib/utils";
 import {
   getMetadataArray,
   getMetadataField,
+  sortWavelengths,
 } from "@/components/runs/metadata-badges";
 
 // ---------------------------------------------------------------------------
@@ -65,7 +66,9 @@ export function PlateReaderRunBadges({
 }: {
   metadata: Record<string, unknown>;
 }) {
-  const wavelengths = getMetadataArray(metadata, "wavelengths");
+  const wavelengths = sortWavelengths(
+    getMetadataArray(metadata, "wavelengths")
+  );
   const mode = getMetadataField(metadata, "measurement_mode");
   const type = getMetadataField(metadata, "measurement_type");
 
@@ -118,7 +121,9 @@ export function GelDocRunBadges({
 }) {
   const captureType = getMetadataField(metadata, "capture_type");
   const imagingMode = getMetadataField(metadata, "imaging_mode");
-  const wavelengths = getMetadataArray(metadata, "wavelengths");
+  const wavelengths = sortWavelengths(
+    getMetadataArray(metadata, "wavelengths")
+  );
   const colors = getMetadataArray(metadata, "colors");
 
   if (!captureType && !imagingMode && !wavelengths.length && !colors.length)

--- a/web-app/lib/api/instrument-runs.ts
+++ b/web-app/lib/api/instrument-runs.ts
@@ -208,7 +208,7 @@ export async function buildRunListQuery(filters: RunListFilters) {
   // Plate-reader metadata column filters (leverages the GIN index).
   if (filters.wavelength) {
     conditions.push(
-      sql`${instrumentRuns.metadata}->>'wavelength' = ${filters.wavelength}`
+      sql`${instrumentRuns.metadata}->'wavelengths' @> ${JSON.stringify([filters.wavelength])}::jsonb`
     );
   }
   if (filters.measurementMode) {
@@ -441,7 +441,6 @@ export type PlateReaderFilterOptions = {
 };
 
 const ALLOWED_METADATA_KEYS = new Set([
-  "wavelength",
   "measurement_mode",
   "measurement_type",
   "capture_type",
@@ -478,7 +477,7 @@ export async function getPlateReaderFilterOptions(
   instrumentId: string
 ): Promise<PlateReaderFilterOptions> {
   const [wavelengths, measurementModes, measurementTypes] = await Promise.all([
-    distinctMetadataValues(instrumentId, "wavelength"),
+    distinctMetadataArrayValues(instrumentId, "wavelengths"),
     distinctMetadataValues(instrumentId, "measurement_mode"),
     distinctMetadataValues(instrumentId, "measurement_type"),
   ]);


### PR DESCRIPTION
## Summary

Two related improvements to multi-wavelength run metadata:

1. **Standardize SpectraMax `wavelength` metadata into a `wavelengths` array**, mirroring the Azure 600 Gel Doc shape. SpectraMax `.xls` files can declare multiple wavelengths (e.g. `750 / 700 / 650 / 600`), but we were collapsing them into a single `"750 nm, 700 nm, ..."` string that couldn't be filtered or color-coded per-wavelength. Metadata now stores numeric strings (`["750", "700", "650", "600"]`) and the UI owns display formatting.
2. **Collapse the wavelength column in runs tables** so rows stay compact when runs have many wavelengths / wavelength colors. Up to `maxVisible` badges render inline, followed by a `+N` overflow badge; hovering the cell reveals every badge on a single row in a tooltip.

## Changes

**Lambda / parser**

- `lambda/src/data_hub_lambda/spectramax_plate_reader/utils.py`: `parse_metadata` now returns `"wavelengths": list[str]` (numeric strings, no `nm` suffix) instead of `"wavelength": str`. Return type widened to `dict[str, object]`.
- Updated unit tests (`lambda/tests/spectramax_plate_reader/test_parse_metadata.py`) and integration tests (`lambda/tests/integration/test_lambda_api.py`) to assert the new shape. Added `test_four_wavelengths` to cover multi-wavelength parsing.

**Web app — API**

- `web-app/lib/api/instrument-runs.ts`: wavelength filter switched from `->>'wavelength' = $value` to a JSONB containment check (`->'wavelengths' @> '[$value]'::jsonb`). `getPlateReaderFilterOptions` now pulls distinct values from the array via `distinctMetadataArrayValues("wavelengths")`. Removed `"wavelength"` from `ALLOWED_METADATA_KEYS`; `"wavelengths"` was already allow-listed for the gel doc.

**Web app — UI**

- New `TruncatedBadges` component + `sortWavelengths` helper in `web-app/components/runs/metadata-badges.tsx` (re-exported from `runs-table/metadata-utils.tsx`). Extracted a `BadgeRow` helper shared with `MetadataArrayBadges`.
- `plate-reader-runs-table.tsx`: column renamed "Wavelength" → "Wavelengths", now renders `TruncatedBadges` (`maxVisible={1}`) with per-wavelength colors, and sorts wavelengths numerically (cells + filter dropdown).
- `gel-doc-runs-table.tsx`: wavelengths column uses `TruncatedBadges` (`maxVisible={1}`, numeric sort); wavelength-colors column uses `TruncatedBadges` (`maxVisible={2}`, no sort).
- `run-metadata-badges.tsx`: plate reader + gel doc run-detail sections read `wavelengths` as an array (row label flips between "Wavelength" / "Wavelengths"), applies `buildWavelengthColorMap` for consistent per-wavelength colors, and sorts numerically.

## Breaking changes

- **Metadata schema:** SpectraMax runs now write `wavelengths: string[]` instead of `wavelength: string`. Existing rows in `instrument_runs.metadata` still carry the old `"wavelength"` key and will render as `—` in the wavelengths column until they're reprocessed. No DB migration required (metadata is JSONB), but consumers reading `metadata.wavelength` for SpectraMax need to switch to `metadata.wavelengths`.
- The `wavelength` filter query param is unchanged externally but now maps to an array containment query server-side — no action needed for clients.

## Driveby changes

- Renamed the plate reader column header "Wavelength" → "Wavelengths" to match the gel doc and the new array shape.
- Added a reusable `sortWavelengths` helper (ascending numeric, non-numeric values pushed to end) so the runs table, filter dropdown, and run-detail sections stay consistent.
- Factored `BadgeRow` out of `MetadataArrayBadges` so the tooltip and inline renderers share layout code.

## Testing

- [x] `make check-all` (ruff, pyright, prettier, eslint, tsc) passes
- [x] `uv run pytest lambda/tests/spectramax_plate_reader/ lambda/tests/integration/ -v` passes, including new `test_four_wavelengths`
- [x] `uv run data-hub-process spectramax <sample.xls>` emits `"wavelengths": [...]` JSON
- [x] Plate reader runs table: run with 1 wavelength renders as a single badge (no tooltip); run with ≥2 wavelengths renders `<first> +N` with a hover tooltip showing all wavelengths in ascending numeric order
- [x] Plate reader wavelength column filter dropdown lists wavelengths in ascending numeric order and filters correctly against the `wavelengths` array
- [x] Gel doc runs table: wavelengths column truncates at 1, wavelength-colors column truncates at 2, both surface full lists in the hover tooltip
- [x] Run detail page (plate reader + gel doc): wavelengths render as individual color-coded badges in ascending numeric order; label reads "Wavelength" for a single value and "Wavelengths" for multiple
- [x] Reprocess an existing SpectraMax run and verify the runs list, run detail, and filter all pick up the new `wavelengths` array