### PR TITLE
Watcher: Resolve `uv` binary for LocalSystem service and classify upgrade failures

### DIFF
--- a/watcher/src/data_hub_watcher/self_update.py
+++ b/watcher/src/data_hub_watcher/self_update.py
@@ -17,12 +17,14 @@ spinning up a Click context or a real Windows service.
 from __future__ import annotations
 import json
 import logging
+import os
 import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
 from enum import Enum
 from importlib.metadata import PackageNotFoundError, distribution
+from pathlib import Path
 from typing import Any
 
 from packaging.version import InvalidVersion, Version
@@ -37,6 +39,25 @@ PACKAGE_NAME = "data-hub-watcher"
 # Default index for `pip install` invocations. PyPI is hard-coded for now;
 # can be made configurable per channel later.
 DEFAULT_INDEX_URL = "https://pypi.org/simple/"
+
+
+class UvExecutableNotFoundError(RuntimeError):
+    """Raised when the self-updater can't locate a `uv` binary.
+
+    Carries the list of candidate paths we probed so callers can attach
+    it to the ``UPDATE_FAILED`` event for operator-side diagnosis — the
+    single most useful data point for a stuck lab PC is knowing exactly
+    where we looked and didn't find anything.
+    """
+
+    def __init__(self, candidates: list[str]) -> None:
+        self.candidates = list(candidates)
+        hint = (
+            "Install uv for the service account or re-run "
+            "`data-hub-watcher self-update` from a shell where `uv` is on PATH."
+        )
+        joined = ", ".join(candidates) if candidates else "(none)"
+        super().__init__(f"Could not locate `uv` executable; tried: {joined}. {hint}")
 
 
 class InstallMethod(str, Enum):
