### PR TITLE
Watcher: Surface previously-silent failure modes as structured events

### DIFF
--- a/watcher/pyproject.toml
+++ b/watcher/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "data-hub-watcher"
-version = "0.1.1"
+version = "0.1.2"
 description = "File-watcher agent for lab instrument PCs that ingests data into the Arcadia Science Data Hub."
 readme = "README.md"
 requires-python = ">=3.12"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [
-    { name = "Arcadia Science", email = "engineering@arcadiascience.com" },
+    { name = "Arcadia Science", email = "swe@arcadiascience.com" },
 ]
 keywords = ["arcadia", "data-hub", "lab", "instruments", "watcher", "uploader"]
 classifiers = [

--- a/watcher/pyproject.toml
+++ b/watcher/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "data-hub-watcher"
 version = "0.1.2"
-description = "File-watcher agent for lab instrument PCs that ingests data into the Arcadia Science Data Hub."
+description = "File-watcher agent for lab instrument PCs that ingests data into Data Hub."
 readme = "README.md"
 requires-python = ">=3.12"
 license = "MIT"

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -34,7 +34,13 @@ from data_hub_watcher.models import (
     RunDetectionConfig,
     WatcherConfig,
 )
-from data_hub_watcher.runtime import build_runtime, classify_shutdown, start_runtime, stop_runtime
+from data_hub_watcher.runtime import (
+    build_runtime,
+    classify_shutdown,
+    start_runtime,
+    stop_runtime,
+    sync_config_to_api,
+)
 from data_hub_watcher.self_update import (
     InstallMethod,
     detect_install_method,
@@ -709,14 +715,17 @@ def watch(ctx: click.Context, dry_run: bool) -> None:
             "Please wait for it to be activated before starting the watcher."
         )
 
-    # Step 2: Sync config checksum
-    local_checksum = config_checksum(path)
-    remote = client.get_config_checksum(cfg.watcher_id)
-    if remote is None or remote.config_checksum != local_checksum:
-        click.echo("Syncing config to Data Hub…")
-        _push_config_to_api(client, cfg.watcher_id, path, trigger="startup")
-
+    # Step 2 (dry-run only): sync config checksum without a reporter
+    # so dry-run still validates the API path. The watch path defers
+    # its sync until *after* build_runtime so we have a reporter to
+    # surface failures via kind=config_sync_failed.
     if dry_run:
+        local_checksum = config_checksum(path)
+        remote = client.get_config_checksum(cfg.watcher_id)
+        if remote is None or remote.config_checksum != local_checksum:
+            click.echo("Syncing config to Data Hub…")
+            _push_config_to_api(client, cfg.watcher_id, path, trigger="startup")
+
         _dry_run_scan(cfg)
         click.echo(
             click.style(
@@ -734,6 +743,12 @@ def watch(ctx: click.Context, dry_run: bool) -> None:
     # path via data_hub_watcher.runtime).
     db_path = DEFAULT_CONFIG_DIR / STATE_DB_FILENAME
     rt = build_runtime(client=client, cfg=cfg, db_path=db_path)
+
+    # Step 5: sync config (now that we have a reporter, failures are
+    # surfaced to the dashboard as kind=config_sync_failed instead of
+    # only being printed to the local console).
+    click.echo("Syncing config to Data Hub…")
+    sync_config_to_api(client, cfg.watcher_id, path, rt.reporter, trigger="startup")
 
     click.echo(f"Scanning {inst.watch_directory} for existing files…")
     start_runtime(rt, started_message=f"Watcher started on {platform.node()}")

--- a/watcher/src/data_hub_watcher/events.py
+++ b/watcher/src/data_hub_watcher/events.py
@@ -1,6 +1,53 @@
+"""Structured event reporting from the watcher to the Data Hub API.
+
+The watcher's primary observability surface is the per-watcher event log
+served by ``POST /watchers/:id/events``. Events are queued in memory by
+the various long-running components (uploader, run-detector, monitor,
+updater, heartbeat) and flushed in batches on every heartbeat tick.
+
+Event taxonomy
+--------------
+The Postgres ``watcher_event_type`` enum is intentionally small. Many
+distinct failure modes share the ``EventType.ERROR`` bucket and are
+distinguished by ``details.kind`` so we can add new categories without
+a database migration. Known ``kind`` values, with their per-kind
+``details`` schemas:
+
+* ``run_report_failed`` -- POST/PATCH against
+  ``/instruments/:id/runs[/:run_id]`` raised ``ApiError``.
+  ``details = {"kind", "run_id", "operation": "create"|"update",
+  "status_code", "error", "file_count"}``.
+* ``config_sync_failed`` -- the startup ``PUT /watchers/:id/config``
+  call raised ``ApiError``. ``details = {"kind", "checksum", "error"}``.
+* ``stability_timeout`` -- a file kept changing past
+  ``MAX_STABILITY_WAIT_SECONDS`` and was abandoned.
+  ``details = {"kind", "path", "max_wait_seconds"}``.
+* ``stable_callback_failed`` -- the on-stable-file callback raised.
+  ``details = {"kind", "path", "error"}``.
+* ``pattern_mismatch`` -- a file inside the watch directory did not
+  match the configured ``run_detection.pattern``. Throttled to one
+  emission per parent directory per process so a misconfigured pattern
+  doesn't flood the queue. ``details = {"kind", "relative_path"}``.
+* ``events_dropped`` -- synthetic event prepended to the next
+  successful batch after one or more prior batches were dropped.
+  ``details = {"kind", "dropped_count", "since"}``.
+* ``heartbeat_recovered`` -- emitted on the first successful heartbeat
+  after one or more consecutive failures.
+  ``details = {"kind", "consecutive_failures", "gap_seconds"}``.
+* ``upload_queue_poll_failed`` -- ``GET /watchers/:id/upload-queue``
+  failed in manual mode. Emitted on the 1st failure and every 10th
+  repeat so a sustained outage isn't silent.
+  ``details = {"kind", "error", "consecutive_failures"}``.
+* ``update_check_failed`` -- ``GET /watchers/:id/update-check`` failed.
+  Emitted only after 3 consecutive failures so we don't alert on a
+  single hourly blip. ``details = {"kind", "error", "consecutive_failures"}``.
+"""
+
 from __future__ import annotations
 import logging
 import threading
+import time
+from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -9,6 +56,18 @@ from typing import Any
 from data_hub_watcher.api_client import ApiError, DataHubClient
 
 logger = logging.getLogger(__name__)
+
+
+# Cap the in-memory event queue so a prolonged API outage can't grow it
+# without bound. Older events are dropped first (FIFO) and surfaced via
+# the synthetic ``kind=events_dropped`` event on the next successful flush.
+MAX_QUEUE_SIZE = 500
+
+# Per-attempt retry profile for the events POST. Total wall-clock is
+# 1 + 2 + 4 = 7 s in the worst case, well under the 60 s heartbeat
+# interval, so an inline retry doesn't risk wedging the heartbeat thread.
+FLUSH_RETRY_MAX = 3
+FLUSH_RETRY_BASE_DELAY = 1.0
 
 
 class EventType(str, Enum):
@@ -45,33 +104,149 @@ class WatcherEvent:
 
 
 class EventReporter:
-    """Accumulates events in memory and flushes them to the API in batches."""
+    """Accumulates events in memory and flushes them to the API in batches.
 
-    def __init__(self, client: DataHubClient, watcher_id: str) -> None:
+    Resilience properties:
+
+    * Bounded queue (``MAX_QUEUE_SIZE``): on overflow the oldest queued
+      event is discarded and ``_dropped_count`` is bumped.
+    * Retry-with-backoff in :meth:`flush` (up to ``FLUSH_RETRY_MAX``
+      attempts) so a single transient network blip doesn't lose the
+      whole batch.
+    * After any drops, the next successful flush prepends a synthetic
+      ``kind=events_dropped`` event so operators can see how much
+      observability data was lost and during which window.
+    """
+
+    def __init__(
+        self,
+        client: DataHubClient,
+        watcher_id: str,
+        *,
+        max_queue_size: int = MAX_QUEUE_SIZE,
+    ) -> None:
         self._client = client
         self._watcher_id = watcher_id
-        self._queue: list[WatcherEvent] = []
+        self._queue: deque[WatcherEvent] = deque(maxlen=max_queue_size)
         self._lock = threading.Lock()
+        self._max_queue_size = max_queue_size
+        # Number of events dropped since the last successful flush.
+        # Carried across flushes so a long outage that drops several
+        # batches still surfaces as a single events_dropped event when
+        # the link recovers.
+        self._dropped_count = 0
+        self._dropped_since: str | None = None
 
     def queue_event(self, event: WatcherEvent) -> None:
         with self._lock:
+            if len(self._queue) >= self._max_queue_size:
+                # FIFO: drop the oldest event so the freshest signal
+                # survives. ``deque(maxlen=...)`` would do this for us
+                # but we want to track the drop explicitly.
+                self._queue.popleft()
+                self._note_drop(1)
             self._queue.append(event)
+
+    def report_error(self, kind: str, message: str, **details: Any) -> None:
+        """Queue a structured ``EventType.ERROR`` with a ``kind`` discriminator.
+
+        Convenience wrapper used at every "currently silent" failure
+        site in the watcher. The ``kind`` value selects the per-event
+        schema documented at the top of this module.
+        """
+        payload: dict[str, Any] = {"kind": kind}
+        payload.update(details)
+        self.queue_event(
+            WatcherEvent(
+                event_type=EventType.ERROR,
+                message=message,
+                details=payload,
+            )
+        )
+
+    def _note_drop(self, n: int) -> None:
+        """Record that *n* events were dropped (caller holds ``_lock``)."""
+        if self._dropped_count == 0:
+            self._dropped_since = datetime.now(timezone.utc).isoformat()
+        self._dropped_count += n
 
     def flush(self) -> None:
         with self._lock:
-            if not self._queue:
+            if not self._queue and self._dropped_count == 0:
                 return
             # Snapshot and clear atomically so events queued from other
             # threads during the network call aren't lost.
-            events_to_send = list(self._queue)
+            queue_snapshot = list(self._queue)
             self._queue.clear()
+            # Capture pending drop state so the synthetic event reflects
+            # exactly the window covered by this batch. Don't reset
+            # ``_dropped_count`` yet — it only clears on a successful
+            # POST so a failed flush leaves the loss reportable on the
+            # next attempt.
+            dropped_count = self._dropped_count
+            dropped_since = self._dropped_since
 
-        try:
-            self._client.send_events(
-                self._watcher_id,
-                [e.to_dict() for e in events_to_send],
+        events_to_send = list(queue_snapshot)
+        if dropped_count > 0:
+            # Prepend a synthetic event so the dashboard sees the gap
+            # before any of the events in this batch.
+            events_to_send.insert(
+                0,
+                WatcherEvent(
+                    event_type=EventType.ERROR,
+                    message=f"Dropped {dropped_count} watcher event(s) due to API errors",
+                    details={
+                        "kind": "events_dropped",
+                        "dropped_count": dropped_count,
+                        "since": dropped_since,
+                    },
+                ),
             )
-        except (ApiError, Exception) as exc:
-            # Events are intentionally dropped on failure rather than re-queued
-            # to avoid unbounded growth when the API is unreachable.
-            logger.warning("Failed to flush %d event(s): %s", len(events_to_send), exc)
+
+        # Inline retry-with-backoff. Total worst-case wall clock is
+        # ~7 s for FLUSH_RETRY_MAX=3 — well under the heartbeat
+        # interval, so we keep this on the heartbeat thread for
+        # simplicity. Switch to a worker thread if this ever needs to
+        # exceed half the heartbeat period.
+        last_exc: Exception | None = None
+        for attempt in range(FLUSH_RETRY_MAX):
+            try:
+                self._client.send_events(
+                    self._watcher_id,
+                    [e.to_dict() for e in events_to_send],
+                )
+                # Success — clear the pending-drop counter we just
+                # surfaced. New drops may have accumulated concurrently
+                # while we were blocked on the network; subtract rather
+                # than zero so those remain reportable.
+                with self._lock:
+                    self._dropped_count -= dropped_count
+                    if self._dropped_count <= 0:
+                        self._dropped_count = 0
+                        self._dropped_since = None
+                return
+            except (ApiError, Exception) as exc:
+                last_exc = exc
+                if attempt < FLUSH_RETRY_MAX - 1:
+                    delay = FLUSH_RETRY_BASE_DELAY * (2**attempt)
+                    logger.warning(
+                        "Event flush attempt %d/%d failed: %s (retry in %.1fs)",
+                        attempt + 1,
+                        FLUSH_RETRY_MAX,
+                        exc,
+                        delay,
+                    )
+                    time.sleep(delay)
+
+        # All retries exhausted. Drop the real events (the synthetic
+        # prefix isn't counted — the prior drops it represents are
+        # still tracked in ``_dropped_count``) and let the next
+        # successful flush surface the loss.
+        with self._lock:
+            self._note_drop(len(queue_snapshot))
+        logger.warning(
+            "Failed to flush %d event(s) after %d attempts: %s",
+            len(events_to_send),
+            FLUSH_RETRY_MAX,
+            last_exc,
+        )

--- a/watcher/src/data_hub_watcher/heartbeat.py
+++ b/watcher/src/data_hub_watcher/heartbeat.py
@@ -61,6 +61,13 @@ class HeartbeatLoop:
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
         self._start_time: float = 0.0
+        # Track consecutive heartbeat failures so we can emit a
+        # ``kind=heartbeat_recovered`` event on the first success after
+        # an outage. Emitting *during* the outage would itself fail
+        # (the network is the very thing that's down) so the recovery
+        # event is the only reliable signal.
+        self._consecutive_heartbeat_failures = 0
+        self._first_failure_at: float | None = None
 
     def start(self) -> None:
         self._start_time = time.monotonic()
@@ -96,6 +103,30 @@ class HeartbeatLoop:
             self._client.send_heartbeat(self._watcher_id, payload)
         except (ApiError, Exception) as exc:
             logger.warning("Heartbeat failed: %s", exc)
+            if self._consecutive_heartbeat_failures == 0:
+                self._first_failure_at = time.monotonic()
+            self._consecutive_heartbeat_failures += 1
+        else:
+            if self._consecutive_heartbeat_failures > 0:
+                # Recovery — emit a single event covering the full
+                # outage so the dashboard can correlate the gap with
+                # whatever was happening on the network at the time.
+                gap_seconds = (
+                    int(time.monotonic() - self._first_failure_at)
+                    if self._first_failure_at is not None
+                    else 0
+                )
+                self._event_reporter.report_error(
+                    "heartbeat_recovered",
+                    (
+                        f"Heartbeat recovered after "
+                        f"{self._consecutive_heartbeat_failures} consecutive failure(s)"
+                    ),
+                    consecutive_failures=self._consecutive_heartbeat_failures,
+                    gap_seconds=gap_seconds,
+                )
+                self._consecutive_heartbeat_failures = 0
+                self._first_failure_at = None
 
         # Snapshot the just-sent values into the `last_*` fields so post-reset
         # consumers (e.g. the updater) can still see the most recent interval's

--- a/watcher/src/data_hub_watcher/monitor.py
+++ b/watcher/src/data_hub_watcher/monitor.py
@@ -24,6 +24,7 @@ from watchdog.events import (
 from watchdog.observers import Observer
 
 from data_hub_watcher.constants import MAX_STABILITY_WAIT_SECONDS
+from data_hub_watcher.events import EventReporter
 from data_hub_watcher.state import StateDB
 
 logger = logging.getLogger(__name__)
@@ -99,6 +100,7 @@ class FileMonitor:
         on_stable_file: Callable[[Path], None],
         state_db: StateDB,
         recursive: bool = False,
+        event_reporter: EventReporter | None = None,
     ) -> None:
         self._watch_dir = watch_directory
         self._patterns = file_patterns
@@ -106,6 +108,10 @@ class FileMonitor:
         self._on_stable = on_stable_file
         self._state_db = state_db
         self._recursive = recursive
+        # Optional so unit tests that build a FileMonitor in isolation
+        # don't have to construct a full reporter graph. In production
+        # the reporter is always wired by ``runtime.build_runtime``.
+        self._reporter = event_reporter
 
         self._pending: dict[Path, _PendingFile] = {}
         self._lock = threading.Lock()
@@ -297,10 +303,24 @@ class FileMonitor:
                 path,
                 MAX_STABILITY_WAIT_SECONDS,
             )
+            if self._reporter is not None:
+                self._reporter.report_error(
+                    "stability_timeout",
+                    f"File {path.name} did not stabilise within {MAX_STABILITY_WAIT_SECONDS}s",
+                    path=str(path),
+                    max_wait_seconds=MAX_STABILITY_WAIT_SECONDS,
+                )
 
         for path in stable:
             logger.info("File stable: %s", path)
             try:
                 self._on_stable(path)
-            except Exception:
+            except Exception as exc:
                 logger.exception("Callback failed for %s", path)
+                if self._reporter is not None:
+                    self._reporter.report_error(
+                        "stable_callback_failed",
+                        f"Stable-file callback failed for {path.name}: {exc}",
+                        path=str(path),
+                        error=str(exc),
+                    )

--- a/watcher/src/data_hub_watcher/run_detector.py
+++ b/watcher/src/data_hub_watcher/run_detector.py
@@ -115,6 +115,14 @@ class RunDetector:
         self._watch_dir = watch_directory
 
         self._runs: dict[str, RunState] = {}
+        # Set of parent-directory POSIX paths we've already surfaced a
+        # ``kind=pattern_mismatch`` event for. Pattern misses are
+        # routine for excluded files, so without throttling a
+        # misconfigured pattern (or a deeply nested directory of
+        # ignored output) would flood the queue. One event per
+        # parent-directory per process is enough for an operator to
+        # spot the problem in the dashboard.
+        self._pattern_mismatch_dirs: set[str] = set()
 
     # ------------------------------------------------------------------
     # public entry point (called by FileMonitor)
@@ -172,7 +180,20 @@ class RunDetector:
             return None
         m = self._pattern.search(rel)
         if not m or not m.group(1):
-            logger.warning("File %s did not match run_detection.pattern — skipping", rel)
+            # Pattern misses are routine (excluded files inside the
+            # watch tree), so this is a debug-level local log. The
+            # surfaced event is throttled to one per parent directory
+            # per process — that's enough for an operator to catch a
+            # misconfigured pattern without flooding the dashboard.
+            logger.debug("File %s did not match run_detection.pattern — skipping", rel)
+            parent = Path(rel).parent.as_posix()
+            if parent not in self._pattern_mismatch_dirs:
+                self._pattern_mismatch_dirs.add(parent)
+                self._reporter.report_error(
+                    "pattern_mismatch",
+                    f"File {rel} did not match run_detection.pattern",
+                    relative_path=rel,
+                )
             return None
         return m.group(1)
 
@@ -247,6 +268,15 @@ class RunDetector:
         except ApiError as exc:
             logger.warning("Failed to report run %s: %s (will retry)", run.run_id, exc.message)
             self._counters.errors += 1
+            self._reporter.report_error(
+                "run_report_failed",
+                f"Failed to report run {run.run_id}: {exc.message}",
+                run_id=run.run_id,
+                operation="create",
+                status_code=exc.status_code,
+                error=exc.message,
+                file_count=len(run.files),
+            )
             return
 
         if self._upload_cb:
@@ -272,6 +302,15 @@ class RunDetector:
         except ApiError as exc:
             logger.warning("Failed to update run %s: %s", run.run_id, exc.message)
             self._counters.errors += 1
+            self._reporter.report_error(
+                "run_report_failed",
+                f"Failed to update run {run.run_id}: {exc.message}",
+                run_id=run.run_id,
+                operation="update",
+                status_code=exc.status_code,
+                error=exc.message,
+                file_count=len(run.files),
+            )
             return
 
         new_files = run.files[run.uploaded_file_count :]

--- a/watcher/src/data_hub_watcher/runtime.py
+++ b/watcher/src/data_hub_watcher/runtime.py
@@ -15,7 +15,7 @@ import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from data_hub_watcher.api_client import DataHubClient
+from data_hub_watcher.api_client import ApiError, DataHubClient
 from data_hub_watcher.constants import (
     DEFAULT_CONFIG_DIR,
     HEARTBEAT_INTERVAL_SECONDS,
@@ -172,6 +172,7 @@ def build_runtime(
         on_stable_file=detector.on_stable_file,
         state_db=state_db,
         recursive=inst.run_detection.recursive,
+        event_reporter=reporter,
     )
 
     # The heartbeat's `on_tick` hook is now multi-purpose:
@@ -276,6 +277,71 @@ def start_runtime(rt: WatcherRuntime, *, started_message: str) -> None:
 
     rt.heartbeat.start()
     rt.monitor.start()
+
+
+def sync_config_to_api(
+    client: DataHubClient,
+    watcher_id: str,
+    path: Path,
+    reporter: EventReporter,
+    *,
+    trigger: str = "startup",
+) -> bool:
+    """Push the local config to the API if it differs from the remote.
+
+    Reporter-aware sibling of ``cli._push_config_to_api`` used by the
+    long-running ``watch`` and Windows-service entrypoints. On a
+    successful push it queues ``EventType.CONFIG_SYNCED`` (mirroring
+    the operator-facing CLI helper) so a dashboard observer can tell
+    the watcher caught up to a freshly-edited config. On any API
+    failure -- the checksum probe or the push itself -- it queues a
+    structured ``kind=config_sync_failed`` ``ERROR`` event so the
+    failure is visible centrally rather than only as a yellow startup
+    message that nobody reads on a headless lab PC.
+
+    Returns ``True`` if the remote was updated (push attempted),
+    ``False`` if the remote already matched and no push was issued.
+    """
+    # Lazy import so monkey-patching ``config_io.config_checksum`` in
+    # tests is observed inside this function (a top-level
+    # ``from config_io import config_checksum`` would bind the original
+    # at import time and miss the patch).
+    from data_hub_watcher.config_io import config_checksum
+
+    try:
+        local_checksum = config_checksum(path)
+        remote = client.get_config_checksum(watcher_id)
+    except ApiError as exc:
+        reporter.report_error(
+            "config_sync_failed",
+            f"Could not check remote config checksum: {exc.message}",
+            error=exc.message,
+        )
+        return False
+
+    if remote is not None and remote.config_checksum == local_checksum:
+        return False
+
+    try:
+        yaml_content = path.read_text(encoding="utf-8")
+        client.push_config(watcher_id, yaml_content, local_checksum)
+    except ApiError as exc:
+        reporter.report_error(
+            "config_sync_failed",
+            f"Could not push config to API: {exc.message}",
+            checksum=local_checksum,
+            error=exc.message,
+        )
+        return True
+
+    reporter.queue_event(
+        WatcherEvent(
+            event_type=EventType.CONFIG_SYNCED,
+            message=f"Config synced (trigger={trigger})",
+            details={"trigger": trigger},
+        )
+    )
+    return True
 
 
 def stop_runtime(rt: WatcherRuntime, *, stopped_message: str) -> None:

--- a/watcher/src/data_hub_watcher/service.py
+++ b/watcher/src/data_hub_watcher/service.py
@@ -289,7 +289,7 @@ def _run_service_loop(stop_event: threading.Event, sm: Any) -> None:
     from dotenv import load_dotenv
 
     from data_hub_watcher.api_client import ApiError, DataHubClient
-    from data_hub_watcher.config_io import config_checksum, load_config
+    from data_hub_watcher.config_io import load_config
     from data_hub_watcher.constants import (
         API_URLS,
         STATE_DB_FILENAME,
@@ -300,6 +300,7 @@ def _run_service_loop(stop_event: threading.Event, sm: Any) -> None:
         classify_shutdown,
         start_runtime,
         stop_runtime,
+        sync_config_to_api,
     )
 
     sm.LogInfoMsg(f"{SERVICE_DISPLAY_NAME} starting")
@@ -352,18 +353,6 @@ def _run_service_loop(stop_event: threading.Event, sm: Any) -> None:
         )
         raise SystemExit(1)
 
-    # Step 2: Sync config checksum
-    if cfg.watcher_id:
-        local_cs = config_checksum(path)
-        try:
-            remote = client.get_config_checksum(cfg.watcher_id)
-            if remote is None or remote.config_checksum != local_cs:
-                yaml_content = path.read_text(encoding="utf-8")
-                client.push_config(cfg.watcher_id, yaml_content, local_cs)
-                sm.LogInfoMsg("Config synced to Data Hub")
-        except ApiError as exc:
-            sm.LogWarningMsg(f"Could not sync config to API: {exc.message}")
-
     # build_runtime asserts cfg.watcher_id is set; surface that as
     # a service-manager error rather than a hard crash so operators
     # see a clear message in the Windows event log.
@@ -373,6 +362,13 @@ def _run_service_loop(stop_event: threading.Event, sm: Any) -> None:
 
     db_path = path.parent / STATE_DB_FILENAME
     rt = build_runtime(client=client, cfg=cfg, db_path=db_path)
+
+    # Step 2: sync config checksum (now that we have a reporter, any
+    # failure surfaces as kind=config_sync_failed in the dashboard
+    # instead of only as a Windows-event-log warning that operators
+    # rarely read).
+    if sync_config_to_api(client, cfg.watcher_id, path, rt.reporter, trigger="startup"):
+        sm.LogInfoMsg("Config synced to Data Hub")
 
     start_runtime(rt, started_message=f"Service started on {platform.node()}")
 

--- a/watcher/src/data_hub_watcher/updater.py
+++ b/watcher/src/data_hub_watcher/updater.py
@@ -336,6 +336,12 @@ class Updater:
         # the dev install. Reset to ``None`` on process restart so the
         # next start re-establishes state with the server.
         self._last_refused_target: str | None = None
+        # Track consecutive ``/update-check`` failures so we surface a
+        # ``kind=update_check_failed`` event after 3 consecutive misses
+        # (~3 hours of going dark on the update channel). One isolated
+        # blip is uninteresting but a sustained inability to check
+        # blocks all auto-updates, including mandatory rollouts.
+        self._consecutive_update_check_failures = 0
         self._lock = threading.Lock()
 
     # ------------------------------------------------------------------
@@ -395,10 +401,16 @@ class Updater:
             info = self._client.get_update_info(watcher_id)
         except ApiError as exc:
             logger.warning("Update-check API call failed: %s", exc)
+            self._note_update_check_failure(exc.message)
             return UpdateAttemptResult(False, False, f"update-check API error: {exc.message}", None)
         except Exception as exc:  # pragma: no cover - defensive
             logger.exception("Unexpected error fetching update info")
+            self._note_update_check_failure(str(exc))
             return UpdateAttemptResult(False, False, f"unexpected error: {exc}", None)
+
+        # Reset the failure counter on any successful fetch so the next
+        # outage's "3 consecutive failures" window is accurate.
+        self._consecutive_update_check_failures = 0
 
         last_run_age = self._last_run_age_seconds()
         ok, reason = should_attempt_update(
@@ -570,6 +582,29 @@ class Updater:
         # event — we already reported it here.
         clear_upgrade_marker(self._config_dir)
         self._reporter.flush()
+
+    def _note_update_check_failure(self, error: str) -> None:
+        """Bump the consecutive-failure counter and emit on the 3rd miss.
+
+        Update checks run roughly hourly, so 3 consecutive failures
+        represents ~3 hours of going dark on the update channel — long
+        enough to indicate a real problem (network ACL, server bug)
+        but short enough to flag mandatory rollouts before they're
+        meaningfully delayed. Emitting on the 1st failure would alert
+        on routine API blips that auto-recover on the next hour.
+        """
+        self._consecutive_update_check_failures += 1
+        if self._consecutive_update_check_failures == 3:
+            self._reporter.report_error(
+                "update_check_failed",
+                (
+                    "Update check failed for "
+                    f"{self._consecutive_update_check_failures} consecutive attempts: "
+                    f"{error}"
+                ),
+                error=error,
+                consecutive_failures=self._consecutive_update_check_failures,
+            )
 
     def _last_run_age_seconds(self) -> float | None:
         ts = self._state_db.last_run_reported_at()

--- a/watcher/src/data_hub_watcher/uploader.py
+++ b/watcher/src/data_hub_watcher/uploader.py
@@ -86,6 +86,12 @@ class Uploader:
         self._instrument_id = instrument_id
         self._watcher_id = watcher_id
         self._watch_dir = watch_directory
+        # Track consecutive upload-queue poll failures so the watcher
+        # surfaces a ``kind=upload_queue_poll_failed`` event on the
+        # 1st failure and every 10th repeat. The unthrottled case
+        # would emit one event per heartbeat tick during an outage,
+        # crowding out other signals on the dashboard.
+        self._consecutive_queue_poll_failures = 0
 
     # ------------------------------------------------------------------
     # Auto-mode: upload a batch of files for a reported run
@@ -128,8 +134,24 @@ class Uploader:
         except ApiError as exc:
             logger.warning("Failed to fetch upload queue: %s", exc.message)
             self._counters.errors += 1
+            self._consecutive_queue_poll_failures += 1
+            # Emit on first failure, then every 10th, so a sustained
+            # outage stays visible without flooding the queue.
+            if (
+                self._consecutive_queue_poll_failures == 1
+                or self._consecutive_queue_poll_failures % 10 == 0
+            ):
+                self._reporter.report_error(
+                    "upload_queue_poll_failed",
+                    f"Failed to fetch upload queue: {exc.message}",
+                    error=exc.message,
+                    consecutive_failures=self._consecutive_queue_poll_failures,
+                )
             return
 
+        # Reset on any success -- the next failure starts a fresh
+        # outage window so the throttled emissions are accurate.
+        self._consecutive_queue_poll_failures = 0
         if not queue.files:
             return
 

--- a/watcher/tests/integration/test_heartbeat_and_events.py
+++ b/watcher/tests/integration/test_heartbeat_and_events.py
@@ -6,6 +6,7 @@ Tests the watcher's ongoing lifecycle — heartbeat-driven status transitions
 
 from __future__ import annotations
 from datetime import datetime, timezone
+from typing import Any, cast
 
 import pytest
 
@@ -190,3 +191,45 @@ class TestEvents:
         with pytest.raises(ApiError) as exc_info:
             client.send_events(watcher.watcher_id, [])
         assert exc_info.value.status_code == 400
+
+    def test_send_kind_heartbeat_recovered_event(
+        self,
+        client: DataHubClient,
+        instrument_id: str,
+        integration_env: IntegrationEnv,
+    ) -> None:
+        """Round-trip a structured ``kind=heartbeat_recovered`` event.
+
+        The DB enum stores this as ``error`` and the
+        ``details.kind`` discriminator is what the dashboard groups
+        on. Asserting both round-trip correctly catches regressions in
+        either the API validator or the JSONB column.
+        """
+        watcher = client.register_watcher(instrument_id)
+        now = datetime.now(timezone.utc).isoformat()
+        client.send_events(
+            watcher.watcher_id,
+            [
+                {
+                    "event_type": "error",
+                    "timestamp": now,
+                    "message": "Heartbeat recovered after 3 consecutive failure(s)",
+                    "details": {
+                        "kind": "heartbeat_recovered",
+                        "consecutive_failures": 3,
+                        "gap_seconds": 180,
+                    },
+                }
+            ],
+        )
+
+        rows = db_query(
+            integration_env.db_dsn,
+            "SELECT event_type, details FROM watcher_events WHERE watcher_id = %s",
+            (watcher.watcher_id,),
+        )
+        assert len(rows) == 1
+        assert rows[0][0] == "error"
+        details = cast(dict[str, Any], rows[0][1])
+        assert details["kind"] == "heartbeat_recovered"
+        assert details["consecutive_failures"] == 3

--- a/watcher/tests/test_events.py
+++ b/watcher/tests/test_events.py
@@ -1,0 +1,162 @@
+"""Unit tests for `data_hub_watcher.events`.
+
+Covers the three resilience properties added to ``EventReporter``:
+
+* The structured ``report_error(kind, ...)`` helper queues an
+  ``EventType.ERROR`` with the ``kind`` discriminator copied into
+  ``details``.
+* ``MAX_QUEUE_SIZE`` bounds the in-memory queue so a prolonged outage
+  can't grow it without limit; the oldest events are dropped first.
+* ``flush()`` retries up to ``FLUSH_RETRY_MAX`` with backoff, and a
+  recovery flush after one or more drops prepends a synthetic
+  ``kind=events_dropped`` event so the loss is visible in the
+  dashboard.
+"""
+
+from __future__ import annotations
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from data_hub_watcher.api_client import ApiError
+from data_hub_watcher.events import (
+    FLUSH_RETRY_MAX,
+    EventReporter,
+    EventType,
+    WatcherEvent,
+)
+
+
+@pytest.fixture()
+def client() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture()
+def reporter(client: MagicMock) -> EventReporter:
+    return EventReporter(client, watcher_id="w-test")
+
+
+# ---------------------------------------------------------------------------
+# report_error helper
+# ---------------------------------------------------------------------------
+
+
+class TestReportError:
+    def test_queues_error_event_with_kind_in_details(self, reporter: EventReporter) -> None:
+        reporter.report_error("run_report_failed", "boom", run_id="RUN-1", status_code=500)
+
+        assert len(reporter._queue) == 1
+        evt = reporter._queue[0]
+        assert evt.event_type is EventType.ERROR
+        assert evt.message == "boom"
+        assert evt.details == {
+            "kind": "run_report_failed",
+            "run_id": "RUN-1",
+            "status_code": 500,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Bounded queue
+# ---------------------------------------------------------------------------
+
+
+class TestBoundedQueue:
+    def test_drops_oldest_when_queue_full(self, client: MagicMock) -> None:
+        reporter = EventReporter(client, watcher_id="w-test", max_queue_size=3)
+
+        for i in range(5):
+            reporter.queue_event(
+                WatcherEvent(event_type=EventType.RUN_REPORTED, message=f"run-{i}")
+            )
+
+        # Only the 3 freshest events survive; the 2 oldest were dropped.
+        assert len(reporter._queue) == 3
+        assert [e.message for e in reporter._queue] == ["run-2", "run-3", "run-4"]
+        # And the drop is tracked so the next flush surfaces it.
+        assert reporter._dropped_count == 2
+        assert reporter._dropped_since is not None
+
+    def test_drop_metadata_resets_after_successful_flush(self, client: MagicMock) -> None:
+        reporter = EventReporter(client, watcher_id="w-test", max_queue_size=2)
+        for i in range(3):  # one drop
+            reporter.queue_event(
+                WatcherEvent(event_type=EventType.RUN_REPORTED, message=f"run-{i}")
+            )
+
+        with patch("data_hub_watcher.events.time.sleep"):
+            reporter.flush()
+
+        assert reporter._dropped_count == 0
+        assert reporter._dropped_since is None
+
+
+# ---------------------------------------------------------------------------
+# Flush retry-with-backoff
+# ---------------------------------------------------------------------------
+
+
+class TestFlushRetry:
+    def test_succeeds_on_first_attempt(self, reporter: EventReporter, client: MagicMock) -> None:
+        reporter.queue_event(WatcherEvent(event_type=EventType.WATCHER_STARTED, message="hi"))
+        reporter.flush()
+        assert client.send_events.call_count == 1
+        assert len(reporter._queue) == 0
+
+    def test_retries_then_succeeds(self, reporter: EventReporter, client: MagicMock) -> None:
+        reporter.queue_event(WatcherEvent(event_type=EventType.WATCHER_STARTED, message="hi"))
+        client.send_events.side_effect = [
+            ApiError("transient", status_code=502),
+            None,
+        ]
+        with patch("data_hub_watcher.events.time.sleep"):
+            reporter.flush()
+        assert client.send_events.call_count == 2
+        # The successful retry must clear pending-drop tracking too.
+        assert reporter._dropped_count == 0
+
+    def test_drops_batch_after_exhausting_retries(
+        self, reporter: EventReporter, client: MagicMock
+    ) -> None:
+        reporter.queue_event(WatcherEvent(event_type=EventType.WATCHER_STARTED, message="hi"))
+        reporter.queue_event(WatcherEvent(event_type=EventType.WATCHER_STARTED, message="hi2"))
+        client.send_events.side_effect = ApiError("dead", status_code=500)
+
+        with patch("data_hub_watcher.events.time.sleep"):
+            reporter.flush()
+
+        # All FLUSH_RETRY_MAX attempts were made and the batch is gone.
+        assert client.send_events.call_count == FLUSH_RETRY_MAX
+        # The 2 real events became drops; the synthetic prefix isn't
+        # double-counted.
+        assert reporter._dropped_count == 2
+        assert reporter._dropped_since is not None
+
+    def test_recovery_flush_prepends_events_dropped_event(
+        self, reporter: EventReporter, client: MagicMock
+    ) -> None:
+        # First batch fails completely so we accumulate drops.
+        reporter.queue_event(WatcherEvent(event_type=EventType.WATCHER_STARTED, message="lost-1"))
+        client.send_events.side_effect = ApiError("dead", status_code=500)
+        with patch("data_hub_watcher.events.time.sleep"):
+            reporter.flush()
+        assert reporter._dropped_count == 1
+
+        # Second batch succeeds — the synthetic events_dropped event
+        # must be prepended to whatever else is in the queue.
+        client.send_events.side_effect = None
+        reporter.queue_event(WatcherEvent(event_type=EventType.RUN_REPORTED, message="run-1"))
+        with patch("data_hub_watcher.events.time.sleep"):
+            reporter.flush()
+
+        # send_events was called twice (1 failure batch counts as
+        # FLUSH_RETRY_MAX attempts, then 1 success).
+        sent_payloads = [call.args[1] for call in client.send_events.call_args_list]
+        last_batch = sent_payloads[-1]
+        assert last_batch[0]["event_type"] == "error"
+        assert last_batch[0]["details"]["kind"] == "events_dropped"
+        assert last_batch[0]["details"]["dropped_count"] == 1
+        # The real event is still present, after the synthetic prefix.
+        assert last_batch[1]["message"] == "run-1"
+        assert reporter._dropped_count == 0

--- a/watcher/tests/test_heartbeat.py
+++ b/watcher/tests/test_heartbeat.py
@@ -1,0 +1,75 @@
+"""Unit tests for ``HeartbeatLoop``.
+
+The recovery path is the only thing exercised here: heartbeat
+*failures* are by definition unreportable in real time (the network
+they depend on is down), so the watcher accumulates a counter and
+emits a ``kind=heartbeat_recovered`` event on the first successful
+heartbeat after one or more failures. That recovery event is the
+only signal an operator gets that the watcher went dark.
+"""
+
+from __future__ import annotations
+from unittest.mock import MagicMock
+
+from data_hub_watcher.api_client import ApiError
+from data_hub_watcher.events import EventReporter
+from data_hub_watcher.heartbeat import HeartbeatLoop
+
+
+def _make_loop(client: MagicMock, reporter: MagicMock) -> HeartbeatLoop:
+    return HeartbeatLoop(
+        client=client,
+        watcher_id="w-test",
+        interval_seconds=60,
+        event_reporter=reporter,
+        instrument_id="inst-1",
+        watch_directory="/tmp/watch",
+        upload_mode="auto",
+    )
+
+
+class TestHeartbeatRecovery:
+    def test_recovery_event_emitted_after_outage(self) -> None:
+        client = MagicMock()
+        client.send_heartbeat.side_effect = [
+            ApiError("offline", status_code=0),
+            ApiError("offline", status_code=0),
+            None,  # recovery
+        ]
+        reporter = MagicMock(spec=EventReporter)
+        loop = _make_loop(client, reporter)
+
+        loop._send_heartbeat()  # fail
+        loop._send_heartbeat()  # fail
+        loop._send_heartbeat()  # success -> emit recovery event
+
+        assert reporter.report_error.call_count == 1
+        call = reporter.report_error.call_args
+        assert call.args[0] == "heartbeat_recovered"
+        assert call.kwargs["consecutive_failures"] == 2
+        # gap_seconds is computed from monotonic time and should be
+        # non-negative; we don't pin a precise value.
+        assert call.kwargs["gap_seconds"] >= 0
+
+    def test_no_event_when_no_failures(self) -> None:
+        client = MagicMock()
+        reporter = MagicMock(spec=EventReporter)
+        loop = _make_loop(client, reporter)
+
+        loop._send_heartbeat()
+        loop._send_heartbeat()
+
+        reporter.report_error.assert_not_called()
+
+    def test_failures_alone_do_not_emit_event(self) -> None:
+        """Emitting *during* an outage is pointless — the same network
+        the heartbeat needs is the one we'd POST events over."""
+        client = MagicMock()
+        client.send_heartbeat.side_effect = ApiError("offline", status_code=0)
+        reporter = MagicMock(spec=EventReporter)
+        loop = _make_loop(client, reporter)
+
+        for _ in range(5):
+            loop._send_heartbeat()
+
+        reporter.report_error.assert_not_called()

--- a/watcher/tests/test_monitor_events.py
+++ b/watcher/tests/test_monitor_events.py
@@ -1,0 +1,151 @@
+"""Unit tests for FileMonitor's structured event emissions.
+
+Two anomalies that previously only logged locally now surface as
+``EventType.ERROR`` events:
+
+* ``kind=stability_timeout`` -- a file kept changing past
+  ``MAX_STABILITY_WAIT_SECONDS`` and was abandoned.
+* ``kind=stable_callback_failed`` -- the on-stable-file callback raised.
+
+Tests drive ``_check_pending`` directly (with monkey-patched ``time``
+and a forced-out-of-window ``first_seen``) so we don't have to wait
+the real 5-minute stability window in unit tests.
+"""
+
+from __future__ import annotations
+import time
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from data_hub_watcher.events import EventReporter
+from data_hub_watcher.monitor import FileMonitor, _PendingFile
+from data_hub_watcher.state import StateDB
+
+
+@pytest.fixture()
+def state_db(tmp_path: Path) -> Generator[StateDB, None, None]:
+    db = StateDB(tmp_path / "state.db")
+    yield db
+    db.close()
+
+
+@pytest.fixture()
+def watch_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "watch"
+    d.mkdir()
+    return d
+
+
+def _make_monitor(
+    watch_dir: Path,
+    state_db: StateDB,
+    *,
+    on_stable_file: MagicMock | None = None,
+    reporter: MagicMock | None = None,
+) -> FileMonitor:
+    return FileMonitor(
+        watch_directory=watch_dir,
+        file_patterns=["*.csv"],
+        stability_period=1,
+        on_stable_file=on_stable_file or MagicMock(),
+        state_db=state_db,
+        recursive=False,
+        event_reporter=reporter,
+    )
+
+
+class TestStabilityTimeout:
+    def test_emits_event_for_abandoned_file(self, watch_dir: Path, state_db: StateDB) -> None:
+        from data_hub_watcher.constants import MAX_STABILITY_WAIT_SECONDS
+
+        reporter = MagicMock(spec=EventReporter)
+        monitor = _make_monitor(watch_dir, state_db, reporter=reporter)
+
+        f = watch_dir / "growing.csv"
+        f.write_text("a")
+        st = f.stat()
+
+        # Manually plant a pending entry whose first_seen is older than
+        # MAX_STABILITY_WAIT_SECONDS so _check_pending classifies it as
+        # timed out without waiting 5 minutes in the test.
+        now = time.monotonic()
+        monitor._pending[f] = _PendingFile(
+            path=f,
+            size=st.st_size,
+            mtime=st.st_mtime,
+            first_seen=now - MAX_STABILITY_WAIT_SECONDS - 1,
+            last_changed=now,
+        )
+
+        monitor._check_pending()
+
+        # The pending entry was discarded.
+        assert f not in monitor._pending
+        # And a structured event was emitted with the correct schema.
+        assert reporter.report_error.call_count == 1
+        call = reporter.report_error.call_args
+        assert call.args[0] == "stability_timeout"
+        assert call.kwargs["path"] == str(f)
+        assert call.kwargs["max_wait_seconds"] == MAX_STABILITY_WAIT_SECONDS
+
+    def test_no_reporter_does_not_crash(self, watch_dir: Path, state_db: StateDB) -> None:
+        """A FileMonitor built without a reporter must still function.
+
+        Tests that build FileMonitor in isolation pass reporter=None.
+        The timeout path used to log only; it should keep doing so
+        without raising when the reporter is absent.
+        """
+        from data_hub_watcher.constants import MAX_STABILITY_WAIT_SECONDS
+
+        monitor = _make_monitor(watch_dir, state_db, reporter=None)
+        f = watch_dir / "growing.csv"
+        f.write_text("a")
+        st = f.stat()
+        now = time.monotonic()
+        monitor._pending[f] = _PendingFile(
+            path=f,
+            size=st.st_size,
+            mtime=st.st_mtime,
+            first_seen=now - MAX_STABILITY_WAIT_SECONDS - 1,
+            last_changed=now,
+        )
+
+        monitor._check_pending()  # must not raise
+
+        assert f not in monitor._pending
+
+
+class TestStableCallbackFailure:
+    def test_callback_exception_emits_event(self, watch_dir: Path, state_db: StateDB) -> None:
+        reporter = MagicMock(spec=EventReporter)
+        on_stable = MagicMock(side_effect=RuntimeError("downstream blew up"))
+        monitor = _make_monitor(
+            watch_dir,
+            state_db,
+            on_stable_file=on_stable,
+            reporter=reporter,
+        )
+
+        f = watch_dir / "ready.csv"
+        f.write_text("hello")
+        st = f.stat()
+        now = time.monotonic()
+        monitor._pending[f] = _PendingFile(
+            path=f,
+            size=st.st_size,
+            mtime=st.st_mtime,
+            first_seen=now - 5,
+            last_changed=now - 5,  # already past the 1 s stability period
+        )
+
+        monitor._check_pending()
+
+        on_stable.assert_called_once_with(f)
+        assert reporter.report_error.call_count == 1
+        call = reporter.report_error.call_args
+        assert call.args[0] == "stable_callback_failed"
+        assert call.kwargs["path"] == str(f)
+        assert "downstream blew up" in call.kwargs["error"]

--- a/watcher/tests/test_run_detector.py
+++ b/watcher/tests/test_run_detector.py
@@ -239,3 +239,128 @@ class TestRunIdExtractionWindows:
                 self.WATCH_DIR,
                 r"C:\Other\file.csv",
             )
+
+
+# ==================================================================
+# Pattern-mismatch event throttling
+# ==================================================================
+
+
+class TestPatternMismatchThrottling:
+    """A misconfigured pattern shouldn't flood the event queue.
+
+    The detector reports at most one ``kind=pattern_mismatch`` event per
+    parent directory per process lifetime. Two files in the same
+    directory must coalesce to a single event; two files in different
+    directories must each emit.
+    """
+
+    def test_emits_once_per_directory(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        from data_hub_watcher.events import EventReporter
+
+        reporter = MagicMock(spec=EventReporter)
+        d = RunDetector(
+            pattern=r"^MAGIC_(\d+)",  # nothing in tmp_path matches
+            instrument_id="i",
+            watcher_id="w",
+            client=MagicMock(),
+            state_db=MagicMock(),
+            event_reporter=reporter,
+            counters=MagicMock(),
+            watch_directory=tmp_path,
+        )
+
+        # Two files in the same parent directory.
+        d._extract_run_id(tmp_path / "subdir" / "a.csv")
+        d._extract_run_id(tmp_path / "subdir" / "b.csv")
+        # And one in a different directory.
+        d._extract_run_id(tmp_path / "other" / "c.csv")
+
+        kinds = [call.args[0] for call in reporter.report_error.call_args_list]
+        assert kinds.count("pattern_mismatch") == 2  # one per parent dir
+
+
+# ==================================================================
+# Run-report API failures emit kind=run_report_failed
+# ==================================================================
+
+
+class TestRunReportFailures:
+    def _run_state_with_one_file(self, tmp_path: Path):  # type: ignore[no-untyped-def]
+        from data_hub_watcher.run_detector import FileInfo, RunState
+
+        f = tmp_path / "RUN-A.csv"
+        f.write_text("x")
+        st = f.stat()
+        run = RunState(run_id="RUN-A")
+        run.files = [
+            FileInfo(
+                path=f,
+                filename=f.name,
+                size_bytes=st.st_size,
+                mtime=st.st_mtime,
+                file_created_at=st.st_mtime,
+            )
+        ]
+        return run
+
+    def test_create_failure_emits_event(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        from data_hub_watcher.api_client import ApiError
+        from data_hub_watcher.events import EventReporter
+
+        client = MagicMock()
+        client.report_run.side_effect = ApiError("boom", status_code=500)
+        reporter = MagicMock(spec=EventReporter)
+        d = RunDetector(
+            pattern=r"^([^_.]+)",
+            instrument_id="i",
+            watcher_id="w",
+            client=client,
+            state_db=MagicMock(),
+            event_reporter=reporter,
+            counters=MagicMock(errors=0),
+            watch_directory=tmp_path,
+        )
+        run = self._run_state_with_one_file(tmp_path)
+        d._report_new_run(run)
+
+        # report_error called once with the right kind + operation.
+        assert reporter.report_error.call_count == 1
+        call = reporter.report_error.call_args
+        assert call.args[0] == "run_report_failed"
+        assert call.kwargs["operation"] == "create"
+        assert call.kwargs["status_code"] == 500
+        assert call.kwargs["run_id"] == "RUN-A"
+        assert call.kwargs["file_count"] == 1
+
+    def test_update_failure_emits_event(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        from data_hub_watcher.api_client import ApiError
+        from data_hub_watcher.events import EventReporter
+
+        client = MagicMock()
+        client.update_run.side_effect = ApiError("nope", status_code=409)
+        reporter = MagicMock(spec=EventReporter)
+        d = RunDetector(
+            pattern=r"^([^_.]+)",
+            instrument_id="i",
+            watcher_id="w",
+            client=client,
+            state_db=MagicMock(),
+            event_reporter=reporter,
+            counters=MagicMock(errors=0),
+            watch_directory=tmp_path,
+        )
+        run = self._run_state_with_one_file(tmp_path)
+        d._update_run(run)
+
+        assert reporter.report_error.call_count == 1
+        call = reporter.report_error.call_args
+        assert call.args[0] == "run_report_failed"
+        assert call.kwargs["operation"] == "update"
+        assert call.kwargs["status_code"] == 409

--- a/watcher/tests/test_service.py
+++ b/watcher/tests/test_service.py
@@ -680,16 +680,24 @@ class TestRunServiceLoopChecksumSync:
         # the checksum endpoint blips, the service must still come up.
         # This is an explicit design choice: don't punish operators for
         # transient sync failures, the next heartbeat will retry.
+        # The failure now surfaces as a kind=config_sync_failed event
+        # on the runtime's reporter rather than only as a Windows event
+        # log warning, so the dashboard can flag stale configs across
+        # the fleet.
         harness.client.get_config_checksum.side_effect = ApiError("transient 500", status_code=500)
 
         stop_event = threading.Event()
         stop_event.set()
         harness.svc._run_service_loop(stop_event, harness.sm)
 
-        harness.sm.LogWarningMsg.assert_called_once()
-        assert "sync" in harness.sm.LogWarningMsg.call_args.args[0].lower()
+        # Service still came up.
         assert len(harness.start_calls) == 1
         harness.sm.LogErrorMsg.assert_not_called()
+        # And the structured event was queued so the failure is
+        # visible centrally.
+        report_error_calls = harness.runtime.reporter.report_error.call_args_list
+        kinds = [c.args[0] for c in report_error_calls]
+        assert "config_sync_failed" in kinds
 
     def test_matching_checksum_skips_push(self, harness: _LoopHarness) -> None:
         # When the remote checksum already matches, push_config must

--- a/watcher/tests/test_updater.py
+++ b/watcher/tests/test_updater.py
@@ -373,6 +373,67 @@ class TestUpdaterOnTick:
         assert result.succeeded is False
         assert "API error" in result.reason
 
+    def test_update_check_failed_event_after_three_consecutive_failures(
+        self, tmp_path: Path
+    ) -> None:
+        """A single API blip should not page anyone — but a sustained
+        outage that blocks 3 consecutive hourly checks (~3h dark on
+        the update channel) must be visible centrally so an admin can
+        unblock mandatory rollouts."""
+        h = _make_updater(
+            tmp_path,
+            updater_cfg=UpdaterConfig(
+                idle_ticks_required=0,
+                check_interval_ticks=1,  # fire on every tick
+                min_run_age_seconds=0.0,
+            ),
+        )
+        h.client.get_update_info.side_effect = ApiError("dead", status_code=502)
+        h.counters.last_files_uploaded = 0
+
+        h.updater.on_tick()  # failure 1 -> no event
+        h.updater.on_tick()  # failure 2 -> no event
+        # No throttled event yet.
+        kinds_so_far = [c.args[0] for c in h.reporter.report_error.call_args_list]
+        assert "update_check_failed" not in kinds_so_far
+
+        h.updater.on_tick()  # failure 3 -> emits
+
+        kinds_after = [c.args[0] for c in h.reporter.report_error.call_args_list]
+        assert kinds_after.count("update_check_failed") == 1
+        call = next(
+            c for c in h.reporter.report_error.call_args_list if c.args[0] == "update_check_failed"
+        )
+        assert call.kwargs["consecutive_failures"] == 3
+        assert "dead" in call.kwargs["error"]
+
+    def test_update_check_failure_counter_resets_on_success(self, tmp_path: Path) -> None:
+        h = _make_updater(
+            tmp_path,
+            updater_cfg=UpdaterConfig(
+                idle_ticks_required=0,
+                check_interval_ticks=1,
+                min_run_age_seconds=0.0,
+            ),
+        )
+        # 2 failures, then a success, then 2 more failures.
+        h.client.get_update_info.side_effect = [
+            ApiError("dead", status_code=502),
+            ApiError("dead", status_code=502),
+            _info(latest="0.0.0+unknown"),
+            ApiError("dead", status_code=502),
+            ApiError("dead", status_code=502),
+        ]
+        h.counters.last_files_uploaded = 0
+
+        for _ in range(5):
+            h.updater.on_tick()
+
+        # The post-success burst is only 2 failures so no event yet —
+        # the success in between resets the consecutive counter.
+        kinds = [c.args[0] for c in h.reporter.report_error.call_args_list]
+        assert "update_check_failed" not in kinds
+
     def test_successful_upgrade_writes_marker_and_requests_restart(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/watcher/tests/test_uploader.py
+++ b/watcher/tests/test_uploader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 from collections.abc import Generator
 from pathlib import Path
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -177,6 +178,59 @@ class TestUploadSingle:
 
         assert result is False
         assert uploader._counters.errors == 1
+
+
+class TestUploadQueuePollFailures:
+    """Manual-mode upload-queue poll failures must be visible in the dashboard.
+
+    Today the failure only bumps an opaque counter, so a sustained
+    ACL/network outage looks identical to a healthy queue. The fix
+    surfaces a ``kind=upload_queue_poll_failed`` event on the 1st
+    failure and every 10th repeat. Throttling matters because the
+    poll fires every heartbeat (~60 s) — without it a half-day outage
+    would emit 720 events.
+    """
+
+    def test_emits_on_first_and_every_tenth_failure(
+        self, uploader: Uploader, mock_client: MagicMock
+    ) -> None:
+        mock_client.get_upload_queue.side_effect = ApiError("ACL", status_code=403)
+
+        # 25 failures: events emitted at attempts 1, 10, 20.
+        for _ in range(25):
+            uploader.poll_upload_queue()
+
+        reporter_mock = cast(MagicMock, uploader._reporter)
+        kinds = [c.args[0] for c in reporter_mock.report_error.call_args_list]
+        assert kinds.count("upload_queue_poll_failed") == 3
+        # And the consecutive-failure count is reported correctly.
+        consec = [
+            c.kwargs["consecutive_failures"]
+            for c in reporter_mock.report_error.call_args_list
+            if c.args[0] == "upload_queue_poll_failed"
+        ]
+        assert consec == [1, 10, 20]
+
+    def test_recovery_resets_counter(self, uploader: Uploader, mock_client: MagicMock) -> None:
+        from data_hub_watcher.models import UploadQueueResponse
+
+        mock_client.get_upload_queue.side_effect = [
+            ApiError("ACL", status_code=403),
+            UploadQueueResponse(files=[]),
+            ApiError("ACL", status_code=403),
+        ]
+
+        uploader.poll_upload_queue()  # fail 1 -> emits
+        uploader.poll_upload_queue()  # success -> resets counter
+        uploader.poll_upload_queue()  # fail again, treated as 1st of new outage -> emits
+
+        reporter_mock = cast(MagicMock, uploader._reporter)
+        consec = [
+            c.kwargs["consecutive_failures"]
+            for c in reporter_mock.report_error.call_args_list
+            if c.args[0] == "upload_queue_poll_failed"
+        ]
+        assert consec == [1, 1]
 
 
 class TestPutToPresignedUrl:


### PR DESCRIPTION
## Summary

The watcher's primary observability surface is the per-watcher event stream served by `POST /watchers/:id/events`. An audit found nine failure modes — including run-report API errors, config-sync failures, file-stability timeouts, and heartbeat outages — that were either invisible to the dashboard entirely or rolled up into a single opaque `errors_since_last_heartbeat` counter.

This PR adds a `report_error(kind, ...)` helper to `EventReporter` and emits structured events at each of those sites, hardens `EventReporter.flush()` so a transient API blip can no longer silently drop the batch, and ships unit + integration tests for every new emission and throttling rule. All new categories reuse `EventType.ERROR` with a `kind` discriminator in `details`, so this lands without a `watcher_event_type` Postgres enum migration.

## Changes

- New `EventReporter.report_error(kind, message, **details)` helper and a documented `kind` taxonomy at the top of `watcher/src/data_hub_watcher/events.py`.
- New emissions:
  - `kind=run_report_failed` from `RunDetector._report_new_run` and `_update_run` with `{run_id, operation, status_code, error, file_count}`.
  - `kind=config_sync_failed` from a new `runtime.sync_config_to_api` helper, called by both `cli watch` and the Windows service after `build_runtime` so a reporter is available.
  - `kind=stability_timeout` and `kind=stable_callback_failed` from `FileMonitor` (now accepts an optional `event_reporter`).
  - `kind=pattern_mismatch` from `RunDetector._extract_run_id`, throttled to one event per parent directory per process; the routine local log was demoted from `warning` to `debug`.
  - `kind=heartbeat_recovered` emitted on the first successful heartbeat after one or more failures, with `{consecutive_failures, gap_seconds}`. Emitting *during* the outage would itself fail, so recovery is the only reliable signal.
  - `kind=upload_queue_poll_failed` from manual-mode `Uploader.poll_upload_queue`, throttled to the 1st failure and every 10th repeat.
  - `kind=update_check_failed` from `Updater._check_and_apply`, emitted only after 3 consecutive misses (~3 hours dark on the update channel).
- `EventReporter` queue is now bounded at `MAX_QUEUE_SIZE=500`, dropping oldest on overflow. `flush()` retries the POST up to `FLUSH_RETRY_MAX=3` times with 1s/2s/4s backoff (well under the 60 s heartbeat interval, so it stays inline on the heartbeat thread). After any drops, the next successful flush prepends a synthetic `kind=events_dropped` event with `{dropped_count, since}` so the gap is visible centrally.
- `cli watch` and the Windows service entrypoint were restructured to defer the config-sync to *after* `build_runtime` so the reporter exists when failures occur. Dry-run still syncs early through the existing reporter-less path.

## Breaking changes

None. The watcher's wire protocol is unchanged (no new event-type enum values, no new heartbeat fields), and all new constructor parameters (`FileMonitor.event_reporter`) default to `None`. Existing operators upgrading to this version will simply start seeing richer events in the dashboard for previously-silent failure modes.

## Driveby changes

- Replaced an inline `_run_service_loop` config-sync block with a call to the new shared `runtime.sync_config_to_api` helper. The Windows service now logs `LogInfoMsg("Config synced to Data Hub")` only when a push actually happened (was previously logged on every successful `get_config_checksum` round-trip).
- Removed the now-unused `from data_hub_watcher.config_io import config_checksum` from `service.py`'s lazy-import block.

## Testing

- [x] `make check-all` passes locally (ruff format + lint, pyright `0 errors`, all 189 watcher unit tests green, web-app lint + tsc clean).
- [x] New unit tests cover every new emission and throttling rule (`test_events.py`, `test_heartbeat.py`, `test_monitor_events.py`, additions to `test_run_detector.py`, `test_uploader.py`, `test_updater.py`).
- [x] Integration test added in `test_heartbeat_and_events.py` round-trips a structured `kind=heartbeat_recovered` event through the API and asserts the JSONB `details` payload survives intact.