### PR TITLE
Add `service reinstall` command to the watcher CLI

### DIFF
--- a/.github/workflows/publish-watcher.yml
+++ b/.github/workflows/publish-watcher.yml
@@ -113,17 +113,58 @@ jobs:
         with:
           python-version: "3.12"
 
+      # PyPI's publish → index-visibility path is eventually consistent:
+      # the wheel is on object storage within seconds but the Simple /
+      # JSON indexes and their CDN mirrors can lag by up to a couple of
+      # minutes, especially when digital-attestation generation stretches
+      # the publish step. Poll the JSON API until the exact version we
+      # just uploaded is visible so the `uv pip install` below isn't
+      # racing a stale index listing. Generally faster than retrying the
+      # full install because it hits only a small JSON document.
+      - name: Wait for PyPI to expose target version
+        env:
+          TARGET_VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          for attempt in $(seq 1 30); do
+            if curl -fsS "https://pypi.org/pypi/data-hub-watcher/$TARGET_VERSION/json" >/dev/null; then
+              echo "data-hub-watcher==$TARGET_VERSION is visible on the PyPI JSON API (attempt $attempt)"
+              exit 0
+            fi
+            echo "Attempt $attempt: not yet visible; sleeping 10s"
+            sleep 10
+          done
+          echo "Timed out waiting for data-hub-watcher==$TARGET_VERSION on PyPI"
+          exit 1
+
       # Pinning the install to the exact version we just published catches
       # the (rare) case where a stale prior release shadows the build via
-      # a slow-propagating mirror.
+      # a slow-propagating mirror. The retry loop covers the Simple-index
+      # / CDN propagation lag that the JSON-API wait above doesn't always
+      # fully eliminate: `--no-cache` + `--refresh` force uv to re-fetch
+      # the index listing on each attempt (without them the in-run cache
+      # keeps returning the stale view), and the progressive backoff
+      # (15 / 30 / 45 / 60 / 75s) comfortably covers typical propagation
+      # windows without masking a genuinely broken release for long.
       - name: Install from PyPI
         env:
           TARGET_VERSION: ${{ needs.build.outputs.version }}
         run: |
           uv venv .verify
-          uv pip install \
-            --python .verify/bin/python \
-            "data-hub-watcher==$TARGET_VERSION"
+          for attempt in 1 2 3 4 5; do
+            if uv pip install \
+              --python .verify/bin/python \
+              --no-cache \
+              --refresh \
+              "data-hub-watcher==$TARGET_VERSION"; then
+              echo "Install succeeded on attempt $attempt"
+              exit 0
+            fi
+            sleep_for=$((attempt * 15))
+            echo "Attempt $attempt failed; sleeping ${sleep_for}s before retry"
+            sleep "$sleep_for"
+          done
+          echo "Install from PyPI failed after 5 attempts"
+          exit 1
 
       # Both invocations must succeed — `--version` exercises Click + the
       # importlib.metadata version reader, and the explicit Python import

--- a/docs/guides/installing-a-watcher.md
+++ b/docs/guides/installing-a-watcher.md
@@ -115,6 +115,7 @@ Other service commands:
 data-hub-watcher service status    # Check if the service is running
 data-hub-watcher service stop      # Stop the service
 data-hub-watcher service uninstall # Remove the service
