### PR TITLE
Watcher: Implement server-driven auto-update via PyPI

### DIFF
--- a/.github/workflows/publish-watcher.yml
+++ b/.github/workflows/publish-watcher.yml
@@ -4,12 +4,15 @@ name: Publish watcher
 #   * `watcher-v*` git tag → publish to PyPI. The version in
 #     `watcher/pyproject.toml` must match the tag (enforced by the
 #     `py-check-watcher-version` Make target before we build).
-#   * Manual dispatch from `production` → re-run the publish + verify
-#     pipeline against PyPI for an already-built tag (e.g. to retry
-#     after a transient index outage). Restricted to `production` so
-#     a feature branch can't accidentally publish whatever version is
-#     in its `pyproject.toml`; the `pypi` deployment environment
+#   * Manual dispatch from `production` or `staging` → re-run the
+#     publish + verify pipeline against PyPI for an already-built tag
+#     (e.g. to retry after a transient index outage, or to test the
+#     release pipeline from staging). The `pypi` deployment environment
 #     additionally gates the publish step on its own approvers.
+#
+# TODO: restrict manual dispatch back to `production` only once staging
+# testing is complete. Allowing `staging` here is temporary to let us
+# exercise the release pipeline without cutting a production release.
 #
 # Authentication is OIDC trusted publishing (no API token in repo
 # secrets); the matching publisher must be configured on PyPI under
@@ -30,11 +33,15 @@ jobs:
     runs-on: ubuntu-latest
     # Tag pushes always pass this guard (their ref is `refs/tags/...`,
     # never `refs/heads/...`). Manual dispatch must come from
-    # `production`. `publish` and `verify` depend on `build` via
-    # `needs:`, so skipping `build` skips the whole pipeline.
+    # `production` or `staging` (staging is temporary — see TODO above).
+    # `publish` and `verify` depend on `build` via `needs:`, so
+    # skipping `build` skips the whole pipeline.
     if: >-
       github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/production')
+      (github.event_name == 'workflow_dispatch' && (
+        github.ref == 'refs/heads/production' ||
+        github.ref == 'refs/heads/staging'
+      ))
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:

--- a/.github/workflows/publish-watcher.yml
+++ b/.github/workflows/publish-watcher.yml
@@ -1,0 +1,139 @@
+name: Publish watcher
+
+# Two trigger paths:
+#   * `watcher-v*` git tag → publish to TestPyPI by default. The version
+#     in `watcher/pyproject.toml` must match the tag (enforced by the
+#     `py-check-watcher-version` Make target before we build).
+#   * Manual dispatch → operator chooses TestPyPI or PyPI. Useful for
+#     re-running the verification job, or for promoting a TestPyPI build
+#     to PyPI once it's been smoke-tested.
+#
+# Authentication is OIDC trusted publishing (no API token in repo
+# secrets); the matching publisher must be configured on TestPyPI / PyPI
+# under Project → Publishing for `Arcadia-Science/data-hub` and the
+# workflow `publish-watcher.yml`.
+on:
+  push:
+    tags:
+      - "watcher-v*"
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Index to publish to"
+        type: choice
+        required: true
+        default: testpypi
+        options:
+          - testpypi
+          - pypi
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build wheel + sdist
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+
+      # Refuse to publish unless the git tag and the package version line
+      # up — guards against shipping `watcher-v0.3.0` from a repo whose
+      # `[project].version` is still `0.2.9`.
+      - name: Verify tag matches watcher/pyproject.toml version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: make py-check-watcher-version
+
+      - name: Read package version
+        id: version
+        run: |
+          VERSION=$(awk -F'"' '/^version[[:space:]]*=/{print $2; exit}' watcher/pyproject.toml)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building data-hub-watcher==$VERSION"
+
+      - name: Build wheel + sdist
+        run: uv build --package data-hub-watcher --out-dir dist
+
+      - name: List built artifacts
+        run: ls -la dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to ${{ (github.event_name == 'workflow_dispatch' && inputs.repository == 'pypi') && 'PyPI' || 'TestPyPI' }}
+    needs: build
+    runs-on: ubuntu-latest
+    # Distinct deployment environments per index so publishing rules
+    # (required reviewers, allowed branches/tags) can be tightened on
+    # PyPI without slowing down TestPyPI iteration.
+    environment:
+      name: ${{ (github.event_name == 'workflow_dispatch' && inputs.repository == 'pypi') && 'pypi' || 'testpypi' }}
+    permissions:
+      # OIDC trusted publishing requires `id-token: write`. No secrets
+      # required — pypa's action exchanges the GitHub OIDC token for a
+      # short-lived API token at the index.
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        if: github.event_name != 'workflow_dispatch' || inputs.repository == 'testpypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          # TestPyPI sometimes lags on metadata indexing; allow re-runs
+          # by skipping files that already exist with the same hash.
+          skip-existing: true
+
+      - name: Publish to PyPI
+        if: github.event_name == 'workflow_dispatch' && inputs.repository == 'pypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+
+  verify:
+    name: Smoke-test the published wheel
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+
+      # Pinning the install to the exact version we just published catches
+      # the (rare) case where a stale prior release shadows the build via
+      # a slow-propagating mirror.
+      - name: Install from index
+        env:
+          TARGET_VERSION: ${{ needs.build.outputs.version }}
+          INDEX_URL: ${{ (github.event_name == 'workflow_dispatch' && inputs.repository == 'pypi') && 'https://pypi.org/simple/' || 'https://test.pypi.org/simple/' }}
+        run: |
+          uv venv .verify
+          # TestPyPI does not mirror our runtime dependencies; pull those
+          # from the real PyPI via --extra-index-url so the smoke install
+          # can resolve `pydantic`, `click`, etc. on the test path too.
+          uv pip install \
+            --python .verify/bin/python \
+            --index-url "$INDEX_URL" \
+            --extra-index-url https://pypi.org/simple/ \
+            "data-hub-watcher==$TARGET_VERSION"
+
+      # Both invocations must succeed — `--version` exercises Click + the
+      # importlib.metadata version reader, and the explicit Python import
+      # ensures no module-level side-effect crashes the package on first
+      # import (a common source of "works on my machine" PyPI failures).
+      - name: Smoke-test CLI
+        run: |
+          .verify/bin/data-hub-watcher --version
+          .verify/bin/python -c "import data_hub_watcher; print('import OK')"

--- a/.github/workflows/publish-watcher.yml
+++ b/.github/workflows/publish-watcher.yml
@@ -1,31 +1,23 @@
 name: Publish watcher
 
 # Two trigger paths:
-#   * `watcher-v*` git tag → publish to TestPyPI by default. The version
-#     in `watcher/pyproject.toml` must match the tag (enforced by the
+#   * `watcher-v*` git tag → publish to PyPI. The version in
+#     `watcher/pyproject.toml` must match the tag (enforced by the
 #     `py-check-watcher-version` Make target before we build).
-#   * Manual dispatch → operator chooses TestPyPI or PyPI. Useful for
-#     re-running the verification job, or for promoting a TestPyPI build
-#     to PyPI once it's been smoke-tested.
+#   * Manual dispatch → re-run the publish + verify pipeline against
+#     PyPI for an already-built tag (e.g. to retry after a transient
+#     index outage). Manual runs from `main` are also allowed for
+#     out-of-band hot-fix builds.
 #
 # Authentication is OIDC trusted publishing (no API token in repo
-# secrets); the matching publisher must be configured on TestPyPI / PyPI
-# under Project → Publishing for `Arcadia-Science/data-hub` and the
-# workflow `publish-watcher.yml`.
+# secrets); the matching publisher must be configured on PyPI under
+# Project → Publishing for `Arcadia-Science/data-hub` and the workflow
+# `publish-watcher.yml`.
 on:
   push:
     tags:
       - "watcher-v*"
   workflow_dispatch:
-    inputs:
-      repository:
-        description: "Index to publish to"
-        type: choice
-        required: true
-        default: testpypi
-        options:
-          - testpypi
-          - pypi
 
 permissions:
   contents: read
@@ -68,14 +60,15 @@ jobs:
           if-no-files-found: error
 
   publish:
-    name: Publish to ${{ (github.event_name == 'workflow_dispatch' && inputs.repository == 'pypi') && 'PyPI' || 'TestPyPI' }}
+    name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
-    # Distinct deployment environments per index so publishing rules
-    # (required reviewers, allowed branches/tags) can be tightened on
-    # PyPI without slowing down TestPyPI iteration.
+    # Gate PyPI publishes on a deployment environment so we can attach
+    # required reviewers / branch protection to the release pipeline
+    # without touching this workflow file.
     environment:
-      name: ${{ (github.event_name == 'workflow_dispatch' && inputs.repository == 'pypi') && 'pypi' || 'testpypi' }}
+      name: pypi
+      url: https://pypi.org/project/data-hub-watcher/${{ needs.build.outputs.version }}/
     permissions:
       # OIDC trusted publishing requires `id-token: write`. No secrets
       # required — pypa's action exchanges the GitHub OIDC token for a
@@ -87,19 +80,12 @@ jobs:
           name: dist
           path: dist/
 
-      - name: Publish to TestPyPI
-        if: github.event_name != 'workflow_dispatch' || inputs.repository == 'testpypi'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          # TestPyPI sometimes lags on metadata indexing; allow re-runs
-          # by skipping files that already exist with the same hash.
-          skip-existing: true
-
       - name: Publish to PyPI
-        if: github.event_name == 'workflow_dispatch' && inputs.repository == 'pypi'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          # Allow re-runs against an existing version (same hash) so a
+          # mid-pipeline retry doesn't fail with `400: file already
+          # exists`. Mismatched hashes still fail the upload.
           skip-existing: true
 
   verify:
@@ -114,19 +100,13 @@ jobs:
       # Pinning the install to the exact version we just published catches
       # the (rare) case where a stale prior release shadows the build via
       # a slow-propagating mirror.
-      - name: Install from index
+      - name: Install from PyPI
         env:
           TARGET_VERSION: ${{ needs.build.outputs.version }}
-          INDEX_URL: ${{ (github.event_name == 'workflow_dispatch' && inputs.repository == 'pypi') && 'https://pypi.org/simple/' || 'https://test.pypi.org/simple/' }}
         run: |
           uv venv .verify
-          # TestPyPI does not mirror our runtime dependencies; pull those
-          # from the real PyPI via --extra-index-url so the smoke install
-          # can resolve `pydantic`, `click`, etc. on the test path too.
           uv pip install \
             --python .verify/bin/python \
-            --index-url "$INDEX_URL" \
-            --extra-index-url https://pypi.org/simple/ \
             "data-hub-watcher==$TARGET_VERSION"
 
       # Both invocations must succeed — `--version` exercises Click + the

--- a/.github/workflows/publish-watcher.yml
+++ b/.github/workflows/publish-watcher.yml
@@ -4,10 +4,12 @@ name: Publish watcher
 #   * `watcher-v*` git tag → publish to PyPI. The version in
 #     `watcher/pyproject.toml` must match the tag (enforced by the
 #     `py-check-watcher-version` Make target before we build).
-#   * Manual dispatch → re-run the publish + verify pipeline against
-#     PyPI for an already-built tag (e.g. to retry after a transient
-#     index outage). Manual runs from `main` are also allowed for
-#     out-of-band hot-fix builds.
+#   * Manual dispatch from `production` → re-run the publish + verify
+#     pipeline against PyPI for an already-built tag (e.g. to retry
+#     after a transient index outage). Restricted to `production` so
+#     a feature branch can't accidentally publish whatever version is
+#     in its `pyproject.toml`; the `pypi` deployment environment
+#     additionally gates the publish step on its own approvers.
 #
 # Authentication is OIDC trusted publishing (no API token in repo
 # secrets); the matching publisher must be configured on PyPI under
@@ -26,6 +28,13 @@ jobs:
   build:
     name: Build wheel + sdist
     runs-on: ubuntu-latest
+    # Tag pushes always pass this guard (their ref is `refs/tags/...`,
+    # never `refs/heads/...`). Manual dispatch must come from
+    # `production`. `publish` and `verify` depend on `build` via
+    # `needs:`, so skipping `build` skips the whole pipeline.
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/production')
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,22 @@ py-test-integration:
 py-test:
 	uv run pytest -v
 
+# Used by the publish-watcher workflow to refuse releases where the git tag
+# (e.g. `watcher-v0.3.0`) doesn't match `[project].version` in
+# watcher/pyproject.toml. Reads the tag from the GITHUB_REF / TAG env var
+# so it can be invoked from CI without parsing argv. Locally, run
+# `TAG=watcher-v0.1.0 make py-check-watcher-version` to verify a tag.
+.PHONY: py-check-watcher-version
+py-check-watcher-version:
+	@TAG="$${TAG:-$${GITHUB_REF##refs/tags/}}"; \
+	VERSION=$$(uv run python -c 'import tomllib, pathlib; print(tomllib.loads(pathlib.Path("watcher/pyproject.toml").read_text())["project"]["version"])'); \
+	EXPECTED="watcher-v$$VERSION"; \
+	if [ "$$TAG" != "$$EXPECTED" ]; then \
+		echo "Tag mismatch: git tag '$$TAG' does not match watcher/pyproject.toml version '$$VERSION' (expected tag '$$EXPECTED')."; \
+		exit 1; \
+	fi; \
+	echo "OK: tag $$TAG matches watcher/pyproject.toml version $$VERSION"
+
 # Web app.
 .PHONY: fe-format
 fe-format:

--- a/docs/api.md
+++ b/docs/api.md
@@ -59,6 +59,7 @@ Tokens are hashed with SHA-256 before storage. The plaintext token is shown once
 | `PUT` | `/api/v1/watchers/:watcherId/config` | Push config YAML and checksum |
 | `GET` | `/api/v1/watchers/:watcherId/config-checksum` | Get the config checksum |
 | `GET` | `/api/v1/watchers/:watcherId/upload-queue` | Get pending upload queue |
+| `GET` | `/api/v1/watchers/:watcherId/update-check` | Get server-advertised release info (latest version, channel, mandatory flag); used by the watcher's self-update CLI and background auto-updater. See [Upgrading the watcher](guides/upgrading-the-watcher.md). |
 
 ### Tokens
 

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -2,7 +2,7 @@
 
 ## GitHub Actions
 
-Four workflows run on pushes to `staging`/`production` and on pull requests targeting those branches.
+Four workflows run on pushes to `staging`/`production` and on pull requests targeting those branches. A fifth (`publish-watcher.yml`) runs only on `watcher-v*` tag pushes and manual dispatch.
 
 ### Python lint and typecheck (`python-lint.yml`)
 
@@ -28,6 +28,16 @@ Four workflows run on pushes to `staging`/`production` and on pull requests targ
 - Starts a Postgres 17 service container and Node.js 24.
 - `make fe-test-mcp` — runs in-memory MCP protocol tests (mocked data layer, no database).
 - `make fe-test-integration` — runs Vitest integration tests that test the API routes and MCP server over HTTP against a real database.
