### PR TITLE
Watchers: Enforce one active watcher per instrument

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -49,8 +49,9 @@ Tokens are hashed with SHA-256 before storage. The plaintext token is shown once
 | Method | Path | Description |
 | --- | --- | --- |
 | `GET` | `/api/v1/watchers` | List all watchers |
-| `POST` | `/api/v1/watchers/register` | Register a new watcher |
+| `POST` | `/api/v1/watchers/register` | Register a new watcher (returns `409 CONFLICT` if the instrument already has an active watcher; the existing watcher's id is included in `error.details.existing_watcher_id`) |
 | `GET` | `/api/v1/watchers/:watcherId` | Get watcher details |
+| `DELETE` | `/api/v1/watchers/:watcherId` | Deregister (soft-delete) a watcher |
 | `POST` | `/api/v1/watchers/:watcherId/heartbeat` | Send a heartbeat |
 | `GET` | `/api/v1/watchers/:watcherId/heartbeats` | Get heartbeat history |
 | `POST` | `/api/v1/watchers/:watcherId/events` | Submit watcher events |

--- a/docs/guides/installing-a-watcher.md
+++ b/docs/guides/installing-a-watcher.md
@@ -148,6 +148,15 @@ Add `--dry-run` to preview without uploading.
 
 The instrument was registered but hasn't been confirmed by an admin yet. Ask your admin to click "Confirm" on the instrument in the web app's Instruments page.
 
+### "Instrument already has an active watcher"
+
+Each instrument can have at most one active watcher at a time. If `init` fails with this error, an earlier install (often on a different PC, or before a reimage) is still registered against the instrument. The CLI prints the existing watcher's id; deregister it before re-running `init`:
+
+- **Web UI** — go to **Watchers**, open the existing watcher, and click **Deregister**.
+- **API** — `curl -X DELETE -H "Authorization: Bearer $DATA_HUB_API_KEY" https://<host>/api/v1/watchers/<existing_watcher_id>`
+
+Deregistration is a soft-delete: heartbeats, events, and runs reported by the old watcher remain visible in the **Deregistered** tab for auditing.
+
 ### "Connection error" or "Request timed out"
 
 The watcher can't reach the Data Hub API. Check:

--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -40,7 +40,7 @@ Interactive setup wizard that:
 2. Prompts for an API key (or reads `DATA_HUB_API_KEY` from the environment). The key is saved to a per-environment file at `~/.data-hub/.env.<environment>` (e.g. `.env.staging`), so switching between environments later doesn't require re-entering it.
 3. Fetches existing instruments from the API or registers a new one.
 4. Prompts for the watch directory, file patterns, run detection pattern, stability period, and upload mode.
-5. Registers the watcher with the API.
+5. Registers the watcher with the API. An instrument can have at most one active (non-deregistered) watcher at a time — registration fails if one already exists, and the CLI prints the existing watcher's id along with the deregister command needed to free it up.
 6. Saves the config to `~/.data-hub/config.yaml`, the API key to `~/.data-hub/.env.<environment>`, and syncs the config to the API.
 
 ### `watch`

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -288,6 +288,21 @@ def init(ctx: click.Context, show_key: bool) -> None:
             os_info=f"{platform.system()} {platform.release()}",
         )
     except ApiError as exc:
+        # 409 means another active watcher is already registered for this
+        # instrument. Surface an actionable message pointing the operator at
+        # the deregister flow rather than the raw API error text.
+        if exc.status_code == 409:
+            existing_id = ""
+            if exc.detail and exc.detail.details:
+                existing_id = str(exc.detail.details.get("existing_watcher_id") or "")
+            id_suffix = f" (id: {existing_id})" if existing_id else ""
+            raise click.ClickException(
+                f"Instrument '{selected.id}' already has an active watcher{id_suffix}.\n"
+                "If this is a replacement install, deregister the existing watcher first:\n"
+                "  - In the web UI: Watchers → open the existing watcher → Deregister\n"
+                f"  - Or via API: DELETE /api/v1/watchers/{existing_id or '<watcher_id>'}\n"
+                "Then re-run `data-hub-watcher init`."
+            ) from exc
         raise click.ClickException(f"Failed to register watcher: {exc.message}") from exc
 
     watcher_id = reg.watcher_id