@@ -210,6 +231,103 @@ def evaluate_update(
 # ---------------------------------------------------------------------------
 
 
+def _uv_binary_name() -> str:
+    """Filename of the `uv` executable for the current platform.
+
+    Windows services don't inherit the `.EXE` shim resolution the user
+    shell gets via `PATHEXT`, so we look for the fully-qualified filename.
+    """
+    return "uv.exe" if sys.platform == "win32" else "uv"
+
+
+def _sys_prefix_uv_candidates(prefix: str) -> list[Path]:
+    """Derive likely `uv` binary locations from an install prefix.
+
+    When the watcher runs as a Windows LocalSystem service the user's
+    PATH isn't inherited, so `shutil.which("uv")` misses the `uv.exe`
+    dropped at ``%USERPROFILE%\\.local\\bin\\uv.exe`` by the standalone
+    installer. An `uv tool` install's ``sys.prefix`` lives under the same
+    user profile, so we can walk up to it and probe the standard install
+    location without hitting the SYSTEM-scope PATH.
+
+    Layouts we recognise:
+
+    - Windows: ``<home>\\AppData\\Roaming\\uv\\tools\\data-hub-watcher``
+      → probe ``<home>\\.local\\bin\\uv.exe``.
+    - POSIX:   ``<home>/.local/share/uv/tools/data-hub-watcher``
+      → probe ``<home>/.local/bin/uv``.
+    """
+    binary = _uv_binary_name()
+    candidates: list[Path] = []
+    prefix_posix = prefix.replace("\\", "/")
+
+    # Windows uv-tool layout: <home>/AppData/Roaming/uv/tools/data-hub-watcher
+    marker = "/AppData/Roaming/uv/tools/"
+    idx = prefix_posix.find(marker)
+    if idx != -1:
+        home = prefix_posix[:idx]
+        candidates.append(Path(home) / ".local" / "bin" / binary)
+
+    # POSIX uv-tool layout: <home>/.local/share/uv/tools/data-hub-watcher
+    marker = "/.local/share/uv/tools/"
+    idx = prefix_posix.find(marker)
+    if idx != -1:
+        home = prefix_posix[:idx]
+        candidates.append(Path(home) / ".local" / "bin" / binary)
+
+    # Last-ditch: whatever the current user's home directory is, even if
+    # the prefix doesn't match a known layout (covers relocated installs).
+    home_env = os.environ.get("USERPROFILE") or os.environ.get("HOME")
+    if home_env:
+        candidates.append(Path(home_env) / ".local" / "bin" / binary)
+
+    return candidates
+
+
+def _resolve_uv_executable(
+    override: str | None = None,
+    *,
+    prefix: str | None = None,
+) -> tuple[str | None, list[str]]:
+    """Locate `uv`, PATH-first then `sys.prefix`-derived.
+
+    Returns ``(resolved_path, candidates_tried)``. The candidates list is
+    always populated even on success so callers can log what was tried.
+
+    Precedence:
+    1. *override* (explicit caller-supplied path, e.g. from a test or a
+       future registry-stored config value).
+    2. ``shutil.which("uv")`` — covers the common case where the service
+       account's PATH is correct.
+    3. ``sys.prefix``-derived candidate — covers Windows LocalSystem, where
+       the user's ``~/.local/bin`` isn't on the SYSTEM PATH.
+    """
+    tried: list[str] = []
+
+    # An explicit override wins unconditionally. Callers (tests, future
+    # registry-stored service config) are trusted to pass a path they
+    # actually want us to use; validating existence here would break
+    # the historical `uv_executable="/usr/local/bin/uv"` contract that
+    # unit tests rely on to assert the generated argv without mocking
+    # the filesystem.
+    if override:
+        tried.append(override)
+        return override, tried
+
+    which_hit = shutil.which("uv")
+    if which_hit:
+        tried.append(which_hit)
+        return which_hit, tried
+
+    raw_prefix = prefix or sys.prefix
+    for candidate in _sys_prefix_uv_candidates(raw_prefix):
+        tried.append(str(candidate))
+        if candidate.exists():
+            return str(candidate), tried
+
+    return None, tried
+
+
 def build_upgrade_command(
     method: InstallMethod,
     *,
@@ -223,12 +341,21 @@ def build_upgrade_command(
     Pinning *target_version* lets the server roll a specific release out
     rather than always landing on whatever the index calls "latest" — which
     matters when we want to roll back by re-pinning to an older version.
+
+    Raises :class:`UvExecutableNotFoundError` when *method* is
+    ``UV_TOOL`` but no ``uv`` binary can be located. Previously this
+    fell back to the literal bare string ``"uv"``, which produced an
+    opaque ``[WinError 2] The system cannot find the file specified``
+    from ``subprocess.run`` — raising a typed error here lets the
+    caller emit a diagnosable ``UPDATE_FAILED`` event instead.
     """
     pkg_spec = PACKAGE_NAME if not target_version else f"{PACKAGE_NAME}=={target_version}"
     index = index_url or DEFAULT_INDEX_URL
 
     if method is InstallMethod.UV_TOOL:
-        uv_path = uv_executable or shutil.which("uv") or "uv"
+        uv_path, tried = _resolve_uv_executable(uv_executable)
+        if uv_path is None:
+            raise UvExecutableNotFoundError(tried)
         # `uv tool install --reinstall` is more deterministic than `upgrade`
         # — it works whether or not the previous version is already at the
         # target, and it lets us pin to an explicit version for rollback.

--- a/watcher/src/data_hub_watcher/updater.py
+++ b/watcher/src/data_hub_watcher/updater.py
@@ -37,6 +37,8 @@ from data_hub_watcher.heartbeat import WatcherCounters
 from data_hub_watcher.models import WatcherConfig, WatcherUpdateInfoResponse
 from data_hub_watcher.self_update import (
     InstallMethod,
+    UvExecutableNotFoundError,
+    build_upgrade_command,
     detect_install_method,
     evaluate_update,
     run_upgrade,
@@ -456,6 +458,30 @@ class Updater:
                 self._last_refused_target = target
             return UpdateAttemptResult(True, False, reason, target, {"method": method.value})
 
+        # Resolve the upgrade argv up-front. Doing this before we emit
+        # UPDATE_STARTED / write the marker means a missing `uv` binary
+        # (the Windows-service / LocalSystem PATH failure mode) becomes
+        # a single diagnosable UPDATE_FAILED with the paths we probed —
+        # rather than an UPDATE_STARTED followed by an opaque
+        # `[WinError 2] The system cannot find the file specified`
+        # from inside subprocess.run.
+        try:
+            command = build_upgrade_command(method, target_version=target)
+        except UvExecutableNotFoundError as exc:
+            reason = "uv executable not found"
+            logger.warning("Refusing auto-update: %s (%s)", reason, exc)
+            self._emit_failure(
+                target,
+                reason,
+                extra={
+                    "install_method": method.value,
+                    "attempted_subprocess": False,
+                    "error_class": type(exc).__name__,
+                    "candidates_tried": exc.candidates,
+                },
+            )
+            return UpdateAttemptResult(True, False, reason, target, {"method": method.value})
+
         details_started: dict[str, Any] = {
             "current_version": WATCHER_VERSION,
             "target_version": target,
@@ -499,9 +525,36 @@ class Updater:
             try:
                 try:
                     result = self._upgrade_runner(method, target_version=target)
+                except FileNotFoundError as exc:
+                    # CreateProcess / execve couldn't find the program.
+                    # Usually means `uv` slipped off PATH between our
+                    # resolver and the subprocess call (or a permission
+                    # error masquerading as one). Classify separately
+                    # from the generic `subprocess raised:` branch so
+                    # operators don't have to decode `[WinError 2]`.
+                    logger.exception("Upgrade subprocess could not start")
+                    self._emit_failure(
+                        target,
+                        f"upgrade command not executable: {exc}",
+                        extra={
+                            "install_method": method.value,
+                            "error_class": type(exc).__name__,
+                            "command": command,
+                        },
+                    )
+                    outcome.append(UpdateAttemptResult(True, False, str(exc), target))
+                    return
                 except Exception as exc:
                     logger.exception("Upgrade subprocess raised")
-                    self._emit_failure(target, f"subprocess raised: {exc}")
+                    self._emit_failure(
+                        target,
+                        f"subprocess raised: {exc}",
+                        extra={
+                            "install_method": method.value,
+                            "error_class": type(exc).__name__,
+                            "command": command,
+                        },
+                    )
                     outcome.append(UpdateAttemptResult(True, False, str(exc), target))
                     return
 
@@ -511,7 +564,12 @@ class Updater:
                     self._emit_failure(
                         target,
                         f"subprocess exited {result.returncode}",
-                        extra={"stdout_tail": stdout, "stderr_tail": stderr},
+                        extra={
+                            "install_method": method.value,
+                            "command": command,
+                            "stdout_tail": stdout,
+                            "stderr_tail": stderr,
+                        },
                     )
                     outcome.append(
                         UpdateAttemptResult(True, False, f"exit code {result.returncode}", target)

--- a/watcher/tests/test_self_update.py
+++ b/watcher/tests/test_self_update.py
@@ -22,6 +22,7 @@ from data_hub_watcher.self_update import (
     PACKAGE_NAME,
     InstallMethod,
     UpdateDecision,
+    UvExecutableNotFoundError,
     build_upgrade_command,
     detect_install_method,
     evaluate_update,
@@ -251,6 +252,65 @@ class TestBuildUpgradeCommand:
     def test_unsupported_methods_raise(self, method: InstallMethod) -> None:
         with pytest.raises(ValueError, match="Cannot build an upgrade command"):
             build_upgrade_command(method, target_version="0.3.0")
+
+    def test_uv_tool_uses_path_lookup_when_no_override(self) -> None:
+        # Without an explicit `uv_executable` the builder must fall back
+        # to `shutil.which("uv")`. Patching it here also guards against a
+        # test runner that happens to have a stale `uv` on PATH — we
+        # want the argv to reflect the resolver's output deterministically.
+        with patch("data_hub_watcher.self_update.shutil.which", return_value="/tmp/fake/uv"):
+            cmd = build_upgrade_command(
+                InstallMethod.UV_TOOL,
+                target_version="0.3.0",
+            )
+        assert cmd[0] == "/tmp/fake/uv"
+        assert cmd[1:4] == ["tool", "install", "--reinstall"]
+
+    def test_uv_tool_falls_back_to_sys_prefix_derived_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Reproduces the Windows LocalSystem service failure mode: PATH
+        # has no `uv`, but the uv-tool install lives under the user
+        # profile and we can derive `<home>\.local\bin\uv.exe` from it.
+        fake_home = tmp_path / "lab-user"
+        fake_bin = fake_home / ".local" / "bin"
+        fake_bin.mkdir(parents=True)
+        uv_exe = fake_bin / "uv.exe"
+        uv_exe.write_text("")
+
+        fake_prefix = str(fake_home / "AppData" / "Roaming" / "uv" / "tools" / "data-hub-watcher")
+        monkeypatch.setattr("data_hub_watcher.self_update.sys.prefix", fake_prefix)
+        monkeypatch.setattr("data_hub_watcher.self_update.sys.platform", "win32")
+        monkeypatch.setattr("data_hub_watcher.self_update.shutil.which", lambda _: None)
+
+        cmd = build_upgrade_command(InstallMethod.UV_TOOL, target_version="0.3.0")
+        assert cmd[0] == str(uv_exe)
+
+    def test_uv_tool_raises_when_nothing_resolves(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No override, nothing on PATH, no uv-tool-shaped prefix, no
+        # ~/.local/bin/uv — the builder must raise the typed error and
+        # surface the candidates it tried so the caller can attach them
+        # to a dashboard event.
+        monkeypatch.setattr("data_hub_watcher.self_update.shutil.which", lambda _: None)
+        monkeypatch.setattr(
+            "data_hub_watcher.self_update.sys.prefix",
+            str(tmp_path / "unrelated" / "prefix"),
+        )
+        # Point HOME / USERPROFILE at an empty dir so the final
+        # last-ditch probe also misses.
+        empty_home = tmp_path / "empty-home"
+        empty_home.mkdir()
+        monkeypatch.setenv("HOME", str(empty_home))
+        monkeypatch.setenv("USERPROFILE", str(empty_home))
+
+        with pytest.raises(UvExecutableNotFoundError) as excinfo:
+            build_upgrade_command(InstallMethod.UV_TOOL, target_version="0.3.0")
+        # The candidates list is the single most useful artifact for an
+        # operator debugging a stuck lab PC; pin its shape.
+        assert excinfo.value.candidates
+        assert all(isinstance(c, str) for c in excinfo.value.candidates)
 
 
 # ---------------------------------------------------------------------------

--- a/watcher/tests/test_updater.py
+++ b/watcher/tests/test_updater.py
@@ -508,6 +508,118 @@ class TestUpdaterOnTick:
         emitted = [c.args[0].event_type for c in h.reporter.queue_event.call_args_list]
         assert EventType.UPDATE_FAILED in emitted
 
+    def test_upgrade_runner_raising_file_not_found_is_classified(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Reproduces the failure that prompted this change: on a Windows
+        # LocalSystem service `subprocess.run(["uv", ...])` raises
+        # FileNotFoundError because the service account's PATH doesn't
+        # see the user's uv install. Previously this surfaced as the
+        # opaque `subprocess raised: [WinError 2] ...` reason with no
+        # argv or error class attached — now we classify the branch and
+        # attach both so operators can diagnose from the dashboard
+        # without needing to open `watcher.log` on the PC.
+        winerror2 = FileNotFoundError("[WinError 2] The system cannot find the file specified")
+        runner = MagicMock(side_effect=winerror2)
+        h = _make_updater(tmp_path, upgrade_runner=runner)
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.detect_install_method",
+            lambda: InstallMethod.UV_TOOL,
+        )
+        # Force the command-build to succeed regardless of whether the
+        # test host has `uv` on PATH, so we're testing the FileNotFound
+        # branch from the subprocess call — not the pre-flight
+        # UvExecutableNotFoundError branch (which is exercised in the
+        # next test).
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.build_upgrade_command",
+            lambda method, target_version=None: [
+                "/fake/bin/uv",
+                "tool",
+                "install",
+                "--reinstall",
+                "--index-url",
+                "https://pypi.org/simple/",
+                f"data-hub-watcher=={target_version}",
+            ],
+        )
+
+        h.counters.last_files_uploaded = 0
+        h.updater.on_tick()
+        h.updater.on_tick()
+        result = h.updater.on_tick()
+
+        assert result is not None
+        assert result.attempted is True
+        assert result.succeeded is False
+        h.request_restart.assert_not_called()
+
+        emitted_events = [c.args[0] for c in h.reporter.queue_event.call_args_list]
+        update_failed = [e for e in emitted_events if e.event_type is EventType.UPDATE_FAILED]
+        assert len(update_failed) == 1
+        details = update_failed[0].details
+        # Reason must be classified (not the generic `subprocess raised:` prefix)
+        # so the dashboard row is immediately diagnosable.
+        assert details["reason"].startswith("upgrade command not executable:")
+        assert details["error_class"] == "FileNotFoundError"
+        assert details["command"][0] == "/fake/bin/uv"
+        assert details["command"][1:4] == ["tool", "install", "--reinstall"]
+        assert details["install_method"] == "uv-tool"
+
+    def test_uv_not_found_refuses_before_update_started(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # When no `uv` binary is locatable we must fail fast: no
+        # UPDATE_STARTED, no on-disk marker, just a single UPDATE_FAILED
+        # carrying the paths we probed so the operator knows where to
+        # drop a binary (or what PATH to fix) on the lab PC.
+        from data_hub_watcher.self_update import UvExecutableNotFoundError
+
+        runner = MagicMock()  # must not be called
+        h = _make_updater(tmp_path, upgrade_runner=runner)
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.detect_install_method",
+            lambda: InstallMethod.UV_TOOL,
+        )
+
+        def _raise(method: Any, target_version: str | None = None) -> list[str]:
+            raise UvExecutableNotFoundError(
+                [r"C:\Users\lab\.local\bin\uv.exe", r"C:\ProgramData\uv\uv.exe"]
+            )
+
+        monkeypatch.setattr("data_hub_watcher.updater.build_upgrade_command", _raise)
+
+        h.counters.last_files_uploaded = 0
+        h.updater.on_tick()
+        h.updater.on_tick()
+        result = h.updater.on_tick()
+
+        assert result is not None
+        assert result.attempted is True
+        assert result.succeeded is False
+        runner.assert_not_called()
+        h.request_restart.assert_not_called()
+        # No marker: we refused before dispatching the subprocess, so
+        # there's nothing for the next process startup to evaluate.
+        assert not (tmp_path / ".data-hub" / UPGRADE_MARKER_FILENAME).exists()
+
+        emitted_events = [c.args[0] for c in h.reporter.queue_event.call_args_list]
+        types = [e.event_type for e in emitted_events]
+        # Critical: no UPDATE_STARTED for a subprocess that never ran.
+        assert EventType.UPDATE_STARTED not in types
+        update_failed = [e for e in emitted_events if e.event_type is EventType.UPDATE_FAILED]
+        assert len(update_failed) == 1
+        details = update_failed[0].details
+        assert details["reason"] == "uv executable not found"
+        assert details["error_class"] == "UvExecutableNotFoundError"
+        assert details["attempted_subprocess"] is False
+        assert details["candidates_tried"] == [
+            r"C:\Users\lab\.local\bin\uv.exe",
+            r"C:\ProgramData\uv\uv.exe",
+        ]
+
     def test_editable_install_refuses_auto_update(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

Fixes the auto-upgrade failure mode that produced `update_failed` with `reason: "subprocess raised: [WinError 2] The system cannot find the file specified"` on Windows service watchers. The in-service updater was calling `subprocess.run(["uv", ...])` with the literal bare string when `shutil.which("uv")` missed — which it reliably does under LocalSystem, whose PATH doesn't include the user's `~/.local/bin` where `uv.exe` lives.

## Changes

- Added `_resolve_uv_executable` with a layered resolution order (explicit override → `shutil.which("uv")` → `sys.prefix`-derived candidate for the standard uv-tool layout on Windows and POSIX → `USERPROFILE`/`HOME` last-ditch probe).
- Rewrote `build_upgrade_command`'s `UV_TOOL` branch to use the resolver and raise a new `UvExecutableNotFoundError` (carrying the candidate list) instead of falling back to the bare `"uv"`.
- `Updater._apply` now builds the argv up-front: `UvExecutableNotFoundError` becomes a single pre-flight `UPDATE_FAILED` with `attempted_subprocess=false`, `error_class`, and `candidates_tried` — no misleading `UPDATE_STARTED`, no on-disk marker for the next startup to misinterpret.
- `Updater._run_upgrade` classifies `FileNotFoundError` separately from the generic `Exception` branch; all three failure branches (CreateProcess-time, arbitrary exception, non-zero exit) now attach `error_class`, `command`, and `install_method` to the event `details` so operators can diagnose stuck PCs from the Watchers page without opening `watcher.log`.

## Breaking changes

None. `build_upgrade_command`'s public contract now raises `UvExecutableNotFoundError` for `UV_TOOL` when nothing resolves, but existing callers (`run_upgrade`, the in-service updater) already wrap it and surface the failure as `UPDATE_FAILED`; direct external callers don't exist.

## Driveby changes

None.

## Testing

- [x] `make check-all` clean (ruff + pyright + prettier + eslint + tsc).
- [x] Added `test_uv_tool_uses_path_lookup_when_no_override`, `test_uv_tool_falls_back_to_sys_prefix_derived_path`, and `test_uv_tool_raises_when_nothing_resolves` in `watcher/tests/test_self_update.py`.
- [x] Added `test_upgrade_runner_raising_file_not_found_is_classified` (pins the exact `[WinError 2]` shape the original event showed) and `test_uv_not_found_refuses_before_update_started` (pins the pre-flight refusal path and its `candidates_tried` payload) in `watcher/tests/test_updater.py`.
- [x] Post-merge: cut `watcher-v0.1.3`, approve the `pypi` deployment, bump `WATCHER_LATEST_VERSION` per environment. Note: existing `0.1.1`/`0.1.2` fleet needs one manual `data-hub-watcher self-update` per PC from an operator shell to pick up `0.1.3` — today's in-service auto-updater is what's broken.