+
+### Publish watcher (`publish-watcher.yml`)
+
+Triggered on `watcher-v*` tag pushes and manual `workflow_dispatch`. Builds the `data-hub-watcher` package, publishes it to PyPI via OIDC trusted publishing, and verifies the upload by installing the freshly published wheel into a clean venv. Three sequential jobs:
+
+1. **build** — Verifies the git tag matches `watcher/pyproject.toml` (`make py-check-watcher-version`), builds the wheel and sdist with `uv build --package data-hub-watcher`, and uploads them as a workflow artifact.
+2. **publish** — Downloads the artifact and uploads it to PyPI with [`pypa/gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypi-publish) using OIDC trusted publishing. Gated on the `pypi` GitHub deployment environment so reviewer-required releases can be enforced from the GitHub UI without editing the workflow file.
+3. **verify** — In a fresh `uv venv`, installs `data-hub-watcher==<tag-version>` from PyPI and runs `data-hub-watcher --version` plus `python -c "import data_hub_watcher"` as a smoke test. Catches stale-mirror shadows and module-level import side-effect crashes.
+
+See the [Watcher (PyPI)](#watcher-pypi) deployment section for the operator-facing release flow.
 
 ## Branch strategy
 
@@ -211,6 +221,29 @@ make docker-push-lambda ENV=staging
 # Deploy to staging (loads infra/.env.staging automatically).
 make sam-deploy ENV=staging
 ```
+
+### Watcher (PyPI)
+
+The `data-hub-watcher` Python package is published to [PyPI](https://pypi.org/project/data-hub-watcher/) so lab PCs can install and self-update via `uv tool install data-hub-watcher` (see the [installing-a-watcher](guides/installing-a-watcher.md) guide for the operator path).
+
+Releases are tag-driven. To cut a new version:
+
+1. Bump `[project].version` in `watcher/pyproject.toml` on `staging` (or a release branch) and merge to `production` once the change has been smoke-tested.
+2. Tag the release commit with the matching `watcher-vX.Y.Z` tag and push the tag:
+
+   ```sh
+   git tag watcher-v0.3.0
+   git push origin watcher-v0.3.0
+   ```
+
+3. The `publish-watcher.yml` workflow runs automatically. Its `build` job refuses to proceed if the tag and `pyproject.toml` version disagree, so a typo in either fails fast before anything reaches PyPI.
+4. Approve the `pypi` deployment in GitHub if reviewer protection is enabled. Once approved, `publish` uploads to PyPI and `verify` smoke-tests the wheel from a clean venv.
+
+To re-run the publish + verify pipeline against an already-tagged build (e.g. after a transient PyPI outage), use **Actions → Publish watcher → Run workflow** on the `production` branch. `skip-existing: true` on the publish step makes the retry safe — files already uploaded with the same hash are skipped rather than failing the run.
+
+Trusted publishing is configured under **Project → Publishing** on PyPI for `Arcadia-Science/data-hub` and the workflow `publish-watcher.yml`; no API token lives in repo secrets. If trust is ever revoked or rotated, update it there and re-run the workflow.
+
+After a release lands on PyPI, bump the server-side `WATCHER_LATEST_VERSION` env var in Vercel (per environment) so the `/update-check` endpoint advertises the new target. Lab PCs running an auto-update-capable build will pick it up on their next hourly tick (see the [auto-update section](guides/installing-a-watcher.md#automatic-background-updates) of the install guide). Do **not** bump `WATCHER_LATEST_VERSION` ahead of the PyPI publish — the watcher's upgrade subprocess will fail to resolve a version that doesn't yet exist on the index. Set `WATCHER_MANDATORY_UPDATE=true` only for security or wire-protocol fixes; otherwise the activity-window guard suffices.
 
 ## Running checks locally
 

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -224,26 +224,9 @@ make sam-deploy ENV=staging
 
 ### Watcher (PyPI)
 
-The `data-hub-watcher` Python package is published to [PyPI](https://pypi.org/project/data-hub-watcher/) so lab PCs can install and self-update via `uv tool install data-hub-watcher` (see the [installing-a-watcher](guides/installing-a-watcher.md) guide for the operator path).
-
-Releases are tag-driven. To cut a new version:
-
-1. Bump `[project].version` in `watcher/pyproject.toml` on `staging` (or a release branch) and merge to `production` once the change has been smoke-tested.
-2. Tag the release commit with the matching `watcher-vX.Y.Z` tag and push the tag:
-
-   ```sh
-   git tag watcher-v0.3.0
-   git push origin watcher-v0.3.0
-   ```
-
-3. The `publish-watcher.yml` workflow runs automatically. Its `build` job refuses to proceed if the tag and `pyproject.toml` version disagree, so a typo in either fails fast before anything reaches PyPI.
-4. Approve the `pypi` deployment in GitHub if reviewer protection is enabled. Once approved, `publish` uploads to PyPI and `verify` smoke-tests the wheel from a clean venv.
-
-To re-run the publish + verify pipeline against an already-tagged build (e.g. after a transient PyPI outage), use **Actions → Publish watcher → Run workflow** on the `production` branch. `skip-existing: true` on the publish step makes the retry safe — files already uploaded with the same hash are skipped rather than failing the run.
+The `data-hub-watcher` Python package is published to [PyPI](https://pypi.org/project/data-hub-watcher/) so lab PCs can install and self-update via `uv tool install data-hub-watcher`. The full release flow — version bump, tag, approval, env-var roll-out, mandatory updates, and rollback — is documented in the operator-facing [Upgrading the watcher](guides/upgrading-the-watcher.md) guide; this section is intentionally a pointer rather than a second source of truth so the two can't drift.
 
 Trusted publishing is configured under **Project → Publishing** on PyPI for `Arcadia-Science/data-hub` and the workflow `publish-watcher.yml`; no API token lives in repo secrets. If trust is ever revoked or rotated, update it there and re-run the workflow.
-
-After a release lands on PyPI, bump the server-side `WATCHER_LATEST_VERSION` env var in Vercel (per environment) so the `/update-check` endpoint advertises the new target. Lab PCs running an auto-update-capable build will pick it up on their next hourly tick (see the [auto-update section](guides/installing-a-watcher.md#automatic-background-updates) of the install guide). Do **not** bump `WATCHER_LATEST_VERSION` ahead of the PyPI publish — the watcher's upgrade subprocess will fail to resolve a version that doesn't yet exist on the index. Set `WATCHER_MANDATORY_UPDATE=true` only for security or wire-protocol fixes; otherwise the activity-window guard suffices.
 
 ## Running checks locally
 

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -31,7 +31,7 @@ Four workflows run on pushes to `staging`/`production` and on pull requests targ
 
 ### Publish watcher (`publish-watcher.yml`)
 
-Triggered on `watcher-v*` tag pushes and manual `workflow_dispatch`. Builds the `data-hub-watcher` package, publishes it to PyPI via OIDC trusted publishing, and verifies the upload by installing the freshly published wheel into a clean venv. Three sequential jobs:
+Triggered on `watcher-v*` tag pushes and manual `workflow_dispatch` from `production`. The `build` job's `if:` guard refuses dispatches from any other branch so a feature branch can't accidentally publish whatever version is in its `pyproject.toml`. Builds the `data-hub-watcher` package, publishes it to PyPI via OIDC trusted publishing, and verifies the upload by installing the freshly published wheel into a clean venv. Three sequential jobs:
 
 1. **build** — Verifies the git tag matches `watcher/pyproject.toml` (`make py-check-watcher-version`), builds the wheel and sdist with `uv build --package data-hub-watcher`, and uploads them as a workflow artifact.
 2. **publish** — Downloads the artifact and uploads it to PyPI with [`pypa/gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypi-publish) using OIDC trusted publishing. Gated on the `pypi` GitHub deployment environment so reviewer-required releases can be enforced from the GitHub UI without editing the workflow file.

--- a/docs/guides/installing-a-watcher.md
+++ b/docs/guides/installing-a-watcher.md
@@ -19,15 +19,6 @@ uv tool install data-hub-watcher
 
 This installs the `data-hub-watcher` CLI into an isolated venv managed by `uv`, on PATH for any shell.
 
-Until the package ships to PyPI, install from TestPyPI instead. TestPyPI doesn't mirror our runtime deps, so pull those from the real PyPI via `--extra-index-url`:
-
-```sh
-uv tool install \
-  --index-url https://test.pypi.org/simple/ \
-  --extra-index-url https://pypi.org/simple/ \
-  data-hub-watcher
-```
-
 After installation, every example below that says `data-hub-watcher …` runs the installed CLI directly. `data-hub-watcher` (used by developers working from a checkout) also works.
 
 ### Windows service support
@@ -174,6 +165,43 @@ After a successful upgrade you must restart the watcher (or the Windows
 service) for the new code to take effect — `self-update` does not restart
 the running process. To run upgrades unattended, schedule the command via
 Windows Task Scheduler (e.g. weekly).
+
+### Automatic background updates
+
+When the watcher runs as a Windows service it also polls the Data Hub
+API roughly once an hour and applies new releases on its own — no
+operator action and no Task Scheduler entry required. The service:
+
+1. Calls `GET /api/v1/watchers/<watcher-id>/update-check` and compares
+   the server's `latest_version` against its own.
+2. Only attempts an upgrade if **all** of these are true:
+   - a newer version is available;
+   - no files have been uploaded for several heartbeats in a row; and
+   - no run has been reported within roughly 5× the configured
+     `stability_period_seconds`.
+3. Runs the same `uv tool install --reinstall` (or `pip install -U`)
+   command described above. While the subprocess is running the
+   service emits an `update_started` event you can see in the Watchers
+   page.
+4. On success, exits non-zero so the Windows SCM restarts the service
+   into the new wheel. The new process emits `update_succeeded` once
+   it confirms the new version is actually loaded; if something went
+   wrong (e.g. the new code crashes at startup) you'll see
+   `update_failed` instead.
+
+When the server flags a release as **mandatory**, the activity-window
+guard is skipped and the upgrade fires on the next hourly check
+regardless of in-flight uploads — use this only for security fixes or
+wire-protocol changes where running known-bad code is worse than a
+brief outage.
+
+Auto-update is **disabled** in the `preview` environment so PR
+preview deployments can never push code to production lab PCs.
+
+If you'd rather pin a specific version, run `data-hub-watcher
+self-update --check` to see the server's target and follow up with a
+manual `uv tool install data-hub-watcher==<pinned>` — the next
+auto-update tick will see the pin matches the server's target and skip.
 
 ## Manual uploads
 

--- a/docs/guides/installing-a-watcher.md
+++ b/docs/guides/installing-a-watcher.md
@@ -180,9 +180,11 @@ operator action and no Task Scheduler entry required. The service:
    - no run has been reported within roughly 5× the configured
      `stability_period_seconds`.
 3. Runs the same `uv tool install --reinstall` (or `pip install -U`)
-   command described above. While the subprocess is running the
-   service emits an `update_started` event you can see in the Watchers
-   page.
+   command described above on a dedicated background thread, so
+   heartbeats keep flowing while the install executes (which can
+   take 30–60 s on slow links). The service emits an `update_started`
+   event before the subprocess starts, so you'll see the upgrade
+   begin in the Watchers page even if the install itself is slow.
 4. On success, exits non-zero so the Windows SCM restarts the service
    into the new wheel. The new process emits `update_succeeded` once
    it confirms the new version is actually loaded; if something went

--- a/docs/guides/installing-a-watcher.md
+++ b/docs/guides/installing-a-watcher.md
@@ -11,7 +11,7 @@ This guide is for lab operators setting up the Data Hub Watcher on an instrument
 
 ## Installation
 
-The watcher is published as a versioned package — for production lab PCs, install it directly from the index without cloning the repo:
+The watcher is published as a versioned package on PyPI. For use on lab PCs, install it directly from PyPI:
 
 ```sh
 uv tool install data-hub-watcher
@@ -19,7 +19,7 @@ uv tool install data-hub-watcher
 
 This installs the `data-hub-watcher` CLI into an isolated venv managed by `uv`, on PATH for any shell.
 
-After installation, every example below that says `data-hub-watcher …` runs the installed CLI directly. `data-hub-watcher` (used by developers working from a checkout) also works.
+After installation, every example below that says `data-hub-watcher …` runs the installed CLI directly.
 
 ### Windows service support
 
@@ -36,7 +36,7 @@ If you're modifying the watcher itself, install in editable mode from the repo s
 ```sh
 git clone https://github.com/Arcadia-Science/data-hub
 cd data-hub
-uv sync --all-packages
+uv sync --all-packages --extra windows-service
 uv run data-hub-watcher --help
 ```
 
@@ -151,7 +151,7 @@ data-hub-watcher self-update --check    # report status only, no upgrade
 data-hub-watcher self-update --force    # re-run the upgrade subprocess even if the version already matches
 ```
 
-After a successful upgrade you must restart the watcher (or the Windows service) for the new code to take effect — `self-update` does not restart the running process. Lab PCs running the Windows service get auto-restart for free via the SCM's failure-actions policy; see the upgrade guide for details.
+After a successful upgrade you must restart the watcher (or the Windows service) for the new code to take effect — `self-update` does not restart the running process. Lab PCs running the Windows service get auto-restart for free via the SCM's failure-actions policy; see the [upgrade guide](./upgrading-the-watcher.md) for details.
 
 ## Manual uploads
 
@@ -182,7 +182,7 @@ Each instrument can have at most one active watcher at a time. If `init` fails w
 - **Web UI** — go to **Watchers**, open the existing watcher, and click **Deregister**.
 - **API** — `curl -X DELETE -H "Authorization: Bearer $DATA_HUB_API_KEY" https://<host>/api/v1/watchers/<existing_watcher_id>`
 
-Deregistration is a soft-delete: heartbeats, events, and runs reported by the old watcher remain visible in the **Deregistered** tab for auditing.
+Deregistration is a soft-delete: heartbeats, events, and runs reported by the old watcher remain visible in **Watchers > Deregistered** (in the web app) for auditing.
 
 ### "Connection error" or "Request timed out"
 

--- a/docs/guides/installing-a-watcher.md
+++ b/docs/guides/installing-a-watcher.md
@@ -11,30 +11,52 @@ This guide is for lab operators setting up the Data Hub Watcher on an instrument
 
 ## Installation
 
-Clone the repository and sync dependencies with `uv`:
+The watcher is published as a versioned package — for production lab PCs, install it directly from the index without cloning the repo:
 
 ```sh
-git clone <repo-url>
-cd data-hub
-uv sync --all-packages
+uv tool install data-hub-watcher
 ```
 
-All `data-hub-watcher` commands below should be run from the `data-hub` project directory using `uv run`, which ensures the correct virtual environment is used.
+This installs the `data-hub-watcher` CLI into an isolated venv managed by `uv`, on PATH for any shell.
+
+Until the package ships to PyPI, install from TestPyPI instead. TestPyPI doesn't mirror our runtime deps, so pull those from the real PyPI via `--extra-index-url`:
+
+```sh
+uv tool install \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  data-hub-watcher
+```
+
+After installation, every example below that says `data-hub-watcher …` runs the installed CLI directly. `data-hub-watcher` (used by developers working from a checkout) also works.
 
 ### Windows service support
 
-If you want the watcher to run as a Windows service, install the extra dependency:
+The watcher can run as a Windows service. Install it with the `windows-service` extra so the `pywin32` dependency is included:
 
 ```sh
-uv sync --all-packages --extra windows-service
+uv tool install "data-hub-watcher[windows-service]"
 ```
+
+### Developer install (from a checkout)
+
+If you're modifying the watcher itself, install in editable mode from the repo so your local edits are reflected immediately:
+
+```sh
+git clone https://github.com/Arcadia-Science/data-hub
+cd data-hub
+uv sync --all-packages
+uv run data-hub-watcher --help
+```
+
+When working from the checkout, prefix every example below with `uv run` (e.g. `uv run data-hub-watcher init`) so the editable install in `.venv/` is used.
 
 ## Setup
 
 Run the interactive setup wizard:
 
 ```sh
-uv run data-hub-watcher init
+data-hub-watcher init
 ```
 
 The wizard will walk you through:
@@ -66,7 +88,7 @@ The wizard saves configuration to `~/.data-hub/config.yaml`, the API key to `~/.
 First, verify your setup with a dry run:
 
 ```sh
-uv run data-hub-watcher watch --dry-run
+data-hub-watcher watch --dry-run
 ```
 
 This validates the config, checks that the API is reachable and the instrument is active, and previews what files would be uploaded — without actually starting the monitor.
@@ -74,7 +96,7 @@ This validates the config, checks that the API is reachable and the instrument i
 When you're ready:
 
 ```sh
-uv run data-hub-watcher watch
+data-hub-watcher watch
 ```
 
 The watcher will now:
@@ -92,16 +114,16 @@ Press `Ctrl+C` to stop.
 On Windows, you can install the watcher as a service so it starts automatically:
 
 ```sh
-uv run data-hub-watcher service install
-uv run data-hub-watcher service start
+data-hub-watcher service install
+data-hub-watcher service start
 ```
 
 Other service commands:
 
 ```sh
-uv run data-hub-watcher service status    # Check if the service is running
-uv run data-hub-watcher service stop      # Stop the service
-uv run data-hub-watcher service uninstall # Remove the service
+data-hub-watcher service status    # Check if the service is running
+data-hub-watcher service stop      # Stop the service
+data-hub-watcher service uninstall # Remove the service
 ```
 
 ## Changing configuration
@@ -109,19 +131,19 @@ uv run data-hub-watcher service uninstall # Remove the service
 To re-prompt each config field with current values as defaults:
 
 ```sh
-uv run data-hub-watcher config edit
+data-hub-watcher config edit
 ```
 
 To open the YAML file directly in your editor:
 
 ```sh
-uv run data-hub-watcher config open
+data-hub-watcher config open
 ```
 
 To view the current config:
 
 ```sh
-uv run data-hub-watcher config show
+data-hub-watcher config show
 ```
 
 Changes are automatically synced to the server after editing.
@@ -158,13 +180,13 @@ Windows Task Scheduler (e.g. weekly).
 To upload a specific file outside the normal watch loop:
 
 ```sh
-uv run data-hub-watcher upload --file /path/to/file.csv --run-id RUN001
+data-hub-watcher upload --file /path/to/file.csv --run-id RUN001
 ```
 
 To process the server-side upload queue (manual mode):
 
 ```sh
-uv run data-hub-watcher upload
+data-hub-watcher upload
 ```
 
 Add `--dry-run` to preview without uploading.
@@ -194,9 +216,9 @@ The watcher can't reach the Data Hub API. Check:
 
 ### Files aren't being detected
 
-- Verify the watch directory is correct: `uv run data-hub-watcher config show`
+- Verify the watch directory is correct: `data-hub-watcher config show`
 - Check that file patterns match your files. The watcher uses glob matching (e.g., `*.csv` matches `data.csv` but not `data.CSV` on case-sensitive systems).
-- Run `uv run data-hub-watcher watch --dry-run` to see what files the watcher would pick up.
+- Run `data-hub-watcher watch --dry-run` to see what files the watcher would pick up.
 
 ### Files are detected but not uploading
 
@@ -209,5 +231,5 @@ The watcher can't reach the Data Hub API. Check:
 The watcher writes rotating logs to `~/.data-hub/watcher.log` (10 MB, 5 backups). Check this file for detailed error information. You can also run with `--verbose` for debug-level console output:
 
 ```sh
-uv run data-hub-watcher --verbose watch
+data-hub-watcher --verbose watch
 ```

--- a/docs/guides/installing-a-watcher.md
+++ b/docs/guides/installing-a-watcher.md
@@ -126,6 +126,33 @@ uv run data-hub-watcher config show
 
 Changes are automatically synced to the server after editing.
 
+## Upgrading the watcher
+
+If the watcher was installed from PyPI (recommended for lab PCs), it can
+upgrade itself in place:
+
+```sh
+data-hub-watcher self-update            # check + upgrade if needed
+data-hub-watcher self-update --check    # report status only, no upgrade
+data-hub-watcher self-update --force    # re-run the upgrade subprocess
+                                         # even if the version already matches
+```
+
+The command asks the Data Hub API for the latest published version, compares
+it to the locally installed version, and runs the appropriate upgrade
+command for your install method:
+
+- **`uv tool install` installs** → `uv tool install --reinstall data-hub-watcher==<latest>`
+- **plain venv pip installs** → `<python> -m pip install -U data-hub-watcher==<latest>`
+- **editable / `uv sync` checkouts** → refused with a clear error; upgrade
+  these manually with `git pull && uv sync` since auto-upgrading would
+  shadow your source tree.
+
+After a successful upgrade you must restart the watcher (or the Windows
+service) for the new code to take effect — `self-update` does not restart
+the running process. To run upgrades unattended, schedule the command via
+Windows Task Scheduler (e.g. weekly).
+
 ## Manual uploads
 
 To upload a specific file outside the normal watch loop:

--- a/docs/guides/installing-a-watcher.md
+++ b/docs/guides/installing-a-watcher.md
@@ -141,69 +141,17 @@ Changes are automatically synced to the server after editing.
 
 ## Upgrading the watcher
 
-If the watcher was installed from PyPI (recommended for lab PCs), it can
-upgrade itself in place:
+The watcher can upgrade itself in place, either on demand via `data-hub-watcher self-update` or — when running as a Windows service — automatically on an hourly background tick. The full release flow, mandatory-update behavior, rollback steps, and operator troubleshooting all live in [Upgrading the watcher](upgrading-the-watcher.md).
+
+If you just want the quick command:
 
 ```sh
 data-hub-watcher self-update            # check + upgrade if needed
 data-hub-watcher self-update --check    # report status only, no upgrade
-data-hub-watcher self-update --force    # re-run the upgrade subprocess
-                                         # even if the version already matches
+data-hub-watcher self-update --force    # re-run the upgrade subprocess even if the version already matches
 ```
 
-The command asks the Data Hub API for the latest published version, compares
-it to the locally installed version, and runs the appropriate upgrade
-command for your install method:
-
-- **`uv tool install` installs** → `uv tool install --reinstall data-hub-watcher==<latest>`
-- **plain venv pip installs** → `<python> -m pip install -U data-hub-watcher==<latest>`
-- **editable / `uv sync` checkouts** → refused with a clear error; upgrade
-  these manually with `git pull && uv sync` since auto-upgrading would
-  shadow your source tree.
-
-After a successful upgrade you must restart the watcher (or the Windows
-service) for the new code to take effect — `self-update` does not restart
-the running process. To run upgrades unattended, schedule the command via
-Windows Task Scheduler (e.g. weekly).
-
-### Automatic background updates
-
-When the watcher runs as a Windows service it also polls the Data Hub
-API roughly once an hour and applies new releases on its own — no
-operator action and no Task Scheduler entry required. The service:
-
-1. Calls `GET /api/v1/watchers/<watcher-id>/update-check` and compares
-   the server's `latest_version` against its own.
-2. Only attempts an upgrade if **all** of these are true:
-   - a newer version is available;
-   - no files have been uploaded for several heartbeats in a row; and
-   - no run has been reported within roughly 5× the configured
-     `stability_period_seconds`.
-3. Runs the same `uv tool install --reinstall` (or `pip install -U`)
-   command described above on a dedicated background thread, so
-   heartbeats keep flowing while the install executes (which can
-   take 30–60 s on slow links). The service emits an `update_started`
-   event before the subprocess starts, so you'll see the upgrade
-   begin in the Watchers page even if the install itself is slow.
-4. On success, exits non-zero so the Windows SCM restarts the service
-   into the new wheel. The new process emits `update_succeeded` once
-   it confirms the new version is actually loaded; if something went
-   wrong (e.g. the new code crashes at startup) you'll see
-   `update_failed` instead.
-
-When the server flags a release as **mandatory**, the activity-window
-guard is skipped and the upgrade fires on the next hourly check
-regardless of in-flight uploads — use this only for security fixes or
-wire-protocol changes where running known-bad code is worse than a
-brief outage.
-
-Auto-update is **disabled** in the `preview` environment so PR
-preview deployments can never push code to production lab PCs.
-
-If you'd rather pin a specific version, run `data-hub-watcher
-self-update --check` to see the server's target and follow up with a
-manual `uv tool install data-hub-watcher==<pinned>` — the next
-auto-update tick will see the pin matches the server's target and skip.
+After a successful upgrade you must restart the watcher (or the Windows service) for the new code to take effect — `self-update` does not restart the running process. Lab PCs running the Windows service get auto-restart for free via the SCM's failure-actions policy; see the upgrade guide for details.
 
 ## Manual uploads
 

--- a/docs/guides/upgrading-the-watcher.md
+++ b/docs/guides/upgrading-the-watcher.md
@@ -136,6 +136,12 @@ The upgrade subprocess started but didn't end up running the new version on the 
 - **`subprocess exited <N>`** — the upgrade command itself failed. The event details include the last 1000 bytes of stdout/stderr; the most common cause is a transient PyPI / mirror failure or the version not yet existing on the index (see the "don't bump ahead of publish" note above).
 - **`expected '<target>' after upgrade, running '<current>'`** — the subprocess succeeded, the service restarted, but the running interpreter still imports the old version. Almost always means a stale `__pycache__` or a separate copy of the package on `sys.path`. Run `uv tool uninstall data-hub-watcher && uv tool install data-hub-watcher==<target>` as the service account.
 
+### `update_failed` without a preceding `update_started`
+
+When `details.attempted_subprocess` is `false`, the auto-updater never ran the upgrade command — it refused before starting one. The `details.reason` field tells you why:
+
+- **`install method '<editable|unknown>' not eligible for auto-update`** — the watcher detected a development-style install (editable `uv sync`, or a distribution whose metadata couldn't be located) and refused so it wouldn't silently shadow the source tree with an index build. Resolve by switching the host to a PyPI install (`uv tool install data-hub-watcher`) or, on a developer machine, ignoring the event. To avoid spamming the events stream, the watcher emits this at most once per server target — a rebump of `WATCHER_LATEST_VERSION` will trigger one fresh event per stuck PC.
+
 ### Auto-update never fires
 
 Check, in order:

--- a/docs/guides/upgrading-the-watcher.md
+++ b/docs/guides/upgrading-the-watcher.md
@@ -1,0 +1,153 @@
+# Upgrading the watcher
+
+This guide covers everything that happens between a new `data-hub-watcher` release landing on PyPI and the upgraded code running on a lab instrument PC. It's written for two audiences: **lab operators** keeping a single PC up to date (start at [How upgrades reach a lab PC](#how-upgrades-reach-a-lab-pc)), and **release admins** cutting a new version and rolling it out to the fleet (jump to [Cutting a new release](#cutting-a-new-release)).
+
+If you're installing the watcher for the first time, see [Installing a watcher](installing-a-watcher.md) first; this guide assumes the watcher is already registered against an instrument.
+
+## How upgrades reach a lab PC
+
+Three paths feed an upgraded wheel into the running watcher. Lab PCs running as a Windows service get the auto-update path for free; everything else upgrades on demand via the CLI.
+
+### Background auto-update (Windows service, recommended)
+
+When the watcher runs as a Windows service in `staging` or `production`, the in-process updater polls the API roughly once an hour and applies new releases on its own — no operator action and no Task Scheduler entry required.
+
+On each tick the service:
+
+1. Calls `GET /api/v1/watchers/<watcher-id>/update-check` and compares the server's `latest_version` against its own.
+2. Only attempts an upgrade if **all** of these are true: a newer version is available, no files have been uploaded for several heartbeats in a row, and no run has been reported within roughly 5× the configured `stability_period_seconds`. The activity-window guard exists so the watcher never takes itself down mid-acquisition.
+3. Runs `uv tool install --reinstall data-hub-watcher==<latest>` (or the `pip install -U` equivalent for non-uv installs) on a dedicated background thread, so heartbeats keep flowing while the install executes — which can take 30–60 s on slow links. Before the subprocess starts, the service emits an `update_started` event you can see in the **Watchers** page.
+4. On success, exits non-zero so the Windows SCM restarts the service into the new wheel via its configured failure-actions policy. The new process emits `update_succeeded` once it confirms the new version is actually loaded; if the new code crashes at startup or otherwise doesn't take effect, you'll see `update_failed` instead.
+
+Auto-update is **disabled** in the `preview` environment so PR preview deployments can never push code to production lab PCs.
+
+### Manual operator-driven upgrade (`self-update`)
+
+Any watcher installed from PyPI — service or foreground — can upgrade itself in place via the CLI. This is the right path on macOS / Linux instrument PCs, on Windows PCs running the watcher in a console window, or any time you want an upgrade now rather than on the next hourly tick.
+
+```sh
+data-hub-watcher self-update            # check + upgrade if needed
+data-hub-watcher self-update --check    # report status only, no upgrade
+data-hub-watcher self-update --force    # re-run the upgrade subprocess
+                                        # even if the version already matches
+```
+
+The command asks the API for the latest published version, compares it to the locally installed version, and runs the appropriate upgrade subprocess for your install method:
+
+| Install method | Upgrade command |
+| --- | --- |
+| `uv tool install` | `uv tool install --reinstall data-hub-watcher==<latest>` |
+| Plain venv `pip install` | `<python> -m pip install -U data-hub-watcher==<latest>` |
+| Editable / `uv sync` checkout | Refused; upgrade manually with `git pull && uv sync` |
+
+After a successful CLI upgrade you must restart the watcher (or the Windows service) for the new code to take effect — `self-update` does not restart the running process. To run upgrades unattended without the Windows service, schedule the CLI via Windows Task Scheduler (e.g. weekly).
+
+### Editable / developer checkouts
+
+If the watcher is installed editable from a checkout (`uv sync --all-packages`), both the auto-updater and `self-update` will refuse to act and tell you to upgrade manually with `git pull && uv sync`. Auto-upgrading would silently shadow your source tree with an index build, which has burned us before — the refusal is intentional.
+
+The detection lives in `data_hub_watcher.self_update.detect_install_method` and reads `direct_url.json` from the dist's metadata; the editable check takes precedence over every other heuristic, so even an editable install whose `.venv` happens to live under a `uv/tools/` directory still gets refused.
+
+## Pinning a specific version
+
+If you want a specific PC to stay on a particular release rather than tracking the server's `latest_version`, pin it explicitly:
+
+```sh
+uv tool install data-hub-watcher==<pinned>
+```
+
+Run `data-hub-watcher self-update --check` afterwards to confirm what the server's target is. As long as the pinned version matches `latest_version`, the auto-update tick is a no-op. The moment the server's target moves past your pin, the next tick will try to upgrade past it again — pinning is per-machine state, not server-side state. To park a fleet on a given version intentionally, the right knob is the server-side `WATCHER_LATEST_VERSION` env var (see [Cutting a new release](#cutting-a-new-release)).
+
+## Cutting a new release
+
+This section is for admins shipping a new `data-hub-watcher` build. The flow is intentionally tag-driven so you can't accidentally publish from a feature branch.
+
+### 1. Bump the version
+
+Edit `[project].version` in `watcher/pyproject.toml`. Follow [PEP 440](https://peps.python.org/pep-0440/) (`X.Y.Z`, with optional pre-release suffixes). Open the bump as a PR against `staging`, smoke-test it from a checkout, then merge to `production` once it's clean.
+
+Bumping the version on `staging` alone is not enough — `publish-watcher.yml` only runs on `watcher-v*` tags, and tags should always point at a `production` commit so the published wheel matches what's deployed to the web app.
+
+### 2. Tag the release commit and push the tag
+
+```sh
+git checkout production
+git pull
+git tag watcher-v0.3.0
+git push origin watcher-v0.3.0
+```
+
+The `publish-watcher.yml` workflow runs automatically. Its `build` job calls `make py-check-watcher-version`, which refuses to proceed if the git tag and `watcher/pyproject.toml` disagree — so a typo in either fails fast before anything reaches PyPI.
+
+### 3. Approve the `pypi` deployment
+
+`publish-watcher.yml` is gated on the `pypi` GitHub deployment environment. Approve it under **Actions → Publish watcher** in the GitHub UI. Once approved, the `publish` job uploads the wheel + sdist to PyPI via OIDC trusted publishing (no API token in repo secrets), and the `verify` job installs `data-hub-watcher==<tag-version>` from PyPI into a clean venv and runs `data-hub-watcher --version` plus `python -c "import data_hub_watcher"` as a smoke test. The verify step catches stale-mirror shadows and module-level import side-effects that would otherwise only surface on a lab PC.
+
+If a transient PyPI outage breaks one of those steps after a successful build, you can re-run the workflow from the GitHub UI: **Actions → Publish watcher → Run workflow** on the `production` branch. The `skip-existing: true` flag on the publish step makes the retry safe — files already uploaded with the same hash are skipped rather than failing the run with `400: file already exists`. Manual dispatch from any branch other than `production` is refused by the workflow's `if:` guard.
+
+### 4. Roll the release out
+
+Once the new version is live on PyPI, bump the server-side `WATCHER_LATEST_VERSION` env var in Vercel (per environment) so the `/update-check` endpoint advertises the new target. Lab PCs running an auto-update-capable build will pick it up on their next hourly tick.
+
+The supported watcher release env vars are:
+
+| Env var | Purpose |
+| --- | --- |
+| `WATCHER_LATEST_VERSION` | Required to advertise a release. `null`/unset means "no update info available" and the watcher skips its update attempt. |
+| `WATCHER_MIN_SUPPORTED_VERSION` | Optional floor; surfaced in the response for future use. Not yet enforced server-side. |
+| `WATCHER_RELEASE_CHANNEL` | Defaults to `stable`. Surfaced in the response and shown in `self-update` output. |
+| `WATCHER_MANDATORY_UPDATE` | Set to `true` / `1` to flag the release as mandatory (see below). |
+
+Do **not** bump `WATCHER_LATEST_VERSION` ahead of the PyPI publish — the watcher's upgrade subprocess will fail to resolve a version that doesn't yet exist on the index, and you'll see a wave of `update_failed` events from the fleet. Always: tag → publish → verify → bump env var.
+
+If the rollout needs to be paged through (e.g. you want only `staging` lab PCs to see the new version while you babysit it for a day), bump only the staging environment's `WATCHER_LATEST_VERSION`. The `production` environment keeps advertising the previous version until you bump it explicitly.
+
+## Mandatory updates
+
+By default the activity-window guard means a watcher mid-acquisition won't auto-update — it'll wait for the next idle window. For releases that fix a security issue, a wire-protocol break, or any other case where running the known-bad version is worse than a brief outage, set `WATCHER_MANDATORY_UPDATE=true` alongside the version bump. Mandatory rollouts skip the activity-window guard and fire on the very next hourly check on every lab PC.
+
+Use this sparingly. The activity-window guard exists for a reason — a forced upgrade in the middle of a multi-hour microscopy run will lose data. Reserve it for cases where leaving the bad version in place is strictly worse than restarting the watcher in flight.
+
+Note also that mandatory rollouts are versioned, not absolute: the server compares the running version against `latest_version` and only forces the upgrade when they differ. A correctly-pinned PC that already matches `latest_version` won't be forced to do anything.
+
+## Rolling back
+
+Rollback is just another release. To revert the fleet from `0.3.0` to `0.2.5`:
+
+1. Set `WATCHER_LATEST_VERSION=0.2.5` in Vercel for the affected environment(s).
+2. Set `WATCHER_MANDATORY_UPDATE=true` if you need the rollback to bypass the activity-window guard (most rollback scenarios qualify — you're rolling back precisely because the running version is misbehaving).
+3. Wait for the next hourly tick on each PC. Lab PCs running an auto-update-capable build will downgrade themselves; PCs being upgraded manually need a `data-hub-watcher self-update` (or an `uv tool install data-hub-watcher==0.2.5` if `self-update` itself is what's broken).
+4. Once the fleet has converged, set `WATCHER_MANDATORY_UPDATE` back to `false`.
+
+There is no separate "yank" step — a rolled-back release is still on PyPI and still reinstallable, just not advertised by `/update-check`.
+
+## Troubleshooting
+
+### `update_started` is followed by `update_failed`
+
+The upgrade subprocess started but didn't end up running the new version on the next process startup. The `details.reason` field on the `update_failed` event tells you which sub-case fired:
+
+- **`subprocess raised: …`** — `subprocess.run` itself raised before it could exec the upgrade command. Typically `FileNotFoundError` because `uv` isn't on PATH for the service account, or a permission error. Check `~/.data-hub/watcher.log` for the full traceback.
+- **`subprocess exited <N>`** — the upgrade command itself failed. The event details include the last 1000 bytes of stdout/stderr; the most common cause is a transient PyPI / mirror failure or the version not yet existing on the index (see the "don't bump ahead of publish" note above).
+- **`expected '<target>' after upgrade, running '<current>'`** — the subprocess succeeded, the service restarted, but the running interpreter still imports the old version. Almost always means a stale `__pycache__` or a separate copy of the package on `sys.path`. Run `uv tool uninstall data-hub-watcher && uv tool install data-hub-watcher==<target>` as the service account.
+
+### Auto-update never fires
+
+Check, in order:
+
+- The watcher is running as a service, not in a console window. Foreground `data-hub-watcher watch` does run the in-process updater, but on a developer-style install it'll typically be refused as editable.
+- The environment isn't `preview`. Auto-update is hard-disabled there.
+- The activity-window guard isn't holding things up. The instrument has to have been quiet for several heartbeats; on a busy plate reader you may simply never hit the idle window. Use the CLI path (`data-hub-watcher self-update`) for an immediate upgrade, or set `WATCHER_MANDATORY_UPDATE=true` if the release warrants it.
+- The dashboard's **Last Heartbeat** is recent. If the watcher has gone stale, it's not ticking and won't auto-update.
+
+### `data-hub-watcher self-update --check` says "(none configured)"
+
+`WATCHER_LATEST_VERSION` is unset for that environment. Either you're running against a `preview` build that doesn't have the env var set, or someone unset it in Vercel. The CLI returns successfully and treats this as "no update available" — the same response code path used by an up-to-date watcher — so this is benign, just informational.
+
+### "Refusing to self-update an editable / unknown install"
+
+You're running from a checkout (`uv sync --all-packages`). This is the [editable install refusal](#editable--developer-checkouts) — upgrade manually with `git pull && uv sync` from your repo. If you genuinely need to switch a developer machine onto a PyPI build, `uv tool install data-hub-watcher` from a separate shell will get you a parallel install on PATH, and you can switch between them by un-shadowing whichever you don't want active.
+
+### A failed upgrade left a stale marker
+
+The on-disk upgrade marker at `~/.data-hub/.upgrade-in-progress` is consumed and deleted on read by the next process startup, so a single failure won't be reported indefinitely. If you see the file persisting across multiple restarts, the watcher is failing to start up at all (so it never reaches the `evaluate_upgrade_marker` step). Delete the marker manually, fix the underlying startup issue, and the next clean start will report cleanly.

--- a/docs/guides/upgrading-the-watcher.md
+++ b/docs/guides/upgrading-the-watcher.md
@@ -16,6 +16,7 @@ On each tick the service:
 
 1. Calls `GET /api/v1/watchers/<watcher-id>/update-check` and compares the server's `latest_version` against its own.
 2. Only attempts an upgrade if **all** of these are true: a newer version is available, no files have been uploaded for several heartbeats in a row, and no run has been reported within roughly 5× the configured `stability_period_seconds`. The activity-window guard exists so the watcher never takes itself down mid-acquisition.
+    - **Exception:** releases flagged as `mandatory` on the server skip the activity-window check entirely and are applied immediately — this is reserved for security fixes or breaking wire-protocol changes where leaving the old version running is worse than a brief interruption.
 3. Runs `uv tool install --reinstall data-hub-watcher==<latest>` (or the `pip install -U` equivalent for non-uv installs) on a dedicated background thread, so heartbeats keep flowing while the install executes — which can take 30–60 s on slow links. Before the subprocess starts, the service emits an `update_started` event you can see in the **Watchers** page.
 4. On success, exits non-zero so the Windows SCM restarts the service into the new wheel via its configured failure-actions policy. The new process emits `update_succeeded` once it confirms the new version is actually loaded; if the new code crashes at startup or otherwise doesn't take effect, you'll see `update_failed` instead.
 
@@ -44,7 +45,7 @@ After a successful CLI upgrade you must restart the watcher (or the Windows serv
 
 ### Editable / developer checkouts
 
-If the watcher is installed editable from a checkout (`uv sync --all-packages`), both the auto-updater and `self-update` will refuse to act and tell you to upgrade manually with `git pull && uv sync`. Auto-upgrading would silently shadow your source tree with an index build, which has burned us before — the refusal is intentional.
+If the watcher is installed editable from a checkout (`uv sync --all-packages`), both the auto-updater and `self-update` will refuse to act and tell you to upgrade manually with `git pull && uv sync`. The refusal is intentional, since auto-upgrading would silently shadow your source tree with an index build.
 
 The detection lives in `data_hub_watcher.self_update.detect_install_method` and reads `direct_url.json` from the dist's metadata; the editable check takes precedence over every other heuristic, so even an editable install whose `.venv` happens to live under a `uv/tools/` directory still gets refused.
 
@@ -81,9 +82,13 @@ The `publish-watcher.yml` workflow runs automatically. Its `build` job calls `ma
 
 ### 3. Approve the `pypi` deployment
 
-`publish-watcher.yml` is gated on the `pypi` GitHub deployment environment. Approve it under **Actions → Publish watcher** in the GitHub UI. Once approved, the `publish` job uploads the wheel + sdist to PyPI via OIDC trusted publishing (no API token in repo secrets), and the `verify` job installs `data-hub-watcher==<tag-version>` from PyPI into a clean venv and runs `data-hub-watcher --version` plus `python -c "import data_hub_watcher"` as a smoke test. The verify step catches stale-mirror shadows and module-level import side-effects that would otherwise only surface on a lab PC.
+`publish-watcher.yml` is gated on the `pypi` GitHub deployment environment. Approve it under **Actions → Publish watcher** in the GitHub UI.
 
-If a transient PyPI outage breaks one of those steps after a successful build, you can re-run the workflow from the GitHub UI: **Actions → Publish watcher → Run workflow** on the `production` branch. The `skip-existing: true` flag on the publish step makes the retry safe — files already uploaded with the same hash are skipped rather than failing the run with `400: file already exists`. Manual dispatch from any branch other than `production` is refused by the workflow's `if:` guard.
+Once approved, the `publish` job uploads the wheel + sdist to PyPI via OIDC trusted publishing (no API token in repo secrets), and the `verify` job installs `data-hub-watcher==<tag-version>` from PyPI into a clean venv and runs `data-hub-watcher --version` plus `python -c "import data_hub_watcher"` as a smoke test. The verify step catches stale-mirror shadows and module-level import side-effects that would otherwise only surface on a lab PC.
+
+If a transient PyPI outage breaks one of those steps after a successful build, you can re-run the workflow from the GitHub UI: **Actions → Publish watcher → Run workflow** on the `production` branch. The `skip-existing: true` flag on the publish step makes the retry safe — files already uploaded with the same hash are skipped rather than failing the run with `400: file already exists`.
+
+Manual dispatch from any branch other than `production` is refused by the workflow's `if:` guard.
 
 ### 4. Roll the release out
 

--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -30,6 +30,8 @@ uv run data-hub-watcher init
 uv run data-hub-watcher watch
 ```
 
+For lab-PC installs (PyPI), see [Installing a watcher](guides/installing-a-watcher.md). For releasing new versions and how the in-place upgrade flow works (CLI `self-update` and the Windows-service auto-updater), see [Upgrading the watcher](guides/upgrading-the-watcher.md).
+
 ## Commands
 
 ### `init`
@@ -102,6 +104,10 @@ Manage the watcher as a Windows service:
 | `service start` | Start the service |
 | `service stop` | Stop the service |
 | `service status` | Show service status |
+
+### `self-update`
+
+Checks the API for a newer published version and runs the appropriate `uv tool install --reinstall` (or `pip install -U`) subprocess in place. See [Upgrading the watcher](guides/upgrading-the-watcher.md) for the supported install methods, the activity-window guard, mandatory updates, and rollback flow.
 
 ## Configuration
 

--- a/packages/shared/src/data_hub_shared/testing.py
+++ b/packages/shared/src/data_hub_shared/testing.py
@@ -250,6 +250,12 @@ def start_test_server() -> Generator[IntegrationEnv, None, None]:
         "AWS_SECRET_ACCESS_KEY": os.environ.get("AWS_SECRET_ACCESS_KEY", "test-secret"),
         "AWS_REGION": os.environ.get("AWS_REGION", "us-east-1"),
         "S3_RAW_DATA_BUCKET": os.environ.get("S3_RAW_DATA_BUCKET", "data-hub-test-raw"),
+        # Stable defaults for the watcher update-check endpoint so Python
+        # integration tests can assert on a known target version.
+        "WATCHER_LATEST_VERSION": os.environ.get("WATCHER_LATEST_VERSION", "9.9.9"),
+        "WATCHER_MIN_SUPPORTED_VERSION": os.environ.get("WATCHER_MIN_SUPPORTED_VERSION", "0.1.0"),
+        "WATCHER_RELEASE_CHANNEL": os.environ.get("WATCHER_RELEASE_CHANNEL", "stable"),
+        "WATCHER_MANDATORY_UPDATE": os.environ.get("WATCHER_MANDATORY_UPDATE", "false"),
     }
 
     build_result = subprocess.run(

--- a/uv.lock
+++ b/uv.lock
@@ -415,7 +415,7 @@ requires-dist = [
 
 [[package]]
 name = "data-hub-watcher"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "watcher" }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -420,6 +420,7 @@ source = { editable = "watcher" }
 dependencies = [
     { name = "click" },
     { name = "data-hub-shared" },
+    { name = "packaging" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -435,6 +436,7 @@ windows-service = [
 requires-dist = [
     { name = "click", specifier = ">=8.2.1" },
     { name = "data-hub-shared", editable = "packages/shared" },
+    { name = "packaging", specifier = ">=24.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "pywin32", marker = "extra == 'windows-service'" },

--- a/uv.lock
+++ b/uv.lock
@@ -419,7 +419,6 @@ version = "0.1.0"
 source = { editable = "watcher" }
 dependencies = [
     { name = "click" },
-    { name = "data-hub-shared" },
     { name = "packaging" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -432,10 +431,14 @@ windows-service = [
     { name = "pywin32" },
 ]
 
+[package.dev-dependencies]
+test = [
+    { name = "data-hub-shared" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.2.1" },
-    { name = "data-hub-shared", editable = "packages/shared" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
     { name = "python-dotenv", specifier = ">=1.0" },
@@ -444,6 +447,9 @@ requires-dist = [
     { name = "watchdog", specifier = ">=4.0.0" },
 ]
 provides-extras = ["windows-service"]
+
+[package.metadata.requires-dev]
+test = [{ name = "data-hub-shared", editable = "packages/shared" }]
 
 [[package]]
 name = "distlib"

--- a/watcher/LICENSE
+++ b/watcher/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Arcadia Science
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/watcher/README.md
+++ b/watcher/README.md
@@ -1,0 +1,29 @@
+# data-hub-watcher
+
+A file-watcher agent that runs on lab instrument PCs and uploads new files to the [Arcadia Science Data Hub](https://github.com/Arcadia-Science/data-hub). It groups files into runs, retries uploads, sends heartbeats, and can optionally run as a Windows service.
+
+## Install
+
+```sh
+uv tool install data-hub-watcher
+```
+
+The CLI is published as the `data-hub-watcher` script. After installing, walk through the interactive setup wizard:
+
+```sh
+data-hub-watcher init
+```
+
+## Usage
+
+```sh
+data-hub-watcher watch          # start watching for files
+data-hub-watcher self-update    # check for and apply package updates
+data-hub-watcher service install  # Windows: install as a service
+```
+
+See [the operator guide](https://github.com/Arcadia-Science/data-hub/blob/main/docs/guides/installing-a-watcher.md) for the full setup walk-through, configuration reference, and troubleshooting.
+
+## License
+
+MIT — see the `LICENSE` file bundled with the wheel.

--- a/watcher/pyproject.toml
+++ b/watcher/pyproject.toml
@@ -1,10 +1,30 @@
 [project]
 name = "data-hub-watcher"
 version = "0.1.0"
+description = "File-watcher agent for lab instrument PCs that ingests data into the Arcadia Science Data Hub."
+readme = "README.md"
 requires-python = ">=3.12"
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [
+    { name = "Arcadia Science", email = "engineering@arcadiascience.com" },
+]
+keywords = ["arcadia", "data-hub", "lab", "instruments", "watcher", "uploader"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Science/Research",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering",
+    "Topic :: System :: Filesystems",
+    "Topic :: System :: Monitoring",
+]
 dependencies = [
     "click>=8.2.1",
-    "data-hub-shared",
     "packaging>=24.0",
     "pydantic>=2.11.9",
     "pyyaml>=6.0",
@@ -15,6 +35,20 @@ dependencies = [
 [project.optional-dependencies]
 windows-service = ["pywin32"]
 
+[project.urls]
+Homepage = "https://github.com/Arcadia-Science/data-hub"
+Documentation = "https://github.com/Arcadia-Science/data-hub/blob/main/docs/watcher.md"
+Repository = "https://github.com/Arcadia-Science/data-hub"
+Issues = "https://github.com/Arcadia-Science/data-hub/issues"
+
+# Test-only deps live in a PEP 735 group instead of `[project].dependencies`
+# so the published wheel does not advertise `data-hub-shared` as a runtime
+# requirement — the integration suite imports it (see `watcher/tests/integration/*`)
+# but no runtime watcher code does, and the package is not published to PyPI.
+# `uv sync` includes this group by default for local development.
+[dependency-groups]
+test = ["data-hub-shared"]
+
 [tool.uv.sources]
 data-hub-shared = { workspace = true }
 
@@ -22,7 +56,7 @@ data-hub-shared = { workspace = true }
 data-hub-watcher = "data_hub_watcher.cli:cli"
 
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/watcher/pyproject.toml
+++ b/watcher/pyproject.toml
@@ -37,7 +37,11 @@ windows-service = ["pywin32"]
 
 [project.urls]
 Homepage = "https://github.com/Arcadia-Science/data-hub"
-Documentation = "https://github.com/Arcadia-Science/data-hub/blob/main/docs/watcher.md"
+# Operator-facing install + auto-update guide — what someone landing on
+# the PyPI page actually needs. The developer-facing `docs/watcher.md`
+# describes the editable-checkout workflow and is reachable from the
+# repository link below.
+Documentation = "https://github.com/Arcadia-Science/data-hub/blob/production/docs/guides/installing-a-watcher.md"
 Repository = "https://github.com/Arcadia-Science/data-hub"
 Issues = "https://github.com/Arcadia-Science/data-hub/issues"
 

--- a/watcher/pyproject.toml
+++ b/watcher/pyproject.toml
@@ -5,6 +5,7 @@ requires-python = ">=3.12"
 dependencies = [
     "click>=8.2.1",
     "data-hub-shared",
+    "packaging>=24.0",
     "pydantic>=2.11.9",
     "pyyaml>=6.0",
     "python-dotenv>=1.0",

--- a/watcher/pyproject.toml
+++ b/watcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-hub-watcher"
-version = "0.2.0"
+version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
     "click>=8.2.1",

--- a/watcher/src/data_hub_watcher/api_client.py
+++ b/watcher/src/data_hub_watcher/api_client.py
@@ -19,6 +19,7 @@ from data_hub_watcher.models import (
     RunDetailResponse,
     RunResponse,
     UploadQueueResponse,
+    WatcherUpdateInfoResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -174,6 +175,15 @@ class DataHubClient:
     def send_events(self, watcher_id: str, events: list[dict[str, Any]]) -> EventsResponse:
         resp = self._request("POST", f"/watchers/{watcher_id}/events", json={"events": events})
         return EventsResponse.model_validate(resp.json())
+
+    def get_update_info(self, watcher_id: str) -> WatcherUpdateInfoResponse:
+        """Fetch server-reported watcher release metadata.
+
+        Used by `self-update` and the in-process updater to decide whether
+        the running watcher should upgrade itself.
+        """
+        resp = self._request("GET", f"/watchers/{watcher_id}/update-check")
+        return WatcherUpdateInfoResponse.model_validate(resp.json())
 
     # ------------------------------------------------------------------
     # Runs

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -7,7 +7,6 @@ import re
 import signal
 import subprocess
 import sys
-import time
 from pathlib import Path
 from typing import Any
 
@@ -750,8 +749,20 @@ def watch(ctx: click.Context, dry_run: bool) -> None:
     signal.signal(signal.SIGINT, _shutdown)
     signal.signal(signal.SIGTERM, _shutdown)
 
-    while True:
-        time.sleep(1)
+    # Block on the runtime's shutdown event so the in-process auto-updater
+    # can request a restart from the heartbeat thread without needing a
+    # signal. Ctrl+C still works because the SIGINT handler raises
+    # SystemExit(0) directly out of `Event.wait` (Python interrupts the
+    # blocking call to deliver the signal).
+    while not rt.shutdown_event.wait(timeout=1.0):
+        pass
+
+    click.echo("\nUpgrade installed; restarting to load the new version…")
+    stop_runtime(rt, stopped_message="Watcher restarting for auto-update")
+    # Exit non-zero so any supervisor (or the operator's wrapper script)
+    # restarts us. The `data-hub-watcher service` Windows path uses the
+    # SCM's failure-actions config to do this automatically.
+    raise SystemExit(1)
 
 
 # ---------------------------------------------------------------------------

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -22,6 +22,7 @@ from data_hub_watcher.constants import (
     RUN_DETECTION_PRESETS,
     STATE_DB_FILENAME,
     SUPPORTED_ENVIRONMENTS,
+    WATCHER_VERSION,
     env_file_path,
     load_env,
     resolve_config_path,
@@ -35,6 +36,12 @@ from data_hub_watcher.models import (
     WatcherConfig,
 )
 from data_hub_watcher.runtime import build_runtime, start_runtime, stop_runtime
+from data_hub_watcher.self_update import (
+    InstallMethod,
+    detect_install_method,
+    evaluate_update,
+    run_upgrade,
+)
 from data_hub_watcher.state import StateDB
 from data_hub_watcher.uploader import Uploader
 
@@ -840,6 +847,91 @@ def upload(ctx: click.Context, file_path: str | None, run_id: str | None, dry_ru
         reporter.flush()
         click.echo(click.style(f"✓ Processed {len(queue.files)} file(s).", fg="green"))
         state_db.close()
+
+
+# ---------------------------------------------------------------------------
+# self-update command
+# ---------------------------------------------------------------------------
+
+
+@cli.command("self-update")
+@click.option(
+    "--check",
+    is_flag=True,
+    help="Print the server-reported target version without performing the upgrade.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Run the upgrade subprocess even if the local version already matches the target.",
+)
+@click.pass_context
+def self_update(ctx: click.Context, check: bool, force: bool) -> None:
+    """Check the server for a newer watcher release and upgrade in place.
+
+    Designed for unattended use — schedule via Windows Task Scheduler
+    (e.g. weekly) so lab PCs converge on the latest published version
+    without operator intervention.
+    """
+    cfg, client, _path = _load_and_client(ctx)
+    if not cfg.watcher_id:
+        raise click.ClickException("No watcher_id in config. Run 'data-hub-watcher init' first.")
+
+    click.echo(f"Current version: {WATCHER_VERSION}")
+
+    try:
+        info = client.get_update_info(cfg.watcher_id)
+    except ApiError as exc:
+        raise click.ClickException(f"Failed to fetch update info: {exc.message}") from exc
+
+    target_label = info.latest_version or "(none configured)"
+    mandatory_label = " [mandatory]" if info.mandatory else ""
+    click.echo(f"Server target:   {target_label} (channel={info.channel}){mandatory_label}")
+
+    decision = evaluate_update(info, force=force)
+
+    if check:
+        verb = "Would upgrade" if decision.should_update else "No upgrade needed"
+        click.echo(f"{verb}: {decision.reason}.")
+        return
+
+    if not decision.should_update:
+        click.echo(f"Already up to date: {decision.reason}.")
+        return
+
+    method = detect_install_method()
+    click.echo(f"Install method:  {method.value}")
+    if method in (InstallMethod.EDITABLE, InstallMethod.UNKNOWN):
+        raise click.ClickException(
+            "Refusing to self-update an editable / unknown install. "
+            "Upgrade manually with 'git pull && uv sync' from your checkout."
+        )
+
+    click.echo(f"Upgrading {decision.current_version} -> {decision.target_version}…")
+    try:
+        result = run_upgrade(method, target_version=decision.target_version)
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if result.stdout:
+        click.echo(result.stdout.rstrip())
+    if result.stderr:
+        click.echo(result.stderr.rstrip(), err=True)
+
+    if result.returncode != 0:
+        raise click.ClickException(
+            f"Upgrade subprocess exited with code {result.returncode}. "
+            "The previous installation should still be functional; review "
+            "the output above and try again."
+        )
+
+    click.echo(
+        click.style(
+            f"\u2713 Upgrade to {decision.target_version} complete. "
+            "Restart the watcher (or the Windows service) to load the new code.",
+            fg="green",
+        )
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -757,12 +757,22 @@ def watch(ctx: click.Context, dry_run: bool) -> None:
     while not rt.shutdown_event.wait(timeout=1.0):
         pass
 
-    click.echo("\nUpgrade installed; restarting to load the new version…")
-    stop_runtime(rt, stopped_message="Watcher restarting for auto-update")
-    # Exit non-zero so any supervisor (or the operator's wrapper script)
-    # restarts us. The `data-hub-watcher service` Windows path uses the
-    # SCM's failure-actions config to do this automatically.
-    raise SystemExit(1)
+    # Distinguish an upgrade-driven shutdown from a generic one by
+    # checking the dedicated event — mirrors the Windows-service main
+    # loop in `service._run_service_loop`. This keeps the operator-
+    # facing message accurate if any future code path ever sets
+    # `shutdown_event` for a non-upgrade reason.
+    if rt.upgrade_restart_event.is_set():
+        click.echo("\nUpgrade installed; restarting to load the new version…")
+        stop_runtime(rt, stopped_message="Watcher restarting for auto-update")
+        # Exit non-zero so any supervisor (or the operator's wrapper
+        # script) restarts us. The `data-hub-watcher service` Windows
+        # path uses the SCM's failure-actions config to do this
+        # automatically.
+        raise SystemExit(1)
+
+    stop_runtime(rt, stopped_message="Watcher stopped")
+    raise SystemExit(0)
 
 
 # ---------------------------------------------------------------------------

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -34,7 +34,7 @@ from data_hub_watcher.models import (
     RunDetectionConfig,
     WatcherConfig,
 )
-from data_hub_watcher.runtime import build_runtime, start_runtime, stop_runtime
+from data_hub_watcher.runtime import build_runtime, classify_shutdown, start_runtime, stop_runtime
 from data_hub_watcher.self_update import (
     InstallMethod,
     detect_install_method,
@@ -758,21 +758,28 @@ def watch(ctx: click.Context, dry_run: bool) -> None:
         pass
 
     # Distinguish an upgrade-driven shutdown from a generic one by
-    # checking the dedicated event — mirrors the Windows-service main
-    # loop in `service._run_service_loop`. This keeps the operator-
-    # facing message accurate if any future code path ever sets
-    # `shutdown_event` for a non-upgrade reason.
-    if rt.upgrade_restart_event.is_set():
-        click.echo("\nUpgrade installed; restarting to load the new version…")
-        stop_runtime(rt, stopped_message="Watcher restarting for auto-update")
-        # Exit non-zero so any supervisor (or the operator's wrapper
-        # script) restarts us. The `data-hub-watcher service` Windows
-        # path uses the SCM's failure-actions config to do this
-        # automatically.
-        raise SystemExit(1)
-
-    stop_runtime(rt, stopped_message="Watcher stopped")
-    raise SystemExit(0)
+    # delegating to `classify_shutdown` — the same helper used by the
+    # Windows service path in `service._run_service_loop`, so the two
+    # entrypoints can't drift on the WATCHER_STOPPED message text.
+    decision = classify_shutdown(rt, role="Watcher")
+    if decision.is_upgrade_restart:
+        # Foreground `data-hub-watcher watch` doesn't have an SCM to
+        # auto-restart it, so the message has to cover both audiences:
+        # Windows-service operators (whose SCM picks the new wheel up
+        # via the failure-actions policy on the non-zero exit below)
+        # and console / macOS / Linux operators (who need to re-run
+        # the command manually). The previous "restarting…" wording
+        # was only accurate under the SCM.
+        click.echo(
+            "\nUpgrade installed. Re-run data-hub-watcher watch to load the new "
+            "version (or install the service for automatic restart)."
+        )
+    stop_runtime(rt, stopped_message=decision.stopped_message)
+    # Exit non-zero on upgrade restart so any supervisor (or the
+    # operator's wrapper script) restarts us. The `data-hub-watcher
+    # service` Windows path uses the SCM's failure-actions config to
+    # do this automatically.
+    raise SystemExit(1 if decision.is_upgrade_restart else 0)
 
 
 # ---------------------------------------------------------------------------

--- a/watcher/src/data_hub_watcher/constants.py
+++ b/watcher/src/data_hub_watcher/constants.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import os
 import re
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -9,6 +10,21 @@ API_URLS: dict[str, str] = {
     "staging": "https://data-hub-env-staging-arcadia-science.vercel.app/api/v1",
     "production": "https://data-hub.arcadiascience.com/api/v1",
 }
+
+
+def _read_watcher_version() -> str:
+    # Resolve the installed distribution version once at import time so the
+    # value can be embedded in heartbeats. When the watcher is being run from
+    # an editable checkout outside its own metadata (e.g. some test contexts)
+    # the dist may not be importable; fall back to a sentinel rather than
+    # crashing the heartbeat loop.
+    try:
+        return version("data-hub-watcher")
+    except PackageNotFoundError:
+        return "0.0.0+unknown"
+
+
+WATCHER_VERSION: str = _read_watcher_version()
 
 DEFAULT_CONFIG_DIR = Path("~/.data-hub").expanduser()
 DEFAULT_CONFIG_FILENAME = "config.yaml"

--- a/watcher/src/data_hub_watcher/events.py
+++ b/watcher/src/data_hub_watcher/events.py
@@ -19,6 +19,13 @@ class EventType(str, Enum):
     RUN_REPORTED = "run_reported"
     CONFIG_SYNCED = "config_synced"
     ERROR = "error"
+    # Auto-update lifecycle. UPDATE_STARTED is emitted when the in-process
+    # updater begins running the upgrade subprocess; UPDATE_SUCCEEDED /
+    # UPDATE_FAILED are emitted after the new version starts up (or
+    # doesn't), keyed off the on-disk upgrade marker.
+    UPDATE_STARTED = "update_started"
+    UPDATE_SUCCEEDED = "update_succeeded"
+    UPDATE_FAILED = "update_failed"
 
 
 @dataclass

--- a/watcher/src/data_hub_watcher/heartbeat.py
+++ b/watcher/src/data_hub_watcher/heartbeat.py
@@ -16,11 +16,21 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class WatcherCounters:
-    """Mutable counters reset after each heartbeat."""
+    """Mutable counters reset after each heartbeat.
+
+    The ``last_*`` snapshots persist across resets so consumers that run
+    *after* a heartbeat (e.g. the updater on the post-heartbeat tick
+    callback) can still observe the activity from the just-elapsed
+    interval. Without these the post-reset value is always zero, which
+    would falsely look like an idle window.
+    """
 
     files_uploaded: int = 0
     runs_reported: int = 0
     errors: int = 0
+    last_files_uploaded: int = 0
+    last_runs_reported: int = 0
+    last_errors: int = 0
 
 
 class HeartbeatLoop:
@@ -87,8 +97,13 @@ class HeartbeatLoop:
         except (ApiError, Exception) as exc:
             logger.warning("Heartbeat failed: %s", exc)
 
-        # Reset counters after every attempt (success or failure) so the next
-        # heartbeat only reports activity since the previous one, not cumulative.
+        # Snapshot the just-sent values into the `last_*` fields so post-reset
+        # consumers (e.g. the updater) can still see the most recent interval's
+        # activity. Then reset the live counters so the next heartbeat only
+        # reports activity since the previous one, not cumulative.
+        self.counters.last_files_uploaded = self.counters.files_uploaded
+        self.counters.last_runs_reported = self.counters.runs_reported
+        self.counters.last_errors = self.counters.errors
         self.counters.files_uploaded = 0
         self.counters.runs_reported = 0
         self.counters.errors = 0

--- a/watcher/src/data_hub_watcher/heartbeat.py
+++ b/watcher/src/data_hub_watcher/heartbeat.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from data_hub_watcher.api_client import ApiError, DataHubClient
+from data_hub_watcher.constants import WATCHER_VERSION
 from data_hub_watcher.events import EventReporter
 
 logger = logging.getLogger(__name__)
@@ -99,6 +100,7 @@ class HeartbeatLoop:
             "instrument_id": self._instrument_id,
             "watch_directory": self._watch_directory,
             "upload_mode": self._upload_mode,
+            "watcher_version": WATCHER_VERSION,
             "files_uploaded_since_last_heartbeat": self.counters.files_uploaded,
             "runs_reported_since_last_heartbeat": self.counters.runs_reported,
             "errors_since_last_heartbeat": self.counters.errors,

--- a/watcher/src/data_hub_watcher/models.py
+++ b/watcher/src/data_hub_watcher/models.py
@@ -236,3 +236,19 @@ class ApiErrorDetail(BaseModel):
     code: str
     message: str
     details: dict | None = None
+
+
+class WatcherUpdateInfoResponse(BaseModel):
+    """Server-reported release metadata for the `data-hub-watcher` package.
+
+    `latest_version` is `None` when the server has not been configured with a
+    target version yet — clients should treat this as "no update info
+    available" and skip the upgrade attempt rather than erroring out.
+    """
+
+    model_config = _API_MODEL_CONFIG
+
+    latest_version: str | None = None
+    min_supported_version: str | None = None
+    channel: str = "stable"
+    mandatory: bool = False

--- a/watcher/src/data_hub_watcher/runtime.py
+++ b/watcher/src/data_hub_watcher/runtime.py
@@ -54,6 +54,47 @@ class WatcherRuntime:
     upgrade_restart_event: threading.Event = field(default_factory=threading.Event)
 
 
+@dataclass(frozen=True)
+class ShutdownReason:
+    """Why the runtime is shutting down + the matching WATCHER_STOPPED message.
+
+    The CLI ``watch`` command and the Windows service both poll the
+    runtime's ``shutdown_event`` and need to attribute the resulting
+    ``WATCHER_STOPPED`` event to either a normal stop or an
+    auto-update-driven restart. Centralising the message text here keeps
+    the two paths in sync — historically the service path always logged
+    "Service stopped" even on auto-update restarts, which made it
+    impossible to correlate an ``update_started`` event with the
+    matching ``watcher_stopped`` event in the dashboard.
+    """
+
+    is_upgrade_restart: bool
+    stopped_message: str
+
+
+def classify_shutdown(rt: WatcherRuntime, *, role: str) -> ShutdownReason:
+    """Pick the right ``stopped_message`` for the WATCHER_STOPPED event.
+
+    *role* is the human-readable noun for this entrypoint
+    (``"Watcher"`` for the CLI, ``"Service"`` for the Windows service)
+    so the message reads naturally in the events stream regardless of
+    which path triggered the shutdown.
+
+    Note: the CLI's signal-initiated stop has its own "stopped by user"
+    message and does not go through this helper — at that point we
+    already know the cause is an operator signal, not the auto-updater.
+    """
+    if rt.upgrade_restart_event.is_set():
+        return ShutdownReason(
+            is_upgrade_restart=True,
+            stopped_message=f"{role} restarting for auto-update",
+        )
+    return ShutdownReason(
+        is_upgrade_restart=False,
+        stopped_message=f"{role} stopped",
+    )
+
+
 def build_runtime(
     *,
     client: DataHubClient,

--- a/watcher/src/data_hub_watcher/runtime.py
+++ b/watcher/src/data_hub_watcher/runtime.py
@@ -11,17 +11,23 @@ and thereby silently skipping manual-mode upload-queue polling.
 
 from __future__ import annotations
 import logging
-from dataclasses import dataclass
+import threading
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from data_hub_watcher.api_client import DataHubClient
-from data_hub_watcher.constants import HEARTBEAT_INTERVAL_SECONDS, PRUNE_DAYS
+from data_hub_watcher.constants import (
+    DEFAULT_CONFIG_DIR,
+    HEARTBEAT_INTERVAL_SECONDS,
+    PRUNE_DAYS,
+)
 from data_hub_watcher.events import EventReporter, EventType, WatcherEvent
 from data_hub_watcher.heartbeat import HeartbeatLoop, WatcherCounters
 from data_hub_watcher.models import WatcherConfig
 from data_hub_watcher.monitor import FileMonitor
 from data_hub_watcher.run_detector import RunDetector
 from data_hub_watcher.state import StateDB
+from data_hub_watcher.updater import Updater, evaluate_upgrade_marker
 from data_hub_watcher.uploader import Uploader
 
 logger = logging.getLogger(__name__)
@@ -38,6 +44,14 @@ class WatcherRuntime:
     detector: RunDetector
     monitor: FileMonitor
     heartbeat: HeartbeatLoop
+    updater: Updater
+    # Set when the in-process updater has successfully installed a new
+    # watcher version and wants the main loop to exit non-zero so the
+    # Windows SCM (or a foreground operator running ``watch``) restarts
+    # us into the new code. The CLI / service main loops poll this event
+    # in their stop wait so a shutdown can be triggered from any thread.
+    shutdown_event: threading.Event = field(default_factory=threading.Event)
+    upgrade_restart_event: threading.Event = field(default_factory=threading.Event)
 
 
 def build_runtime(
@@ -64,6 +78,27 @@ def build_runtime(
 
     counters = WatcherCounters()
     reporter = EventReporter(client, watcher_id)
+
+    shutdown_event = threading.Event()
+    upgrade_restart_event = threading.Event()
+
+    def _request_upgrade_restart(target_version: str) -> None:
+        logger.info(
+            "Auto-update: requesting service restart to load watcher %s",
+            target_version,
+        )
+        upgrade_restart_event.set()
+        shutdown_event.set()
+
+    updater = Updater(
+        client=client,
+        reporter=reporter,
+        counters=counters,
+        state_db=state_db,
+        cfg=cfg,
+        config_dir=DEFAULT_CONFIG_DIR,
+        request_upgrade_restart=_request_upgrade_restart,
+    )
 
     is_auto = inst.upload_mode == "auto"
 
@@ -98,15 +133,23 @@ def build_runtime(
         recursive=inst.run_detection.recursive,
     )
 
-    # In manual mode the server controls which files to upload. We
-    # piggyback on the heartbeat tick to poll the server's upload queue,
-    # so uploads happen at the same cadence as heartbeats without a
-    # separate timer.
-    def _poll_upload_queue() -> None:
+    # The heartbeat's `on_tick` hook is now multi-purpose:
+    #   1. In manual mode, poll the server's upload queue (uploads
+    #      naturally inherit the heartbeat cadence).
+    #   2. Always: feed the in-process auto-updater so it can count
+    #      idle ticks and run a server update-check roughly hourly.
+    # Each side wraps its own try/except so a failure on one side
+    # never blocks the other.
+    def _on_tick() -> None:
+        if not is_auto:
+            try:
+                uploader.poll_upload_queue()
+            except Exception:
+                logger.exception("Upload queue poll failed")
         try:
-            uploader.poll_upload_queue()
+            updater.on_tick()
         except Exception:
-            logger.exception("Upload queue poll failed")
+            logger.exception("Updater tick failed")
 
     heartbeat = HeartbeatLoop(
         client=client,
@@ -117,7 +160,7 @@ def build_runtime(
         watch_directory=str(inst.watch_directory),
         upload_mode=inst.upload_mode,
         counters=counters,
-        on_tick=_poll_upload_queue if not is_auto else None,
+        on_tick=_on_tick,
     )
 
     return WatcherRuntime(
@@ -128,6 +171,9 @@ def build_runtime(
         detector=detector,
         monitor=monitor,
         heartbeat=heartbeat,
+        updater=updater,
+        shutdown_event=shutdown_event,
+        upgrade_restart_event=upgrade_restart_event,
     )
 
 
@@ -137,6 +183,11 @@ def start_runtime(rt: WatcherRuntime, *, started_message: str) -> None:
     The `started_message` varies by entry point (`"Watcher started on …"`
     from the CLI vs `"Service started on …"` from the Windows service)
     so operators can tell from the event log which code path launched.
+
+    Also inspects the on-disk upgrade marker before any threads start so
+    a recently-attempted self-update is reported as
+    ``UPDATE_SUCCEEDED`` / ``UPDATE_FAILED`` from this fresh process,
+    not from the doomed old process that asked for the restart.
     """
     rt.reporter.queue_event(
         WatcherEvent(
@@ -144,6 +195,35 @@ def start_runtime(rt: WatcherRuntime, *, started_message: str) -> None:
             message=started_message,
         )
     )
+
+    outcome = evaluate_upgrade_marker(DEFAULT_CONFIG_DIR)
+    if outcome.found:
+        if outcome.succeeded:
+            rt.reporter.queue_event(
+                WatcherEvent(
+                    event_type=EventType.UPDATE_SUCCEEDED,
+                    message=(
+                        f"Restarted into upgraded watcher "
+                        f"{outcome.previous_version} -> {outcome.target_version}"
+                    ),
+                    details={
+                        "previous_version": outcome.previous_version,
+                        "target_version": outcome.target_version,
+                    },
+                )
+            )
+        else:
+            rt.reporter.queue_event(
+                WatcherEvent(
+                    event_type=EventType.UPDATE_FAILED,
+                    message=f"Watcher upgrade did not take effect: {outcome.reason}",
+                    details={
+                        "previous_version": outcome.previous_version,
+                        "target_version": outcome.target_version,
+                        "reason": outcome.reason,
+                    },
+                )
+            )
 
     # Rebuild in-memory run state from the local DB before any file
     # events fire. Without this, every restart starts with an empty

--- a/watcher/src/data_hub_watcher/self_update.py
+++ b/watcher/src/data_hub_watcher/self_update.py
@@ -1,0 +1,274 @@
+"""Self-update orchestration for the watcher package.
+
+This module is intentionally framework-agnostic so it can be driven from
+two places:
+
+* `data-hub-watcher self-update` — the operator-facing CLI command,
+  scheduled e.g. via Windows Task Scheduler.
+* An in-process updater invoked from the running service during idle
+  windows (added on top of these helpers).
+
+Both paths need to answer the same questions: how is this watcher
+installed, what command upgrades it, and is a newer version actually
+available? Keeping that logic here makes it unit-testable without
+spinning up a Click context or a real Windows service.
+"""
+
+from __future__ import annotations
+import json
+import logging
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from importlib.metadata import PackageNotFoundError, distribution
+from typing import Any
+
+from packaging.version import InvalidVersion, Version
+
+from data_hub_watcher.constants import WATCHER_VERSION
+from data_hub_watcher.models import WatcherUpdateInfoResponse
+
+logger = logging.getLogger(__name__)
+
+PACKAGE_NAME = "data-hub-watcher"
+
+# Default index for `pip install` invocations. PyPI is hard-coded for now;
+# can be made configurable per channel later.
+DEFAULT_INDEX_URL = "https://pypi.org/simple/"
+
+
+class InstallMethod(str, Enum):
+    """How the running watcher distribution was installed.
+
+    The value drives which subprocess we spawn to upgrade in place.
+    """
+
+    UV_TOOL = "uv-tool"
+    """Installed via `uv tool install data-hub-watcher`. Upgrade by
+    re-running `uv tool upgrade data-hub-watcher`."""
+
+    PIP = "pip"
+    """Installed into a regular venv via pip (or uv pip). Upgrade by
+    re-running `<sys.executable> -m pip install -U data-hub-watcher`."""
+
+    EDITABLE = "editable"
+    """Installed editable from a local checkout (e.g. workspace `uv sync`).
+    Refuse to self-update — the developer should `git pull && uv sync`
+    instead. Auto-updating an editable install would silently shadow the
+    source tree with an index-built copy."""
+
+    UNKNOWN = "unknown"
+    """Distribution metadata couldn't be located. Treat as a hard error;
+    we can't safely upgrade something we can't even find."""
+
+
+@dataclass
+class UpdateDecision:
+    """Outcome of comparing the local version against server-reported info.
+
+    Captures *why* we decided what we decided so callers can produce
+    actionable log lines and `UPDATE_*` events.
+    """
+
+    should_update: bool
+    reason: str
+    current_version: str
+    target_version: str | None
+
+
+# ---------------------------------------------------------------------------
+# Install-method detection
+# ---------------------------------------------------------------------------
+
+
+def detect_install_method(prefix: str | None = None) -> InstallMethod:
+    """Inspect distribution metadata + `sys.prefix` to classify the install.
+
+    *prefix* defaults to ``sys.prefix`` and is overridable for tests.
+
+    Detection order matters: we read `direct_url.json` first because an
+    editable install may also live inside a uv-managed prefix and we'd
+    rather refuse to upgrade an editable checkout than silently overwrite
+    it with an index build.
+    """
+    try:
+        dist = distribution(PACKAGE_NAME)
+    except PackageNotFoundError:
+        return InstallMethod.UNKNOWN
+
+    # PEP 610 — pip / uv write a `direct_url.json` file alongside the dist
+    # info when a package was installed from a non-index source. The
+    # `dir_info.editable` flag is the canonical signal for `pip install -e`
+    # and `uv sync` workspace installs.
+    direct_url_text = dist.read_text("direct_url.json")
+    if direct_url_text:
+        try:
+            direct_url = json.loads(direct_url_text)
+        except json.JSONDecodeError:
+            direct_url = {}
+        if isinstance(direct_url, dict):
+            dir_info = direct_url.get("dir_info") or {}
+            if isinstance(dir_info, dict) and dir_info.get("editable"):
+                return InstallMethod.EDITABLE
+
+    raw_prefix = prefix or sys.prefix
+    # Normalize backslashes manually so the substring check works on a
+    # Windows-style path even when this runs on a POSIX test host (where
+    # `Path(...).as_posix()` would still keep the backslashes intact).
+    prefix_posix = raw_prefix.replace("\\", "/")
+    if "/uv/tools/data-hub-watcher" in prefix_posix:
+        return InstallMethod.UV_TOOL
+
+    return InstallMethod.PIP
+
+
+# ---------------------------------------------------------------------------
+# Version comparison
+# ---------------------------------------------------------------------------
+
+
+def _safe_parse(version_str: str | None) -> Version | None:
+    if not version_str:
+        return None
+    try:
+        return Version(version_str)
+    except InvalidVersion:
+        logger.warning("Ignoring un-parseable version string: %r", version_str)
+        return None
+
+
+def evaluate_update(
+    info: WatcherUpdateInfoResponse,
+    *,
+    current_version: str = WATCHER_VERSION,
+    force: bool = False,
+) -> UpdateDecision:
+    """Decide whether the running watcher should upgrade.
+
+    `force=True` short-circuits the version comparison and always returns
+    `should_update=True` (as long as the server reports a target). Used
+    by the `--force` flag on the CLI for ops debugging.
+    """
+    target = info.latest_version
+    if target is None:
+        return UpdateDecision(
+            should_update=False,
+            reason="server has no release info configured",
+            current_version=current_version,
+            target_version=None,
+        )
+
+    current = _safe_parse(current_version)
+    target_v = _safe_parse(target)
+
+    if force:
+        return UpdateDecision(
+            should_update=target_v is not None,
+            reason="forced by caller",
+            current_version=current_version,
+            target_version=target,
+        )
+
+    if current is None or target_v is None:
+        # If either side is un-parseable we can't make a safe ordering
+        # decision; refuse the update rather than risk a downgrade.
+        return UpdateDecision(
+            should_update=False,
+            reason="could not compare versions",
+            current_version=current_version,
+            target_version=target,
+        )
+
+    if info.mandatory and current != target_v:
+        return UpdateDecision(
+            should_update=True,
+            reason="server marked release as mandatory",
+            current_version=current_version,
+            target_version=target,
+        )
+
+    if current >= target_v:
+        return UpdateDecision(
+            should_update=False,
+            reason="already at or ahead of target",
+            current_version=current_version,
+            target_version=target,
+        )
+
+    return UpdateDecision(
+        should_update=True,
+        reason="newer version available",
+        current_version=current_version,
+        target_version=target,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Upgrade execution
+# ---------------------------------------------------------------------------
+
+
+def build_upgrade_command(
+    method: InstallMethod,
+    *,
+    target_version: str | None = None,
+    index_url: str | None = None,
+    python_executable: str | None = None,
+    uv_executable: str | None = None,
+) -> list[str]:
+    """Translate an install method into the concrete subprocess argv.
+
+    Pinning *target_version* lets the server roll a specific release out
+    rather than always landing on whatever the index calls "latest" — which
+    matters when we want to roll back by re-pinning to an older version.
+    """
+    pkg_spec = PACKAGE_NAME if not target_version else f"{PACKAGE_NAME}=={target_version}"
+    index = index_url or DEFAULT_INDEX_URL
+
+    if method is InstallMethod.UV_TOOL:
+        uv_path = uv_executable or shutil.which("uv") or "uv"
+        # `uv tool install --reinstall` is more deterministic than `upgrade`
+        # — it works whether or not the previous version is already at the
+        # target, and it lets us pin to an explicit version for rollback.
+        cmd = [uv_path, "tool", "install", "--reinstall"]
+        if target_version:
+            cmd += ["--index-url", index]
+        cmd.append(pkg_spec)
+        return cmd
+
+    if method is InstallMethod.PIP:
+        py = python_executable or sys.executable
+        cmd = [py, "-m", "pip", "install", "--upgrade", "--index-url", index, pkg_spec]
+        return cmd
+
+    raise ValueError(
+        f"Cannot build an upgrade command for install method {method.value!r}; "
+        "only uv-tool and pip installs support self-update."
+    )
+
+
+def run_upgrade(
+    method: InstallMethod,
+    *,
+    target_version: str | None = None,
+    index_url: str | None = None,
+    runner: Any = subprocess.run,
+) -> subprocess.CompletedProcess[str]:
+    """Execute the upgrade subprocess and capture stdout/stderr.
+
+    *runner* is injected so unit tests can assert on the argv without
+    actually shelling out. The default runs `subprocess.run` with text mode
+    + captured output so callers can log it.
+    """
+    if method in (InstallMethod.EDITABLE, InstallMethod.UNKNOWN):
+        raise RuntimeError(
+            f"Refusing to self-update install method {method.value!r}: "
+            "this looks like a development checkout. "
+            "Upgrade manually with `git pull && uv sync` instead."
+        )
+
+    cmd = build_upgrade_command(method, target_version=target_version, index_url=index_url)
+    logger.info("Running watcher self-update: %s", " ".join(cmd))
+    return runner(cmd, capture_output=True, text=True, check=False)

--- a/watcher/src/data_hub_watcher/service.py
+++ b/watcher/src/data_hub_watcher/service.py
@@ -373,9 +373,24 @@ def _run_service_loop(stop_event: threading.Event, sm: Any) -> None:
 
     sm.LogInfoMsg(f"{SERVICE_DISPLAY_NAME} is running")
 
-    stop_event.wait()
+    # Wait for either the SCM's stop_event (operator-initiated stop, or
+    # OS shutdown) or the runtime's shutdown_event (in-process updater
+    # finished installing a new wheel and wants the SCM to restart us).
+    # Polling on a 1-second tick keeps wakeup latency low for both paths.
+    while not stop_event.is_set():
+        if rt.shutdown_event.wait(timeout=1.0):
+            break
 
     stop_runtime(rt, stopped_message="Service stopped")
+
+    if rt.upgrade_restart_event.is_set():
+        sm.LogInfoMsg(f"{SERVICE_DISPLAY_NAME} restarting to load upgraded watcher")
+        # Exit non-zero so the SCM's failure-actions config kicks in and
+        # restarts the service on the configured 60 s delay. Without
+        # SERVICE_CONFIG_FAILURE_ACTIONS_FLAG this would look like a
+        # graceful exit and the SCM wouldn't restart us — see the long
+        # comment on `_configure_recovery` for details.
+        raise SystemExit(1)
 
     sm.LogInfoMsg(f"{SERVICE_DISPLAY_NAME} stopped")
 

--- a/watcher/src/data_hub_watcher/service.py
+++ b/watcher/src/data_hub_watcher/service.py
@@ -295,7 +295,12 @@ def _run_service_loop(stop_event: threading.Event, sm: Any) -> None:
         STATE_DB_FILENAME,
         env_file_path,
     )
-    from data_hub_watcher.runtime import build_runtime, start_runtime, stop_runtime
+    from data_hub_watcher.runtime import (
+        build_runtime,
+        classify_shutdown,
+        start_runtime,
+        stop_runtime,
+    )
 
     sm.LogInfoMsg(f"{SERVICE_DISPLAY_NAME} starting")
 
@@ -381,9 +386,14 @@ def _run_service_loop(stop_event: threading.Event, sm: Any) -> None:
         if rt.shutdown_event.wait(timeout=1.0):
             break
 
-    stop_runtime(rt, stopped_message="Service stopped")
+    # Classify before tearing the runtime down so the WATCHER_STOPPED
+    # event message reflects whether this is an upgrade-driven restart
+    # or a normal stop. Shared with the CLI ``watch`` path via
+    # ``classify_shutdown`` so the two entrypoints can't drift.
+    decision = classify_shutdown(rt, role="Service")
+    stop_runtime(rt, stopped_message=decision.stopped_message)
 
-    if rt.upgrade_restart_event.is_set():
+    if decision.is_upgrade_restart:
         sm.LogInfoMsg(f"{SERVICE_DISPLAY_NAME} restarting to load upgraded watcher")
         # Exit non-zero so the SCM's failure-actions config kicks in and
         # restarts the service on the configured 60 s delay. Without

--- a/watcher/src/data_hub_watcher/state.py
+++ b/watcher/src/data_hub_watcher/state.py
@@ -303,6 +303,20 @@ class StateDB:
             )
             self._conn.commit()
 
+    def last_run_reported_at(self) -> str | None:
+        """Most recent ``reported_at`` timestamp across all runs, or None.
+
+        Used by the updater to gate auto-updates on a quiet-instrument
+        window: we don't want to take down the watcher in the middle of
+        an actively-running experiment.
+        """
+        with self._lock:
+            cur = self._conn.execute("SELECT MAX(reported_at) FROM runs")
+            row = cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        return str(row[0])
+
     def record_run_uploaded(self, run_id: str) -> None:
         now = datetime.now(timezone.utc).isoformat()
         with self._lock:

--- a/watcher/src/data_hub_watcher/updater.py
+++ b/watcher/src/data_hub_watcher/updater.py
@@ -328,6 +328,14 @@ class Updater:
         self._idle_ticks = 0
         self._ticks_since_check = 0
         self._upgrade_in_progress = False
+        # Per-target memo for the "ineligible install method" refusal
+        # path: we want one ``UPDATE_FAILED`` event per *new* server
+        # target so admins can spot lab PCs stuck on a dev install
+        # during a (possibly mandatory) rollout, but not every hourly
+        # tick — which would spam the dashboard for the whole life of
+        # the dev install. Reset to ``None`` on process restart so the
+        # next start re-establishes state with the server.
+        self._last_refused_target: str | None = None
         self._lock = threading.Lock()
 
     # ------------------------------------------------------------------
@@ -418,8 +426,22 @@ class Updater:
 
         method = detect_install_method()
         if method in (InstallMethod.EDITABLE, InstallMethod.UNKNOWN):
-            reason = f"refusing auto-update for install method {method.value!r}"
-            logger.info(reason)
+            reason = f"install method {method.value!r} not eligible for auto-update"
+            logger.info("Refusing auto-update: %s", reason)
+            # Emit one UPDATE_FAILED per new server target so the
+            # dashboard surfaces stuck dev/unknown installs — critical
+            # during a mandatory rollout where the operator needs to
+            # know which PCs aren't going to apply the release. The
+            # `_last_refused_target` memo throttles repeats: a developer
+            # box on an editable install would otherwise generate one
+            # event per hourly tick for the entire life of the install.
+            if self._last_refused_target != target:
+                self._emit_failure(
+                    target,
+                    reason,
+                    extra={"install_method": method.value, "attempted_subprocess": False},
+                )
+                self._last_refused_target = target
             return UpdateAttemptResult(True, False, reason, target, {"method": method.value})
 
         details_started: dict[str, Any] = {

--- a/watcher/src/data_hub_watcher/updater.py
+++ b/watcher/src/data_hub_watcher/updater.py
@@ -1,0 +1,491 @@
+"""In-process self-update orchestrated from the running watcher service.
+
+The operator-facing ``data-hub-watcher self-update`` CLI command (see
+``self_update.py``) lets operators trigger an upgrade interactively, but
+unattended lab PCs need a path that doesn't require anyone to log in. The
+``Updater`` class below runs from inside the heartbeat loop, polls the
+server's ``/update-check`` endpoint roughly hourly, and -- when an update
+is both available and safe to apply (no recent uploads, no recent run
+activity, not a preview environment) -- shells out to the same
+``run_upgrade`` subprocess used by the CLI. On success it asks the runtime
+to exit non-zero so the Windows SCM's failure-actions config restarts the
+service into the new version.
+
+To detect upgrades that don't take effect (e.g. the new code crashes at
+startup so the service stays in a restart loop) the updater writes an
+``.upgrade-in-progress`` marker file under ``~/.data-hub`` *before* it
+runs the upgrade subprocess. The next process startup inspects the
+marker, compares ``WATCHER_VERSION`` against the recorded target, and
+emits ``UPDATE_SUCCEEDED`` or ``UPDATE_FAILED`` accordingly. The marker
+is then cleared so a single failure isn't reported indefinitely.
+"""
+
+from __future__ import annotations
+import json
+import logging
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from data_hub_watcher.api_client import ApiError, DataHubClient
+from data_hub_watcher.constants import HEARTBEAT_INTERVAL_SECONDS, WATCHER_VERSION
+from data_hub_watcher.events import EventReporter, EventType, WatcherEvent
+from data_hub_watcher.heartbeat import WatcherCounters
+from data_hub_watcher.models import WatcherConfig, WatcherUpdateInfoResponse
+from data_hub_watcher.self_update import (
+    InstallMethod,
+    detect_install_method,
+    evaluate_update,
+    run_upgrade,
+)
+from data_hub_watcher.state import StateDB
+
+logger = logging.getLogger(__name__)
+
+
+UPGRADE_MARKER_FILENAME = ".upgrade-in-progress"
+
+# Default cadence: with a 60-second heartbeat, this works out to roughly
+# "5 minutes idle before we even consider an update" and "one update
+# check per hour". Both are deliberately conservative — we'd rather miss
+# an update window than interrupt a running experiment.
+DEFAULT_IDLE_TICKS_REQUIRED = 5
+DEFAULT_CHECK_INTERVAL_TICKS = 60
+
+# Multiplier on `stability_period_seconds` used to decide whether the
+# instrument has been quiet long enough to safely restart. 5x means a
+# config with the default 5-second stability window only auto-updates
+# when no run has been reported in the last 25 seconds — short enough
+# to allow updates between experiments, long enough that we won't
+# clobber a multi-file run mid-acquisition.
+DEFAULT_RUN_QUIET_MULTIPLIER = 5
+
+
+@dataclass
+class UpdaterConfig:
+    """Tunable knobs for the auto-update gate."""
+
+    idle_ticks_required: int = DEFAULT_IDLE_TICKS_REQUIRED
+    check_interval_ticks: int = DEFAULT_CHECK_INTERVAL_TICKS
+    # If set, overrides the `stability_period_seconds * multiplier`
+    # default. Tests use a small explicit value so they don't have to
+    # reason about heartbeat timing.
+    min_run_age_seconds: float | None = None
+    run_quiet_multiplier: int = DEFAULT_RUN_QUIET_MULTIPLIER
+
+
+@dataclass
+class UpdateAttemptResult:
+    """Outcome of a single ``Updater.on_tick`` invocation.
+
+    Returned (rather than only logged) so unit tests can assert the
+    exact decision path without monkeypatching logging.
+    """
+
+    attempted: bool
+    succeeded: bool
+    reason: str
+    target_version: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Marker file helpers
+# ---------------------------------------------------------------------------
+
+
+def upgrade_marker_path(config_dir: Path) -> Path:
+    return config_dir / UPGRADE_MARKER_FILENAME
+
+
+def write_upgrade_marker(
+    config_dir: Path,
+    *,
+    target_version: str,
+    previous_version: str,
+) -> Path:
+    """Persist a JSON marker recording an in-flight upgrade.
+
+    Written *before* the upgrade subprocess runs so a crash mid-upgrade
+    still leaves a trail for the post-restart inspection in
+    :func:`evaluate_upgrade_marker`.
+    """
+    config_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "target_version": target_version,
+        "previous_version": previous_version,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+    }
+    path = upgrade_marker_path(config_dir)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def clear_upgrade_marker(config_dir: Path) -> None:
+    upgrade_marker_path(config_dir).unlink(missing_ok=True)
+
+
+@dataclass
+class UpgradeMarkerOutcome:
+    """Result of inspecting a post-restart upgrade marker."""
+
+    found: bool
+    succeeded: bool | None
+    target_version: str | None
+    previous_version: str | None
+    reason: str
+
+
+def evaluate_upgrade_marker(
+    config_dir: Path,
+    *,
+    current_version: str = WATCHER_VERSION,
+) -> UpgradeMarkerOutcome:
+    """Read and clear an upgrade marker, classifying the outcome.
+
+    Called once per process start (from ``start_runtime``). If the marker
+    is absent, returns a "no-op" outcome and the runtime emits no events.
+    Otherwise the runtime queues an ``UPDATE_SUCCEEDED`` /
+    ``UPDATE_FAILED`` event based on whether ``current_version`` matches
+    the recorded target.
+    """
+    path = upgrade_marker_path(config_dir)
+    if not path.exists():
+        return UpgradeMarkerOutcome(
+            found=False,
+            succeeded=None,
+            target_version=None,
+            previous_version=None,
+            reason="no marker present",
+        )
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        # Corrupt marker — drop it so we don't keep reporting the same
+        # failure on every restart, but still flag it so an operator can
+        # investigate via the server-side event log.
+        path.unlink(missing_ok=True)
+        return UpgradeMarkerOutcome(
+            found=True,
+            succeeded=False,
+            target_version=None,
+            previous_version=None,
+            reason=f"marker unreadable: {exc}",
+        )
+
+    target = data.get("target_version") if isinstance(data, dict) else None
+    previous = data.get("previous_version") if isinstance(data, dict) else None
+    path.unlink(missing_ok=True)
+
+    if target == current_version:
+        return UpgradeMarkerOutcome(
+            found=True,
+            succeeded=True,
+            target_version=target,
+            previous_version=previous,
+            reason="restarted into target version",
+        )
+
+    return UpgradeMarkerOutcome(
+        found=True,
+        succeeded=False,
+        target_version=target,
+        previous_version=previous,
+        reason=(f"expected {target!r} after upgrade, running {current_version!r}"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure decision function — kept stand-alone for unit testing
+# ---------------------------------------------------------------------------
+
+
+def should_attempt_update(
+    info: WatcherUpdateInfoResponse,
+    *,
+    current_version: str,
+    idle_ticks: int,
+    idle_ticks_required: int,
+    last_run_age_seconds: float | None,
+    min_run_age_seconds: float,
+) -> tuple[bool, str]:
+    """Decide whether the in-process updater should fire right now.
+
+    The version-comparison half delegates to :func:`evaluate_update` so
+    we share the same "newer / mandatory / un-parseable" logic with the
+    operator-facing CLI command. The activity-window half is exclusive
+    to the in-process path: the CLI doesn't care whether the watcher is
+    busy because the operator triggered it explicitly.
+    """
+    decision = evaluate_update(info, current_version=current_version)
+    if not decision.should_update:
+        return False, decision.reason
+
+    if info.mandatory:
+        # Mandatory rollouts override the activity-window guard. The
+        # rationale: if a release is mandatory it's typically a security
+        # fix or wire-protocol change, and the cost of taking the
+        # watcher down briefly is lower than the cost of leaving a
+        # known-bad version running.
+        return True, "mandatory rollout"
+
+    if idle_ticks < idle_ticks_required:
+        return (
+            False,
+            f"recent upload activity ({idle_ticks}/{idle_ticks_required} idle ticks)",
+        )
+
+    if last_run_age_seconds is not None and last_run_age_seconds < min_run_age_seconds:
+        return (
+            False,
+            (
+                f"recent run activity ("
+                f"last run {last_run_age_seconds:.0f}s ago, "
+                f"need {min_run_age_seconds:.0f}s of quiet)"
+            ),
+        )
+
+    return True, "idle window and newer version available"
+
+
+# ---------------------------------------------------------------------------
+# Updater
+# ---------------------------------------------------------------------------
+
+
+class Updater:
+    """Heartbeat-tick callback that polls for and applies updates.
+
+    Construction is intentionally side-effect-free — wiring happens in
+    :mod:`data_hub_watcher.runtime`. The only state held here is two
+    counters (idle-ticks observed, ticks-since-last-check) plus
+    references to collaborators.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: DataHubClient,
+        reporter: EventReporter,
+        counters: WatcherCounters,
+        state_db: StateDB,
+        cfg: WatcherConfig,
+        config_dir: Path,
+        request_upgrade_restart: Callable[[str], None],
+        updater_cfg: UpdaterConfig | None = None,
+        upgrade_runner: Callable[..., Any] | None = None,
+    ) -> None:
+        self._client = client
+        self._reporter = reporter
+        self._counters = counters
+        self._state_db = state_db
+        self._cfg = cfg
+        self._config_dir = config_dir
+        self._request_upgrade_restart = request_upgrade_restart
+        c = updater_cfg or UpdaterConfig()
+        self._idle_ticks_required = c.idle_ticks_required
+        self._check_interval_ticks = c.check_interval_ticks
+        self._min_run_age_seconds = (
+            c.min_run_age_seconds
+            if c.min_run_age_seconds is not None
+            else float(cfg.instrument.stability_period_seconds * c.run_quiet_multiplier)
+        )
+        # Default to the real `run_upgrade` from `self_update`; tests
+        # inject a stub that returns a synthetic CompletedProcess so they
+        # don't have to monkeypatch a module-level symbol.
+        self._upgrade_runner = upgrade_runner or run_upgrade
+
+        self._idle_ticks = 0
+        self._ticks_since_check = 0
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Heartbeat callback
+    # ------------------------------------------------------------------
+
+    def on_tick(self) -> UpdateAttemptResult | None:
+        """Run from the heartbeat loop after each successful heartbeat.
+
+        Returns ``None`` on ticks where we don't even attempt a server
+        check (the common case). Returns an :class:`UpdateAttemptResult`
+        on ticks where we did call ``/update-check``, which lets tests
+        assert on the decision without monkeypatching logging.
+        """
+        with self._lock:
+            if self._cfg.environment == "preview":
+                # Preview deployments are short-lived URL-suffixed builds
+                # and must never push code to production lab PCs.
+                return None
+
+            if self._counters.last_files_uploaded == 0:
+                self._idle_ticks += 1
+            else:
+                self._idle_ticks = 0
+
+            self._ticks_since_check += 1
+            if self._ticks_since_check < self._check_interval_ticks:
+                return None
+            self._ticks_since_check = 0
+
+        return self._check_and_apply()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _check_and_apply(self) -> UpdateAttemptResult:
+        watcher_id = self._cfg.watcher_id
+        if not watcher_id:
+            # Defensive — `build_runtime` already asserts this, but the
+            # type system can't see through the assert.
+            return UpdateAttemptResult(False, False, "no watcher_id in config", None)
+
+        try:
+            info = self._client.get_update_info(watcher_id)
+        except ApiError as exc:
+            logger.warning("Update-check API call failed: %s", exc)
+            return UpdateAttemptResult(False, False, f"update-check API error: {exc.message}", None)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Unexpected error fetching update info")
+            return UpdateAttemptResult(False, False, f"unexpected error: {exc}", None)
+
+        last_run_age = self._last_run_age_seconds()
+        ok, reason = should_attempt_update(
+            info,
+            current_version=WATCHER_VERSION,
+            idle_ticks=self._idle_ticks,
+            idle_ticks_required=self._idle_ticks_required,
+            last_run_age_seconds=last_run_age,
+            min_run_age_seconds=self._min_run_age_seconds,
+        )
+        if not ok:
+            logger.debug(
+                "Skipping update attempt: %s (current=%s, target=%s)",
+                reason,
+                WATCHER_VERSION,
+                info.latest_version,
+            )
+            return UpdateAttemptResult(False, False, reason, info.latest_version)
+
+        return self._apply(info)
+
+    def _apply(self, info: WatcherUpdateInfoResponse) -> UpdateAttemptResult:
+        target = info.latest_version
+        assert target is not None  # guaranteed by should_attempt_update
+
+        method = detect_install_method()
+        if method in (InstallMethod.EDITABLE, InstallMethod.UNKNOWN):
+            reason = f"refusing auto-update for install method {method.value!r}"
+            logger.info(reason)
+            return UpdateAttemptResult(True, False, reason, target, {"method": method.value})
+
+        details_started: dict[str, Any] = {
+            "current_version": WATCHER_VERSION,
+            "target_version": target,
+            "channel": info.channel,
+            "mandatory": info.mandatory,
+            "install_method": method.value,
+        }
+        self._reporter.queue_event(
+            WatcherEvent(
+                event_type=EventType.UPDATE_STARTED,
+                message=f"Upgrading watcher {WATCHER_VERSION} -> {target}",
+                details=details_started,
+            )
+        )
+        # Flush immediately so the dashboard sees UPDATE_STARTED even if
+        # the upgrade subprocess hangs or wedges the heartbeat thread.
+        self._reporter.flush()
+
+        write_upgrade_marker(
+            self._config_dir,
+            target_version=target,
+            previous_version=WATCHER_VERSION,
+        )
+
+        try:
+            result = self._upgrade_runner(method, target_version=target)
+        except Exception as exc:
+            logger.exception("Upgrade subprocess raised")
+            self._emit_failure(target, f"subprocess raised: {exc}")
+            return UpdateAttemptResult(True, False, str(exc), target)
+
+        if result.returncode != 0:
+            stdout = (result.stdout or "")[-1000:]
+            stderr = (result.stderr or "")[-1000:]
+            self._emit_failure(
+                target,
+                f"subprocess exited {result.returncode}",
+                extra={"stdout_tail": stdout, "stderr_tail": stderr},
+            )
+            return UpdateAttemptResult(True, False, f"exit code {result.returncode}", target)
+
+        # The new wheel is installed but the running interpreter still
+        # has the old code loaded. UPDATE_SUCCEEDED is emitted from the
+        # *next* startup once the marker confirms the new version is
+        # actually running — see `evaluate_upgrade_marker`. Here we just
+        # request the runtime to exit non-zero so the SCM restarts us.
+        logger.info("Upgrade subprocess succeeded; requesting service restart")
+        self._request_upgrade_restart(target)
+        return UpdateAttemptResult(True, True, "upgrade subprocess succeeded", target)
+
+    def _emit_failure(
+        self,
+        target: str,
+        reason: str,
+        *,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        details: dict[str, Any] = {
+            "current_version": WATCHER_VERSION,
+            "target_version": target,
+            "reason": reason,
+        }
+        if extra:
+            details.update(extra)
+        self._reporter.queue_event(
+            WatcherEvent(
+                event_type=EventType.UPDATE_FAILED,
+                message=f"Watcher upgrade to {target} failed: {reason}",
+                details=details,
+            )
+        )
+        # Drop the marker so a failed in-process upgrade doesn't pollute
+        # the next startup with a misleading "expected X, running Y"
+        # event — we already reported it here.
+        clear_upgrade_marker(self._config_dir)
+        self._reporter.flush()
+
+    def _last_run_age_seconds(self) -> float | None:
+        ts = self._state_db.last_run_reported_at()
+        if ts is None:
+            return None
+        try:
+            t = datetime.fromisoformat(ts)
+        except ValueError:
+            return None
+        if t.tzinfo is None:
+            t = t.replace(tzinfo=timezone.utc)
+        return (datetime.now(timezone.utc) - t).total_seconds()
+
+
+__all__ = [
+    "DEFAULT_CHECK_INTERVAL_TICKS",
+    "DEFAULT_IDLE_TICKS_REQUIRED",
+    "DEFAULT_RUN_QUIET_MULTIPLIER",
+    "HEARTBEAT_INTERVAL_SECONDS",
+    "UPGRADE_MARKER_FILENAME",
+    "UpdateAttemptResult",
+    "Updater",
+    "UpdaterConfig",
+    "UpgradeMarkerOutcome",
+    "clear_upgrade_marker",
+    "evaluate_upgrade_marker",
+    "should_attempt_update",
+    "upgrade_marker_path",
+    "write_upgrade_marker",
+]

--- a/watcher/src/data_hub_watcher/updater.py
+++ b/watcher/src/data_hub_watcher/updater.py
@@ -83,10 +83,15 @@ class UpdateAttemptResult:
 
     Returned (rather than only logged) so unit tests can assert the
     exact decision path without monkeypatching logging.
+
+    ``succeeded`` is ``True`` / ``False`` for finished decisions, and
+    ``None`` when an upgrade subprocess was dispatched off-thread but
+    its result isn't available yet (the heartbeat-thread caller
+    returns immediately rather than blocking on the subprocess).
     """
 
     attempted: bool
-    succeeded: bool
+    succeeded: bool | None
     reason: str
     target_version: str | None = None
     extra: dict[str, Any] = field(default_factory=dict)
@@ -257,13 +262,28 @@ def should_attempt_update(
 # ---------------------------------------------------------------------------
 
 
+def _default_upgrade_executor(fn: Callable[[], None]) -> None:
+    """Run *fn* on a daemon thread named ``upgrade-worker``.
+
+    The default executor used by :class:`Updater`. Detaching the
+    upgrade subprocess from the heartbeat thread is what lets
+    heartbeats keep flowing during a slow ``uv tool install``
+    (which can take 30–60 s and would otherwise wedge the loop
+    long enough for the dashboard to flag the watcher as stale).
+    Daemon=True so an interpreter shutdown doesn't block on a
+    pending subprocess.
+    """
+    threading.Thread(target=fn, daemon=True, name="upgrade-worker").start()
+
+
 class Updater:
     """Heartbeat-tick callback that polls for and applies updates.
 
     Construction is intentionally side-effect-free — wiring happens in
-    :mod:`data_hub_watcher.runtime`. The only state held here is two
-    counters (idle-ticks observed, ticks-since-last-check) plus
-    references to collaborators.
+    :mod:`data_hub_watcher.runtime`. State held: two counters (idle
+    ticks observed, ticks-since-last-check), an ``_upgrade_in_progress``
+    flag that gates concurrent dispatches, and references to the
+    collaborators.
     """
 
     def __init__(
@@ -278,6 +298,7 @@ class Updater:
         request_upgrade_restart: Callable[[str], None],
         updater_cfg: UpdaterConfig | None = None,
         upgrade_runner: Callable[..., Any] | None = None,
+        upgrade_executor: Callable[[Callable[[], None]], None] | None = None,
     ) -> None:
         self._client = client
         self._reporter = reporter
@@ -298,9 +319,15 @@ class Updater:
         # inject a stub that returns a synthetic CompletedProcess so they
         # don't have to monkeypatch a module-level symbol.
         self._upgrade_runner = upgrade_runner or run_upgrade
+        # Default executor spawns a daemon thread so the heartbeat
+        # loop returns immediately. Tests pass an inline executor
+        # (``lambda fn: fn()``) to make the dispatch synchronous and
+        # keep their assertions deterministic.
+        self._upgrade_executor = upgrade_executor or _default_upgrade_executor
 
         self._idle_ticks = 0
         self._ticks_since_check = 0
+        self._upgrade_in_progress = False
         self._lock = threading.Lock()
 
     # ------------------------------------------------------------------
@@ -320,6 +347,18 @@ class Updater:
                 # Preview deployments are short-lived URL-suffixed builds
                 # and must never push code to production lab PCs.
                 return None
+
+            if self._upgrade_in_progress:
+                # A previous tick dispatched an upgrade to the executor
+                # and the subprocess hasn't returned yet. Skip the API
+                # call and counter advancement so we don't double-spawn
+                # or spam the dashboard with redundant decisions while
+                # the worker is still running.
+                return UpdateAttemptResult(
+                    attempted=False,
+                    succeeded=None,
+                    reason="upgrade subprocess already in progress",
+                )
 
             if self._counters.last_files_uploaded == 0:
                 self._idle_ticks += 1
@@ -397,8 +436,11 @@ class Updater:
                 details=details_started,
             )
         )
-        # Flush immediately so the dashboard sees UPDATE_STARTED even if
-        # the upgrade subprocess hangs or wedges the heartbeat thread.
+        # Flush immediately so the dashboard sees UPDATE_STARTED before
+        # the upgrade subprocess even starts. The subprocess itself runs
+        # off-thread (see executor below) so heartbeats keep flowing,
+        # but flushing here also covers the corner case where a slow
+        # subprocess delays the next heartbeat.
         self._reporter.flush()
 
         write_upgrade_marker(
@@ -407,31 +449,78 @@ class Updater:
             previous_version=WATCHER_VERSION,
         )
 
-        try:
-            result = self._upgrade_runner(method, target_version=target)
-        except Exception as exc:
-            logger.exception("Upgrade subprocess raised")
-            self._emit_failure(target, f"subprocess raised: {exc}")
-            return UpdateAttemptResult(True, False, str(exc), target)
+        with self._lock:
+            self._upgrade_in_progress = True
 
-        if result.returncode != 0:
-            stdout = (result.stdout or "")[-1000:]
-            stderr = (result.stderr or "")[-1000:]
-            self._emit_failure(
-                target,
-                f"subprocess exited {result.returncode}",
-                extra={"stdout_tail": stdout, "stderr_tail": stderr},
-            )
-            return UpdateAttemptResult(True, False, f"exit code {result.returncode}", target)
+        # Mutable cell capturing the subprocess outcome. When the
+        # executor runs synchronously (test default), the worker fills
+        # this in before we return and we surface the real result. When
+        # the executor dispatches to a thread (production default), the
+        # cell stays empty and we return a "dispatched" placeholder so
+        # the heartbeat-thread caller can record what happened on this
+        # tick without blocking on the subprocess.
+        outcome: list[UpdateAttemptResult] = []
 
-        # The new wheel is installed but the running interpreter still
-        # has the old code loaded. UPDATE_SUCCEEDED is emitted from the
-        # *next* startup once the marker confirms the new version is
-        # actually running — see `evaluate_upgrade_marker`. Here we just
-        # request the runtime to exit non-zero so the SCM restarts us.
-        logger.info("Upgrade subprocess succeeded; requesting service restart")
-        self._request_upgrade_restart(target)
-        return UpdateAttemptResult(True, True, "upgrade subprocess succeeded", target)
+        def _run_upgrade() -> None:
+            try:
+                try:
+                    result = self._upgrade_runner(method, target_version=target)
+                except Exception as exc:
+                    logger.exception("Upgrade subprocess raised")
+                    self._emit_failure(target, f"subprocess raised: {exc}")
+                    outcome.append(UpdateAttemptResult(True, False, str(exc), target))
+                    return
+
+                if result.returncode != 0:
+                    stdout = (result.stdout or "")[-1000:]
+                    stderr = (result.stderr or "")[-1000:]
+                    self._emit_failure(
+                        target,
+                        f"subprocess exited {result.returncode}",
+                        extra={"stdout_tail": stdout, "stderr_tail": stderr},
+                    )
+                    outcome.append(
+                        UpdateAttemptResult(True, False, f"exit code {result.returncode}", target)
+                    )
+                    return
+
+                # The new wheel is installed but the running interpreter
+                # still has the old code loaded. UPDATE_SUCCEEDED is
+                # emitted from the *next* startup once the marker
+                # confirms the new version is actually running — see
+                # `evaluate_upgrade_marker`. Here we just request the
+                # runtime to exit non-zero so the SCM restarts us.
+                logger.info("Upgrade subprocess succeeded; requesting service restart")
+                self._request_upgrade_restart(target)
+                outcome.append(
+                    UpdateAttemptResult(True, True, "upgrade subprocess succeeded", target)
+                )
+            finally:
+                # Always clear the in-progress flag so a one-shot failure
+                # doesn't permanently disable future update attempts.
+                # On success, the runtime is about to be torn down by
+                # `request_upgrade_restart` so the flag's value past
+                # this point is moot.
+                with self._lock:
+                    self._upgrade_in_progress = False
+
+        self._upgrade_executor(_run_upgrade)
+
+        if outcome:
+            return outcome[0]
+
+        # Async dispatch: the worker is still running. Return a
+        # placeholder reflecting that we kicked off the subprocess on
+        # this tick; the actual success/failure will be reported via
+        # `request_upgrade_restart` (success) or queued
+        # ``UPDATE_FAILED`` events (failure) once the worker finishes.
+        return UpdateAttemptResult(
+            attempted=True,
+            succeeded=None,
+            reason="upgrade subprocess dispatched (running off-thread)",
+            target_version=target,
+            extra={"in_progress": True, "method": method.value},
+        )
 
     def _emit_failure(
         self,

--- a/watcher/tests/integration/test_update_check.py
+++ b/watcher/tests/integration/test_update_check.py
@@ -1,0 +1,48 @@
+"""Integration tests: watcher update-check endpoint via DataHubClient.
+
+The TS-side tests in `web-app/tests/integration/watchers.test.ts` cover
+the HTTP shape; this file ensures the Python `DataHubClient` plumbing
+parses the response into the typed `WatcherUpdateInfoResponse` model
+correctly so the CLI / in-process updater can consume it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from data_hub_shared.testing import IntegrationEnv, db_update
+from data_hub_watcher.api_client import ApiError, DataHubClient
+
+pytestmark = pytest.mark.integration
+
+
+class TestUpdateCheck:
+    def test_get_update_info_returns_seeded_release(
+        self, client: DataHubClient, instrument_id: str
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        info = client.get_update_info(watcher.watcher_id)
+
+        # The seeded test server config (see data_hub_shared.testing)
+        # advertises "9.9.9" so we always know what to compare against,
+        # regardless of where the real release line is.
+        assert info.latest_version == "9.9.9"
+        assert info.min_supported_version == "0.1.0"
+        assert info.channel == "stable"
+        assert info.mandatory is False
+
+    def test_get_update_info_returns_404_for_soft_deleted_watcher(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        watcher = client.register_watcher(instrument_id)
+        db_update(
+            integration_env.db_dsn,
+            "UPDATE watchers SET deleted_at = NOW() WHERE id = %s",
+            (watcher.watcher_id,),
+        )
+        with pytest.raises(ApiError) as exc_info:
+            client.get_update_info(watcher.watcher_id)
+        assert exc_info.value.status_code == 404

--- a/watcher/tests/test_runtime.py
+++ b/watcher/tests/test_runtime.py
@@ -7,9 +7,10 @@ forgot to wire `on_tick` on the `HeartbeatLoop`. These tests lock in the
 wiring contract per `upload_mode` so any future drift fails loudly:
 
 * auto mode    -> `detector._upload_cb` is `uploader.upload_files`
-                  and `heartbeat._on_tick` is `None`
+                  and `heartbeat._on_tick` ticks the auto-updater only
 * manual mode  -> `detector._upload_cb` is `None`
                   and `heartbeat._on_tick` polls `uploader.poll_upload_queue`
+                  *and* ticks the auto-updater
 """
 
 from __future__ import annotations
@@ -26,6 +27,7 @@ from data_hub_watcher.monitor import FileMonitor
 from data_hub_watcher.run_detector import RunDetector
 from data_hub_watcher.runtime import build_runtime
 from data_hub_watcher.state import StateDB
+from data_hub_watcher.updater import Updater
 from data_hub_watcher.uploader import Uploader
 
 
@@ -83,14 +85,22 @@ class TestBuildRuntimeAutoMode:
         finally:
             rt.state_db.close()
 
-    def test_heartbeat_on_tick_is_none(self, tmp_path: Path, db_path: Path) -> None:
+    def test_heartbeat_on_tick_only_drives_updater(self, tmp_path: Path, db_path: Path) -> None:
         cfg = _make_config(tmp_path, upload_mode="auto")
         rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
 
         try:
-            # Auto mode has no server-driven upload queue to poll, so the
-            # heartbeat tick must not invoke any extra callback.
-            assert rt.heartbeat._on_tick is None
+            # Auto mode has no server-driven upload queue to poll, but
+            # the in-process updater still needs a tick on every
+            # heartbeat — it gates auto-updates on the cumulative idle
+            # window across many heartbeats. So the hook is non-None
+            # and ticking it must not call `poll_upload_queue`.
+            assert rt.heartbeat._on_tick is not None
+            rt.uploader.poll_upload_queue = MagicMock()  # type: ignore[method-assign]
+            rt.updater.on_tick = MagicMock(return_value=None)  # type: ignore[method-assign]
+            rt.heartbeat._on_tick()
+            rt.uploader.poll_upload_queue.assert_not_called()
+            rt.updater.on_tick.assert_called_once_with()
         finally:
             rt.state_db.close()
 
@@ -119,8 +129,12 @@ class TestBuildRuntimeManualMode:
             assert rt.heartbeat._on_tick is not None
 
             rt.uploader.poll_upload_queue = MagicMock()  # type: ignore[method-assign]
+            rt.updater.on_tick = MagicMock(return_value=None)  # type: ignore[method-assign]
             rt.heartbeat._on_tick()
             rt.uploader.poll_upload_queue.assert_called_once_with()
+            # The same hook must also feed the auto-updater so its idle
+            # counter advances regardless of upload_mode.
+            rt.updater.on_tick.assert_called_once_with()
         finally:
             rt.state_db.close()
 
@@ -135,9 +149,30 @@ class TestBuildRuntimeManualMode:
             rt.uploader.poll_upload_queue = MagicMock(  # type: ignore[method-assign]
                 side_effect=RuntimeError("boom")
             )
+            rt.updater.on_tick = MagicMock(return_value=None)  # type: ignore[method-assign]
             assert rt.heartbeat._on_tick is not None
             rt.heartbeat._on_tick()
             rt.uploader.poll_upload_queue.assert_called_once_with()
+            # Updater must still tick even when the upload-queue poll
+            # blew up, otherwise a permanently-failing manual-mode
+            # poll would also disable auto-updates.
+            rt.updater.on_tick.assert_called_once_with()
+        finally:
+            rt.state_db.close()
+
+    def test_on_tick_swallows_updater_exceptions(self, tmp_path: Path, db_path: Path) -> None:
+        """Same containment guarantee for the updater half of the hook:
+        a buggy update check must not kill the heartbeat thread."""
+        cfg = _make_config(tmp_path, upload_mode="auto")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+
+        try:
+            rt.updater.on_tick = MagicMock(  # type: ignore[method-assign]
+                side_effect=RuntimeError("update broke")
+            )
+            assert rt.heartbeat._on_tick is not None
+            rt.heartbeat._on_tick()
+            rt.updater.on_tick.assert_called_once_with()
         finally:
             rt.state_db.close()
 
@@ -159,6 +194,7 @@ class TestBuildRuntimeSharedDependencies:
             assert isinstance(rt.detector, RunDetector)
             assert isinstance(rt.monitor, FileMonitor)
             assert isinstance(rt.heartbeat, HeartbeatLoop)
+            assert isinstance(rt.updater, Updater)
         finally:
             rt.state_db.close()
 

--- a/watcher/tests/test_runtime.py
+++ b/watcher/tests/test_runtime.py
@@ -25,7 +25,11 @@ from data_hub_watcher.heartbeat import HeartbeatLoop, WatcherCounters
 from data_hub_watcher.models import InstrumentConfig, RunDetectionConfig, WatcherConfig
 from data_hub_watcher.monitor import FileMonitor
 from data_hub_watcher.run_detector import RunDetector
-from data_hub_watcher.runtime import build_runtime
+from data_hub_watcher.runtime import (
+    ShutdownReason,
+    build_runtime,
+    classify_shutdown,
+)
 from data_hub_watcher.state import StateDB
 from data_hub_watcher.updater import Updater
 from data_hub_watcher.uploader import Uploader
@@ -235,3 +239,56 @@ class TestBuildRuntimeErrors:
         cfg = _make_config(tmp_path, upload_mode="auto", watcher_id=None)
         with pytest.raises(ValueError, match="watcher_id"):
             build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+
+
+class TestClassifyShutdown:
+    """Pin the WATCHER_STOPPED message text shared by the CLI ``watch``
+    command and the Windows service. Both call sites used to hard-code
+    their own strings, which made the service path's WATCHER_STOPPED
+    indistinguishable from a normal stop on auto-update restarts —
+    breaking dashboard correlation with the matching ``update_started``
+    event.
+    """
+
+    def test_normal_stop_uses_role_stopped(self, tmp_path: Path, db_path: Path) -> None:
+        cfg = _make_config(tmp_path, upload_mode="auto")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+        try:
+            decision = classify_shutdown(rt, role="Watcher")
+            assert decision == ShutdownReason(
+                is_upgrade_restart=False,
+                stopped_message="Watcher stopped",
+            )
+        finally:
+            rt.state_db.close()
+
+    def test_upgrade_restart_uses_role_specific_message(
+        self, tmp_path: Path, db_path: Path
+    ) -> None:
+        cfg = _make_config(tmp_path, upload_mode="auto")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+        try:
+            rt.upgrade_restart_event.set()
+            decision = classify_shutdown(rt, role="Service")
+            assert decision.is_upgrade_restart is True
+            # The message is keyed on the *role* so the CLI and the
+            # service produce naturally-readable but distinct text in
+            # the events stream — a single "Watcher restarting…" log
+            # would look weird on Windows where the dashboard already
+            # shows the watcher's host as a service.
+            assert decision.stopped_message == "Service restarting for auto-update"
+        finally:
+            rt.state_db.close()
+
+    def test_role_is_substituted_into_both_messages(self, tmp_path: Path, db_path: Path) -> None:
+        cfg = _make_config(tmp_path, upload_mode="auto")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+        try:
+            assert classify_shutdown(rt, role="Watcher").stopped_message == "Watcher stopped"
+            rt.upgrade_restart_event.set()
+            assert (
+                classify_shutdown(rt, role="Watcher").stopped_message
+                == "Watcher restarting for auto-update"
+            )
+        finally:
+            rt.state_db.close()

--- a/watcher/tests/test_self_update.py
+++ b/watcher/tests/test_self_update.py
@@ -237,13 +237,15 @@ class TestBuildUpgradeCommand:
         ]
 
     def test_custom_index_url_is_propagated(self) -> None:
+        # Exercises the `index_url` passthrough that an internal PyPI
+        # mirror or air-gapped lab proxy would set.
         cmd = build_upgrade_command(
             InstallMethod.PIP,
             target_version="0.3.0",
-            index_url="https://test.pypi.org/simple/",
+            index_url="https://pypi.example.com/simple/",
             python_executable="python",
         )
-        assert "https://test.pypi.org/simple/" in cmd
+        assert "https://pypi.example.com/simple/" in cmd
 
     @pytest.mark.parametrize("method", [InstallMethod.EDITABLE, InstallMethod.UNKNOWN])
     def test_unsupported_methods_raise(self, method: InstallMethod) -> None:

--- a/watcher/tests/test_self_update.py
+++ b/watcher/tests/test_self_update.py
@@ -1,0 +1,316 @@
+"""Unit tests for `data_hub_watcher.self_update`.
+
+The self-update path runs in unattended contexts (Windows Task Scheduler,
+the in-process updater on the running service) where a wrong decision
+can downgrade a fleet of watchers. These tests pin the install-method
+detection, the version-comparison decision matrix, and the
+upgrade-command synthesis so regressions surface as clear test failures.
+"""
+
+from __future__ import annotations
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from data_hub_watcher.models import WatcherUpdateInfoResponse
+from data_hub_watcher.self_update import (
+    DEFAULT_INDEX_URL,
+    PACKAGE_NAME,
+    InstallMethod,
+    UpdateDecision,
+    build_upgrade_command,
+    detect_install_method,
+    evaluate_update,
+    run_upgrade,
+)
+
+# ---------------------------------------------------------------------------
+# Install-method detection
+# ---------------------------------------------------------------------------
+
+
+class _FakeDist:
+    def __init__(self, direct_url: dict[str, Any] | None) -> None:
+        self._direct_url = direct_url
+
+    def read_text(self, name: str) -> str | None:
+        if name != "direct_url.json":
+            return None
+        if self._direct_url is None:
+            return None
+        return json.dumps(self._direct_url)
+
+
+def _patch_distribution(direct_url: dict[str, Any] | None) -> Any:
+    """Replace `importlib.metadata.distribution` for the duration of a test."""
+    return patch(
+        "data_hub_watcher.self_update.distribution",
+        return_value=_FakeDist(direct_url),
+    )
+
+
+class TestDetectInstallMethod:
+    def test_returns_unknown_when_distribution_missing(self) -> None:
+        from importlib.metadata import PackageNotFoundError
+
+        with patch(
+            "data_hub_watcher.self_update.distribution",
+            side_effect=PackageNotFoundError(PACKAGE_NAME),
+        ):
+            assert detect_install_method() is InstallMethod.UNKNOWN
+
+    def test_returns_editable_for_dir_info_editable_true(self) -> None:
+        with _patch_distribution({"dir_info": {"editable": True}, "url": "file:///x"}):
+            assert detect_install_method() is InstallMethod.EDITABLE
+
+    def test_returns_uv_tool_when_prefix_under_uv_tools(self) -> None:
+        with _patch_distribution(None):
+            prefix = "/home/user/.local/share/uv/tools/data-hub-watcher"
+            assert detect_install_method(prefix=prefix) is InstallMethod.UV_TOOL
+
+    def test_returns_uv_tool_on_windows_path(self) -> None:
+        with _patch_distribution(None):
+            prefix = r"C:\Users\lab\AppData\Roaming\uv\tools\data-hub-watcher"
+            # On a non-Windows test runner Path.resolve() will keep the raw
+            # string, so we assert the substring match still works after
+            # `as_posix()` normalization.
+            assert detect_install_method(prefix=prefix) is InstallMethod.UV_TOOL
+
+    def test_returns_pip_for_plain_venv(self) -> None:
+        with _patch_distribution(None):
+            assert (
+                detect_install_method(prefix="/home/user/projects/foo/.venv") is InstallMethod.PIP
+            )
+
+    def test_editable_takes_precedence_over_uv_tools_path(self) -> None:
+        # If a dev somehow has an editable install whose .venv lives under a
+        # `uv/tools/` directory, we must still refuse to upgrade — editable
+        # wins over the path heuristic.
+        with _patch_distribution({"dir_info": {"editable": True}, "url": "file:///x"}):
+            prefix = "/home/user/.local/share/uv/tools/data-hub-watcher"
+            assert detect_install_method(prefix=prefix) is InstallMethod.EDITABLE
+
+    def test_malformed_direct_url_falls_back_to_path_heuristic(self) -> None:
+        with patch(
+            "data_hub_watcher.self_update.distribution",
+            return_value=_FakeDist(direct_url=None),
+        ):
+            # Simulate present-but-malformed JSON via a custom fake dist.
+            class _BadDist:
+                def read_text(self, name: str) -> str:
+                    return "not-json"
+
+            with patch(
+                "data_hub_watcher.self_update.distribution",
+                return_value=_BadDist(),
+            ):
+                assert detect_install_method(prefix="/opt/venv") is InstallMethod.PIP
+
+
+# ---------------------------------------------------------------------------
+# Version comparison
+# ---------------------------------------------------------------------------
+
+
+def _info(
+    *,
+    latest: str | None = "0.3.0",
+    minimum: str | None = None,
+    channel: str = "stable",
+    mandatory: bool = False,
+) -> WatcherUpdateInfoResponse:
+    return WatcherUpdateInfoResponse(
+        latest_version=latest,
+        min_supported_version=minimum,
+        channel=channel,
+        mandatory=mandatory,
+    )
+
+
+class TestEvaluateUpdate:
+    def test_no_target_means_no_update(self) -> None:
+        decision = evaluate_update(_info(latest=None), current_version="0.1.0")
+        assert decision == UpdateDecision(
+            should_update=False,
+            reason="server has no release info configured",
+            current_version="0.1.0",
+            target_version=None,
+        )
+
+    def test_current_older_than_target_triggers_update(self) -> None:
+        decision = evaluate_update(_info(latest="0.3.0"), current_version="0.1.0")
+        assert decision.should_update is True
+        assert decision.target_version == "0.3.0"
+
+    def test_current_equals_target_skips_update(self) -> None:
+        decision = evaluate_update(_info(latest="0.3.0"), current_version="0.3.0")
+        assert decision.should_update is False
+        assert "already at or ahead" in decision.reason
+
+    def test_current_newer_than_target_skips_update(self) -> None:
+        # Operators sometimes test a pre-release locally — never auto-downgrade.
+        decision = evaluate_update(_info(latest="0.3.0"), current_version="0.4.0")
+        assert decision.should_update is False
+
+    def test_mandatory_forces_update_even_for_dev_pre_release(self) -> None:
+        # A mandatory rollout exists to evict known-buggy versions; the
+        # comparison must still be != rather than > so a pre-release
+        # operator is also forced back onto the canonical release.
+        decision = evaluate_update(
+            _info(latest="0.3.0", mandatory=True),
+            current_version="0.4.0.dev1",
+        )
+        assert decision.should_update is True
+        assert "mandatory" in decision.reason
+
+    def test_force_flag_overrides_skip_decision(self) -> None:
+        decision = evaluate_update(
+            _info(latest="0.3.0"),
+            current_version="0.3.0",
+            force=True,
+        )
+        assert decision.should_update is True
+        assert "forced" in decision.reason
+
+    def test_force_with_no_target_still_skips(self) -> None:
+        decision = evaluate_update(
+            _info(latest=None),
+            current_version="0.1.0",
+            force=True,
+        )
+        assert decision.should_update is False
+
+    def test_unparseable_current_version_skips_update(self) -> None:
+        decision = evaluate_update(
+            _info(latest="0.3.0"),
+            current_version="garbage",
+        )
+        assert decision.should_update is False
+        assert "could not compare" in decision.reason
+
+
+# ---------------------------------------------------------------------------
+# Upgrade command synthesis
+# ---------------------------------------------------------------------------
+
+
+class TestBuildUpgradeCommand:
+    def test_uv_tool_uses_install_reinstall(self) -> None:
+        cmd = build_upgrade_command(
+            InstallMethod.UV_TOOL,
+            target_version="0.3.0",
+            uv_executable="/usr/local/bin/uv",
+        )
+        assert cmd == [
+            "/usr/local/bin/uv",
+            "tool",
+            "install",
+            "--reinstall",
+            "--index-url",
+            DEFAULT_INDEX_URL,
+            "data-hub-watcher==0.3.0",
+        ]
+
+    def test_uv_tool_without_target_version_drops_index(self) -> None:
+        cmd = build_upgrade_command(InstallMethod.UV_TOOL, uv_executable="uv")
+        assert cmd == ["uv", "tool", "install", "--reinstall", "data-hub-watcher"]
+
+    def test_pip_uses_current_python_executable(self) -> None:
+        cmd = build_upgrade_command(
+            InstallMethod.PIP,
+            target_version="0.3.0",
+            python_executable="/opt/venv/bin/python",
+        )
+        assert cmd == [
+            "/opt/venv/bin/python",
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "--index-url",
+            DEFAULT_INDEX_URL,
+            "data-hub-watcher==0.3.0",
+        ]
+
+    def test_custom_index_url_is_propagated(self) -> None:
+        cmd = build_upgrade_command(
+            InstallMethod.PIP,
+            target_version="0.3.0",
+            index_url="https://test.pypi.org/simple/",
+            python_executable="python",
+        )
+        assert "https://test.pypi.org/simple/" in cmd
+
+    @pytest.mark.parametrize("method", [InstallMethod.EDITABLE, InstallMethod.UNKNOWN])
+    def test_unsupported_methods_raise(self, method: InstallMethod) -> None:
+        with pytest.raises(ValueError, match="Cannot build an upgrade command"):
+            build_upgrade_command(method, target_version="0.3.0")
+
+
+# ---------------------------------------------------------------------------
+# Upgrade execution wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRunUpgrade:
+    def test_invokes_runner_with_built_command(self) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_runner(cmd: list[str], **kwargs: Any) -> Any:
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+
+            class _Result:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return _Result()
+
+        result = run_upgrade(
+            InstallMethod.PIP,
+            target_version="0.3.0",
+            runner=fake_runner,
+        )
+        assert result.returncode == 0
+        assert captured["cmd"][0] == sys.executable
+        assert captured["cmd"][-1] == "data-hub-watcher==0.3.0"
+        assert captured["kwargs"]["check"] is False
+        assert captured["kwargs"]["capture_output"] is True
+        assert captured["kwargs"]["text"] is True
+
+    @pytest.mark.parametrize("method", [InstallMethod.EDITABLE, InstallMethod.UNKNOWN])
+    def test_refuses_editable_and_unknown(self, method: InstallMethod) -> None:
+        def runner(*args: Any, **kwargs: Any) -> Any:  # pragma: no cover
+            raise AssertionError("runner should not be invoked")
+
+        with pytest.raises(RuntimeError, match="Refusing to self-update"):
+            run_upgrade(method, runner=runner)
+
+
+# ---------------------------------------------------------------------------
+# Smoke test: detect_install_method on the actual installed dist
+# ---------------------------------------------------------------------------
+
+
+def test_real_install_method_detection_returns_a_known_value() -> None:
+    """In CI / dev, the watcher is installed editable via `uv sync`.
+
+    This guard ensures the real-world detection path returns *something*
+    sensible (i.e. not a crash), without asserting which specific method
+    — it varies between local dev and CI runners.
+    """
+    method = detect_install_method()
+    assert isinstance(method, InstallMethod)
+    # Sanity: the dist should be importable in the test env.
+    assert method is not InstallMethod.UNKNOWN
+    # Local checkouts should always come up as editable. Skip the assertion
+    # if the test env isn't running from the workspace (e.g. when run
+    # against a pre-built wheel) by checking sys.prefix.
+    workspace_root = Path(__file__).resolve().parents[2]
+    if str(workspace_root) in str(Path(sys.prefix).resolve()):
+        assert method is InstallMethod.EDITABLE

--- a/watcher/tests/test_service.py
+++ b/watcher/tests/test_service.py
@@ -464,6 +464,11 @@ class _LoopHarness:
         self.client.get_instrument.return_value = _make_instrument_detail("active")
         self.client.get_config_checksum.return_value = None
         self.runtime = MagicMock(name="WatcherRuntime")
+        # Replace the auto-update plumbing fields with real Events so the
+        # service loop's wait-and-test sequence behaves naturally rather
+        # than always seeing truthy MagicMock attributes.
+        self.runtime.shutdown_event = threading.Event()
+        self.runtime.upgrade_restart_event = threading.Event()
         self.start_calls: list[Any] = []
         self.stop_calls: list[Any] = []
         self.sm = MagicMock(name="servicemanager")
@@ -634,6 +639,33 @@ class TestRunServiceLoopFailures:
         harness.sm.LogErrorMsg.assert_called_once()
         assert "watcher_id" in harness.sm.LogErrorMsg.call_args.args[0]
         assert harness.start_calls == []
+
+
+class TestRunServiceLoopUpgradeRestart:
+    """The in-process auto-updater asks the runtime to exit non-zero on
+    success so the SCM's failure-actions config restarts the service
+    into the new wheel. Lock that contract in here."""
+
+    def test_upgrade_restart_event_causes_systemexit_one(self, harness: _LoopHarness) -> None:
+        # Simulate the heartbeat-thread Updater finishing a successful
+        # upgrade by pre-setting both events. The loop should bail out
+        # of the wait, run stop_runtime, then raise SystemExit(1) so the
+        # SCM treats this as a failure and applies its restart policy.
+        harness.runtime.shutdown_event.set()
+        harness.runtime.upgrade_restart_event.set()
+        stop_event = threading.Event()  # NOT pre-set
+
+        with pytest.raises(SystemExit) as excinfo:
+            harness.svc._run_service_loop(stop_event, harness.sm)
+
+        assert excinfo.value.code == 1
+        # Cleanup must still run before the non-zero exit so the heartbeat
+        # thread, file monitor, etc. have a chance to flush their state.
+        assert len(harness.stop_calls) == 1
+        # And the operator-facing log line must distinguish this from a
+        # normal stop so the Windows event log shows what happened.
+        log_messages = [c.args[0] for c in harness.sm.LogInfoMsg.call_args_list]
+        assert any("upgraded" in m.lower() for m in log_messages)
 
 
 class TestRunServiceLoopChecksumSync:

--- a/watcher/tests/test_service.py
+++ b/watcher/tests/test_service.py
@@ -662,6 +662,12 @@ class TestRunServiceLoopUpgradeRestart:
         # Cleanup must still run before the non-zero exit so the heartbeat
         # thread, file monitor, etc. have a chance to flush their state.
         assert len(harness.stop_calls) == 1
+        # The WATCHER_STOPPED event must distinguish an upgrade restart
+        # from a normal stop, otherwise the dashboard can't correlate it
+        # with the preceding update_started event. The message is
+        # produced by `classify_shutdown` and shared with the CLI watch
+        # path so the two entrypoints can't drift.
+        assert harness.stop_calls[0][1] == "Service restarting for auto-update"
         # And the operator-facing log line must distinguish this from a
         # normal stop so the Windows event log shows what happened.
         log_messages = [c.args[0] for c in harness.sm.LogInfoMsg.call_args_list]

--- a/watcher/tests/test_updater.py
+++ b/watcher/tests/test_updater.py
@@ -10,6 +10,9 @@ without spinning up a real heartbeat loop or hitting the network.
 from __future__ import annotations
 import json
 import subprocess
+import threading
+import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -100,6 +103,16 @@ class _UpdaterHarness:
     request_restart: MagicMock
 
 
+def _inline_executor(fn: Callable[[], None]) -> None:
+    """Synchronous executor used by the test harness.
+
+    Calling ``fn()`` inline (instead of spawning a daemon thread)
+    keeps assertions that depend on subprocess outcomes deterministic
+    without explicit thread joins.
+    """
+    fn()
+
+
 def _make_updater(
     tmp_path: Path,
     *,
@@ -107,6 +120,7 @@ def _make_updater(
     client: MagicMock | None = None,
     upgrade_runner: Any = None,
     updater_cfg: UpdaterConfig | None = None,
+    upgrade_executor: Callable[[Callable[[], None]], None] = _inline_executor,
 ) -> _UpdaterHarness:
     cfg = cfg or _make_config(tmp_path)
     client = client or MagicMock()
@@ -116,6 +130,10 @@ def _make_updater(
     state_db.last_run_reported_at.return_value = None
     request_restart = MagicMock()
 
+    # Default to an inline (synchronous) upgrade executor so the
+    # majority of tests can assert on subprocess outcomes without
+    # threading. Tests that exercise the async dispatch path opt in
+    # by passing the production threading executor explicitly.
     updater = Updater(
         client=client,
         reporter=reporter,
@@ -131,6 +149,7 @@ def _make_updater(
             min_run_age_seconds=10.0,
         ),
         upgrade_runner=upgrade_runner,
+        upgrade_executor=upgrade_executor,
     )
     return _UpdaterHarness(
         updater=updater,
@@ -451,3 +470,149 @@ class TestUpdaterOnTick:
         # index build.
         runner.assert_not_called()
         h.request_restart.assert_not_called()
+
+
+class TestUpdaterAsyncDispatch:
+    """The upgrade subprocess runs off the heartbeat thread.
+
+    Locks in the contract added to keep heartbeats flowing during a
+    slow ``uv tool install`` (which can take 30–60 s and would
+    otherwise wedge the heartbeat loop long enough for the dashboard
+    to flag the watcher as stale).
+    """
+
+    def test_on_tick_returns_immediately_while_subprocess_runs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A runner that blocks until the test releases it. Using the
+        # real threading executor (not the inline test default) so the
+        # subprocess is on a worker thread and `on_tick` doesn't wait.
+        release = threading.Event()
+        finished = threading.Event()
+
+        def slow_runner(method: Any, *, target_version: str) -> Any:
+            release.wait(timeout=5.0)
+            finished.set()
+            return _success_completed_process()
+
+        h = _make_updater(
+            tmp_path,
+            upgrade_runner=slow_runner,
+            upgrade_executor=lambda fn: threading.Thread(
+                target=fn, daemon=True, name="upgrade-worker-test"
+            ).start(),
+        )
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.detect_install_method",
+            lambda: InstallMethod.UV_TOOL,
+        )
+
+        h.counters.last_files_uploaded = 0
+        h.updater.on_tick()
+        h.updater.on_tick()
+
+        # The blocking subprocess must not delay this call. We cap the
+        # wall-clock cost at well under the 5 s upper bound of the
+        # blocked runner, so a regression that ran the subprocess
+        # synchronously would fail this assertion loudly rather than
+        # passing on a fast machine.
+        start = time.monotonic()
+        result = h.updater.on_tick()
+        elapsed = time.monotonic() - start
+        assert elapsed < 1.0, f"on_tick took {elapsed:.2f}s — subprocess must run off-thread"
+
+        # The dispatched-but-not-finished placeholder.
+        assert result is not None
+        assert result.attempted is True
+        assert result.succeeded is None
+        assert "dispatched" in result.reason
+        assert result.target_version == "9.9.9"
+        # Marker is on disk pre-dispatch (so a crashed-mid-upgrade
+        # process still leaves a trail for the next startup).
+        assert (tmp_path / ".data-hub" / UPGRADE_MARKER_FILENAME).exists()
+
+        # Now let the worker complete and verify the post-conditions.
+        release.set()
+        assert finished.wait(timeout=5.0)
+        # Wait for the worker to drop the in-progress flag and call
+        # request_restart — request_restart is the runtime-side hook
+        # whose call signals the heartbeat loop to exit.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if h.request_restart.call_count == 1:
+                break
+            time.sleep(0.01)
+        h.request_restart.assert_called_once_with("9.9.9")
+
+    def test_concurrent_tick_during_upgrade_is_a_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # While an upgrade is in flight, a follow-up tick must not
+        # spawn a second subprocess or hit /update-check again.
+        release = threading.Event()
+        runner_calls = 0
+
+        def slow_runner(method: Any, *, target_version: str) -> Any:
+            nonlocal runner_calls
+            runner_calls += 1
+            release.wait(timeout=5.0)
+            return _success_completed_process()
+
+        h = _make_updater(
+            tmp_path,
+            upgrade_runner=slow_runner,
+            upgrade_executor=lambda fn: threading.Thread(
+                target=fn, daemon=True, name="upgrade-worker-test"
+            ).start(),
+        )
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.detect_install_method",
+            lambda: InstallMethod.UV_TOOL,
+        )
+
+        h.counters.last_files_uploaded = 0
+        h.updater.on_tick()
+        h.updater.on_tick()
+        first = h.updater.on_tick()
+        assert first is not None
+        assert first.succeeded is None
+
+        # Wait briefly for the worker to flip _upgrade_in_progress=True
+        # before the next tick (the worker reaches the runner
+        # immediately, the flag is set on the dispatch path).
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if h.updater._upgrade_in_progress:
+                break
+            time.sleep(0.01)
+
+        second = h.updater.on_tick()
+        assert second is not None
+        assert second.attempted is False
+        assert "in progress" in second.reason
+        # Critical: no second API call, no second subprocess.
+        assert h.client.get_update_info.call_count == 1
+        assert runner_calls == 1
+
+        release.set()
+
+    def test_default_executor_is_threading_based(self, tmp_path: Path) -> None:
+        # Smoke check that the production default actually offloads to
+        # a background thread named for log-readability. Catches a
+        # regression where someone might "simplify" the default back
+        # to inline execution.
+        from data_hub_watcher.updater import _default_upgrade_executor
+
+        seen_threads: list[str] = []
+        done = threading.Event()
+
+        def record() -> None:
+            seen_threads.append(threading.current_thread().name)
+            done.set()
+
+        _default_upgrade_executor(record)
+        assert done.wait(timeout=2.0)
+        assert seen_threads == ["upgrade-worker"]
+        assert seen_threads[0] != threading.current_thread().name

--- a/watcher/tests/test_updater.py
+++ b/watcher/tests/test_updater.py
@@ -470,6 +470,84 @@ class TestUpdaterOnTick:
         # index build.
         runner.assert_not_called()
         h.request_restart.assert_not_called()
+        # And the dashboard must still see *something* — otherwise an
+        # admin pushing a (possibly mandatory) rollout has no signal
+        # that this PC is stuck on a dev install. Exactly one
+        # UPDATE_FAILED event with the install-method reason.
+        emitted_events = [c.args[0] for c in h.reporter.queue_event.call_args_list]
+        update_failed = [e for e in emitted_events if e.event_type is EventType.UPDATE_FAILED]
+        assert len(update_failed) == 1
+        evt = update_failed[0]
+        assert evt.details["target_version"] == "9.9.9"
+        assert evt.details["install_method"] == "editable"
+        assert evt.details["attempted_subprocess"] is False
+        assert "not eligible" in evt.details["reason"]
+
+    def test_editable_refusal_throttled_to_one_event_per_target(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An editable install will hit the refusal path on every
+        # hourly tick for the whole life of the dev box. We must
+        # still notify the dashboard once per *new* target version,
+        # but not on every tick — that would drown the events stream
+        # for the whole fleet of dev machines.
+        h = _make_updater(tmp_path)
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.detect_install_method",
+            lambda: InstallMethod.EDITABLE,
+        )
+
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+        h.counters.last_files_uploaded = 0
+        # Drive enough ticks to pass the check interval *twice* so two
+        # full /update-check calls land — emulating the hourly tick
+        # firing across multiple hours with the same server target.
+        for _ in range(6):
+            h.updater.on_tick()
+
+        # Both ticks called the API (so the throttle isn't hiding a
+        # missed check) but only one UPDATE_FAILED reached the queue.
+        assert h.client.get_update_info.call_count == 2
+        emitted = [
+            c.args[0]
+            for c in h.reporter.queue_event.call_args_list
+            if c.args[0].event_type is EventType.UPDATE_FAILED
+        ]
+        assert len(emitted) == 1
+
+    def test_editable_refusal_re_emits_when_target_advances(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # When the server bumps `WATCHER_LATEST_VERSION` to a new
+        # release, we *do* want to re-notify — the dashboard event for
+        # the old target doesn't tell the admin this PC is missing the
+        # new one. Throttling is per-target, not "fire at most once
+        # ever".
+        h = _make_updater(tmp_path)
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.detect_install_method",
+            lambda: InstallMethod.UNKNOWN,
+        )
+
+        h.counters.last_files_uploaded = 0
+        # First rollout target.
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+        for _ in range(3):
+            h.updater.on_tick()
+        # Server bumps the target.
+        h.client.get_update_info.return_value = _info(latest="9.9.10")
+        for _ in range(3):
+            h.updater.on_tick()
+
+        emitted = [
+            c.args[0]
+            for c in h.reporter.queue_event.call_args_list
+            if c.args[0].event_type is EventType.UPDATE_FAILED
+        ]
+        assert [e.details["target_version"] for e in emitted] == ["9.9.9", "9.9.10"]
+        # Both events must carry the install_method so the dashboard
+        # can render the "stuck on dev install" filter.
+        assert all(e.details["install_method"] == "unknown" for e in emitted)
 
 
 class TestUpdaterAsyncDispatch:

--- a/watcher/tests/test_updater.py
+++ b/watcher/tests/test_updater.py
@@ -1,0 +1,453 @@
+"""Unit tests for `data_hub_watcher.updater`.
+
+The updater drives unattended self-updates from inside the running
+service, so a wrong decision here can take a fleet of lab PCs down at
+the wrong moment. These tests pin the activity-window decision matrix,
+the on-disk marker round-trip, and the `Updater.on_tick` orchestration
+without spinning up a real heartbeat loop or hitting the network.
+"""
+
+from __future__ import annotations
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from data_hub_watcher.api_client import ApiError
+from data_hub_watcher.events import EventReporter, EventType
+from data_hub_watcher.heartbeat import WatcherCounters
+from data_hub_watcher.models import (
+    InstrumentConfig,
+    RunDetectionConfig,
+    WatcherConfig,
+    WatcherUpdateInfoResponse,
+)
+from data_hub_watcher.self_update import InstallMethod
+from data_hub_watcher.updater import (
+    UPGRADE_MARKER_FILENAME,
+    Updater,
+    UpdaterConfig,
+    UpgradeMarkerOutcome,
+    clear_upgrade_marker,
+    evaluate_upgrade_marker,
+    should_attempt_update,
+    upgrade_marker_path,
+    write_upgrade_marker,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _info(
+    *,
+    latest: str | None = "0.3.0",
+    mandatory: bool = False,
+) -> WatcherUpdateInfoResponse:
+    return WatcherUpdateInfoResponse(
+        latest_version=latest,
+        channel="stable",
+        mandatory=mandatory,
+    )
+
+
+def _make_config(
+    tmp_path: Path,
+    *,
+    environment: str = "staging",
+    stability_period_seconds: int = 5,
+) -> WatcherConfig:
+    watch_dir = tmp_path / "data"
+    watch_dir.mkdir()
+    (watch_dir / "RUN001_sample.csv").write_text("a,b\n1,2\n")
+    instrument = InstrumentConfig(
+        id="test-instrument",
+        watch_directory=watch_dir,
+        file_patterns=["*.csv"],
+        upload_mode="auto",
+        stability_period_seconds=stability_period_seconds,
+        run_detection=RunDetectionConfig(pattern=r"^([^_]+)", recursive=False),
+    )
+    return WatcherConfig(
+        version=1,
+        environment=environment,  # type: ignore[arg-type]
+        api_base_url="https://example.test/api/v1" if environment == "preview" else None,
+        watcher_id="w-test",
+        instrument=instrument,
+    )
+
+
+@dataclass
+class _UpdaterHarness:
+    """Bundle of mocks returned from `_make_updater`.
+
+    Returning a dataclass (rather than a tuple) keeps the call sites
+    readable when a test only cares about a subset of the collaborators
+    and lets pyright see each field as `MagicMock` so `return_value` /
+    `side_effect` assignments type-check cleanly.
+    """
+
+    updater: Updater
+    client: MagicMock
+    reporter: MagicMock
+    state_db: MagicMock
+    counters: WatcherCounters
+    request_restart: MagicMock
+
+
+def _make_updater(
+    tmp_path: Path,
+    *,
+    cfg: WatcherConfig | None = None,
+    client: MagicMock | None = None,
+    upgrade_runner: Any = None,
+    updater_cfg: UpdaterConfig | None = None,
+) -> _UpdaterHarness:
+    cfg = cfg or _make_config(tmp_path)
+    client = client or MagicMock()
+    reporter = MagicMock(spec=EventReporter)
+    counters = WatcherCounters()
+    state_db = MagicMock()
+    state_db.last_run_reported_at.return_value = None
+    request_restart = MagicMock()
+
+    updater = Updater(
+        client=client,
+        reporter=reporter,
+        counters=counters,
+        state_db=state_db,
+        cfg=cfg,
+        config_dir=tmp_path / ".data-hub",
+        request_upgrade_restart=request_restart,
+        updater_cfg=updater_cfg
+        or UpdaterConfig(
+            idle_ticks_required=2,
+            check_interval_ticks=3,
+            min_run_age_seconds=10.0,
+        ),
+        upgrade_runner=upgrade_runner,
+    )
+    return _UpdaterHarness(
+        updater=updater,
+        client=client,
+        reporter=reporter,
+        state_db=state_db,
+        counters=counters,
+        request_restart=request_restart,
+    )
+
+
+def _success_completed_process() -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["uv", "tool", "install", "--reinstall", "data-hub-watcher==0.3.0"],
+        returncode=0,
+        stdout="ok",
+        stderr="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# should_attempt_update
+# ---------------------------------------------------------------------------
+
+
+class TestShouldAttemptUpdate:
+    def test_no_target_means_no_update(self) -> None:
+        ok, reason = should_attempt_update(
+            _info(latest=None),
+            current_version="0.1.0",
+            idle_ticks=10,
+            idle_ticks_required=2,
+            last_run_age_seconds=None,
+            min_run_age_seconds=10.0,
+        )
+        assert ok is False
+        assert "no release info" in reason
+
+    def test_already_at_target_means_no_update(self) -> None:
+        ok, reason = should_attempt_update(
+            _info(latest="0.1.0"),
+            current_version="0.1.0",
+            idle_ticks=10,
+            idle_ticks_required=2,
+            last_run_age_seconds=None,
+            min_run_age_seconds=10.0,
+        )
+        assert ok is False
+        assert "ahead of target" in reason
+
+    def test_idle_window_required(self) -> None:
+        ok, reason = should_attempt_update(
+            _info(latest="0.3.0"),
+            current_version="0.1.0",
+            idle_ticks=1,
+            idle_ticks_required=3,
+            last_run_age_seconds=None,
+            min_run_age_seconds=10.0,
+        )
+        assert ok is False
+        assert "idle ticks" in reason
+
+    def test_recent_run_blocks_update(self) -> None:
+        ok, reason = should_attempt_update(
+            _info(latest="0.3.0"),
+            current_version="0.1.0",
+            idle_ticks=10,
+            idle_ticks_required=2,
+            last_run_age_seconds=5.0,
+            min_run_age_seconds=10.0,
+        )
+        assert ok is False
+        assert "recent run" in reason
+
+    def test_idle_and_quiet_triggers_update(self) -> None:
+        ok, reason = should_attempt_update(
+            _info(latest="0.3.0"),
+            current_version="0.1.0",
+            idle_ticks=10,
+            idle_ticks_required=2,
+            last_run_age_seconds=300.0,
+            min_run_age_seconds=10.0,
+        )
+        assert ok is True
+        assert "newer version" in reason
+
+    def test_mandatory_overrides_activity_window(self) -> None:
+        # A mandatory rollout fires even when uploads happened recently
+        # and a run was reported a moment ago — the cost of a brief
+        # outage is lower than running known-bad code.
+        ok, reason = should_attempt_update(
+            _info(latest="0.3.0", mandatory=True),
+            current_version="0.1.0",
+            idle_ticks=0,
+            idle_ticks_required=2,
+            last_run_age_seconds=1.0,
+            min_run_age_seconds=10.0,
+        )
+        assert ok is True
+        assert "mandatory" in reason
+
+    def test_no_run_history_does_not_block(self) -> None:
+        # `last_run_age_seconds=None` means the local state DB has never
+        # recorded a run — the activity check should pass.
+        ok, _reason = should_attempt_update(
+            _info(latest="0.3.0"),
+            current_version="0.1.0",
+            idle_ticks=10,
+            idle_ticks_required=2,
+            last_run_age_seconds=None,
+            min_run_age_seconds=10.0,
+        )
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# Marker round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestUpgradeMarker:
+    def test_round_trip_success(self, tmp_path: Path) -> None:
+        write_upgrade_marker(tmp_path, target_version="0.3.0", previous_version="0.1.0")
+        outcome = evaluate_upgrade_marker(tmp_path, current_version="0.3.0")
+        assert outcome == UpgradeMarkerOutcome(
+            found=True,
+            succeeded=True,
+            target_version="0.3.0",
+            previous_version="0.1.0",
+            reason="restarted into target version",
+        )
+        # Marker is consumed on read so a single failure isn't reported
+        # over and over on each restart.
+        assert not upgrade_marker_path(tmp_path).exists()
+
+    def test_round_trip_failure(self, tmp_path: Path) -> None:
+        write_upgrade_marker(tmp_path, target_version="0.3.0", previous_version="0.1.0")
+        outcome = evaluate_upgrade_marker(tmp_path, current_version="0.1.0")
+        assert outcome.found is True
+        assert outcome.succeeded is False
+        assert outcome.target_version == "0.3.0"
+        assert outcome.previous_version == "0.1.0"
+        assert "expected" in outcome.reason
+
+    def test_no_marker_returns_no_op(self, tmp_path: Path) -> None:
+        outcome = evaluate_upgrade_marker(tmp_path, current_version="0.1.0")
+        assert outcome.found is False
+        assert outcome.succeeded is None
+
+    def test_corrupt_marker_classified_as_failure(self, tmp_path: Path) -> None:
+        marker = upgrade_marker_path(tmp_path)
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        marker.write_text("not-json", encoding="utf-8")
+        outcome = evaluate_upgrade_marker(tmp_path, current_version="0.1.0")
+        assert outcome.found is True
+        assert outcome.succeeded is False
+        assert "unreadable" in outcome.reason
+        assert not marker.exists()
+
+    def test_clear_is_idempotent(self, tmp_path: Path) -> None:
+        clear_upgrade_marker(tmp_path)
+        clear_upgrade_marker(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Updater.on_tick
+# ---------------------------------------------------------------------------
+
+
+class TestUpdaterOnTick:
+    def test_preview_environment_is_no_op(self, tmp_path: Path) -> None:
+        cfg = _make_config(tmp_path, environment="preview")
+        h = _make_updater(tmp_path, cfg=cfg)
+        for _ in range(20):
+            assert h.updater.on_tick() is None
+        h.request_restart.assert_not_called()
+        h.reporter.queue_event.assert_not_called()
+
+    def test_first_ticks_are_no_op_until_check_interval(self, tmp_path: Path) -> None:
+        h = _make_updater(tmp_path)
+        # Below check_interval_ticks=3 we should not call the API at all.
+        h.counters.last_files_uploaded = 0
+        assert h.updater.on_tick() is None
+        assert h.updater.on_tick() is None
+        h.client.get_update_info.return_value = _info(latest="0.0.0+unknown")
+        result = h.updater.on_tick()
+        assert result is not None
+
+    def test_busy_interval_resets_idle_counter(self, tmp_path: Path) -> None:
+        h = _make_updater(
+            tmp_path,
+            updater_cfg=UpdaterConfig(
+                idle_ticks_required=2,
+                check_interval_ticks=2,
+                min_run_age_seconds=1.0,
+            ),
+        )
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+
+        # Simulate: tick 1 idle, tick 2 busy (uploads happened).
+        h.counters.last_files_uploaded = 0
+        h.updater.on_tick()
+        h.counters.last_files_uploaded = 5
+        result = h.updater.on_tick()
+        assert result is not None
+        # idle_ticks (1) is below the required 2 because of the busy
+        # interval, so the update must be deferred.
+        assert result.attempted is False
+        assert "idle ticks" in result.reason
+
+    def test_api_error_is_reported_but_not_raised(self, tmp_path: Path) -> None:
+        h = _make_updater(tmp_path)
+        h.client.get_update_info.side_effect = ApiError("boom", status_code=500)
+        h.counters.last_files_uploaded = 0
+        for _ in range(2):
+            h.updater.on_tick()
+        # The 3rd tick triggers the API call which fails.
+        result = h.updater.on_tick()
+        assert result is not None
+        assert result.attempted is False
+        assert result.succeeded is False
+        assert "API error" in result.reason
+
+    def test_successful_upgrade_writes_marker_and_requests_restart(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        runner = MagicMock(return_value=_success_completed_process())
+        h = _make_updater(tmp_path, upgrade_runner=runner)
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+        h.state_db.last_run_reported_at.return_value = None
+
+        # detect_install_method should report a clean uv-tool install so
+        # the upgrade is eligible.
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.detect_install_method",
+            lambda: InstallMethod.UV_TOOL,
+        )
+
+        # Burn the first two ticks to satisfy idle + check interval.
+        h.counters.last_files_uploaded = 0
+        h.updater.on_tick()
+        h.updater.on_tick()
+        result = h.updater.on_tick()
+
+        assert result is not None
+        assert result.attempted is True
+        assert result.succeeded is True
+        assert result.target_version == "9.9.9"
+        runner.assert_called_once()
+        h.request_restart.assert_called_once_with("9.9.9")
+
+        # The marker must be on disk so the next process startup can
+        # detect whether the upgrade actually took.
+        marker = tmp_path / ".data-hub" / UPGRADE_MARKER_FILENAME
+        assert marker.exists()
+        data = json.loads(marker.read_text(encoding="utf-8"))
+        assert data["target_version"] == "9.9.9"
+
+        # An UPDATE_STARTED event must have been queued before the
+        # subprocess ran so the dashboard sees the start even if the
+        # subprocess hangs.
+        emitted = [c.args[0].event_type for c in h.reporter.queue_event.call_args_list]
+        assert EventType.UPDATE_STARTED in emitted
+        # UPDATE_SUCCEEDED is intentionally deferred to the post-restart
+        # marker evaluation, not emitted here.
+        assert EventType.UPDATE_SUCCEEDED not in emitted
+
+    def test_failed_upgrade_subprocess_emits_update_failed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        runner = MagicMock(
+            return_value=subprocess.CompletedProcess(
+                args=["x"], returncode=1, stdout="", stderr="kaboom"
+            )
+        )
+        h = _make_updater(tmp_path, upgrade_runner=runner)
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.detect_install_method",
+            lambda: InstallMethod.UV_TOOL,
+        )
+
+        h.counters.last_files_uploaded = 0
+        h.updater.on_tick()
+        h.updater.on_tick()
+        result = h.updater.on_tick()
+
+        assert result is not None
+        assert result.attempted is True
+        assert result.succeeded is False
+        h.request_restart.assert_not_called()
+        # The marker is cleared on a known-failed in-process upgrade so
+        # the next startup doesn't double-report it.
+        assert not (tmp_path / ".data-hub" / UPGRADE_MARKER_FILENAME).exists()
+        emitted = [c.args[0].event_type for c in h.reporter.queue_event.call_args_list]
+        assert EventType.UPDATE_FAILED in emitted
+
+    def test_editable_install_refuses_auto_update(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        runner = MagicMock(return_value=_success_completed_process())
+        h = _make_updater(tmp_path, upgrade_runner=runner)
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.detect_install_method",
+            lambda: InstallMethod.EDITABLE,
+        )
+
+        h.counters.last_files_uploaded = 0
+        h.updater.on_tick()
+        h.updater.on_tick()
+        result = h.updater.on_tick()
+
+        assert result is not None
+        assert result.attempted is True
+        assert result.succeeded is False
+        # An editable checkout must not be silently overwritten by an
+        # index build.
+        runner.assert_not_called()
+        h.request_restart.assert_not_called()

--- a/web-app/app/api/v1/watchers/[watcherId]/events/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/events/route.ts
@@ -12,19 +12,15 @@ import {
 } from "@/lib/api/validators";
 import { findActiveWatcher } from "@/lib/api/watchers";
 import { db } from "@/lib/db";
-import { watcherEvents } from "@/lib/db/schema";
+import { watcherEvents, watcherEventTypeEnum } from "@/lib/db/schema";
 import { and, desc, eq, gte, inArray } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 
-const VALID_EVENT_TYPES = new Set([
-  "watcher_started",
-  "watcher_stopped",
-  "file_uploaded",
-  "upload_failed",
-  "run_reported",
-  "config_synced",
-  "error",
-]);
+// Derived from the Drizzle enum so adding a new event type is a one-line
+// schema change — historically this was a hand-maintained Set and drifted
+// from the DB enum (the auto-update events were defined in the schema but
+// silently 400'd here, dropping the entire batch they appeared in).
+const VALID_EVENT_TYPES = new Set<string>(watcherEventTypeEnum.enumValues);
 
 export async function POST(
   request: NextRequest,

--- a/web-app/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
@@ -87,6 +87,12 @@ export async function POST(
       .set({
         lastHeartbeatAt: new Date(),
         status: status as "registered" | "watching" | "stopped",
+        // Older watchers (pre-version-reporting) won't include this field —
+        // fall back to the existing value rather than nulling it out so the
+        // dashboard keeps the last-known version visible.
+        ...(typeof body.watcher_version === "string" && body.watcher_version
+          ? { watcherVersion: body.watcher_version }
+          : {}),
       })
       .where(eq(watchers.id, watcherId)),
   ]);

--- a/web-app/app/api/v1/watchers/[watcherId]/update-check/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/update-check/route.ts
@@ -1,0 +1,75 @@
+import { authenticateRequest } from "@/lib/api/auth";
+import {
+  apiError,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
+import { isValidUUID } from "@/lib/api/validators";
+import { findActiveWatcher } from "@/lib/api/watchers";
+import type { NextRequest } from "next/server";
+
+/**
+ * Server-reported watcher release metadata.
+ *
+ * Source of truth is environment variables today; a dedicated
+ * `watcher_releases` table can replace this once we need per-channel
+ * rollouts or per-watcher pinned versions:
+ *
+ *   - `WATCHER_LATEST_VERSION`        — required to advertise a release
+ *   - `WATCHER_MIN_SUPPORTED_VERSION` — optional floor for forced upgrades
+ *   - `WATCHER_RELEASE_CHANNEL`       — defaults to "stable"
+ *   - `WATCHER_MANDATORY_UPDATE`      — "true" / "1" to force rollout
+ *
+ * When `WATCHER_LATEST_VERSION` is unset the endpoint still returns 200 so
+ * watchers don't log spurious 5xxs; `latest_version: null` tells the
+ * client to skip the upgrade attempt.
+ */
+type WatcherReleaseInfo = {
+  latest_version: string | null;
+  min_supported_version: string | null;
+  channel: string;
+  mandatory: boolean;
+};
+
+function readReleaseInfo(): WatcherReleaseInfo {
+  const latest = process.env.WATCHER_LATEST_VERSION?.trim() || null;
+  const minSupported =
+    process.env.WATCHER_MIN_SUPPORTED_VERSION?.trim() || null;
+  const channel = process.env.WATCHER_RELEASE_CHANNEL?.trim() || "stable";
+  const mandatoryRaw = process.env.WATCHER_MANDATORY_UPDATE?.trim() ?? "";
+  const mandatory =
+    mandatoryRaw === "1" || mandatoryRaw.toLowerCase() === "true";
+
+  return {
+    latest_version: latest,
+    min_supported_version: minSupported,
+    channel,
+    mandatory: mandatory && latest !== null,
+  };
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ watcherId: string }> }
+) {
+  const authResult = await authenticateRequest(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const { watcherId } = await params;
+  if (!isValidUUID(watcherId)) {
+    return apiError(400, VALIDATION_ERROR, "Invalid watcher ID format");
+  }
+
+  // Soft-deleted watchers can't legitimately self-update — they shouldn't
+  // be calling home at all. Return 404 so the CLI surfaces the same
+  // "Watcher not found" error operators see elsewhere.
+  const watcher = await findActiveWatcher(watcherId);
+  if (!watcher) {
+    return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  return Response.json(readReleaseInfo());
+}

--- a/web-app/components/watchers/watcher-header.tsx
+++ b/web-app/components/watchers/watcher-header.tsx
@@ -60,6 +60,11 @@ export function WatcherHeader({ watcher }: { watcher: WatcherDetail }) {
               status={watcher.effectiveStatus}
               lastOnlineAt={watcher.lastHeartbeatAt}
             />
+            {watcher.watcherVersion && (
+              <Badge variant="outline" className="font-mono text-[10px]">
+                v{watcher.watcherVersion}
+              </Badge>
+            )}
             {isDeregistered && (
               <Badge variant="secondary" className="text-[10px]">
                 Deregistered

--- a/web-app/components/watchers/watchers-table.tsx
+++ b/web-app/components/watchers/watchers-table.tsx
@@ -41,6 +41,7 @@ export function WatchersTable({
             <TableHead>Watcher ID</TableHead>
             <TableHead>Instrument</TableHead>
             <TableHead>Hostname</TableHead>
+            <TableHead>Version</TableHead>
             <TableHead>Status</TableHead>
             <TableHead>Last Heartbeat</TableHead>
             {!isDeregisteredView && <TableHead className="w-[80px]" />}
@@ -74,6 +75,15 @@ export function WatchersTable({
                       <span className="text-muted-foreground">—</span>
                     )}
                   </span>
+                </TableCell>
+                <TableCell>
+                  {row.watcherVersion ? (
+                    <span className="font-mono text-xs">
+                      {row.watcherVersion}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
                 </TableCell>
                 <TableCell>
                   <WatcherStatusBadge status={row.effectiveStatus} />

--- a/web-app/drizzle/0013_add_watcher_version.sql
+++ b/web-app/drizzle/0013_add_watcher_version.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "watchers" ADD COLUMN "watcher_version" text;

--- a/web-app/drizzle/0014_add_watcher_update_events.sql
+++ b/web-app/drizzle/0014_add_watcher_update_events.sql
@@ -1,0 +1,3 @@
+ALTER TYPE "public"."watcher_event_type" ADD VALUE 'update_started';--> statement-breakpoint
+ALTER TYPE "public"."watcher_event_type" ADD VALUE 'update_succeeded';--> statement-breakpoint
+ALTER TYPE "public"."watcher_event_type" ADD VALUE 'update_failed';

--- a/web-app/drizzle/meta/0013_snapshot.json
+++ b/web-app/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,1380 @@
+{
+  "id": "0a93c000-addf-4d81-a9a7-48ebf14869be",
+  "prevId": "c6f97721-3fff-4c67-97a0-a04d2ce3b445",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "file_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raw'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_requested_at": {
+          "name": "upload_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_files_instrument_run_id_relative_path": {
+          "name": "uq_files_instrument_run_id_relative_path",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"relative_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_active_instrument_run_id_filename": {
+          "name": "uq_files_active_instrument_run_id_filename",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_s3_key": {
+          "name": "uq_files_s3_key",
+          "columns": [
+            {
+              "expression": "s3_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"s3_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_instrument_run_id": {
+          "name": "idx_files_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_status_instrument_run_id": {
+          "name": "idx_files_status_instrument_run_id",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_upload_queue": {
+          "name": "idx_files_upload_queue",
+          "columns": [
+            {
+              "expression": "upload_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"upload_requested_at\" is not null and \"files\".\"uploaded_at\" is null and \"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_metadata_gin": {
+          "name": "idx_files_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_instrument_run_id_instrument_runs_id_fk": {
+          "name": "files_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_runs": {
+      "name": "instrument_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "instrument_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lambda'"
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_purged_at": {
+          "name": "files_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instrument_runs_instrument_id_created_at": {
+          "name": "idx_instrument_runs_instrument_id_created_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active": {
+          "name": "idx_instrument_runs_active",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_metadata_gin": {
+          "name": "idx_instrument_runs_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_runs_instrument_id_instruments_id_fk": {
+          "name": "instrument_runs_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_watcher_id_watchers_id_fk": {
+          "name": "instrument_runs_watcher_id_watchers_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_instrument_runs_instrument_id_run_id": {
+          "name": "uq_instrument_runs_instrument_id_run_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instrument_id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instruments": {
+      "name": "instruments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instrument_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instrument_type": {
+          "name": "instrument_type",
+          "type": "instrument_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_personal_access_tokens_user_id": {
+          "name": "idx_personal_access_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_user_id_fk": {
+          "name": "personal_access_tokens_user_id_user_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_attributions": {
+      "name": "run_attributions",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_attributions_run_id": {
+          "name": "idx_run_attributions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_attributions_user_id": {
+          "name": "idx_run_attributions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_attributions_run_id_instrument_runs_id_fk": {
+          "name": "run_attributions_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_attributions_user_id_user_id_fk": {
+          "name": "run_attributions_user_id_user_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_attributions_run_id_user_id_pk": {
+          "name": "run_attributions_run_id_user_id_pk",
+          "columns": [
+            "run_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_events": {
+      "name": "watcher_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "watcher_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_events_watcher_id_timestamp": {
+          "name": "idx_watcher_events_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_watcher_events_watcher_id_event_type": {
+          "name": "idx_watcher_events_watcher_id_event_type",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_events_watcher_id_watchers_id_fk": {
+          "name": "watcher_events_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_events",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_heartbeats": {
+      "name": "watcher_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_mode": {
+          "name": "upload_mode",
+          "type": "upload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_uploaded_since_last": {
+          "name": "files_uploaded_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "runs_reported_since_last": {
+          "name": "runs_reported_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_since_last": {
+          "name": "errors_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_heartbeats_watcher_id_timestamp": {
+          "name": "idx_watcher_heartbeats_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_heartbeats_watcher_id_watchers_id_fk": {
+          "name": "watcher_heartbeats_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_heartbeats",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watchers": {
+      "name": "watchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_info": {
+          "name": "os_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watcher_version": {
+          "name": "watcher_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_checksum": {
+          "name": "config_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_yaml": {
+          "name": "config_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "watcher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_watchers_active_instrument_id": {
+          "name": "uq_watchers_active_instrument_id",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"watchers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchers_instrument_id_instruments_id_fk": {
+          "name": "watchers_instrument_id_instruments_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.file_category": {
+      "name": "file_category",
+      "schema": "public",
+      "values": [
+        "raw",
+        "processed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "detected",
+        "upload_requested",
+        "uploaded",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.instrument_run_source": {
+      "name": "instrument_run_source",
+      "schema": "public",
+      "values": [
+        "lambda",
+        "watcher"
+      ]
+    },
+    "public.instrument_status": {
+      "name": "instrument_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "inactive"
+      ]
+    },
+    "public.instrument_type": {
+      "name": "instrument_type",
+      "schema": "public",
+      "values": [
+        "generic",
+        "plate_reader",
+        "gel_doc",
+        "qpcr",
+        "tape_station",
+        "hina_microscope"
+      ]
+    },
+    "public.upload_mode": {
+      "name": "upload_mode",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual"
+      ]
+    },
+    "public.watcher_event_type": {
+      "name": "watcher_event_type",
+      "schema": "public",
+      "values": [
+        "watcher_started",
+        "watcher_stopped",
+        "file_uploaded",
+        "upload_failed",
+        "run_reported",
+        "config_synced",
+        "error"
+      ]
+    },
+    "public.watcher_status": {
+      "name": "watcher_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "watching",
+        "stopped"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web-app/drizzle/meta/0014_snapshot.json
+++ b/web-app/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1383 @@
+{
+  "id": "199678f9-995e-45d0-aad3-4aafb2f68ece",
+  "prevId": "0a93c000-addf-4d81-a9a7-48ebf14869be",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "file_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raw'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_requested_at": {
+          "name": "upload_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_files_instrument_run_id_relative_path": {
+          "name": "uq_files_instrument_run_id_relative_path",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"relative_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_active_instrument_run_id_filename": {
+          "name": "uq_files_active_instrument_run_id_filename",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_s3_key": {
+          "name": "uq_files_s3_key",
+          "columns": [
+            {
+              "expression": "s3_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"s3_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_instrument_run_id": {
+          "name": "idx_files_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_status_instrument_run_id": {
+          "name": "idx_files_status_instrument_run_id",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_upload_queue": {
+          "name": "idx_files_upload_queue",
+          "columns": [
+            {
+              "expression": "upload_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"upload_requested_at\" is not null and \"files\".\"uploaded_at\" is null and \"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_metadata_gin": {
+          "name": "idx_files_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_instrument_run_id_instrument_runs_id_fk": {
+          "name": "files_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_runs": {
+      "name": "instrument_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "instrument_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lambda'"
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_purged_at": {
+          "name": "files_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instrument_runs_instrument_id_created_at": {
+          "name": "idx_instrument_runs_instrument_id_created_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active": {
+          "name": "idx_instrument_runs_active",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_metadata_gin": {
+          "name": "idx_instrument_runs_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_runs_instrument_id_instruments_id_fk": {
+          "name": "instrument_runs_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_watcher_id_watchers_id_fk": {
+          "name": "instrument_runs_watcher_id_watchers_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_instrument_runs_instrument_id_run_id": {
+          "name": "uq_instrument_runs_instrument_id_run_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instrument_id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instruments": {
+      "name": "instruments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instrument_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instrument_type": {
+          "name": "instrument_type",
+          "type": "instrument_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_personal_access_tokens_user_id": {
+          "name": "idx_personal_access_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_user_id_fk": {
+          "name": "personal_access_tokens_user_id_user_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_attributions": {
+      "name": "run_attributions",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_attributions_run_id": {
+          "name": "idx_run_attributions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_attributions_user_id": {
+          "name": "idx_run_attributions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_attributions_run_id_instrument_runs_id_fk": {
+          "name": "run_attributions_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_attributions_user_id_user_id_fk": {
+          "name": "run_attributions_user_id_user_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_attributions_run_id_user_id_pk": {
+          "name": "run_attributions_run_id_user_id_pk",
+          "columns": [
+            "run_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_events": {
+      "name": "watcher_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "watcher_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_events_watcher_id_timestamp": {
+          "name": "idx_watcher_events_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_watcher_events_watcher_id_event_type": {
+          "name": "idx_watcher_events_watcher_id_event_type",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_events_watcher_id_watchers_id_fk": {
+          "name": "watcher_events_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_events",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_heartbeats": {
+      "name": "watcher_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_mode": {
+          "name": "upload_mode",
+          "type": "upload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_uploaded_since_last": {
+          "name": "files_uploaded_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "runs_reported_since_last": {
+          "name": "runs_reported_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_since_last": {
+          "name": "errors_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_heartbeats_watcher_id_timestamp": {
+          "name": "idx_watcher_heartbeats_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_heartbeats_watcher_id_watchers_id_fk": {
+          "name": "watcher_heartbeats_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_heartbeats",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watchers": {
+      "name": "watchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_info": {
+          "name": "os_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watcher_version": {
+          "name": "watcher_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_checksum": {
+          "name": "config_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_yaml": {
+          "name": "config_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "watcher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_watchers_active_instrument_id": {
+          "name": "uq_watchers_active_instrument_id",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"watchers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchers_instrument_id_instruments_id_fk": {
+          "name": "watchers_instrument_id_instruments_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.file_category": {
+      "name": "file_category",
+      "schema": "public",
+      "values": [
+        "raw",
+        "processed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "detected",
+        "upload_requested",
+        "uploaded",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.instrument_run_source": {
+      "name": "instrument_run_source",
+      "schema": "public",
+      "values": [
+        "lambda",
+        "watcher"
+      ]
+    },
+    "public.instrument_status": {
+      "name": "instrument_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "inactive"
+      ]
+    },
+    "public.instrument_type": {
+      "name": "instrument_type",
+      "schema": "public",
+      "values": [
+        "generic",
+        "plate_reader",
+        "gel_doc",
+        "qpcr",
+        "tape_station",
+        "hina_microscope"
+      ]
+    },
+    "public.upload_mode": {
+      "name": "upload_mode",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual"
+      ]
+    },
+    "public.watcher_event_type": {
+      "name": "watcher_event_type",
+      "schema": "public",
+      "values": [
+        "watcher_started",
+        "watcher_stopped",
+        "file_uploaded",
+        "upload_failed",
+        "run_reported",
+        "config_synced",
+        "error",
+        "update_started",
+        "update_succeeded",
+        "update_failed"
+      ]
+    },
+    "public.watcher_status": {
+      "name": "watcher_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "watching",
+        "stopped"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web-app/drizzle/meta/_journal.json
+++ b/web-app/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1777490067215,
       "tag": "0013_add_watcher_version",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1777493318455,
+      "tag": "0014_add_watcher_update_events",
+      "breakpoints": true
     }
   ]
 }

--- a/web-app/drizzle/meta/_journal.json
+++ b/web-app/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1777417774920,
       "tag": "0012_drop_redundant_idx_files_active",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1777490067215,
+      "tag": "0013_add_watcher_version",
+      "breakpoints": true
     }
   ]
 }

--- a/web-app/lib/api/watchers.ts
+++ b/web-app/lib/api/watchers.ts
@@ -54,6 +54,7 @@ export type WatcherListItem = {
   instrumentId: string;
   instrumentDisplayName: string | null;
   hostname: string | null;
+  watcherVersion: string | null;
   effectiveStatus: EffectiveStatus;
   lastHeartbeatAt: Date | null;
   createdAt: Date;
@@ -74,6 +75,7 @@ export async function getWatcherList(opts: {
       instrumentId: watchers.instrumentId,
       instrumentDisplayName: instruments.displayName,
       hostname: watchers.hostname,
+      watcherVersion: watchers.watcherVersion,
       status: watchers.status,
       lastHeartbeatAt: watchers.lastHeartbeatAt,
       createdAt: watchers.createdAt,
@@ -89,6 +91,7 @@ export async function getWatcherList(opts: {
     instrumentId: row.instrumentId,
     instrumentDisplayName: row.instrumentDisplayName,
     hostname: row.hostname,
+    watcherVersion: row.watcherVersion,
     // Deregistered watchers always show as "stopped" regardless of their
     // last DB status — they can no longer heartbeat so staleness is moot.
     effectiveStatus: row.deletedAt ? "stopped" : computeEffectiveStatus(row),
@@ -121,6 +124,7 @@ export const getWatcherById = cache(async function getWatcherById(
       instrumentDisplayName: instruments.displayName,
       hostname: watchers.hostname,
       osInfo: watchers.osInfo,
+      watcherVersion: watchers.watcherVersion,
       status: watchers.status,
       lastHeartbeatAt: watchers.lastHeartbeatAt,
       configYaml: watchers.configYaml,
@@ -144,6 +148,7 @@ export const getWatcherById = cache(async function getWatcherById(
     instrumentDisplayName: row.instrumentDisplayName,
     hostname: row.hostname,
     osInfo: row.osInfo,
+    watcherVersion: row.watcherVersion,
     effectiveStatus: row.deletedAt ? "stopped" : computeEffectiveStatus(row),
     lastHeartbeatAt: row.lastHeartbeatAt,
     configYaml: row.configYaml,

--- a/web-app/lib/db/schema.ts
+++ b/web-app/lib/db/schema.ts
@@ -36,6 +36,11 @@ export const watcherEventTypeEnum = pgEnum("watcher_event_type", [
   "run_reported",
   "config_synced",
   "error",
+  // Auto-update lifecycle events emitted by the in-process updater. See
+  // `watcher/src/data_hub_watcher/updater.py` for the state machine.
+  "update_started",
+  "update_succeeded",
+  "update_failed",
 ]);
 
 export const uploadModeEnum = pgEnum("upload_mode", ["auto", "manual"]);

--- a/web-app/lib/db/schema.ts
+++ b/web-app/lib/db/schema.ts
@@ -205,6 +205,9 @@ export const watchers = pgTable(
     hostname: text("hostname"),
     // OS description (e.g., "Windows 11 23H2").
     osInfo: text("os_info"),
+    // Installed watcher package version (PEP 440, e.g. "0.2.0"). Reported on
+    // every heartbeat. NULL until a watcher running >= 0.3.0 first checks in.
+    watcherVersion: text("watcher_version"),
     // SHA-256 of the last-pushed config YAML.
     configChecksum: text("config_checksum"),
     // The raw YAML text of the watcher's config file, stored verbatim as

--- a/web-app/tests/integration/global-setup.ts
+++ b/web-app/tests/integration/global-setup.ts
@@ -93,6 +93,14 @@ export async function setup() {
     AWS_REGION: process.env.AWS_REGION ?? "us-east-1",
     S3_RAW_DATA_BUCKET:
       process.env.S3_RAW_DATA_BUCKET ?? "test-raw-data-bucket",
+    // Stable watcher release-info defaults so the `update-check` endpoint
+    // returns deterministic values during integration tests. Individual
+    // tests assert against these exact strings.
+    WATCHER_LATEST_VERSION: process.env.WATCHER_LATEST_VERSION ?? "9.9.9",
+    WATCHER_MIN_SUPPORTED_VERSION:
+      process.env.WATCHER_MIN_SUPPORTED_VERSION ?? "0.1.0",
+    WATCHER_RELEASE_CHANNEL: process.env.WATCHER_RELEASE_CHANNEL ?? "stable",
+    WATCHER_MANDATORY_UPDATE: process.env.WATCHER_MANDATORY_UPDATE ?? "false",
   };
   // Strip Lambda config so "not configured" test cases work regardless of
   // the developer's local .env. Tests that need Lambda stubbed should mock

--- a/web-app/tests/integration/watchers.test.ts
+++ b/web-app/tests/integration/watchers.test.ts
@@ -348,6 +348,48 @@ describe("Watchers API", () => {
   });
 
   // -------------------------------------------------------------------------
+  // GET /api/v1/watchers/:watcherId/update-check
+  // -------------------------------------------------------------------------
+
+  // Update-check is the foundation for the auto-update flow. The exact
+  // response values come from `WATCHER_*` env vars seeded in
+  // `tests/integration/global-setup.ts` so the assertions stay stable as
+  // the real release line moves on.
+  it("GET /api/v1/watchers/:id/update-check returns server-reported release info", async () => {
+    const res = await api(`/api/v1/watchers/${watcherId}/update-check`, {
+      token,
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({
+      latest_version: "9.9.9",
+      min_supported_version: "0.1.0",
+      channel: "stable",
+      mandatory: false,
+    });
+  });
+
+  it("GET /api/v1/watchers/:id/update-check requires authentication", async () => {
+    const res = await api(`/api/v1/watchers/${watcherId}/update-check`);
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/v1/watchers/:id/update-check rejects invalid UUID", async () => {
+    const res = await api("/api/v1/watchers/not-a-uuid/update-check", {
+      token,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /api/v1/watchers/:id/update-check returns 404 for unknown watcher", async () => {
+    const res = await api(
+      "/api/v1/watchers/00000000-0000-0000-0000-000000000000/update-check",
+      { token }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  // -------------------------------------------------------------------------
   // DELETE /api/v1/watchers/:watcherId
   // -------------------------------------------------------------------------
 
@@ -370,6 +412,13 @@ describe("Watchers API", () => {
       token,
     });
     expect(res.status).toBe(409);
+  });
+
+  it("GET /api/v1/watchers/:id/update-check returns 404 for soft-deleted watcher", async () => {
+    const res = await api(`/api/v1/watchers/${watcherId}/update-check`, {
+      token,
+    });
+    expect(res.status).toBe(404);
   });
 
   it("GET /api/v1/watchers excludes deleted watchers by default", async () => {

--- a/web-app/tests/integration/watchers.test.ts
+++ b/web-app/tests/integration/watchers.test.ts
@@ -281,6 +281,42 @@ describe("Watchers API", () => {
     expect(res.status).toBe(400);
   });
 
+  // Regression: the auto-update lifecycle event types are defined on the
+  // Drizzle enum but a hand-maintained allow-list in the route handler
+  // used to omit them, so the watcher's batched flush would 400 and drop
+  // the entire batch. Exercising one of each new type here keeps the
+  // handler honest if the enum grows again.
+  it("POST /api/v1/watchers/:id/events accepts auto-update lifecycle events", async () => {
+    const res = await api(`/api/v1/watchers/${watcherId}/events`, {
+      method: "POST",
+      token,
+      body: {
+        events: [
+          {
+            event_type: "update_started",
+            timestamp: new Date().toISOString(),
+            message: "Upgrading watcher 0.1.0 -> 0.3.0",
+            details: { current_version: "0.1.0", target_version: "0.3.0" },
+          },
+          {
+            event_type: "update_succeeded",
+            timestamp: new Date().toISOString(),
+            message: "Restarted into watcher 0.3.0",
+          },
+          {
+            event_type: "update_failed",
+            timestamp: new Date().toISOString(),
+            message: "Watcher upgrade to 0.3.0 failed: subprocess exited 1",
+            details: { reason: "subprocess exited 1" },
+          },
+        ],
+      },
+    });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.received).toBe(3);
+  });
+
   // -------------------------------------------------------------------------
   // GET /api/v1/watchers/:watcherId/events
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Ships an end-to-end self-update flow for the lab-PC watcher so we can roll out fixes without operators running `git pull && uv sync`.

The watcher is now distributed on PyPI (`uv tool install data-hub-watcher`), reports its installed version on every heartbeat, can upgrade itself in place via `data-hub-watcher self-update`, and — when running as a Windows service — auto-updates from the running process on an hourly idle-window tick, asking the SCM to restart it into the new wheel. 

Server-side, a new `GET /api/v1/watchers/:id/update-check` endpoint sources the target version from `WATCHER_LATEST_VERSION` / `WATCHER_MANDATORY_UPDATE` env vars and the dashboard surfaces the installed version on each watcher.

## Changes

- **PyPI distribution.** New `publish-watcher.yml` workflow (build → publish → verify) triggered on `watcher-v*` tags or manual dispatch from `production`, OIDC trusted publishing, no API token in repo secrets.
  - New `make py-check-watcher-version` guard refuses to ship if the git tag and `watcher/pyproject.toml` disagree. 
  - Watcher package gains presentable PyPI metadata: `description`, `readme`, MIT `LICENSE` bundled in the wheel, `authors`, `urls`, `classifiers`, and a short `watcher/README.md`.
- **`/update-check` API.** New `web-app/app/api/v1/watchers/[watcherId]/update-check/route.ts` returns `{ latest_version, min_supported_version, channel, mandatory }` sourced from env vars.
  - Returns 200 with `latest_version: null` when unset so watchers don't log spurious 5xxs.
  - Returns 404s for soft-deleted watchers.
- **`self-update` CLI.** New `data-hub-watcher self-update [--check|--force]` command. Compares server `latest_version` against `importlib.metadata.version("data-hub-watcher")` using `packaging.version.Version`, then runs the right upgrade subprocess for the install method.
  - `uv tool install --reinstall data-hub-watcher==<v>` for `uv tool` installs
  - `<python> -m pip install -U data-hub-watcher==<v>` for plain venvs, refused for editable / `uv sync` checkouts. Install-method detection uses PEP 610 `direct_url.json` (`dir_info.editable`) plus a `sys.prefix` substring heuristic.
- **In-process auto-updater.** New `Updater` class wired into `HeartbeatLoop`'s `on_tick` polls `/update-check` ~hourly and runs the upgrade subprocess only during idle windows (no recent uploads + no recent run activity, unless the release is flagged mandatory).
  - Refuses to act in `preview` and on editable installs.
  - The subprocess runs on a daemon `upgrade-worker` thread so heartbeats keep flowing during the 30–60 s install.
  - Writes a `~/.data-hub/.upgrade-in-progress` marker before the subprocess so the next process startup can emit `update_succeeded` / `update_failed` based on whether the new version actually loaded.
  - The marker is consumed-on-read so a single failure isn't reported indefinitely.
- **Lifecycle events.** New `update_started` / `update_succeeded` / `update_failed` values added to the `watcher_event_type` enum (migration `0014`).
  - The events POST route now derives `VALID_EVENT_TYPES` from `watcherEventTypeEnum.enumValues` so the DB enum is the single source of truth — fixes a regression where the hand-maintained allowlist would 400 the entire batch when an auto-update event appeared in it.
- **Version reporting.** Heartbeat payload now includes `watcher_version`.
  - New nullable `watchers.watcher_version` column (migration `0013`).
  - Rendered as a `vX.Y.Z` badge on the watcher header and a new "Version" column on the watchers table.
- **Docs.** New `docs/guides/upgrading-the-watcher.md` covers the three on-PC upgrade paths, pinning, mandatory updates, rollback, and operator troubleshooting keyed on the `update_failed.reason` strings the watcher emits.
  - `installing-a-watcher.md` now leads with `uv tool install data-hub-watcher` and keeps the editable-checkout flow as a developer install.
  - `ci-and-deployment.md` documents `publish-watcher.yml`. `api.md` documents `/update-check`.
  - `watcher.md` adds the `self-update` command entry and top-of-file links to both new guides.

## Breaking changes

- **`data-hub-shared` removed from watcher runtime deps.** The published `data-hub-watcher` wheel no longer advertises `data-hub-shared` as a runtime requirement — only the integration tests import it.
  - Moved to a PEP 735 `[dependency-groups].test` block, included by `uv sync` for local dev. No runtime impact for installs, but a `uv pip install data-hub-watcher` no longer pulls `data-hub-shared`.

## Driveby changes

- **Watcher version line reset 0.2.0 → 0.1.0.**
- Hardens `publish-watcher.yml`'s `workflow_dispatch` with an `if:` guard restricting manual runs to `production` (the tag-vs-pyproject check is gated on `startsWith(github.ref, 'refs/tags/')`, so a manual run from a feature branch would have skipped the check).

## Testing

- [x] `make check-all` is green
- [x] New unit tests pass: `watcher/tests/test_self_update.py`, `watcher/tests/test_updater.py` (incl. the `TestUpdaterAsyncDispatch` cases pinning the off-thread dispatch contract), updated `test_runtime.py` and `test_service.py` for the upgrade-restart-event split
- [x] New integration tests pass: `watcher/tests/integration/test_update_check.py`, `web-app/tests/integration/watchers.test.ts` (regression test POSTing each new `update_*` event type)