--- a/watcher/tests/integration/test_watcher_registration.py
+++ b/watcher/tests/integration/test_watcher_registration.py
@@ -70,6 +70,43 @@ class TestRegisterWatcher:
         detail = client.get_instrument(instrument_id)
         assert detail.watcher_count == 1
 
+    def test_register_watcher_active_conflict_409(
+        self, client: DataHubClient, instrument_id: str
+    ) -> None:
+        """A second registration for an instrument with an active watcher must
+        be rejected with 409 and surface the existing watcher id in details."""
+        first = client.register_watcher(instrument_id, hostname="LAB-PC-01")
+
+        with pytest.raises(ApiError) as exc_info:
+            client.register_watcher(instrument_id, hostname="LAB-PC-02")
+
+        assert exc_info.value.status_code == 409
+        detail = exc_info.value.detail
+        assert detail is not None
+        assert detail.code == "CONFLICT"
+        assert detail.details is not None
+        assert detail.details.get("existing_watcher_id") == first.watcher_id
+
+    def test_register_watcher_succeeds_after_deregister(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        """Once the prior active watcher is soft-deleted, a fresh registration
+        for the same instrument should succeed and return a new watcher id."""
+        first = client.register_watcher(instrument_id, hostname="LAB-PC-01")
+
+        db_update(
+            integration_env.db_dsn,
+            "UPDATE watchers SET deleted_at = now() WHERE id = %s",
+            (first.watcher_id,),
+        )
+
+        second = client.register_watcher(instrument_id, hostname="LAB-PC-02")
+        assert second.watcher_id
+        assert second.watcher_id != first.watcher_id
+
 
 # ------------------------------------------------------------------
 # Config push / checksum

--- a/web-app/app/api/v1/watchers/register/route.ts
+++ b/web-app/app/api/v1/watchers/register/route.ts
@@ -1,13 +1,14 @@
 import { authenticateRequest } from "@/lib/api/auth";
 import {
   apiError,
+  CONFLICT,
   NOT_FOUND,
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
 import { db } from "@/lib/db";
 import { instruments, watchers } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 
 export async function POST(request: NextRequest) {
@@ -50,6 +51,27 @@ export async function POST(request: NextRequest) {
       400,
       VALIDATION_ERROR,
       `Instrument '${instrumentId}' is ${instrument.status} and cannot accept new watchers`
+    );
+  }
+
+  // Enforce 1:1 active watcher per instrument. The partial unique index on
+  // `watchers (instrument_id) WHERE deleted_at IS NULL` is the actual safety
+  // net; this lookup gives the CLI a friendlier error with the existing
+  // watcher id so the operator can deregister it.
+  const [existing] = await db
+    .select({ id: watchers.id, hostname: watchers.hostname })
+    .from(watchers)
+    .where(
+      and(eq(watchers.instrumentId, instrumentId), isNull(watchers.deletedAt))
+    )
+    .limit(1);
+
+  if (existing) {
+    return apiError(
+      409,
+      CONFLICT,
+      `Instrument '${instrumentId}' already has an active watcher (id: ${existing.id}). Deregister it before registering a new one.`,
+      { existing_watcher_id: existing.id, hostname: existing.hostname }
     );
   }
 

--- a/web-app/drizzle/0010_enforce_active_watcher_unique.sql
+++ b/web-app/drizzle/0010_enforce_active_watcher_unique.sql
@@ -1,0 +1,18 @@
+-- Pre-flight: ensure at most one active watcher per instrument before
+-- creating the partial unique index. For any (instrument_id) with multiple
+-- active rows, keep the most recently created and soft-delete the rest.
+WITH ranked AS (
+  SELECT id,
+         row_number() OVER (
+           PARTITION BY instrument_id
+           ORDER BY created_at DESC, id DESC
+         ) AS rn
+  FROM watchers
+  WHERE deleted_at IS NULL
+)
+UPDATE watchers
+SET deleted_at = now()
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+--> statement-breakpoint
+DROP INDEX "idx_watchers_instrument_id";--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_watchers_active_instrument_id" ON "watchers" USING btree ("instrument_id") WHERE "watchers"."deleted_at" is null;

--- a/web-app/drizzle/meta/0010_snapshot.json
+++ b/web-app/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1368 @@
+{
+  "id": "36e2285a-77e8-4e31-8b43-975a92abdeb9",
+  "prevId": "eef230a9-9ce9-499c-a0cd-f920941ab529",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "file_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raw'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_requested_at": {
+          "name": "upload_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_files_instrument_run_id_relative_path": {
+          "name": "uq_files_instrument_run_id_relative_path",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"relative_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_s3_key": {
+          "name": "uq_files_s3_key",
+          "columns": [
+            {
+              "expression": "s3_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"s3_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_instrument_run_id": {
+          "name": "idx_files_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_status_instrument_run_id": {
+          "name": "idx_files_status_instrument_run_id",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_active": {
+          "name": "idx_files_active",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_upload_queue": {
+          "name": "idx_files_upload_queue",
+          "columns": [
+            {
+              "expression": "upload_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"upload_requested_at\" is not null and \"files\".\"uploaded_at\" is null and \"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_metadata_gin": {
+          "name": "idx_files_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_instrument_run_id_instrument_runs_id_fk": {
+          "name": "files_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_runs": {
+      "name": "instrument_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "instrument_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lambda'"
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_purged_at": {
+          "name": "files_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instrument_runs_instrument_id_created_at": {
+          "name": "idx_instrument_runs_instrument_id_created_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active": {
+          "name": "idx_instrument_runs_active",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_metadata_gin": {
+          "name": "idx_instrument_runs_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_runs_instrument_id_instruments_id_fk": {
+          "name": "instrument_runs_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_watcher_id_watchers_id_fk": {
+          "name": "instrument_runs_watcher_id_watchers_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_instrument_runs_instrument_id_run_id": {
+          "name": "uq_instrument_runs_instrument_id_run_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instrument_id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instruments": {
+      "name": "instruments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instrument_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instrument_type": {
+          "name": "instrument_type",
+          "type": "instrument_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_personal_access_tokens_user_id": {
+          "name": "idx_personal_access_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_user_id_fk": {
+          "name": "personal_access_tokens_user_id_user_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_attributions": {
+      "name": "run_attributions",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_attributions_run_id": {
+          "name": "idx_run_attributions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_attributions_user_id": {
+          "name": "idx_run_attributions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_attributions_run_id_instrument_runs_id_fk": {
+          "name": "run_attributions_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_attributions_user_id_user_id_fk": {
+          "name": "run_attributions_user_id_user_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_attributions_run_id_user_id_pk": {
+          "name": "run_attributions_run_id_user_id_pk",
+          "columns": [
+            "run_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_events": {
+      "name": "watcher_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "watcher_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_events_watcher_id_timestamp": {
+          "name": "idx_watcher_events_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_watcher_events_watcher_id_event_type": {
+          "name": "idx_watcher_events_watcher_id_event_type",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_events_watcher_id_watchers_id_fk": {
+          "name": "watcher_events_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_events",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_heartbeats": {
+      "name": "watcher_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_mode": {
+          "name": "upload_mode",
+          "type": "upload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_uploaded_since_last": {
+          "name": "files_uploaded_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "runs_reported_since_last": {
+          "name": "runs_reported_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_since_last": {
+          "name": "errors_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_heartbeats_watcher_id_timestamp": {
+          "name": "idx_watcher_heartbeats_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_heartbeats_watcher_id_watchers_id_fk": {
+          "name": "watcher_heartbeats_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_heartbeats",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watchers": {
+      "name": "watchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_info": {
+          "name": "os_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_checksum": {
+          "name": "config_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_yaml": {
+          "name": "config_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "watcher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_watchers_active_instrument_id": {
+          "name": "uq_watchers_active_instrument_id",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"watchers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchers_instrument_id_instruments_id_fk": {
+          "name": "watchers_instrument_id_instruments_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.file_category": {
+      "name": "file_category",
+      "schema": "public",
+      "values": [
+        "raw",
+        "processed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "detected",
+        "upload_requested",
+        "uploaded",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.instrument_run_source": {
+      "name": "instrument_run_source",
+      "schema": "public",
+      "values": [
+        "lambda",
+        "watcher"
+      ]
+    },
+    "public.instrument_status": {
+      "name": "instrument_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "inactive"
+      ]
+    },
+    "public.instrument_type": {
+      "name": "instrument_type",
+      "schema": "public",
+      "values": [
+        "generic",
+        "plate_reader",
+        "gel_doc",
+        "qpcr",
+        "tape_station",
+        "hina_microscope"
+      ]
+    },
+    "public.upload_mode": {
+      "name": "upload_mode",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual"
+      ]
+    },
+    "public.watcher_event_type": {
+      "name": "watcher_event_type",
+      "schema": "public",
+      "values": [
+        "watcher_started",
+        "watcher_stopped",
+        "file_uploaded",
+        "upload_failed",
+        "run_reported",
+        "config_synced",
+        "error"
+      ]
+    },
+    "public.watcher_status": {
+      "name": "watcher_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "watching",
+        "stopped"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web-app/drizzle/meta/_journal.json
+++ b/web-app/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1777404985691,
       "tag": "0009_clammy_tyger_tiger",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1777414700388,
+      "tag": "0010_enforce_active_watcher_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/web-app/lib/db/schema.ts
+++ b/web-app/lib/db/schema.ts
@@ -238,7 +238,9 @@ export const watchers = pgTable(
     }),
   },
   (watcher) => [
-    index("idx_watchers_instrument_id")
+    // Partial unique index — at most one active watcher per instrument.
+    // Doubles as the lookup index used by getWatcherList / findActiveWatcher.
+    uniqueIndex("uq_watchers_active_instrument_id")
       .on(watcher.instrumentId)
       .where(sql`${watcher.deletedAt} is null`),
   ]

--- a/web-app/tests/integration/watchers.test.ts
+++ b/web-app/tests/integration/watchers.test.ts
@@ -53,6 +53,48 @@ describe("Watchers API", () => {
     watcherId = data.watcher_id;
   });
 
+  // Enforces the 1:1 active-watcher-per-instrument invariant. The DB-level
+  // partial unique index on `watchers (instrument_id) WHERE deleted_at IS
+  // NULL` is the actual safety net; the route returns 409 with the existing
+  // watcher id so the CLI can point the operator at the deregister flow.
+  it("POST /api/v1/watchers/register rejects when active watcher exists for instrument", async () => {
+    const res = await api("/api/v1/watchers/register", {
+      method: "POST",
+      token,
+      body: {
+        instrument_id: instrumentId,
+        hostname: "lab-pc-02",
+      },
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.code).toBe("CONFLICT");
+    expect(body.error.details?.existing_watcher_id).toBe(watcherId);
+  });
+
+  it("POST /api/v1/watchers/register allows registration for a different instrument", async () => {
+    const otherInstrumentId = "watcher-test-instrument-other";
+    const db = getTestDb();
+    await db.insert(instruments).values({
+      id: otherInstrumentId,
+      displayName: "Watcher Test Instrument (Other)",
+      status: "active",
+    });
+
+    const res = await api("/api/v1/watchers/register", {
+      method: "POST",
+      token,
+      body: {
+        instrument_id: otherInstrumentId,
+        hostname: "lab-pc-other",
+      },
+    });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.watcher_id).toBeTruthy();
+    expect(data.watcher_id).not.toBe(watcherId);
+  });
+
   it("POST /api/v1/watchers/register rejects missing instrument_id", async () => {
     const res = await api("/api/v1/watchers/register", {
       method: "POST",
@@ -345,5 +387,22 @@ describe("Watchers API", () => {
     const found = body.data.find((w: { id: string }) => w.id === watcherId);
     expect(found).toBeTruthy();
     expect(found.deleted_at).toBeTruthy();
+  });
+
+  // Round-trip: once the original watcher is deregistered, the partial
+  // unique index permits a fresh registration for the same instrument.
+  it("POST /api/v1/watchers/register succeeds again after the previous watcher is deregistered", async () => {
+    const res = await api("/api/v1/watchers/register", {
+      method: "POST",
+      token,
+      body: {
+        instrument_id: instrumentId,
+        hostname: "lab-pc-replacement",
+      },
+    });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.watcher_id).toBeTruthy();
+    expect(data.watcher_id).not.toBe(watcherId);
   });
 });


### PR DESCRIPTION
## Summary

Each instrument can now have at most one active (non-deregistered) watcher at a time. The invariant is enforced at the database level via a partial unique index, surfaced as a friendly `409 CONFLICT` from `POST /api/v1/watchers/register`, and translated by the CLI into an actionable error that points operators at the deregister flow. Heartbeats, events, and runs from previously-registered watchers remain visible after deregistration so the audit trail is preserved.

## Changes

- **DB invariant** (`web-app/drizzle/0010_enforce_active_watcher_unique.sql`, `web-app/lib/db/schema.ts`): replaced the existing partial non-unique `idx_watchers_instrument_id` with a partial unique index `uq_watchers_active_instrument_id ON watchers (instrument_id) WHERE deleted_at IS NULL`. The migration backfills any existing duplicates by keeping the most recently created active row per instrument and soft-deleting the rest.
- **API** (`web-app/app/api/v1/watchers/register/route.ts`): pre-checks for an existing active watcher and returns `409 CONFLICT` with `error.details.existing_watcher_id` (and `hostname`) so callers can route the operator to the right deregister action.
- **CLI** (`watcher/src/data_hub_watcher/cli.py`): catches the new 409 on `data-hub-watcher init` and prints a multi-line message with both the web-UI path and the `DELETE /api/v1/watchers/<id>` API equivalent, including the existing watcher's id.
- **Docs**:
  - `docs/api.md` documents the 409 response on `register` and the `DELETE /api/v1/watchers/:watcherId` endpoint.
  - `docs/watcher.md` notes the 1:1 invariant in the `init` flow description.
  - `docs/guides/installing-a-watcher.md` adds an "Instrument already has an active watcher" troubleshooting section covering both the UI and API deregister paths.
- **Tests**:
  - `watcher/tests/integration/test_watcher_registration.py` adds `test_register_watcher_active_conflict_409` and `test_register_watcher_succeeds_after_deregister`.
  - `web-app/tests/integration/watchers.test.ts` adds vitest cases for the 409 on duplicate registration, registration succeeding for a different instrument, and re-registration succeeding after the prior watcher is deregistered.

## Breaking changes

- `POST /api/v1/watchers/register` now returns `409 CONFLICT` instead of `201 CREATED` when the target instrument already has an active watcher. Any external caller that previously assumed it could register a second watcher per instrument must first call `DELETE /api/v1/watchers/:watcherId` against the existing one. The 409 body includes `error.details.existing_watcher_id` to make this mechanical.
- The migration's pre-flight backfill will soft-delete duplicate active watchers in any environment that has them (likely staging/prod). Heartbeats, events, and runs are preserved; the affected rows simply move to the "Deregistered" view.

## Driveby changes

None — every file in the diff is in service of the one-watcher-per-instrument invariant.

## Testing

- [x] `make check-all` passes (lint, format, type-check across web-app and watcher)
- [x] `pnpm --filter web-app test:integration` — new watcher 409 / re-register cases pass
- [x] `uv run --package data-hub-watcher pytest watcher/tests/integration/test_watcher_registration.py` — new 409 and post-deregister cases pass
- [x] Manually verify migration `0010` against a staging DB snapshot that contains duplicate active watchers; confirm the unique index is created and only one row per instrument has `deleted_at IS NULL`
- [x] Manually run `data-hub-watcher init` against an instrument that already has an active watcher and confirm the CLI prints the new 409 message with the existing watcher id and deregister instructions
- [x] Deregister via the web UI, re-run `data-hub-watcher init`, and confirm registration succeeds with a fresh watcher id
- [x] Confirm the watchers list UI still surfaces the soft-deleted rows under the "Deregistered" tab and that heartbeats/events for those rows remain accessible