+data-hub-watcher service reinstall # Stop, uninstall, install, and start (e.g. after a manual wheel upgrade)
 ```
 
 ## Changing configuration

--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -112,8 +112,9 @@ Manage the watcher as a Windows service:
 | `service start` | Start the service |
 | `service stop` | Stop the service |
 | `service status` | Show service status |
+| `service reinstall` | Stop, uninstall, install, and start in one go |
 
-`service install` accepts `--env-path PATH` to override which `.env` file the SCM-launched process loads (defaults to `~/.data-hub/.env.<environment>`). The installer:
+`service install` (and `service reinstall`) accept `--env-path PATH` to override which `.env` file the SCM-launched process loads (defaults to `~/.data-hub/.env.<environment>`). `service reinstall` is the right command after an out-of-band wheel swap (e.g. `pip install -U data-hub-watcher` from an Administrator shell): the stop and uninstall steps are best-effort so it works equally well when the service is already gone. The installer:
 
 - Registers the service with `Tcpip` and `Dnscache` as start dependencies and `delayedstart=True` so it does not race the boot-time network stack.
 - Configures recovery actions (restart after 60 s on first failure, 120 s on second) with `SERVICE_CONFIG_FAILURE_ACTIONS_FLAG` set, so a non-zero `SystemExit` from the runtime — notably the upgrade-driven restart request — is treated as a failure and the SCM picks the new wheel up automatically.

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -1089,3 +1089,75 @@ def service_status_cmd() -> None:
             click.echo(f"  PID:   {info['pid']}")
     except Exception as exc:
         raise click.ClickException(f"Failed to query service status: {exc}") from exc
+
+
+@service.command("reinstall")
+@click.option(
+    "--env-path",
+    "env_path_override",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help="Path to the .env file. Defaults to ~/.data-hub/.env.<environment>.",
+)
+@click.pass_context
+def service_reinstall(ctx: click.Context, env_path_override: str | None) -> None:
+    """Stop, uninstall, install, and start the watcher Windows service.
+
+    Useful after upgrading the watcher wheel from an Administrator shell so
+    the SCM picks up the new ``data_hub_watcher.service`` entrypoint without
+    needing four separate ``service`` invocations.
+    """
+    _windows_only()
+    path = _resolve_path(ctx)
+    cfg = load_config(path)
+
+    from data_hub_watcher.service import (
+        install_service,
+        start_service,
+        stop_service,
+        uninstall_service,
+    )
+
+    if env_path_override is not None:
+        env_path = Path(env_path_override).resolve()
+    else:
+        env_path = env_file_path(cfg.environment).resolve()
+
+    if not env_path.exists():
+        click.echo(
+            click.style(
+                f"⚠ Warning: {env_path} does not exist. "
+                "Run 'data-hub-watcher init' first or pass --env-path.",
+                fg="yellow",
+            ),
+            err=True,
+        )
+
+    # Stop and uninstall are best-effort: a fresh install (or a half-uninstalled
+    # service) shouldn't block the reinstall from progressing to install+start.
+    # ``uninstall_service`` already swallows StopService errors internally, but
+    # we still call ``stop_service`` first so the operator gets a clear log
+    # line about which step succeeded.
+    try:
+        stop_service()
+        click.echo(click.style("✓ Service stopped.", fg="green"))
+    except Exception as exc:
+        click.echo(f"  (stop skipped: {exc})")
+
+    try:
+        uninstall_service()
+        click.echo(click.style("✓ Service uninstalled.", fg="green"))
+    except Exception as exc:
+        click.echo(f"  (uninstall skipped: {exc})")
+
+    try:
+        install_service(config_path=path.resolve(), env_path=env_path)
+        click.echo(click.style("✓ Service installed.", fg="green"))
+    except Exception as exc:
+        raise click.ClickException(f"Failed to install service: {exc}") from exc
+
+    try:
+        start_service()
+        click.echo(click.style("✓ Service started.", fg="green"))
+    except Exception as exc:
+        raise click.ClickException(f"Failed to start service: {exc}") from exc

--- a/watcher/tests/test_cli_service_reinstall.py
+++ b/watcher/tests/test_cli_service_reinstall.py
@@ -1,0 +1,214 @@
+"""Unit tests for the ``data-hub-watcher service reinstall`` CLI command.
+
+The command is the operator-facing wrapper around stop → uninstall →
+install → start that we need after a manual wheel swap from an
+Administrator shell.  These tests verify two contracts that have
+historically caused real outages on lab PCs:
+
+* The four SCM helpers must be invoked **in order** so we never end up
+  installing a service while the previous one is still half-running.
+* Stop and uninstall must be best-effort.  A clean machine (where the
+  service isn't installed yet) must still progress to ``install_service``
+  and ``start_service`` instead of bailing out at the first error.
+"""
+
+from __future__ import annotations
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from data_hub_watcher import cli as cli_module
+from data_hub_watcher.models import InstrumentConfig, RunDetectionConfig, WatcherConfig
+
+
+def _make_config(tmp_path: Path) -> WatcherConfig:
+    watch_dir = tmp_path / "data"
+    watch_dir.mkdir()
+    (watch_dir / "RUN001_sample.csv").write_text("a,b\n1,2\n")
+    return WatcherConfig(
+        version=1,
+        environment="staging",
+        watcher_id="w-test",
+        instrument=InstrumentConfig(
+            id="test-instrument",
+            watch_directory=watch_dir,
+            file_patterns=["*.csv"],
+            run_detection=RunDetectionConfig(pattern=r"^([^_]+)", recursive=False),
+        ),
+    )
+
+
+@pytest.fixture
+def fake_service_module(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Inject a fake ``data_hub_watcher.service`` module into ``sys.modules``.
+
+    The CLI command imports its helpers lazily inside the function body so
+    we can swap the whole module out without touching the real service
+    code (which pulls in win32 imports).
+    """
+    fake = MagicMock(name="data_hub_watcher.service")
+    monkeypatch.setitem(sys.modules, "data_hub_watcher.service", fake)
+    return fake
+
+
+@pytest.fixture
+def windows_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend we're on Windows so ``_windows_only()`` doesn't bail out."""
+    monkeypatch.setattr(sys, "platform", "win32")
+
+
+@pytest.fixture
+def configured_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Write a placeholder config and route the CLI to it.
+
+    The CLI's ``load_config`` is patched to return an in-memory config so
+    we don't need to round-trip through real YAML parsing here — what we
+    care about is the SCM call sequencing, not config IO.
+    """
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("# placeholder, content is mocked away\n")
+    cfg = _make_config(tmp_path)
+
+    monkeypatch.setattr(cli_module, "resolve_config_path", lambda _override: config_path)
+    monkeypatch.setattr(cli_module, "load_config", lambda _p: cfg)
+    monkeypatch.setattr(cli_module, "env_file_path", lambda _env: tmp_path / ".env.staging")
+    return config_path
+
+
+class TestServiceReinstallHappyPath:
+    def test_calls_stop_uninstall_install_start_in_order(
+        self,
+        windows_platform: None,
+        fake_service_module: MagicMock,
+        configured_path: Path,
+        tmp_path: Path,
+    ) -> None:
+        env_path = tmp_path / ".env.staging"
+        env_path.write_text("")
+
+        manager = MagicMock()
+        manager.attach_mock(fake_service_module.stop_service, "stop_service")
+        manager.attach_mock(fake_service_module.uninstall_service, "uninstall_service")
+        manager.attach_mock(fake_service_module.install_service, "install_service")
+        manager.attach_mock(fake_service_module.start_service, "start_service")
+
+        runner = CliRunner()
+        result = runner.invoke(cli_module.cli, ["service", "reinstall"])
+
+        assert result.exit_code == 0, result.output
+        call_names = [c[0] for c in manager.mock_calls]
+        assert call_names == [
+            "stop_service",
+            "uninstall_service",
+            "install_service",
+            "start_service",
+        ]
+        # install_service must receive resolved paths so the SCM-launched
+        # process can find the config and env file regardless of cwd.
+        kwargs = fake_service_module.install_service.call_args.kwargs
+        assert kwargs["config_path"] == configured_path.resolve()
+        assert kwargs["env_path"] == env_path.resolve()
+
+    def test_stop_failure_is_swallowed_and_install_still_runs(
+        self,
+        windows_platform: None,
+        fake_service_module: MagicMock,
+        configured_path: Path,
+        tmp_path: Path,
+    ) -> None:
+        # Simulates a clean machine: the service isn't installed, so
+        # ``stop_service`` raises. The reinstall must continue.
+        (tmp_path / ".env.staging").write_text("")
+        fake_service_module.stop_service.side_effect = RuntimeError("service does not exist")
+        fake_service_module.uninstall_service.side_effect = RuntimeError("service does not exist")
+
+        runner = CliRunner()
+        result = runner.invoke(cli_module.cli, ["service", "reinstall"])
+
+        assert result.exit_code == 0, result.output
+        fake_service_module.install_service.assert_called_once()
+        fake_service_module.start_service.assert_called_once()
+        assert "stop skipped" in result.output
+        assert "uninstall skipped" in result.output
+
+    def test_install_failure_aborts_before_start(
+        self,
+        windows_platform: None,
+        fake_service_module: MagicMock,
+        configured_path: Path,
+        tmp_path: Path,
+    ) -> None:
+        # If install fails (bad permissions, missing pywin32, etc.) we
+        # MUST NOT try to start a service that doesn't exist — that just
+        # papers over the real error with a confusing second one.
+        (tmp_path / ".env.staging").write_text("")
+        fake_service_module.install_service.side_effect = RuntimeError("access denied")
+
+        runner = CliRunner()
+        result = runner.invoke(cli_module.cli, ["service", "reinstall"])
+
+        assert result.exit_code != 0
+        assert "Failed to install service" in result.output
+        fake_service_module.start_service.assert_not_called()
+
+
+class TestServiceReinstallPlatformGuard:
+    def test_non_windows_platform_exits_one(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_service_module: MagicMock,
+        configured_path: Path,
+    ) -> None:
+        monkeypatch.setattr(sys, "platform", "linux")
+
+        runner = CliRunner()
+        result = runner.invoke(cli_module.cli, ["service", "reinstall"])
+
+        assert result.exit_code == 1
+        assert "Windows" in result.output
+        # None of the service helpers should have been touched.
+        fake_service_module.stop_service.assert_not_called()
+        fake_service_module.install_service.assert_not_called()
+
+
+class TestServiceReinstallEnvPathOverride:
+    def test_env_path_override_is_used(
+        self,
+        windows_platform: None,
+        fake_service_module: MagicMock,
+        configured_path: Path,
+        tmp_path: Path,
+    ) -> None:
+        custom_env = tmp_path / "custom.env"
+        custom_env.write_text("")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_module.cli,
+            ["service", "reinstall", "--env-path", str(custom_env)],
+        )
+
+        assert result.exit_code == 0, result.output
+        kwargs = fake_service_module.install_service.call_args.kwargs
+        assert kwargs["env_path"] == custom_env.resolve()
+
+    def test_missing_env_path_warns_but_proceeds(
+        self,
+        windows_platform: None,
+        fake_service_module: MagicMock,
+        configured_path: Path,
+        tmp_path: Path,
+    ) -> None:
+        # Don't create the env file — the default path won't exist.
+        runner = CliRunner()
+        result = runner.invoke(cli_module.cli, ["service", "reinstall"])
+
+        assert result.exit_code == 0, result.output
+        # Warning is printed to stderr; CliRunner mixes stderr into output
+        # by default, so a substring check is enough.
+        assert "Warning" in result.output
+        assert "does not exist" in result.output
+        fake_service_module.install_service.assert_called_once()


### PR DESCRIPTION
## Summary

Adds a `data-hub-watcher service reinstall` subcommand that stops, uninstalls, installs, and starts the Windows service in one Administrator-shell invocation.

Useful after a manual wheel swap (e.g. `pip install -U data-hub-watcher`) where you want the SCM to pick up the new `data_hub_watcher.service` entrypoint without four separate commands.

## Changes

- New `service reinstall` Click command in `watcher/src/data_hub_watcher/cli.py`. Mirrors `service install`'s `--env-path` override and missing-env-file warning. Stop and uninstall are best-effort (logged as `(stop skipped: …)` / `(uninstall skipped: …)`) so the command also works on a clean machine where the service isn't installed yet. Install or start failures still raise `ClickException` for a clean non-zero exit.
- New unit test file `watcher/tests/test_cli_service_reinstall.py` covering call ordering, swallowed stop/uninstall errors, install-failure aborting before start, the non-Windows platform guard, the `--env-path` override, and the missing-env warning path.
- Doc updates in `docs/watcher.md` (CLI table) and `docs/guides/installing-a-watcher.md` (operator command list).

## Breaking changes

None. New subcommand only — existing `service install / uninstall / start / stop / status` behaviour is unchanged.

## Driveby changes

**.github/workflows/publish-watcher.yml** — Added two layers of propagation-tolerance to the verify job:

1. Wait for PyPI to expose target version (new step before the install). Polls `https://pypi.org/pypi/data-hub-watcher/<version>/json` up to 30 times at 10-second intervals (≤ 5 min). Cheap JSON-API check that generally succeeds before the Simple-API + CDN view converges.
1. Retrying install (replaces the single-shot uv pip install). Up to 5 attempts with progressive backoff (15/30/45/60/75 s → ≤ 3.75 min) and `--no-cache` + `--refresh` on each attempt so uv re-fetches the index listing instead of replaying the in-run cache.

## Testing

- [x] `uv run --package data-hub-watcher pytest tests/test_cli_service_reinstall.py` — 6/6 pass
- [x] `make check-all` — ruff, ruff format, pyright, prettier, eslint, tsc all clean
- [x] Smoke test on a Windows lab PC: install the service via `service install`, then run `service reinstall` and confirm it stops → uninstalls → installs → starts cleanly
- [x] Smoke test on a clean Windows machine (no service installed): `service reinstall` should print the two `skipped` lines and still end up with a running service