### PR TITLE
Watcher: PATCH only newly-stable files instead of the full run manifest

### DIFF
--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -34,6 +34,11 @@ For lab-PC installs (PyPI), see [Installing a watcher](guides/installing-a-watch
 
 ## Commands
 
+All commands accept two global flags:
+
+- `--config PATH` (or the `DATA_HUB_CONFIG_PATH` env var): override the config file path.
+- `--verbose`: enable debug-level logging on stderr.
+
 ### `init`
 
 Interactive setup wizard that:
@@ -44,6 +49,8 @@ Interactive setup wizard that:
 4. Prompts for the watch directory, file patterns, run detection pattern, stability period, and upload mode.
 5. Registers the watcher with the API. An instrument can have at most one active (non-deregistered) watcher at a time — registration fails if one already exists, and the CLI prints the existing watcher's id along with the deregister command needed to free it up.
 6. Saves the config to `~/.data-hub/config.yaml`, the API key to `~/.data-hub/.env.<environment>`, and syncs the config to the API.
+
+The wizard normalizes the pasted API key (stripping zero-width and non-breaking-space characters that Windows clipboards routinely inject) and rejects values that don't start with `dhub_`, so a paste mistake surfaces as a clear error rather than a confusing 401 later. Pass `--show-key` if your terminal mangles hidden input on paste.
 
 ### `watch`
 
@@ -56,11 +63,12 @@ Starts the file monitoring loop. Before entering the loop it:
 
 While running:
 
-- **File monitor** watches the directory for new/modified files using `watchdog` and waits for each file to stabilize (size + mtime unchanged for the configured stability period).
-- **Run detector** groups stable files into runs by applying the configured regex to each file's relative path.
-- **Uploader** requests a presigned S3 URL from the API and uploads each file via HTTP PUT (auto mode), or polls the server's upload queue (manual mode). The watcher does not need AWS credentials.
-- **Heartbeat loop** sends periodic heartbeats (every 60 seconds) to the API. In manual mode, it also polls the upload queue on each tick.
-- **Event reporter** batches and flushes lifecycle events (started, stopped, file uploaded, errors) to the API.
+- **File monitor** watches the directory for new/modified files using `watchdog` and waits for each file to stabilize (size + mtime unchanged for the configured stability period). Files that keep changing for longer than 5 minutes are abandoned and surface as a `stability_timeout` error event.
+- **Run detector** groups stable files into runs by applying the configured regex to each file's relative path. The first file for a run triggers `POST /instruments/:id/runs`; subsequent files for the same run incrementally `PATCH` only the new entries onto the manifest. Files inside the watch tree that don't match the pattern emit a `pattern_mismatch` event (throttled to one per parent directory) so misconfigured patterns surface in the dashboard.
+- **Uploader** requests a presigned S3 URL from the API and uploads each file via HTTP PUT (auto mode), or polls the server's upload queue (manual mode). The watcher does not need AWS credentials. Each upload retries up to 3 times with exponential backoff (1, 2, 4 s) and is recorded locally with its SHA-256 so retries and restarts don't re-upload the same bytes. In manual mode, queue-poll failures are throttled (1st failure, then every 10th) to keep a sustained outage visible without flooding the events stream.
+- **Heartbeat loop** sends periodic heartbeats (every 60 seconds) to the API. The payload includes the watcher version, instrument ID, watch directory, upload mode, per-interval activity counters, and process uptime; a final `status="stopped"` heartbeat is sent on graceful shutdown. In manual mode, the tick also polls the upload queue.
+- **Event reporter** batches and flushes lifecycle events (started, stopped, file uploaded, errors) to the API. See [Observability](#observability) for the full taxonomy.
+- **Auto-updater** runs from the same heartbeat tick on every platform — not only Windows services. It polls `GET /watchers/:id/update-check` roughly hourly and applies new releases when the watcher has been idle long enough not to clobber an in-flight run. The full activity-window guard, mandatory-update behavior, and rollback flow are documented in [Upgrading the watcher](guides/upgrading-the-watcher.md); auto-update is hard-disabled in the `preview` environment.
 
 Use `--dry-run` to validate config and preview what would happen without starting the monitor.
 
@@ -104,6 +112,12 @@ Manage the watcher as a Windows service:
 | `service start` | Start the service |
 | `service stop` | Stop the service |
 | `service status` | Show service status |
+
+`service install` accepts `--env-path PATH` to override which `.env` file the SCM-launched process loads (defaults to `~/.data-hub/.env.<environment>`). The installer:
+
+- Registers the service with `Tcpip` and `Dnscache` as start dependencies and `delayedstart=True` so it does not race the boot-time network stack.
+- Configures recovery actions (restart after 60 s on first failure, 120 s on second) with `SERVICE_CONFIG_FAILURE_ACTIONS_FLAG` set, so a non-zero `SystemExit` from the runtime — notably the upgrade-driven restart request — is treated as a failure and the SCM picks the new wheel up automatically.
+- Persists the config and env-file paths under `HKLM\SYSTEM\CurrentControlSet\Services\DataHubWatcher\{ConfigPath,EnvPath}` so `SvcDoRun` can locate them regardless of which account the service runs under.
 
 ### `self-update`
 
@@ -159,7 +173,13 @@ In YAML, prefer single-quoted strings for patterns so that backslash sequences l
 
 ## Local state
 
-The watcher maintains a SQLite database at `~/.data-hub/watcher.db` to track which files have been uploaded. Records older than 90 days are pruned automatically. Logs are written to `~/.data-hub/watcher.log` (10 MB rotating, 5 backups).
+The watcher maintains a SQLite database at `~/.data-hub/watcher.db` with three tables:
+
+- `uploaded_files` — one row per successful S3 upload, keyed on `(filename, sha256, s3_key)`. Used by the uploader to skip re-uploads on retry and by the initial scan to skip files that have already been sent. Records older than 90 days are pruned automatically.
+- `runs` — tracks which run IDs have been reported and (in auto mode) when their files finished uploading. The most recent `reported_at` timestamp is what the auto-updater consults to gate restarts on a quiet-instrument window.
+- `detected_files` — the file manifest for every reported run, keyed on `(run_id, relative_path)`. Lets the initial scan skip files that are already part of a reported run even in manual mode (where `uploaded_files` stays empty), and lets the run detector hydrate its in-memory state on startup so a restart doesn't re-POST runs the API has already seen.
+
+Logs are written to `~/.data-hub/watcher.log` (10 MB rotating, 5 backups).
 
 ### Initial scan identity
 
@@ -173,3 +193,38 @@ Practical consequences:
 - If an external tool (antivirus, OneDrive/Dropbox sync, backup restore) rewrites a file's mtime without changing its contents, the watcher will re-enqueue it. The server-side dedup (keyed on SHA-256) prevents a duplicate S3 object.
 - If a run's parent folder is renamed or moved, its files look "new" to the next scan and will be re-enqueued. The uploader's own SHA-based dedup prevents a redundant S3 PUT, but it will pay the cost of hashing each affected file once.
 - Upgrading from a pre-`relative_path`/`size_bytes`/`mtime` state DB is a silent, self-healing migration: legacy rows miss the stat lookup, so files are re-enqueued once and then recorded with full stat data on their next upload.
+
+## Observability
+
+The watcher's primary observability surface is the per-watcher event log served by `POST /watchers/:id/events`. Events are queued in memory by the long-running components (uploader, run detector, monitor, heartbeat, updater) and flushed in batches on every heartbeat tick. The queue is bounded to 500 events; on overflow the oldest are dropped (FIFO) and surfaced via a synthetic `events_dropped` event prepended to the next successful flush, so an outage that loses observability data is itself observable when the link recovers.
+
+### Event types
+
+| Event type | When |
+| --- | --- |
+| `watcher_started` / `watcher_stopped` | Process lifecycle. The stopped message distinguishes a normal stop from an upgrade-driven restart. |
+| `config_synced` | Local config differed from the remote checksum and was pushed. Triggered by `init`, `config edit`, `config open`, and on watcher startup. |
+| `run_reported` | A run was POSTed to the API for the first time. |
+| `file_uploaded` / `upload_failed` | Per-file upload outcome. `upload_failed` carries the S3 key and last error. |
+| `update_started` / `update_succeeded` / `update_failed` | Auto-update lifecycle. `update_succeeded` is emitted from the *next* process startup once the new version is confirmed to be loaded. |
+| `error` | Generic bucket; use `details.kind` to discriminate (table below). |
+
+### Error kinds
+
+`error` events use a `details.kind` discriminator so new failure modes can be added without a database migration. Known kinds:
+
+| Kind | Meaning |
+| --- | --- |
+| `run_report_failed` | POST/PATCH against `/instruments/:id/runs[/:run_id]` failed. `details` includes `operation`, `status_code`, `file_count`. |
+| `config_sync_failed` | The startup `PUT /watchers/:id/config` (or its checksum probe) failed. |
+| `stability_timeout` | A file kept changing past 5 minutes and was abandoned. |
+| `stable_callback_failed` | The on-stable-file callback raised. |
+| `pattern_mismatch` | A file inside the watch tree did not match `run_detection.pattern`. Throttled to one emission per parent directory per process. |
+| `events_dropped` | Synthetic event prepended after one or more prior batches were dropped. `details.dropped_count` reports the gap size. |
+| `heartbeat_recovered` | First successful heartbeat after one or more consecutive failures. `details.gap_seconds` reports the outage length. |
+| `upload_queue_poll_failed` | `GET /watchers/:id/upload-queue` failed in manual mode. Emitted on the 1st failure and every 10th repeat. |
+| `update_check_failed` | `GET /watchers/:id/update-check` failed for 3 consecutive attempts (~3 hours of going dark on the update channel). |
+
+### File timestamps
+
+Each file's on-disk creation time (`st_birthtime` where the OS provides it, otherwise `st_mtime`) is captured at stabilization, persisted in `detected_files`, and sent to the API on every run report and presigned-URL request. This lets the dashboard order events by when the instrument actually wrote the file rather than when the watcher uploaded it — useful when an initial scan or backfill uploads files long after their original write time.

--- a/uv.lock
+++ b/uv.lock
@@ -415,7 +415,7 @@ requires-dist = [
 
 [[package]]
 name = "data-hub-watcher"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "watcher" }
 dependencies = [
     { name = "click" },

--- a/watcher/pyproject.toml
+++ b/watcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-hub-watcher"
-version = "0.1.2"
+version = "0.1.3"
 description = "File-watcher agent for lab instrument PCs that ingests data into Data Hub."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/watcher/src/data_hub_watcher/run_detector.py
+++ b/watcher/src/data_hub_watcher/run_detector.py
@@ -61,6 +61,12 @@ class RunState:
     reported: bool = False
     api_run_id: str | None = None
     uploaded_file_count: int = 0
+    # Number of files at the head of `files` that have been successfully
+    # PATCHed to the API. Used as a cursor so `_update_run` can send only
+    # newly-stable files instead of re-transmitting the full manifest on
+    # every call. On a failed PATCH the cursor is left untouched so the
+    # next stable file's PATCH carries the backlog plus the new entry.
+    patched_file_count: int = 0
 
 
 class RunDetector:
@@ -253,6 +259,7 @@ class RunDetector:
             resp = self._client.report_run(self._instrument_id, payload)
             run.reported = True
             run.api_run_id = resp.id
+            run.patched_file_count = len(run.files)
             self._state_db.record_run_reported(run.run_id)
             self._persist_detected_files(run)
             self._counters.runs_reported += 1
@@ -286,19 +293,37 @@ class RunDetector:
             run.uploaded_file_count = len(run.files)
 
     def _update_run(self, run: RunState) -> None:
-        """PATCH the run with the full file list, then upload only new files.
+        """PATCH the run with files added since the last successful PATCH.
 
-        The API receives the complete file manifest each time so it can
-        reconcile its own state, but the upload callback only gets the files
-        that weren't in the previous snapshot to avoid re-uploading.
+        Only un-PATCHed entries are sent — the server dedups on
+        `(instrument_run_id, relative_path)` via a partial unique index,
+        so the full manifest carries no extra information. Skipping the
+        API call entirely when the delta is empty avoids a needless round
+        trip if `on_stable_file` re-fires for an already-reported file.
+
+        On failure the PATCH cursor is left untouched, so the next
+        stable file's PATCH naturally carries the backlog plus the new
+        entry. The upload callback continues to receive only files the
+        uploader hasn't seen yet (`uploaded_file_count` is independent
+        of the PATCH cursor).
         """
+        new_files = run.files[run.patched_file_count :]
+        if not new_files:
+            return
+
         payload = {
-            "detected_files": [self._file_payload(f) for f in run.files],
+            "detected_files": [self._file_payload(f) for f in new_files],
         }
         try:
             self._client.update_run(self._instrument_id, run.run_id, payload)
+            run.patched_file_count = len(run.files)
             self._persist_detected_files(run)
-            logger.info("Updated run %s (now %d files)", run.run_id, len(run.files))
+            logger.info(
+                "Updated run %s (sent %d new file(s), %d total)",
+                run.run_id,
+                len(new_files),
+                len(run.files),
+            )
         except ApiError as exc:
             logger.warning("Failed to update run %s: %s", run.run_id, exc.message)
             self._counters.errors += 1
@@ -313,9 +338,9 @@ class RunDetector:
             )
             return
 
-        new_files = run.files[run.uploaded_file_count :]
-        if self._upload_cb and new_files:
-            succeeded = self._upload_cb(run.run_id, new_files)
+        upload_new = run.files[run.uploaded_file_count :]
+        if self._upload_cb and upload_new:
+            succeeded = self._upload_cb(run.run_id, upload_new)
             run.uploaded_file_count += succeeded
         else:
             run.uploaded_file_count = len(run.files)
@@ -365,6 +390,10 @@ class RunDetector:
                 # anyway if not) or server-driven (manual mode, where
                 # `_upload_cb` is None and this counter is unused).
                 uploaded_file_count=len(files),
+                # Every hydrated file came from `detected_files`, which
+                # is only written after a successful POST/PATCH — so the
+                # PATCH cursor starts at the end of the manifest.
+                patched_file_count=len(files),
             )
             count += 1
         if count:

--- a/watcher/tests/test_run_detector_hydration.py
+++ b/watcher/tests/test_run_detector_hydration.py
@@ -173,8 +173,11 @@ class TestNewFileAfterHydrationTriggersPatch:
         assert args[1] == "run-42"
         payload = args[2]
         rel_paths = [f["relative_path"] for f in payload["detected_files"]]
-        assert "run-42/existing.nd2" in rel_paths
-        assert "run-42/new.nd2" in rel_paths
+        # Hydrated files start with the PATCH cursor at the end of the
+        # manifest, so only the genuinely-new file is sent — the server
+        # dedups regardless, but resending the existing entry would be
+        # the O(N^2) regression this test pins down.
+        assert rel_paths == ["run-42/new.nd2"]
 
     def test_update_run_persists_new_manifest(self, state_db: StateDB, watch_dir: Path) -> None:
         """After a successful PATCH the new file is recorded in `detected_files`."""
@@ -257,3 +260,114 @@ class TestReportNewRunPersistsManifest:
 
         assert state_db.get_detected_files_for_run("run-fail") == []
         assert state_db.get_reported_run_ids_with_files() == []
+
+
+class TestUpdateRunSendsDeltaOnly:
+    """Pin down the delta-PATCH semantics: each `_update_run` call only
+    transmits files that haven't been successfully PATCHed yet."""
+
+    def test_each_patch_sends_only_new_files(self, state_db: StateDB, watch_dir: Path) -> None:
+        client = MagicMock()
+        client.report_run.return_value = MagicMock(id="api-run-id")
+        detector = _make_detector(watch_dir, state_db, client=client)
+
+        run_dir = watch_dir / "run-delta"
+        run_dir.mkdir()
+        f1 = run_dir / "a.nd2"
+        f1.write_bytes(b"a" * 10)
+        f2 = run_dir / "b.nd2"
+        f2.write_bytes(b"b" * 20)
+        f3 = run_dir / "c.nd2"
+        f3.write_bytes(b"c" * 30)
+
+        detector.on_stable_file(f1)
+        detector.on_stable_file(f2)
+        detector.on_stable_file(f3)
+
+        client.report_run.assert_called_once()
+        _, post_payload = client.report_run.call_args.args
+        assert [f["relative_path"] for f in post_payload["detected_files"]] == [
+            "run-delta/a.nd2",
+        ]
+
+        assert client.update_run.call_count == 2
+        first_patch = client.update_run.call_args_list[0].args[2]
+        second_patch = client.update_run.call_args_list[1].args[2]
+        assert [f["relative_path"] for f in first_patch["detected_files"]] == [
+            "run-delta/b.nd2",
+        ]
+        assert [f["relative_path"] for f in second_patch["detected_files"]] == [
+            "run-delta/c.nd2",
+        ]
+
+        rel_paths = {r.relative_path for r in state_db.get_detected_files_for_run("run-delta")}
+        assert rel_paths == {"run-delta/a.nd2", "run-delta/b.nd2", "run-delta/c.nd2"}
+
+    def test_empty_delta_skips_api_call(self, state_db: StateDB, watch_dir: Path) -> None:
+        """Re-firing `on_stable_file` for a known file must not PATCH again.
+
+        `on_stable_file` already dedups by `f.path == path`, so this
+        scenario only happens via direct hydration + a no-op trigger,
+        but the same delta-empty short-circuit guards both paths.
+        """
+        run_dir = watch_dir / "run-empty"
+        run_dir.mkdir()
+        existing = run_dir / "only.nd2"
+        existing.write_bytes(b"x" * 16)
+        st = existing.stat()
+        state_db.record_detected_files(
+            "run-empty",
+            [("run-empty/only.nd2", "only.nd2", st.st_size, st.st_mtime, st.st_mtime)],
+        )
+
+        client = MagicMock()
+        detector = _make_detector(watch_dir, state_db, client=client)
+        detector.hydrate_from_state_db()
+
+        detector._update_run(detector._runs["run-empty"])
+
+        client.update_run.assert_not_called()
+
+    def test_failed_patch_resends_backlog_on_next_call(
+        self, state_db: StateDB, watch_dir: Path
+    ) -> None:
+        """A failed PATCH must not advance the cursor; the backlog plus
+        the next stable file are sent together on the next attempt."""
+        from data_hub_watcher.api_client import ApiError
+
+        client = MagicMock()
+        client.report_run.return_value = MagicMock(id="api-run-id")
+        # First PATCH fails, second PATCH succeeds.
+        client.update_run.side_effect = [ApiError("boom", 500), MagicMock()]
+        detector = _make_detector(watch_dir, state_db, client=client)
+
+        run_dir = watch_dir / "run-retry"
+        run_dir.mkdir()
+        f1 = run_dir / "a.nd2"
+        f1.write_bytes(b"a" * 10)
+        f2 = run_dir / "b.nd2"
+        f2.write_bytes(b"b" * 20)
+        f3 = run_dir / "c.nd2"
+        f3.write_bytes(b"c" * 30)
+
+        detector.on_stable_file(f1)
+        detector.on_stable_file(f2)
+        detector.on_stable_file(f3)
+
+        assert client.update_run.call_count == 2
+        first_patch = client.update_run.call_args_list[0].args[2]
+        second_patch = client.update_run.call_args_list[1].args[2]
+        # First (failed) PATCH carries just b.nd2.
+        assert [f["relative_path"] for f in first_patch["detected_files"]] == [
+            "run-retry/b.nd2",
+        ]
+        # Second (successful) PATCH carries the previously-failed b.nd2
+        # plus the newly-stable c.nd2 — cursor was left at 1 by the
+        # failure so files[1:] now spans both.
+        assert [f["relative_path"] for f in second_patch["detected_files"]] == [
+            "run-retry/b.nd2",
+            "run-retry/c.nd2",
+        ]
+
+        rel_paths = {r.relative_path for r in state_db.get_detected_files_for_run("run-retry")}
+        assert rel_paths == {"run-retry/a.nd2", "run-retry/b.nd2", "run-retry/c.nd2"}


### PR DESCRIPTION
## Summary

`RunDetector._update_run` was re-sending the entire `run.files` list on every PATCH, producing payloads that grew 1, 2, 3, ..., N rows for an N-file run. A recent chlorella batch surfaced this as a single ~325-row INSERT statement that took collateral damage from a Render Postgres backend crash (`57P02`/`CONNECTION_CLOSED`) — the query was healthy, but the spiky shape was the loudest tenant on the DB at the moment of the OOM.

The server-side handler dedups idempotently on `(instrument_run_id, relative_path)` via the partial unique index, so the full manifest carries no semantic value beyond defensive retransmission. Switching to delta-only PATCHes turns the watcher's wire/DB cost from O(N²) into O(N) with no server-side or schema change.

## Changes

- New `RunState.patched_file_count` cursor that tracks files at the head of `run.files` already accepted by a successful POST/PATCH.
- `_update_run` now sends `run.files[patched_file_count:]` only, short-circuits the API call when the delta is empty, advances the cursor on success, and leaves it untouched on failure so the next stable file's PATCH naturally carries the backlog plus the new entry.
- `_report_new_run` and `hydrate_from_state_db` initialize the cursor at `len(run.files)` since the manifest is fully in sync at those points.
- Updated `_update_run`'s docstring to describe the actual semantics — the previous "so the API can reconcile its own state" comment was aspirational and never matched server behavior.
- Renamed the local `new_files` shadowing inside `_update_run` to `upload_new` for the upload-callback slice; the PATCH delta and the upload delta are governed by independent cursors and were confusingly sharing a name.

## Breaking changes

None. The wire contract (POST/PATCH `/api/v1/instruments/:instrumentId/runs/:runId` accepting `detected_files`) is unchanged, the server's dedup behavior is unchanged, and there's no state-DB migration — `patched_file_count` is in-memory only.

## Driveby changes

- Update watcher documentation in `docs/watcher.md`.

## Testing

- [x] `make check-all` passes (ruff, pyright, eslint, tsc).
- [x] `uv run pytest -m "not integration"` — 323 unit tests pass, including 3 new regression tests in `TestUpdateRunSendsDeltaOnly`:
  - [x] Three sequential `on_stable_file` calls produce one POST (1 file) and two PATCHes (1 file each), not 1+2.
  - [x] Empty delta after hydration short-circuits the API call entirely.
  - [x] Failed PATCH leaves the cursor in place; the next PATCH carries the backlog plus the newly-stable file.
- [x] Existing `test_new_file_patches_instead_of_posting` updated to assert delta-only payload contents.