### PR TITLE
Watcher: Fix Windows uv-tool auto-update via SYSTEM-owned scheduled task

### DIFF
--- a/docs/guides/installing-a-watcher.md
+++ b/docs/guides/installing-a-watcher.md
@@ -125,6 +125,21 @@ data-hub-watcher service reinstall # Stop, uninstall, install, and start (e.g. a
 > for the SCM to finish and then aborts with an actionable error rather
 > than the raw `(1072, 'CreateService', 'marked for deletion')` failure.
 
+> **Note (auto-update):** `service install` also drops a small PowerShell
+> worker under `~/.data-hub/upgrade-worker.ps1` and registers it as the
+> `DataHubWatcherUpgrade` Scheduled Task running as `SYSTEM`. The
+> auto-updater and `data-hub-watcher self-update` both route Windows
+> uv-tool upgrades through that task — the watcher's own
+> `Scripts\python.exe` is mapped into the running service process and
+> Windows refuses to let `uv` replace it in place, so the upgrade is
+> driven from a process tree that doesn't include the service. **Lab PCs
+> already running an older watcher build must be upgraded once with
+> `data-hub-watcher service reinstall` after they auto-update into
+> v0.2.0 or later** — that one-time reinstall is what registers the
+> Scheduled Task. The next service start lazily re-registers a missing
+> task on its own, so most fleet PCs will self-heal without operator
+> intervention.
+
 ## Changing configuration
 
 To re-prompt each config field with current values as defaults:

--- a/docs/guides/installing-a-watcher.md
+++ b/docs/guides/installing-a-watcher.md
@@ -118,6 +118,13 @@ data-hub-watcher service uninstall # Remove the service
 data-hub-watcher service reinstall # Stop, uninstall, install, and start (e.g. after a manual wheel upgrade)
 ```
 
+> **Tip:** Close `services.msc` (and any open Event Viewer / Task Manager
+> "Services" tabs) before running `service reinstall`. The Windows SCM
+> defers `DeleteService` until every open handle is closed; if a console
+> is still pointing at `DataHubWatcher`, the reinstall waits up to 30 s
+> for the SCM to finish and then aborts with an actionable error rather
+> than the raw `(1072, 'CreateService', 'marked for deletion')` failure.
+
 ## Changing configuration
 
 To re-prompt each config field with current values as defaults:

--- a/docs/guides/installing-a-watcher.md
+++ b/docs/guides/installing-a-watcher.md
@@ -53,24 +53,17 @@ data-hub-watcher init
 The wizard will walk you through:
 
 1. **Environment** — choose `staging` (for testing), `production`, or `preview` (for testing against a Vercel preview deployment). If you choose `preview`, you'll be prompted for the deployment's API base URL (e.g. `https://data-hub-git-my-branch.vercel.app/api/v1`).
-
 2. **API key** — paste the personal access token. The key is saved to `~/.data-hub/.env.<environment>` (e.g. `~/.data-hub/.env.staging`), so each environment keeps its own key and you can switch between them by re-running `init` without re-entering credentials. You can also set the `DATA_HUB_API_KEY` environment variable before running `init` to skip this prompt.
-
 3. **Instrument** — select an existing instrument from the list, or register a new one by choosing the last option. New instruments start as `pending` and must be activated by an admin in the web app before the watcher can start.
-
 4. **Watch directory** — the absolute path to the folder the instrument writes to.
-
 5. **File patterns** — comma-separated glob patterns (e.g., `*.csv,*.xlsx`). Only files matching these patterns will be uploaded.
-
 6. **Run detection method**:
-   - **`prefix`** — extracts a run ID from each filename using a regex. The default pattern `^([^_]+)` captures everything before the first underscore (e.g., `RUN001_data.csv` → run ID `RUN001`).
-   - **`directory`** — each subdirectory under the watch directory is treated as a separate run.
-
+  - `**prefix`** — extracts a run ID from each filename using a regex. The default pattern `^([^_]+)` captures everything before the first underscore (e.g., `RUN001_data.csv` → run ID `RUN001`).
+  - `**directory**` — each subdirectory under the watch directory is treated as a separate run.
 7. **Stability period** — how many seconds a file must remain unchanged (size + modification time) before it's considered fully written. Increase this for instruments that produce large files slowly. Default is 5 seconds.
-
 8. **Upload mode**:
-   - **`auto`** — files are uploaded to S3 immediately after detection.
-   - **`manual`** — files are reported to the server but not uploaded until an admin approves them via the upload queue.
+  - `**auto`** — files are uploaded to S3 immediately after detection.
+  - `**manual**` — files are reported to the server but not uploaded until an admin approves them via the upload queue.
 
 The wizard saves configuration to `~/.data-hub/config.yaml`, the API key to `~/.data-hub/.env.<environment>`, and syncs the config to the server.
 
@@ -117,28 +110,6 @@ data-hub-watcher service stop      # Stop the service
 data-hub-watcher service uninstall # Remove the service
 data-hub-watcher service reinstall # Stop, uninstall, install, and start (e.g. after a manual wheel upgrade)
 ```
-
-> **Tip:** Close `services.msc` (and any open Event Viewer / Task Manager
-> "Services" tabs) before running `service reinstall`. The Windows SCM
-> defers `DeleteService` until every open handle is closed; if a console
-> is still pointing at `DataHubWatcher`, the reinstall waits up to 30 s
-> for the SCM to finish and then aborts with an actionable error rather
-> than the raw `(1072, 'CreateService', 'marked for deletion')` failure.
-
-> **Note (auto-update):** `service install` also drops a small PowerShell
-> worker under `~/.data-hub/upgrade-worker.ps1` and registers it as the
-> `DataHubWatcherUpgrade` Scheduled Task running as `SYSTEM`. The
-> auto-updater and `data-hub-watcher self-update` both route Windows
-> uv-tool upgrades through that task — the watcher's own
-> `Scripts\python.exe` is mapped into the running service process and
-> Windows refuses to let `uv` replace it in place, so the upgrade is
-> driven from a process tree that doesn't include the service. **Lab PCs
-> already running an older watcher build must be upgraded once with
-> `data-hub-watcher service reinstall` after they auto-update into
-> v0.2.0 or later** — that one-time reinstall is what registers the
-> Scheduled Task. The next service start lazily re-registers a missing
-> task on its own, so most fleet PCs will self-heal without operator
-> intervention.
 
 ## Changing configuration
 
@@ -234,3 +205,4 @@ The watcher writes rotating logs to `~/.data-hub/watcher.log` (10 MB, 5 backups)
 ```sh
 data-hub-watcher --verbose watch
 ```
+

--- a/docs/guides/managing-tokens.md
+++ b/docs/guides/managing-tokens.md
@@ -88,13 +88,15 @@ curl https://data-hub.arcadiascience.com/api/v1/instruments \
 
 Go to **Settings > Access Tokens** in the web app. The table shows:
 
-| Column | Description |
-| --- | --- |
-| **Name** | The label you gave the token |
-| **Token** | The prefix only (e.g., `dhub_a1b2...`) — the full token is never stored |
-| **Last used** | When the token was last used to authenticate an API request |
-| **Expires** | Expiration date, or "Never" |
-| **Created** | When the token was created |
+
+| Column        | Description                                                             |
+| ------------- | ----------------------------------------------------------------------- |
+| **Name**      | The label you gave the token                                            |
+| **Token**     | The prefix only (e.g., `dhub_a1b2...`) — the full token is never stored |
+| **Last used** | When the token was last used to authenticate an API request             |
+| **Expires**   | Expiration date, or "Never"                                             |
+| **Created**   | When the token was created                                              |
+
 
 ## Revoking a token
 
@@ -128,14 +130,12 @@ If you revoke a token that a running watcher is using, the watcher will start fa
 
 1. Create a new token.
 2. On the instrument PC, re-run the setup wizard:
-
-   ```sh
+  ```sh
    data-hub-watcher init
-   ```
-
+  ```
 3. Enter the new token when prompted.
 4. Restart the watcher:
-
-   ```sh
+  ```sh
    data-hub-watcher watch
-   ```
+  ```
+

--- a/docs/guides/upgrading-the-watcher.md
+++ b/docs/guides/upgrading-the-watcher.md
@@ -10,15 +10,17 @@ Three paths feed an upgraded wheel into the running watcher. Lab PCs running as 
 
 ### Background auto-update (Windows service, recommended)
 
-When the watcher runs as a Windows service in `staging` or `production`, the in-process updater polls the API roughly once an hour and applies new releases on its own — no operator action and no Task Scheduler entry required.
+When the watcher runs as a Windows service in `staging` or `production`, the in-process updater polls the API roughly once an hour and applies new releases on its own — no operator action and no manual Task Scheduler setup required.
 
 On each tick the service:
 
 1. Calls `GET /api/v1/watchers/<watcher-id>/update-check` and compares the server's `latest_version` against its own.
 2. Only attempts an upgrade if **all** of these are true: a newer version is available, no files have been uploaded for several heartbeats in a row, and no run has been reported within roughly 5× the configured `stability_period_seconds`. The activity-window guard exists so the watcher never takes itself down mid-acquisition.
     - **Exception:** releases flagged as `mandatory` on the server skip the activity-window check entirely and are applied immediately — this is reserved for security fixes or breaking wire-protocol changes where leaving the old version running is worse than a brief interruption.
-3. Runs `uv tool install --reinstall data-hub-watcher==<latest>` (or the `pip install -U` equivalent for non-uv installs) on a dedicated background thread, so heartbeats keep flowing while the install executes — which can take 30–60 s on slow links. Before the subprocess starts, the service emits an `update_started` event you can see in the **Watchers** page.
-4. On success, exits non-zero so the Windows SCM restarts the service into the new wheel via its configured failure-actions policy. The new process emits `update_succeeded` once it confirms the new version is actually loaded; if the new code crashes at startup or otherwise doesn't take effect, you'll see `update_failed` instead.
+3. Drives the upgrade subprocess via the path appropriate for the install:
+    - **Windows uv-tool installs (the recommended fleet setup)** — writes a request sentinel to `~/.data-hub/.upgrade-request.json` and triggers the `DataHubWatcherUpgrade` Scheduled Task that `service install` registered. The task runs as `SYSTEM`, stops the watcher service, runs `uv tool install --reinstall`, drops a result sentinel for the dashboard, and starts the service again. This out-of-process flow is necessary because `uv` cannot replace `Scripts\python.exe` while it is mapped into the running service process.
+    - **POSIX (Linux/macOS) and Windows pip installs** — runs `uv tool install --reinstall` (or the `pip install -U` equivalent) directly on a background thread, then exits non-zero so the SCM (or the foreground CLI) restarts into the new wheel.
+4. Before any subprocess starts, the service emits an `update_started` event you can see in the **Watchers** page. The new process emits `update_succeeded` once it confirms the new version is actually loaded; if the new code crashes at startup or otherwise doesn't take effect, you'll see `update_failed` instead. On Windows uv-tool installs, the success/failure event also carries the worker's captured `worker_returncode`, `worker_stdout_tail`, and `worker_stderr_tail` so you can debug from the dashboard without opening a remote shell.
 
 Auto-update is **disabled** in the `preview` environment so PR preview deployments can never push code to production lab PCs.
 
@@ -33,15 +35,18 @@ data-hub-watcher self-update --force    # re-run the upgrade subprocess
                                         # even if the version already matches
 ```
 
-The command asks the API for the latest published version, compares it to the locally installed version, and runs the appropriate upgrade subprocess for your install method:
+The command asks the API for the latest published version, compares it to the locally installed version, and runs the appropriate upgrade flow for your install method:
 
-| Install method | Upgrade command |
+| Install method | Upgrade flow |
 | --- | --- |
-| `uv tool install` | `uv tool install --reinstall data-hub-watcher==<latest>` |
-| Plain venv `pip install` | `<python> -m pip install -U data-hub-watcher==<latest>` |
-| Editable / `uv sync` checkout | Refused; upgrade manually with `git pull && uv sync` |
+| Windows + `uv tool install` | Routes through the `DataHubWatcherUpgrade` Scheduled Task — same out-of-process worker the auto-updater uses. The CLI exits as soon as the task accepts the request; watch progress with `data-hub-watcher service status` or by tailing `~/.data-hub/upgrade-worker.log`. |
+| POSIX + `uv tool install` | `uv tool install --reinstall data-hub-watcher==<latest>` inline; output is streamed to your shell. |
+| Plain venv `pip install` | `<python> -m pip install -U data-hub-watcher==<latest>` inline. |
+| Editable / `uv sync` checkout | Refused; upgrade manually with `git pull && uv sync`. |
 
-After a successful CLI upgrade you must restart the watcher (or the Windows service) for the new code to take effect — `self-update` does not restart the running process. To run upgrades unattended without the Windows service, schedule the CLI via Windows Task Scheduler (e.g. weekly).
+The Windows uv-tool path **requires** that `data-hub-watcher service install` (or `service reinstall`) has been run from an Administrator shell at least once on the machine — that is what registers the `DataHubWatcherUpgrade` Scheduled Task. If the task is missing, `self-update` fails fast with an actionable error rather than falling back to the broken in-process reinstall. Fleet PCs that auto-update into a worker-aware build for the first time **must** be reinstalled once with `data-hub-watcher service reinstall` to pick up the new task.
+
+After a successful inline (POSIX or pip) upgrade you must restart the watcher (or the Windows service) for the new code to take effect — `self-update` does not restart the running process on those paths. The Windows uv-tool path drives the service restart for you. To run upgrades unattended on a non-service install, schedule the CLI via Windows Task Scheduler (e.g. weekly).
 
 ### Editable / developer checkouts
 
@@ -162,3 +167,40 @@ You're running from a checkout (`uv sync --all-packages`). This is the [editable
 ### A failed upgrade left a stale marker
 
 The on-disk upgrade marker at `~/.data-hub/.upgrade-in-progress` is consumed and deleted on read by the next process startup, so a single failure won't be reported indefinitely. If you see the file persisting across multiple restarts, the watcher is failing to start up at all (so it never reaches the `evaluate_upgrade_marker` step). Delete the marker manually, fix the underlying startup issue, and the next clean start will report cleanly.
+
+### Windows uv-tool: `update_failed` with `reason: "scheduled task could not be triggered…"`
+
+The watcher tried to dispatch the upgrade through the `DataHubWatcherUpgrade` Scheduled Task, but `schtasks /Run` refused. The most common causes:
+
+- **The task is not registered.** Lab PCs that auto-updated into the worker-aware build for the first time won't have the task on disk. Open an Administrator PowerShell and run `data-hub-watcher service reinstall` — it tears down the previous service registration, drops the worker script under `~/.data-hub/upgrade-worker.ps1`, registers the task, and restarts the service. The next auto-update tick (or `data-hub-watcher self-update`) will find the task and succeed.
+- **The service account can't talk to Task Scheduler.** Inspect `details.schtasks_stderr` on the failed event for the `schtasks.exe` error; `Access is denied` means the service is running as a non-privileged account. Reinstall the service under `LocalSystem` (the default) via `data-hub-watcher service reinstall`.
+
+The watcher self-heals on the **next service start** by lazily re-registering a missing task — so a single SCM-driven restart after the failure usually puts the host back in a good state without any operator action. The error above only fires when both the original and the lazy-repair attempts have failed.
+
+### Windows uv-tool: `update_failed` with `details.worker_result_missing: true`
+
+The marker says the upgrade was dispatched via the worker, but the worker never wrote `~/.data-hub/.upgrade-result.json`. That means the PowerShell worker either crashed between `Stop-Service` and the `uv` invocation, or `Task Scheduler` killed it before it finished. Open `~/.data-hub/upgrade-worker.log` on the lab PC for the captured output — every step the worker takes is logged there with a UTC timestamp. The service itself will still come back up because the worker's `finally` block always tries to `Start-Service`.
+
+### Where to find the raw installer transcript
+
+Whenever an upgrade fires, the watcher mirrors `uv`'s full stdout/stderr to disk in two places so a misleading dashboard event doesn't leave you guessing:
+
+- **In-process upgrades (POSIX, Windows pip)** — every line of subprocess output is logged at `INFO` to `~/.data-hub/watcher.log` (or the platform equivalent), prefixed with `Upgrade subprocess stdout/stderr tail:`. This happens regardless of the subprocess return code, so a partial install where uv exits 0 but printed errors is still recoverable.
+- **Windows uv-tool worker** — every line of uv's output is echoed line-by-line to `~/.data-hub/upgrade-worker.log` with a UTC timestamp (`uv stdout: …` / `uv stderr: …`). Tail this file to watch an upgrade as it happens.
+
+Both files survive a service restart — the watcher only ever appends to them — so an after-the-fact post-mortem of "what did uv actually say five minutes ago?" is always answerable from the lab PC without re-running the upgrade.
+
+### Worker reported success but the dashboard still shows `update_failed`
+
+The post-restart event evaluation prefers the worker's `succeeded` flag over the marker's version comparison: if uv exited non-zero but the install proceeded far enough to fool a version check, the dashboard still emits `update_failed` with the actual installer error in `worker_stderr_tail`. The marker's classification is preserved in `details.marker_succeeded` / `details.marker_reason` so you can see when the two signals disagree (typically a partial install).
+
+### Windows uv-tool: `data-hub-watcher self-update` reports "Upgrade dispatched" but nothing happens
+
+The CLI returns as soon as the Scheduled Task accepts the request — the actual install runs out-of-process under SYSTEM and takes 30–60 s on a typical link. Track progress with:
+
+```powershell
+Get-Service data-hub-watcher           # cycles Stopped -> Start Pending -> Running
+Get-Content ~/.data-hub/upgrade-worker.log -Tail 20 -Wait
+```
+
+The watcher's `update_succeeded` / `update_failed` event lands in the dashboard once the new service process boots and reads the marker + result sentinel. If you don't see one within a couple of minutes, check the worker log.

--- a/docs/guides/upgrading-the-watcher.md
+++ b/docs/guides/upgrading-the-watcher.md
@@ -16,9 +16,9 @@ On each tick the service:
 
 1. Calls `GET /api/v1/watchers/<watcher-id>/update-check` and compares the server's `latest_version` against its own.
 2. Only attempts an upgrade if **all** of these are true: a newer version is available, no files have been uploaded for several heartbeats in a row, and no run has been reported within roughly 5× the configured `stability_period_seconds`. The activity-window guard exists so the watcher never takes itself down mid-acquisition.
-    - **Exception:** releases flagged as `mandatory` on the server skip the activity-window check entirely and are applied immediately — this is reserved for security fixes or breaking wire-protocol changes where leaving the old version running is worse than a brief interruption.
+  - **Exception:** releases flagged as `mandatory` on the server skip the activity-window check entirely and are applied immediately — this is reserved for security fixes or breaking wire-protocol changes where leaving the old version running is worse than a brief interruption.
 3. Drives the upgrade subprocess via the path appropriate for the install:
-    - **Windows uv-tool installs (the recommended fleet setup)** — writes a request sentinel to `~/.data-hub/.upgrade-request.json` and triggers the `DataHubWatcherUpgrade` Scheduled Task that `service install` registered. The task runs as `SYSTEM`, stops the watcher service, runs `uv tool install --reinstall`, drops a result sentinel for the dashboard, and starts the service again. This out-of-process flow is necessary because `uv` cannot replace `Scripts\python.exe` while it is mapped into the running service process.
+  - **Windows uv-tool installs (the recommended fleet setup)** — writes a request sentinel to `~/.data-hub/.upgrade-request.json` and triggers the `DataHubWatcherUpgrade` Scheduled Task that `service install` registered. The task runs as `SYSTEM`, stops the watcher service, runs `uv tool install --reinstall`, drops a result sentinel for the dashboard, and starts the service again. This out-of-process flow is necessary because `uv` cannot replace `Scripts\python.exe` while it is mapped into the running service process.
     - **POSIX (Linux/macOS) and Windows pip installs** — runs `uv tool install --reinstall` (or the `pip install -U` equivalent) directly on a background thread, then exits non-zero so the SCM (or the foreground CLI) restarts into the new wheel.
 4. Before any subprocess starts, the service emits an `update_started` event you can see in the **Watchers** page. The new process emits `update_succeeded` once it confirms the new version is actually loaded; if the new code crashes at startup or otherwise doesn't take effect, you'll see `update_failed` instead. On Windows uv-tool installs, the success/failure event also carries the worker's captured `worker_returncode`, `worker_stdout_tail`, and `worker_stderr_tail` so you can debug from the dashboard without opening a remote shell.
 
@@ -37,12 +37,14 @@ data-hub-watcher self-update --force    # re-run the upgrade subprocess
 
 The command asks the API for the latest published version, compares it to the locally installed version, and runs the appropriate upgrade flow for your install method:
 
-| Install method | Upgrade flow |
-| --- | --- |
-| Windows + `uv tool install` | Routes through the `DataHubWatcherUpgrade` Scheduled Task — same out-of-process worker the auto-updater uses. The CLI exits as soon as the task accepts the request; watch progress with `data-hub-watcher service status` or by tailing `~/.data-hub/upgrade-worker.log`. |
-| POSIX + `uv tool install` | `uv tool install --reinstall data-hub-watcher==<latest>` inline; output is streamed to your shell. |
-| Plain venv `pip install` | `<python> -m pip install -U data-hub-watcher==<latest>` inline. |
-| Editable / `uv sync` checkout | Refused; upgrade manually with `git pull && uv sync`. |
+
+| Install method                | Upgrade flow                                                                                                                                                                                                                                                               |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Windows + `uv tool install`   | Routes through the `DataHubWatcherUpgrade` Scheduled Task — same out-of-process worker the auto-updater uses. The CLI exits as soon as the task accepts the request; watch progress with `data-hub-watcher service status` or by tailing `~/.data-hub/upgrade-worker.log`. |
+| POSIX + `uv tool install`     | `uv tool install --reinstall data-hub-watcher==<latest>` inline; output is streamed to your shell.                                                                                                                                                                         |
+| Plain venv `pip install`      | `<python> -m pip install -U data-hub-watcher==<latest>` inline.                                                                                                                                                                                                            |
+| Editable / `uv sync` checkout | Refused; upgrade manually with `git pull && uv sync`.                                                                                                                                                                                                                      |
+
 
 The Windows uv-tool path **requires** that `data-hub-watcher service install` (or `service reinstall`) has been run from an Administrator shell at least once on the machine — that is what registers the `DataHubWatcherUpgrade` Scheduled Task. If the task is missing, `self-update` fails fast with an actionable error rather than falling back to the broken in-process reinstall. Fleet PCs that auto-update into a worker-aware build for the first time **must** be reinstalled once with `data-hub-watcher service reinstall` to pick up the new task.
 
@@ -101,12 +103,14 @@ Once the new version is live on PyPI, bump the server-side `WATCHER_LATEST_VERSI
 
 The supported watcher release env vars are:
 
-| Env var | Purpose |
-| --- | --- |
-| `WATCHER_LATEST_VERSION` | Required to advertise a release. `null`/unset means "no update info available" and the watcher skips its update attempt. |
-| `WATCHER_MIN_SUPPORTED_VERSION` | Optional floor; surfaced in the response for future use. Not yet enforced server-side. |
-| `WATCHER_RELEASE_CHANNEL` | Defaults to `stable`. Surfaced in the response and shown in `self-update` output. |
-| `WATCHER_MANDATORY_UPDATE` | Set to `true` / `1` to flag the release as mandatory (see below). |
+
+| Env var                         | Purpose                                                                                                                  |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `WATCHER_LATEST_VERSION`        | Required to advertise a release. `null`/unset means "no update info available" and the watcher skips its update attempt. |
+| `WATCHER_MIN_SUPPORTED_VERSION` | Optional floor; surfaced in the response for future use. Not yet enforced server-side.                                   |
+| `WATCHER_RELEASE_CHANNEL`       | Defaults to `stable`. Surfaced in the response and shown in `self-update` output.                                        |
+| `WATCHER_MANDATORY_UPDATE`      | Set to `true` / `1` to flag the release as mandatory (see below).                                                        |
+
 
 Do **not** bump `WATCHER_LATEST_VERSION` ahead of the PyPI publish — the watcher's upgrade subprocess will fail to resolve a version that doesn't yet exist on the index, and you'll see a wave of `update_failed` events from the fleet. Always: tag → publish → verify → bump env var.
 
@@ -137,15 +141,15 @@ There is no separate "yank" step — a rolled-back release is still on PyPI and 
 
 The upgrade subprocess started but didn't end up running the new version on the next process startup. The `details.reason` field on the `update_failed` event tells you which sub-case fired:
 
-- **`subprocess raised: …`** — `subprocess.run` itself raised before it could exec the upgrade command. Typically `FileNotFoundError` because `uv` isn't on PATH for the service account, or a permission error. Check `~/.data-hub/watcher.log` for the full traceback.
-- **`subprocess exited <N>`** — the upgrade command itself failed. The event details include the last 1000 bytes of stdout/stderr; the most common cause is a transient PyPI / mirror failure or the version not yet existing on the index (see the "don't bump ahead of publish" note above).
-- **`expected '<target>' after upgrade, running '<current>'`** — the subprocess succeeded, the service restarted, but the running interpreter still imports the old version. Almost always means a stale `__pycache__` or a separate copy of the package on `sys.path`. Run `uv tool uninstall data-hub-watcher && uv tool install data-hub-watcher==<target>` as the service account.
+- `**subprocess raised: …`** — `subprocess.run` itself raised before it could exec the upgrade command. Typically `FileNotFoundError` because `uv` isn't on PATH for the service account, or a permission error. Check `~/.data-hub/watcher.log` for the full traceback.
+- `**subprocess exited <N>**` — the upgrade command itself failed. The event details include the last 1000 bytes of stdout/stderr; the most common cause is a transient PyPI / mirror failure or the version not yet existing on the index (see the "don't bump ahead of publish" note above).
+- `**expected '<target>' after upgrade, running '<current>'**` — the subprocess succeeded, the service restarted, but the running interpreter still imports the old version. Almost always means a stale `__pycache__` or a separate copy of the package on `sys.path`. Run `uv tool uninstall data-hub-watcher && uv tool install data-hub-watcher==<target>` as the service account.
 
 ### `update_failed` without a preceding `update_started`
 
 When `details.attempted_subprocess` is `false`, the auto-updater never ran the upgrade command — it refused before starting one. The `details.reason` field tells you why:
 
-- **`install method '<editable|unknown>' not eligible for auto-update`** — the watcher detected a development-style install (editable `uv sync`, or a distribution whose metadata couldn't be located) and refused so it wouldn't silently shadow the source tree with an index build. Resolve by switching the host to a PyPI install (`uv tool install data-hub-watcher`) or, on a developer machine, ignoring the event. To avoid spamming the events stream, the watcher emits this at most once per server target — a rebump of `WATCHER_LATEST_VERSION` will trigger one fresh event per stuck PC.
+- `**install method '<editable|unknown>' not eligible for auto-update**` — the watcher detected a development-style install (editable `uv sync`, or a distribution whose metadata couldn't be located) and refused so it wouldn't silently shadow the source tree with an index build. Resolve by switching the host to a PyPI install (`uv tool install data-hub-watcher`) or, on a developer machine, ignoring the event. To avoid spamming the events stream, the watcher emits this at most once per server target — a rebump of `WATCHER_LATEST_VERSION` will trigger one fresh event per stuck PC.
 
 ### Auto-update never fires
 

--- a/uv.lock
+++ b/uv.lock
@@ -415,7 +415,7 @@ requires-dist = [
 
 [[package]]
 name = "data-hub-watcher"
-version = "0.1.4"
+version = "0.2.0"
 source = { editable = "watcher" }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -415,7 +415,7 @@ requires-dist = [
 
 [[package]]
 name = "data-hub-watcher"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "watcher" }
 dependencies = [
     { name = "click" },

--- a/watcher/pyproject.toml
+++ b/watcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-hub-watcher"
-version = "0.1.4"
+version = "0.2.0"
 description = "File-watcher agent for lab instrument PCs that ingests data into Data Hub."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -1116,6 +1116,7 @@ def service_reinstall(ctx: click.Context, env_path_override: str | None) -> None
         start_service,
         stop_service,
         uninstall_service,
+        wait_for_service_removed,
     )
 
     if env_path_override is not None:
@@ -1149,6 +1150,22 @@ def service_reinstall(ctx: click.Context, env_path_override: str | None) -> None
         click.echo(click.style("✓ Service uninstalled.", fg="green"))
     except Exception as exc:
         click.echo(f"  (uninstall skipped: {exc})")
+
+    # ``RemoveService`` only marks the service for deletion; the SCM
+    # finalises the delete asynchronously once every open handle is
+    # closed. Polling here turns the otherwise inscrutable
+    # ``(1072, 'CreateService', 'The specified service has been marked
+    # for deletion.')`` error into either (a) a transparent retry that
+    # succeeds within a few seconds in the common case, or (b) a clear,
+    # actionable message when something is genuinely holding a handle.
+    if not wait_for_service_removed(timeout_seconds=30.0):
+        raise click.ClickException(
+            "Service is still marked for deletion after 30 s. Close any open "
+            "Services consoles (services.msc), Event Viewer windows, or "
+            "Task Manager 'Services' tabs, then re-run "
+            "'data-hub-watcher service install && data-hub-watcher service start'. "
+            "If that doesn't help, reboot to force-clear the SCM handle."
+        )
 
     try:
         install_service(config_path=path.resolve(), env_path=env_path)

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -42,7 +42,10 @@ from data_hub_watcher.runtime import (
     sync_config_to_api,
 )
 from data_hub_watcher.self_update import (
+    DEFAULT_INDEX_URL,
     InstallMethod,
+    UvExecutableNotFoundError,
+    _resolve_uv_executable,
     detect_install_method,
     evaluate_update,
     run_upgrade,
@@ -950,6 +953,20 @@ def self_update(ctx: click.Context, check: bool, force: bool) -> None:
             "Upgrade manually with 'git pull && uv sync' from your checkout."
         )
 
+    # Windows uv-tool installs cannot reinstall in-process: the
+    # operator's own ``data-hub-watcher.exe`` shim has loaded the
+    # venv's ``Scripts\\python.exe`` into the parent process, so
+    # ``uv tool install --reinstall`` would fail with
+    # ``Access is denied. (os error 5)`` when it tries to remove
+    # ``Scripts\\``. Route through the SYSTEM-owned scheduled task
+    # instead, which stops the service before invoking ``uv``.
+    if sys.platform == "win32" and method is InstallMethod.UV_TOOL:
+        _dispatch_self_update_via_worker(
+            target_version=decision.target_version,
+            current_version=decision.current_version,
+        )
+        return
+
     click.echo(f"Upgrading {decision.current_version} -> {decision.target_version}…")
     try:
         result = run_upgrade(method, target_version=decision.target_version)
@@ -974,6 +991,118 @@ def self_update(ctx: click.Context, check: bool, force: bool) -> None:
             "Restart the watcher (or the Windows service) to load the new code.",
             fg="green",
         )
+    )
+
+
+def _dispatch_self_update_via_worker(
+    *,
+    target_version: str | None,
+    current_version: str,
+) -> None:
+    """Trigger the SYSTEM-owned upgrade worker on Windows uv-tool installs.
+
+    Writes the request sentinel + on-disk marker (so the post-restart
+    event evaluation has something to merge) and asks Task Scheduler
+    to run the worker. The CLI then exits — the worker stops the
+    service, runs ``uv``, drops a result sentinel, and starts the
+    service again. The operator watches via ``data-hub-watcher
+    service status`` or by tailing
+    ``~/.data-hub/upgrade-worker.log``.
+
+    Pre-flight failures (no ``uv`` on disk, no scheduled task
+    registered) raise :class:`click.ClickException` with an
+    actionable next step rather than silently returning success.
+    """
+    from data_hub_watcher.scheduled_task import (
+        ScheduledTaskError,
+        task_exists,
+        trigger_upgrade_task,
+    )
+    from data_hub_watcher.updater import write_upgrade_marker
+    from data_hub_watcher.upgrade_worker import (
+        build_pkg_spec,
+        clear_upgrade_request,
+        clear_upgrade_result,
+        detect_installed_extras,
+        upgrade_worker_log_path,
+        write_upgrade_request,
+    )
+
+    if target_version is None:  # pragma: no cover - guarded upstream
+        raise click.ClickException("No target version available for upgrade dispatch.")
+
+    try:
+        uv_path, candidates = _resolve_uv_executable()
+    except UvExecutableNotFoundError as exc:  # pragma: no cover - defensive
+        raise click.ClickException(str(exc)) from exc
+    if uv_path is None:
+        raise click.ClickException(
+            "Could not locate `uv` executable for the upgrade worker. "
+            "Install uv for the service account or pin a known path. "
+            f"Probed: {', '.join(candidates) if candidates else '(none)'}."
+        )
+
+    if not task_exists():
+        # Most likely cause: this PC was upgraded into worker-aware
+        # code from auto-update without re-running ``service install``.
+        raise click.ClickException(
+            "Upgrade scheduled task 'DataHubWatcherUpgrade' is not registered. "
+            "Run 'data-hub-watcher service reinstall' as Administrator (or "
+            "'data-hub-watcher service install' if no service is currently "
+            "registered) and then retry 'data-hub-watcher self-update'."
+        )
+
+    extras = detect_installed_extras()
+    pkg_spec = build_pkg_spec(InstallMethod.UV_TOOL, target_version=target_version, extras=extras)
+
+    # Defensively clear any stale result sentinel from a prior
+    # upgrade so the post-restart evaluation can't misattribute an
+    # old result to this dispatch.
+    clear_upgrade_result(DEFAULT_CONFIG_DIR)
+
+    write_upgrade_marker(
+        DEFAULT_CONFIG_DIR,
+        target_version=target_version,
+        previous_version=current_version,
+    )
+    req = write_upgrade_request(
+        DEFAULT_CONFIG_DIR,
+        target_version=target_version,
+        pkg_spec=pkg_spec,
+        uv_executable=uv_path,
+        index_url=DEFAULT_INDEX_URL,
+        previous_version=current_version,
+        install_method=InstallMethod.UV_TOOL.value,
+    )
+
+    click.echo(
+        f"Dispatching upgrade {current_version} -> {target_version} via worker "
+        f"(request_id={req.request_id})..."
+    )
+    try:
+        trigger_upgrade_task()
+    except ScheduledTaskError as exc:
+        # Roll back the sentinels so a follow-up retry doesn't see a
+        # stale request lying around.
+        from data_hub_watcher.updater import clear_upgrade_marker
+
+        clear_upgrade_marker(DEFAULT_CONFIG_DIR)
+        clear_upgrade_request(DEFAULT_CONFIG_DIR)
+        raise click.ClickException(
+            f"Could not trigger the upgrade scheduled task: {exc}. "
+            "Run 'data-hub-watcher service reinstall' as Administrator and retry."
+        ) from exc
+
+    click.echo(
+        click.style(
+            f"\u2713 Upgrade dispatched. The service will stop, install "
+            f"{target_version}, and restart automatically.",
+            fg="green",
+        )
+    )
+    click.echo(
+        f"  Watch: data-hub-watcher service status\n"
+        f"  Tail:  {upgrade_worker_log_path(DEFAULT_CONFIG_DIR)}"
     )
 
 

--- a/watcher/src/data_hub_watcher/runtime.py
+++ b/watcher/src/data_hub_watcher/runtime.py
@@ -11,6 +11,7 @@ and thereby silently skipping manual-mode upload-queue polling.
 
 from __future__ import annotations
 import logging
+import re
 import sys
 import threading
 from dataclasses import dataclass, field
@@ -78,18 +79,29 @@ class ShutdownReason:
     stopped_message: str
 
 
+# uv's diagnostic lines start with ``error:`` (or ``Error:`` on a few
+# legacy code paths). Anchoring on the prefix lets us pick the actual
+# failure headline rather than picking up an incidental "error" /
+# "failed" inside an informational stderr line — e.g. progress chatter
+# from a vendored library that mentions "no errors so far".
+_UV_ERROR_LINE_RE = re.compile(r"^\s*error\s*:\s*(.+)$", re.IGNORECASE)
+
+
 def _summarize_worker_failure(result: object) -> str:
     """Produce a short, human-readable reason from an :class:`UpgradeResult`.
 
     The dashboard event message is one line wide. We try, in order:
 
-    1. The first non-empty line of stderr that mentions "error" or
-       "failed" — typically the actual ``uv`` error.
-    2. The worker's own ``error`` field, populated when uv couldn't
+    1. The first stderr line matching uv's ``error: <msg>`` convention —
+       this is uv's own headline for the actual failure.
+    2. As a fallback, the first stderr line whose lowercase text
+       contains ``error`` / ``failed`` / ``denied``. Covers tools that
+       don't follow the ``error:`` convention (PowerShell traps,
+       Windows API errors echoed by the worker).
+    3. The worker's own ``error`` field, populated when uv couldn't
        even be launched (e.g. ENOENT) so PowerShell trapped the
        exception.
-    3. A generic "subprocess exited <N>" if all we have is the
-       returncode.
+    4. A generic ``uv exited <N>`` if all we have is the returncode.
 
     The full stdout/stderr tails are still attached to the event
     details — this helper only picks the headline.
@@ -100,16 +112,22 @@ def _summarize_worker_failure(result: object) -> str:
         return "worker reported failure"
 
     if result.stderr_tail:
+        # Cap each candidate line so the event message stays one line
+        # wide — the full text is still in ``worker_stderr_tail`` for
+        # the dashboard expand.
         for line in result.stderr_tail.splitlines():
-            line = line.strip()
-            if not line:
+            stripped = line.strip()
+            match = _UV_ERROR_LINE_RE.match(stripped)
+            if match:
+                return stripped[:200]
+
+        for line in result.stderr_tail.splitlines():
+            stripped = line.strip()
+            if not stripped:
                 continue
-            lowered = line.lower()
+            lowered = stripped.lower()
             if "error" in lowered or "failed" in lowered or "denied" in lowered:
-                # Cap the line so it doesn't blow up the event
-                # message — the full text is still in
-                # ``worker_stderr_tail`` for the dashboard expand.
-                return line[:200]
+                return stripped[:200]
 
     if result.error:
         return f"worker exception: {result.error[:200]}"

--- a/watcher/src/data_hub_watcher/runtime.py
+++ b/watcher/src/data_hub_watcher/runtime.py
@@ -11,6 +11,7 @@ and thereby silently skipping manual-mode upload-queue polling.
 
 from __future__ import annotations
 import logging
+import sys
 import threading
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -28,6 +29,11 @@ from data_hub_watcher.monitor import FileMonitor
 from data_hub_watcher.run_detector import RunDetector
 from data_hub_watcher.state import StateDB
 from data_hub_watcher.updater import Updater, evaluate_upgrade_marker
+from data_hub_watcher.upgrade_worker import (
+    clear_upgrade_request,
+    clear_upgrade_result,
+    read_upgrade_result,
+)
 from data_hub_watcher.uploader import Uploader
 
 logger = logging.getLogger(__name__)
@@ -70,6 +76,59 @@ class ShutdownReason:
 
     is_upgrade_restart: bool
     stopped_message: str
+
+
+def _summarize_worker_failure(result: object) -> str:
+    """Produce a short, human-readable reason from an :class:`UpgradeResult`.
+
+    The dashboard event message is one line wide. We try, in order:
+
+    1. The first non-empty line of stderr that mentions "error" or
+       "failed" — typically the actual ``uv`` error.
+    2. The worker's own ``error`` field, populated when uv couldn't
+       even be launched (e.g. ENOENT) so PowerShell trapped the
+       exception.
+    3. A generic "subprocess exited <N>" if all we have is the
+       returncode.
+
+    The full stdout/stderr tails are still attached to the event
+    details — this helper only picks the headline.
+    """
+    from data_hub_watcher.upgrade_worker import UpgradeResult
+
+    if not isinstance(result, UpgradeResult):
+        return "worker reported failure"
+
+    if result.stderr_tail:
+        for line in result.stderr_tail.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            lowered = line.lower()
+            if "error" in lowered or "failed" in lowered or "denied" in lowered:
+                # Cap the line so it doesn't blow up the event
+                # message — the full text is still in
+                # ``worker_stderr_tail`` for the dashboard expand.
+                return line[:200]
+
+    if result.error:
+        return f"worker exception: {result.error[:200]}"
+
+    if result.returncode not in (0, None):
+        return f"uv exited {result.returncode}"
+
+    return "worker reported failure"
+
+
+def _expecting_worker_result(outcome: object) -> bool:
+    """Return whether the marker we just consumed was a worker dispatch.
+
+    Today this is only true on Windows (the worker is the sole
+    out-of-process upgrade path). Pulled out as a helper so we can
+    grow it later (e.g. a per-marker ``via_worker`` flag) without
+    duplicating the gating logic at every call site.
+    """
+    return sys.platform == "win32"
 
 
 def classify_shutdown(rt: WatcherRuntime, *, role: str) -> ShutdownReason:
@@ -240,7 +299,75 @@ def start_runtime(rt: WatcherRuntime, *, started_message: str) -> None:
 
     outcome = evaluate_upgrade_marker(DEFAULT_CONFIG_DIR)
     if outcome.found:
-        if outcome.succeeded:
+        # Out-of-process upgrades (the Windows uv-tool worker) drop a
+        # ``.upgrade-result.json`` sentinel alongside the marker. The
+        # worker's exit code is more authoritative than the marker
+        # comparison: a partial install can update some files (and
+        # even report a matching version on restart) while uv itself
+        # exited non-zero halfway through — historically those
+        # "partial" failures masqueraded as "expected X, running Y"
+        # and the actual installer error never surfaced to the
+        # dashboard. Trust the worker's ``succeeded`` flag whenever
+        # it's present.
+        worker_result = read_upgrade_result(DEFAULT_CONFIG_DIR)
+
+        worker_failed = worker_result is not None and not worker_result.succeeded
+        worker_warned = (
+            worker_result is not None
+            and worker_result.succeeded
+            and (worker_result.returncode not in (0, None) or worker_result.error)
+        )
+
+        if worker_failed:
+            assert worker_result is not None
+            # Worker explicitly reported failure. Build a concrete
+            # reason from its captured output so the dashboard event
+            # tells the operator exactly which uv error fired,
+            # rather than the generic "expected X, running Y" that
+            # the marker comparison alone would produce.
+            reason = _summarize_worker_failure(worker_result)
+            details: dict[str, object] = {
+                "previous_version": outcome.previous_version,
+                "target_version": outcome.target_version,
+                "reason": reason,
+                "via_worker": True,
+                "worker_returncode": worker_result.returncode,
+                "worker_stdout_tail": worker_result.stdout_tail,
+                "worker_stderr_tail": worker_result.stderr_tail,
+                "worker_error": worker_result.error,
+                "worker_request_id": worker_result.request_id,
+                # The marker's own classification is preserved as
+                # ``marker_reason`` so the dashboard can show "uv
+                # said: X / marker said: Y" when they disagree.
+                "marker_succeeded": outcome.succeeded,
+                "marker_reason": outcome.reason,
+            }
+            rt.reporter.queue_event(
+                WatcherEvent(
+                    event_type=EventType.UPDATE_FAILED,
+                    message=f"Watcher upgrade to {outcome.target_version} failed: {reason}",
+                    details=details,
+                )
+            )
+        elif outcome.succeeded:
+            details = {
+                "previous_version": outcome.previous_version,
+                "target_version": outcome.target_version,
+            }
+            if worker_result is not None:
+                details["via_worker"] = True
+                details["worker_returncode"] = worker_result.returncode
+                details["worker_stdout_tail"] = worker_result.stdout_tail
+                details["worker_stderr_tail"] = worker_result.stderr_tail
+                details["worker_request_id"] = worker_result.request_id
+                # If the worker reported success but had non-empty
+                # stderr or a non-zero returncode that we tolerated
+                # (e.g. uv printing a deprecation warning to stderr),
+                # surface that as a soft warning alongside the
+                # success event so an operator can investigate
+                # without being paged.
+                if worker_warned:
+                    details["worker_warning"] = True
             rt.reporter.queue_event(
                 WatcherEvent(
                     event_type=EventType.UPDATE_SUCCEEDED,
@@ -248,24 +375,47 @@ def start_runtime(rt: WatcherRuntime, *, started_message: str) -> None:
                         f"Restarted into upgraded watcher "
                         f"{outcome.previous_version} -> {outcome.target_version}"
                     ),
-                    details={
-                        "previous_version": outcome.previous_version,
-                        "target_version": outcome.target_version,
-                    },
+                    details=details,
                 )
             )
         else:
+            # No worker result OR worker said success but the
+            # restart didn't actually load the new version. In
+            # either case the marker's "expected X, running Y"
+            # classification is the most informative signal.
+            details = {
+                "previous_version": outcome.previous_version,
+                "target_version": outcome.target_version,
+                "reason": outcome.reason,
+            }
+            if worker_result is not None:
+                details["via_worker"] = True
+                details["worker_returncode"] = worker_result.returncode
+                details["worker_stdout_tail"] = worker_result.stdout_tail
+                details["worker_stderr_tail"] = worker_result.stderr_tail
+                details["worker_error"] = worker_result.error
+                details["worker_request_id"] = worker_result.request_id
+            elif _expecting_worker_result(outcome):
+                # Marker says we dispatched via the worker (target
+                # known, this is a Windows host) but no result
+                # sentinel landed. Either the worker crashed mid-run
+                # or never started. Surface that explicitly so an
+                # operator knows to check ``upgrade-worker.log``.
+                details["worker_result_missing"] = True
             rt.reporter.queue_event(
                 WatcherEvent(
                     event_type=EventType.UPDATE_FAILED,
                     message=f"Watcher upgrade did not take effect: {outcome.reason}",
-                    details={
-                        "previous_version": outcome.previous_version,
-                        "target_version": outcome.target_version,
-                        "reason": outcome.reason,
-                    },
+                    details=details,
                 )
             )
+
+        # Always clear both worker sentinels on the post-restart
+        # inspection so a stale result from a prior upgrade can't
+        # leak into the next one. Mirrors the marker's "consumed on
+        # read" lifecycle in ``evaluate_upgrade_marker``.
+        clear_upgrade_result(DEFAULT_CONFIG_DIR)
+        clear_upgrade_request(DEFAULT_CONFIG_DIR)
 
     # Rebuild in-memory run state from the local DB before any file
     # events fire. Without this, every restart starts with an empty

--- a/watcher/src/data_hub_watcher/scheduled_task.py
+++ b/watcher/src/data_hub_watcher/scheduled_task.py
@@ -1,0 +1,243 @@
+"""Thin wrapper over Windows Task Scheduler (``schtasks.exe``).
+
+Used by the out-of-process upgrade worker (see
+:mod:`data_hub_watcher.upgrade_worker`) to register a SYSTEM-owned,
+on-demand-only task whose action is the worker PowerShell script. We
+shell out to ``schtasks.exe`` rather than using the ``taskschd`` COM
+API (via pywin32) for two reasons:
+
+1. ``schtasks.exe`` ships with every supported Windows version and
+   has stable behaviour going back to Windows XP. The COM API is
+   richer but its idempotency story (in particular, replacing an
+   existing task) is finicky and version-sensitive.
+2. We already pull in pywin32 only when the ``[windows-service]``
+   extra is installed; gating an unrelated COM dependency on the
+   same extra would be confusing, while ``subprocess`` works
+   regardless of how the watcher was installed.
+
+All public functions are import-safe on every platform — they only
+touch ``schtasks.exe`` at call time, so the module can be imported
+from cross-platform code paths (e.g. the ``Updater``) and gated on
+``sys.platform == "win32"`` at the call sites.
+"""
+
+from __future__ import annotations
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# Default task name. Centralised so the install / trigger / uninstall
+# helpers can't drift, and so the dashboard can include it verbatim in
+# the "stuck task" troubleshooting entry.
+UPGRADE_TASK_NAME = "DataHubWatcherUpgrade"
+
+# How long to wait for ``schtasks.exe`` to respond before giving up.
+# Local SCM operations are fast (sub-second) but a heavily loaded
+# system or a hung Task Scheduler service could in principle wedge,
+# and we'd rather surface a clear timeout to the operator than block
+# the heartbeat thread indefinitely.
+_SCHTASKS_TIMEOUT_SECONDS = 30.0
+
+
+class ScheduledTaskError(RuntimeError):
+    """Raised when ``schtasks.exe`` fails or is unavailable.
+
+    Carries the underlying argv and captured stderr so the caller can
+    attach both to a dashboard event without having to log them
+    separately. The message is kept short and actionable so it reads
+    well as a single-line ``UPDATE_FAILED.reason``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        argv: list[str] | None = None,
+        stderr: str = "",
+        returncode: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.argv = list(argv) if argv else []
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def _run_schtasks(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Invoke ``schtasks.exe`` with *args*; raise on argv-level failures only.
+
+    Returns the :class:`subprocess.CompletedProcess` so callers can
+    inspect ``returncode`` themselves — different ``schtasks`` verbs
+    have different "this is fine" exit codes (notably ``/Query`` and
+    ``/Delete`` both return 1 for "task does not exist") and bundling
+    that classification here would force every caller to second-guess
+    us. We only raise for the cases where ``schtasks`` itself couldn't
+    even be invoked.
+    """
+    cmd = ["schtasks.exe", *args]
+    try:
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_SCHTASKS_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError as exc:
+        # Vanishingly rare on a real Windows host but worth a typed
+        # error since the diagnosis is unambiguous: PATH is wrong or
+        # the host is missing system32.
+        raise ScheduledTaskError(
+            "schtasks.exe not found on PATH",
+            argv=cmd,
+            stderr=str(exc),
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise ScheduledTaskError(
+            f"schtasks.exe timed out after {_SCHTASKS_TIMEOUT_SECONDS:.0f}s",
+            argv=cmd,
+            stderr=(exc.stderr.decode("utf-8", errors="replace") if exc.stderr else ""),
+        ) from exc
+
+
+def install_upgrade_task(
+    script_path: Path,
+    *,
+    task_name: str = UPGRADE_TASK_NAME,
+) -> None:
+    """Register the upgrade worker as an on-demand SYSTEM-owned task.
+
+    Idempotent: ``/F`` overwrites an existing task with the same name
+    so a ``service reinstall`` (or a future change to the worker
+    script) cleanly replaces the previous registration without leaving
+    the host with two competing definitions.
+
+    Raises :class:`ScheduledTaskError` when ``schtasks.exe`` itself
+    fails — the caller (typically ``install_service``) surfaces this
+    to the operator as an actionable error rather than silently
+    leaving the host without an upgrade path.
+
+    Notes on the chosen schtasks flags:
+
+    * ``/SC ONCE`` + ``/ST 00:00`` + ``/SD <past-date>``: ``schtasks``
+      requires a schedule even for tasks that will only ever be run
+      on demand. A one-shot trigger in the past is the documented
+      idiom for "this task only ever fires when an explicit
+      ``/Run`` invokes it".
+    * ``/RU SYSTEM``: the worker needs to ``Stop-Service`` /
+      ``Start-Service`` the watcher; SYSTEM is the only built-in
+      principal guaranteed to have those rights and to also be able
+      to write under ``%UserProfile%\\.data-hub`` regardless of which
+      account installed the service.
+    * ``/RL HIGHEST``: makes the task run with the highest privileges
+      its principal supports. Belt-and-braces for SYSTEM, but means
+      a future move to a less-privileged service account (e.g.
+      Network Service) won't silently hit a permission ceiling.
+    * ``/IT N``: the task is non-interactive, so it doesn't need to
+      run while a user is logged on. Fleet lab PCs frequently sit at
+      a locked screen with no interactive session for days at a time.
+    """
+    powershell_path = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+    action = f'"{powershell_path}" -ExecutionPolicy Bypass -NoProfile -File "{script_path}"'
+
+    args = [
+        "/Create",
+        "/TN",
+        task_name,
+        "/TR",
+        action,
+        "/SC",
+        "ONCE",
+        "/ST",
+        "00:00",
+        "/SD",
+        "01/01/2020",
+        "/RU",
+        "SYSTEM",
+        "/RL",
+        "HIGHEST",
+        "/F",
+    ]
+    logger.info(
+        "Registering Windows scheduled task %s for upgrade worker %s",
+        task_name,
+        script_path,
+    )
+    result = _run_schtasks(args)
+    if result.returncode != 0:
+        raise ScheduledTaskError(
+            f"schtasks /Create failed for {task_name!r}",
+            argv=["schtasks.exe", *args],
+            stderr=(result.stderr or result.stdout or "").strip(),
+            returncode=result.returncode,
+        )
+
+
+def trigger_upgrade_task(*, task_name: str = UPGRADE_TASK_NAME) -> None:
+    """Run the upgrade task immediately (asynchronously).
+
+    ``schtasks /Run`` returns as soon as Task Scheduler accepts the
+    request — the worker process keeps running independently. This is
+    exactly what we want: the watcher's heartbeat thread does not
+    block on the upgrade.
+
+    Raises :class:`ScheduledTaskError` when ``schtasks`` fails to even
+    accept the request (typically because the task isn't registered).
+    """
+    args = ["/Run", "/TN", task_name]
+    logger.info("Triggering Windows scheduled task %s", task_name)
+    result = _run_schtasks(args)
+    if result.returncode != 0:
+        raise ScheduledTaskError(
+            f"schtasks /Run failed for {task_name!r}",
+            argv=["schtasks.exe", *args],
+            stderr=(result.stderr or result.stdout or "").strip(),
+            returncode=result.returncode,
+        )
+
+
+def uninstall_upgrade_task(*, task_name: str = UPGRADE_TASK_NAME) -> None:
+    """Remove the upgrade task. Idempotent: missing task is treated as success.
+
+    Used by ``uninstall_service`` and indirectly by ``service
+    reinstall``. We deliberately swallow the "task does not exist"
+    error code rather than raising, so a half-installed host (e.g. an
+    operator who ran ``service install`` before this code shipped) can
+    still go through ``service uninstall`` without an extra cleanup
+    step.
+    """
+    args = ["/Delete", "/TN", task_name, "/F"]
+    logger.info("Removing Windows scheduled task %s", task_name)
+    result = _run_schtasks(args)
+    if result.returncode == 0:
+        return
+    # schtasks /Delete prints "ERROR: The system cannot find the file
+    # specified." to stderr (and exits 1) when the task isn't there.
+    # That's not an error from our perspective — we just want the
+    # task gone.
+    combined = f"{result.stdout or ''}\n{result.stderr or ''}".lower()
+    if "cannot find" in combined or "does not exist" in combined:
+        logger.debug("Scheduled task %s was already absent", task_name)
+        return
+    raise ScheduledTaskError(
+        f"schtasks /Delete failed for {task_name!r}",
+        argv=["schtasks.exe", *args],
+        stderr=(result.stderr or result.stdout or "").strip(),
+        returncode=result.returncode,
+    )
+
+
+def task_exists(*, task_name: str = UPGRADE_TASK_NAME) -> bool:
+    """Return whether *task_name* is registered with Task Scheduler.
+
+    Used by the service startup path to lazily reinstall the task on
+    fleet PCs that auto-updated into this code without re-running
+    ``service install``. A ``False`` return triggers the recovery
+    branch; a :class:`ScheduledTaskError` is treated as "we can't
+    tell" and surfaces upstream so the failure is at least visible.
+    """
+    args = ["/Query", "/TN", task_name]
+    result = _run_schtasks(args)
+    return result.returncode == 0

--- a/watcher/src/data_hub_watcher/self_update.py
+++ b/watcher/src/data_hub_watcher/self_update.py
@@ -335,12 +335,18 @@ def build_upgrade_command(
     index_url: str | None = None,
     python_executable: str | None = None,
     uv_executable: str | None = None,
+    extras: list[str] | None = None,
 ) -> list[str]:
     """Translate an install method into the concrete subprocess argv.
 
     Pinning *target_version* lets the server roll a specific release out
     rather than always landing on whatever the index calls "latest" — which
     matters when we want to roll back by re-pinning to an older version.
+
+    *extras* preserves any optional dependencies the original install
+    requested (e.g. ``["windows-service"]`` so ``pywin32`` survives a
+    reinstall). Defaults to ``None`` for back-compat with the legacy
+    in-process call sites that don't yet pass it.
 
     Raises :class:`UvExecutableNotFoundError` when *method* is
     ``UV_TOOL`` but no ``uv`` binary can be located. Previously this
@@ -349,7 +355,12 @@ def build_upgrade_command(
     from ``subprocess.run`` — raising a typed error here lets the
     caller emit a diagnosable ``UPDATE_FAILED`` event instead.
     """
-    pkg_spec = PACKAGE_NAME if not target_version else f"{PACKAGE_NAME}=={target_version}"
+    # Build the package spec inline rather than importing from
+    # ``upgrade_worker`` to avoid a circular import (the worker module
+    # imports from this one for ``PACKAGE_NAME`` / ``InstallMethod``).
+    extras_part = f"[{','.join(sorted(extras))}]" if extras else ""
+    base_spec = f"{PACKAGE_NAME}{extras_part}"
+    pkg_spec = base_spec if not target_version else f"{base_spec}=={target_version}"
     index = index_url or DEFAULT_INDEX_URL
 
     if method is InstallMethod.UV_TOOL:
@@ -381,6 +392,7 @@ def run_upgrade(
     *,
     target_version: str | None = None,
     index_url: str | None = None,
+    extras: list[str] | None = None,
     runner: Any = subprocess.run,
 ) -> subprocess.CompletedProcess[str]:
     """Execute the upgrade subprocess and capture stdout/stderr.
@@ -396,6 +408,11 @@ def run_upgrade(
             "Upgrade manually with `git pull && uv sync` instead."
         )
 
-    cmd = build_upgrade_command(method, target_version=target_version, index_url=index_url)
+    cmd = build_upgrade_command(
+        method,
+        target_version=target_version,
+        index_url=index_url,
+        extras=extras,
+    )
     logger.info("Running watcher self-update: %s", " ".join(cmd))
     return runner(cmd, capture_output=True, text=True, check=False)

--- a/watcher/src/data_hub_watcher/service.py
+++ b/watcher/src/data_hub_watcher/service.py
@@ -22,7 +22,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from data_hub_watcher.constants import SERVICE_NAME
+from data_hub_watcher.constants import DEFAULT_CONFIG_DIR, SERVICE_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +85,26 @@ def install_service(config_path: Path, env_path: Path) -> None:
 
     _store_paths_in_registry(config_path, env_path)
     _configure_recovery()
+    _install_upgrade_worker()
     logger.info("Service '%s' installed successfully", SERVICE_NAME)
+
+
+def _install_upgrade_worker() -> None:
+    """Drop the upgrade-worker PowerShell script and register the task.
+
+    Splits cleanly from ``install_service`` so unit tests can patch
+    just this function out (the SCM bits don't need to know about the
+    upgrade worker, and the upgrade-worker bits don't need a real
+    ``win32serviceutil`` to test). Failure here is logged but
+    re-raised so the operator running ``service install`` sees a clear
+    error rather than a silently-broken auto-update path.
+    """
+    from data_hub_watcher.scheduled_task import install_upgrade_task
+    from data_hub_watcher.upgrade_worker import write_worker_script
+
+    script_path = write_worker_script(DEFAULT_CONFIG_DIR, service_name=SERVICE_NAME)
+    install_upgrade_task(script_path)
+    logger.info("Upgrade worker script + scheduled task registered")
 
 
 def _store_paths_in_registry(config_path: Path, env_path: Path) -> None:
@@ -214,9 +233,36 @@ def uninstall_service() -> None:
     except Exception:
         pass  # already stopped or doesn't exist
 
+    _uninstall_upgrade_worker()
     _delete_paths_from_registry()
     win32serviceutil.RemoveService(SERVICE_NAME)
     logger.info("Service '%s' removed", SERVICE_NAME)
+
+
+def _uninstall_upgrade_worker() -> None:
+    """Best-effort removal of the upgrade-worker scheduled task + script.
+
+    Idempotent (the underlying ``schtasks /Delete`` swallows
+    "task does not exist") and tolerant of older installs that never
+    registered the task — we don't want to block ``uninstall_service``
+    on a clean slate that's already clean.
+    """
+    from data_hub_watcher.scheduled_task import (
+        ScheduledTaskError,
+        uninstall_upgrade_task,
+    )
+    from data_hub_watcher.upgrade_worker import upgrade_worker_script_path
+
+    try:
+        uninstall_upgrade_task()
+    except ScheduledTaskError as exc:
+        logger.warning("Could not remove upgrade scheduled task: %s", exc)
+
+    script_path = upgrade_worker_script_path(DEFAULT_CONFIG_DIR)
+    try:
+        script_path.unlink(missing_ok=True)
+    except OSError as exc:
+        logger.warning("Could not remove upgrade worker script %s: %s", script_path, exc)
 
 
 def wait_for_service_removed(
@@ -325,6 +371,61 @@ def query_service_status() -> dict[str, Any]:
         ws.CloseServiceHandle(hscm)
 
 
+def _repair_upgrade_worker_if_missing(sm: Any) -> None:
+    """Re-install the upgrade scheduled task on startup if it has gone missing.
+
+    Lab PCs that auto-update into the version that introduced the
+    out-of-process worker won't have run ``service install`` with the
+    new code, so the scheduled task simply isn't there — and the next
+    auto-update tick would fail loudly. Repairing on each service
+    startup means the host self-heals on the very next service restart
+    (which the auto-updater triggers anyway), without any operator
+    intervention.
+
+    Failures are logged via the Windows event log but do not raise:
+    a host that can't register the task should still be able to run
+    the watcher in its current version. The next auto-update attempt
+    will surface the missing task as an ``UPDATE_FAILED`` event with
+    a clearer reason.
+    """
+    try:
+        from data_hub_watcher.scheduled_task import (
+            ScheduledTaskError,
+            install_upgrade_task,
+            task_exists,
+        )
+        from data_hub_watcher.upgrade_worker import write_worker_script
+    except Exception as exc:
+        sm.LogWarningMsg(f"Cannot import upgrade worker modules during startup: {exc}")
+        return
+
+    try:
+        present = task_exists()
+    except ScheduledTaskError as exc:
+        sm.LogWarningMsg(
+            f"Could not query upgrade scheduled task: {exc}. "
+            "Auto-update may be unavailable until 'data-hub-watcher service "
+            "reinstall' is run."
+        )
+        return
+
+    if present:
+        return
+
+    sm.LogInfoMsg(
+        "Upgrade scheduled task missing; re-registering it now (one-time "
+        "self-repair after auto-update into worker-aware code)."
+    )
+    try:
+        script_path = write_worker_script(DEFAULT_CONFIG_DIR, service_name=SERVICE_NAME)
+        install_upgrade_task(script_path)
+    except (OSError, ScheduledTaskError) as exc:
+        sm.LogWarningMsg(
+            f"Failed to register upgrade scheduled task: {exc}. "
+            "Run 'data-hub-watcher service reinstall' as Administrator to retry."
+        )
+
+
 def _run_service_loop(stop_event: threading.Event, sm: Any) -> None:
     """Run the watcher service loop until *stop_event* is set.
 
@@ -365,6 +466,8 @@ def _run_service_loop(stop_event: threading.Event, sm: Any) -> None:
     )
 
     sm.LogInfoMsg(f"{SERVICE_DISPLAY_NAME} starting")
+
+    _repair_upgrade_worker_if_missing(sm)
 
     try:
         path, env_path = _read_paths_from_registry()

--- a/watcher/src/data_hub_watcher/service.py
+++ b/watcher/src/data_hub_watcher/service.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import logging
 import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any
 
@@ -31,6 +32,12 @@ SERVICE_DESCRIPTION = "Monitors instrument directories and uploads data files to
 _REG_KEY = rf"SYSTEM\CurrentControlSet\Services\{SERVICE_NAME}"
 _REG_CONFIG_PATH = "ConfigPath"
 _REG_ENV_PATH = "EnvPath"
+
+# Win32 system error codes returned by ``OpenService`` / ``CreateService``
+# while a service is in the asynchronous DeleteService teardown window.
+# Documented at https://learn.microsoft.com/windows/win32/debug/system-error-codes--1000-1299-.
+_ERROR_SERVICE_DOES_NOT_EXIST = 1060
+_ERROR_SERVICE_MARKED_FOR_DELETE = 1072
 
 # Windows services that must be running before the watcher can usefully
 # contact the Data Hub API. Declaring these as dependencies makes the SCM
@@ -210,6 +217,60 @@ def uninstall_service() -> None:
     _delete_paths_from_registry()
     win32serviceutil.RemoveService(SERVICE_NAME)
     logger.info("Service '%s' removed", SERVICE_NAME)
+
+
+def wait_for_service_removed(
+    *,
+    timeout_seconds: float = 30.0,
+    poll_interval_seconds: float = 0.5,
+) -> bool:
+    """Block until the service is fully removed from the SCM, or *timeout* elapses.
+
+    ``DeleteService`` (called via ``win32serviceutil.RemoveService``) is
+    asynchronous: Windows only *marks* the service for deletion, and the
+    actual record is removed once every open handle to it is closed —
+    including handles held by ``services.msc``, Event Viewer's "Services"
+    pane, Task Manager, and some antivirus / EDR agents that enumerate
+    services.  Until that happens, ``CreateService`` with the same name
+    fails with ``ERROR_SERVICE_MARKED_FOR_DELETE`` (1072), which is the
+    confusing error operators see when ``service reinstall`` runs back-to-
+    back uninstall + install on a host with the Services console open.
+
+    We poll the SCM with ``OpenService``: the service is fully gone the
+    moment that call raises ``ERROR_SERVICE_DOES_NOT_EXIST`` (1060).
+    Returns ``True`` if the service disappeared inside the deadline,
+    ``False`` if it's still hanging around — callers should treat the
+    latter as actionable (close ``services.msc`` and retry) rather than
+    a fatal SCM error.
+    """
+    import pywintypes  # type: ignore[import-untyped]
+    import win32service as ws  # type: ignore[import-untyped]
+
+    deadline = time.monotonic() + timeout_seconds
+    hscm = ws.OpenSCManager(None, None, ws.SC_MANAGER_CONNECT)
+    try:
+        while True:
+            try:
+                hs = ws.OpenService(hscm, SERVICE_NAME, ws.SERVICE_QUERY_STATUS)
+            except pywintypes.error as exc:
+                # winerror lives at index 0 of the (code, func, msg) tuple
+                # but pywintypes.error also exposes it as an attribute on
+                # modern pywin32. Prefer the attribute, fall back to args
+                # so this works against the MagicMock-based test fakes.
+                code = getattr(exc, "winerror", None)
+                if code is None and exc.args:
+                    code = exc.args[0]
+                if code == _ERROR_SERVICE_DOES_NOT_EXIST:
+                    return True
+                raise
+            else:
+                ws.CloseServiceHandle(hs)
+
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(poll_interval_seconds)
+    finally:
+        ws.CloseServiceHandle(hscm)
 
 
 def start_service() -> None:

--- a/watcher/src/data_hub_watcher/updater.py
+++ b/watcher/src/data_hub_watcher/updater.py
@@ -23,6 +23,7 @@ is then cleared so a single failure isn't reported indefinitely.
 from __future__ import annotations
 import json
 import logging
+import sys
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -36,14 +37,21 @@ from data_hub_watcher.events import EventReporter, EventType, WatcherEvent
 from data_hub_watcher.heartbeat import WatcherCounters
 from data_hub_watcher.models import WatcherConfig, WatcherUpdateInfoResponse
 from data_hub_watcher.self_update import (
+    DEFAULT_INDEX_URL,
     InstallMethod,
     UvExecutableNotFoundError,
+    _resolve_uv_executable,
     build_upgrade_command,
     detect_install_method,
     evaluate_update,
     run_upgrade,
 )
 from data_hub_watcher.state import StateDB
+from data_hub_watcher.upgrade_worker import (
+    build_pkg_spec,
+    detect_installed_extras,
+    write_upgrade_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -458,6 +466,26 @@ class Updater:
                 self._last_refused_target = target
             return UpdateAttemptResult(True, False, reason, target, {"method": method.value})
 
+        # Windows uv-tool installs cannot reinstall in-process: the
+        # service's own ``Scripts\\python.exe`` is the file ``uv``
+        # would need to delete. Route those through the SYSTEM-owned
+        # scheduled-task worker instead, which stops the service
+        # before invoking ``uv``. POSIX uv-tool, Windows pip, and
+        # POSIX pip continue to use the inline subprocess path —
+        # they don't have the lock issue and the inline path gives
+        # the dashboard live UPDATE_STARTED → UPDATE_FAILED pairing
+        # without an extra hop through a sentinel file.
+        if sys.platform == "win32" and method is InstallMethod.UV_TOOL:
+            return self._apply_via_worker(info, method, target)
+
+        return self._apply_in_process(info, method, target)
+
+    def _apply_in_process(
+        self,
+        info: WatcherUpdateInfoResponse,
+        method: InstallMethod,
+        target: str,
+    ) -> UpdateAttemptResult:
         # Resolve the upgrade argv up-front. Doing this before we emit
         # UPDATE_STARTED / write the marker means a missing `uv` binary
         # (the Windows-service / LocalSystem PATH failure mode) becomes
@@ -558,17 +586,36 @@ class Updater:
                     outcome.append(UpdateAttemptResult(True, False, str(exc), target))
                     return
 
+                # Always log the subprocess output to ``watcher.log``
+                # regardless of returncode. Historically the only
+                # signal we had on a partial-install (uv exits 0
+                # despite cleanup failures, or the auto-updater
+                # mis-classifies the exit code) was the marker
+                # comparison on the next startup — by which point
+                # the actual installer error was already lost.
+                # Mirroring the output to the local log keeps it
+                # recoverable on a lab PC even when the dashboard
+                # event ends up incomplete.
+                stdout_tail = (result.stdout or "")[-1000:]
+                stderr_tail = (result.stderr or "")[-1000:]
+                logger.info(
+                    "Upgrade subprocess exited %d (stdout tail): %s",
+                    result.returncode,
+                    stdout_tail or "(empty)",
+                )
+                if stderr_tail:
+                    log_method = logger.warning if result.returncode != 0 else logger.info
+                    log_method("Upgrade subprocess stderr tail: %s", stderr_tail)
+
                 if result.returncode != 0:
-                    stdout = (result.stdout or "")[-1000:]
-                    stderr = (result.stderr or "")[-1000:]
                     self._emit_failure(
                         target,
                         f"subprocess exited {result.returncode}",
                         extra={
                             "install_method": method.value,
                             "command": command,
-                            "stdout_tail": stdout,
-                            "stderr_tail": stderr,
+                            "stdout_tail": stdout_tail,
+                            "stderr_tail": stderr_tail,
                         },
                     )
                     outcome.append(
@@ -612,6 +659,154 @@ class Updater:
             reason="upgrade subprocess dispatched (running off-thread)",
             target_version=target,
             extra={"in_progress": True, "method": method.value},
+        )
+
+    def _apply_via_worker(
+        self,
+        info: WatcherUpdateInfoResponse,
+        method: InstallMethod,
+        target: str,
+    ) -> UpdateAttemptResult:
+        """Dispatch an upgrade through the SYSTEM-owned scheduled task.
+
+        Used on Windows uv-tool installs where the in-process
+        ``uv tool install --reinstall`` cannot complete because it
+        would need to delete ``Scripts\\python.exe`` while it's
+        mapped into the running service. The worker stops the service
+        first, runs ``uv``, then starts the service again — we just
+        write the request sentinel and trigger the task.
+
+        Pre-flight failures (no ``uv`` on disk, ``schtasks`` refuses
+        the trigger) are surfaced as ``UPDATE_FAILED`` events with no
+        preceding ``UPDATE_STARTED`` so the dashboard doesn't show a
+        ghost in-flight upgrade. The success / final-failure events
+        are emitted from the post-restart marker evaluation in
+        :mod:`data_hub_watcher.runtime`, which reads the result
+        sentinel the worker drops on disk.
+        """
+        # Lazy import keeps non-Windows test runs from importing the
+        # scheduled-task wrapper (which itself is import-safe today
+        # but might pull in win32 helpers later).
+        from data_hub_watcher.scheduled_task import (
+            ScheduledTaskError,
+            trigger_upgrade_task,
+        )
+
+        uv_path, candidates = _resolve_uv_executable()
+        if uv_path is None:
+            reason = "uv executable not found"
+            logger.warning("Refusing auto-update via worker: %s", reason)
+            self._emit_failure(
+                target,
+                reason,
+                extra={
+                    "install_method": method.value,
+                    "attempted_subprocess": False,
+                    "via_worker": True,
+                    "candidates_tried": candidates,
+                },
+            )
+            return UpdateAttemptResult(True, False, reason, target, {"method": method.value})
+
+        extras = detect_installed_extras()
+        try:
+            pkg_spec = build_pkg_spec(method, target_version=target, extras=extras)
+        except ValueError as exc:
+            # Defensive — we already filtered EDITABLE / UNKNOWN above.
+            self._emit_failure(
+                target,
+                f"could not build pkg spec: {exc}",
+                extra={"install_method": method.value, "attempted_subprocess": False},
+            )
+            return UpdateAttemptResult(True, False, str(exc), target)
+
+        details_started: dict[str, Any] = {
+            "current_version": WATCHER_VERSION,
+            "target_version": target,
+            "channel": info.channel,
+            "mandatory": info.mandatory,
+            "install_method": method.value,
+            "via_worker": True,
+            "pkg_spec": pkg_spec,
+        }
+        self._reporter.queue_event(
+            WatcherEvent(
+                event_type=EventType.UPDATE_STARTED,
+                message=f"Dispatching upgrade {WATCHER_VERSION} -> {target} via worker",
+                details=details_started,
+            )
+        )
+        # Flush before triggering so the dashboard sees the start
+        # even if the service is stopped almost immediately by the
+        # worker (the heartbeat loop doesn't get another chance to
+        # flush before SCM tears it down).
+        self._reporter.flush()
+
+        write_upgrade_marker(
+            self._config_dir,
+            target_version=target,
+            previous_version=WATCHER_VERSION,
+        )
+        write_upgrade_request(
+            self._config_dir,
+            target_version=target,
+            pkg_spec=pkg_spec,
+            uv_executable=uv_path,
+            index_url=DEFAULT_INDEX_URL,
+            previous_version=WATCHER_VERSION,
+            install_method=method.value,
+        )
+
+        try:
+            trigger_upgrade_task()
+        except ScheduledTaskError as exc:
+            # ``schtasks`` refused — most commonly because the task
+            # isn't registered (fleet PC that auto-updated into the
+            # worker-aware code without re-running ``service install``).
+            # Clear our own sentinels so the next tick can try again
+            # from a clean slate, and surface the failure with a
+            # specific reason that points at the recovery command.
+            logger.warning("schtasks /Run failed: %s", exc)
+            clear_upgrade_marker(self._config_dir)
+            from data_hub_watcher.upgrade_worker import clear_upgrade_request
+
+            clear_upgrade_request(self._config_dir)
+            self._emit_failure(
+                target,
+                "scheduled task could not be triggered; "
+                "run 'data-hub-watcher service reinstall' as Administrator",
+                extra={
+                    "install_method": method.value,
+                    "attempted_subprocess": False,
+                    "via_worker": True,
+                    "schtasks_argv": exc.argv,
+                    "schtasks_stderr": exc.stderr,
+                    "schtasks_returncode": exc.returncode,
+                    "error_class": type(exc).__name__,
+                },
+            )
+            return UpdateAttemptResult(
+                True,
+                False,
+                "scheduled task trigger failed",
+                target,
+                {"method": method.value, "via_worker": True},
+            )
+
+        # The worker stops the service before invoking ``uv``, so we
+        # don't expect to be alive much longer. The success /
+        # final-failure event is emitted from the next process's
+        # post-restart marker evaluation. We do NOT call
+        # ``_request_upgrade_restart`` here — the worker drives the
+        # service lifecycle (Stop-Service then Start-Service)
+        # directly via ``schtasks``, bypassing SCM's failure-actions
+        # restart path entirely.
+        return UpdateAttemptResult(
+            attempted=True,
+            succeeded=None,
+            reason="upgrade dispatched to scheduled task",
+            target_version=target,
+            extra={"method": method.value, "via_worker": True},
         )
 
     def _emit_failure(

--- a/watcher/src/data_hub_watcher/upgrade_worker.py
+++ b/watcher/src/data_hub_watcher/upgrade_worker.py
@@ -1,0 +1,577 @@
+"""Out-of-process Windows upgrade worker scaffolding.
+
+On Windows, ``uv tool install --reinstall`` recreates the venv's
+``Scripts\\`` directory, including the ``python.exe`` that the running
+service was launched with. Windows takes an exclusive lock on any
+mapped executable, so the in-process upgrade subprocess fails with
+``Access is denied. (os error 5)`` when it tries to remove that
+directory. This is a structural problem, not a permissions one — we
+need to drive the upgrade from a process tree that does *not* contain
+the service's interpreter.
+
+The fix lives in three pieces:
+
+1. This module defines the on-disk **sentinels** the watcher uses to
+   communicate with the worker (``.upgrade-request.json`` for the
+   inbound request, ``.upgrade-result.json`` for the outbound result),
+   the **package spec** computed from the current install (preserving
+   any extras that were originally installed — historically the
+   in-process path silently dropped ``[windows-service]`` and broke
+   pywin32), and the **PowerShell worker template** itself.
+2. :mod:`data_hub_watcher.scheduled_task` drops the rendered worker
+   onto disk and registers it as an on-demand SYSTEM-owned Windows
+   Scheduled Task.
+3. :mod:`data_hub_watcher.updater` and ``cli.self_update`` write the
+   request sentinel and trigger the task instead of running ``uv``
+   themselves on Windows uv-tool installs.
+
+The worker is intentionally pure PowerShell. We do not invoke any
+Python script for it because any Python interpreter spawned from the
+watcher's venv would re-lock ``Scripts\\python.exe`` and reproduce the
+original problem, and bringing in a second standalone Python solely
+for the upgrade would balloon the install footprint on every lab PC.
+
+This module is import-safe on every platform (no win32 imports) so the
+templating and sentinel helpers can be unit-tested on the Linux CI
+runner.
+"""
+
+from __future__ import annotations
+import json
+import logging
+import os
+import sys
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, distribution
+from pathlib import Path
+from typing import Any
+
+from data_hub_watcher.self_update import PACKAGE_NAME, InstallMethod
+
+logger = logging.getLogger(__name__)
+
+
+UPGRADE_REQUEST_FILENAME = ".upgrade-request.json"
+UPGRADE_RESULT_FILENAME = ".upgrade-result.json"
+UPGRADE_WORKER_SCRIPT_FILENAME = "upgrade-worker.ps1"
+UPGRADE_WORKER_LOG_FILENAME = "upgrade-worker.log"
+
+# The sole optional extra the watcher publishes today. Hard-coded
+# rather than discovered dynamically because (a) extras detection from
+# installed metadata is unreliable across pip / uv versions, and
+# (b) on Windows a missing ``pywin32`` always breaks the service —
+# so we'd rather over-include it on a pip install than silently drop
+# it on a uv-tool reinstall.
+WINDOWS_SERVICE_EXTRA = "windows-service"
+
+
+# ---------------------------------------------------------------------------
+# Sentinels
+# ---------------------------------------------------------------------------
+
+
+def upgrade_request_path(config_dir: Path) -> Path:
+    return config_dir / UPGRADE_REQUEST_FILENAME
+
+
+def upgrade_result_path(config_dir: Path) -> Path:
+    return config_dir / UPGRADE_RESULT_FILENAME
+
+
+def upgrade_worker_script_path(config_dir: Path) -> Path:
+    return config_dir / UPGRADE_WORKER_SCRIPT_FILENAME
+
+
+def upgrade_worker_log_path(config_dir: Path) -> Path:
+    return config_dir / UPGRADE_WORKER_LOG_FILENAME
+
+
+@dataclass
+class UpgradeRequest:
+    """Inbound request the watcher writes for the worker to consume.
+
+    Carries the package spec the worker should pass to ``uv``, the
+    target version (informational, used for the result event), and a
+    request_id (uuid4) so the worker can stamp its result with the
+    same value — letting the post-restart event evaluation correlate
+    a result back to the request that produced it.
+    """
+
+    target_version: str
+    pkg_spec: str
+    uv_executable: str
+    index_url: str
+    request_id: str
+    requested_at: str
+    previous_version: str
+    install_method: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "target_version": self.target_version,
+            "pkg_spec": self.pkg_spec,
+            "uv_executable": self.uv_executable,
+            "index_url": self.index_url,
+            "request_id": self.request_id,
+            "requested_at": self.requested_at,
+            "previous_version": self.previous_version,
+            "install_method": self.install_method,
+        }
+
+
+@dataclass
+class UpgradeResult:
+    """Outbound result the worker writes once ``uv`` finishes.
+
+    The post-restart event-evaluation in :mod:`data_hub_watcher.runtime`
+    merges these fields into the ``UPDATE_SUCCEEDED`` /
+    ``UPDATE_FAILED`` event so the dashboard sees the same level of
+    detail it used to get from the in-process subprocess
+    (``stdout_tail``, ``stderr_tail``, ``returncode``). If the worker
+    crashes between ``Stop-Service`` and writing this file the result
+    sentinel is absent and the event falls back to a generic
+    "worker did not write result" reason.
+    """
+
+    request_id: str
+    target_version: str
+    succeeded: bool
+    returncode: int | None
+    stdout_tail: str
+    stderr_tail: str
+    finished_at: str
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "request_id": self.request_id,
+            "target_version": self.target_version,
+            "succeeded": self.succeeded,
+            "returncode": self.returncode,
+            "stdout_tail": self.stdout_tail,
+            "stderr_tail": self.stderr_tail,
+            "finished_at": self.finished_at,
+            "error": self.error,
+        }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write *payload* as JSON to *path* atomically.
+
+    Use a tempfile + ``os.replace`` so a reader never observes a
+    partially-written sentinel (the worker polls for the request file
+    immediately after the task is triggered, so a torn write would
+    masquerade as a corrupt request).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def write_upgrade_request(
+    config_dir: Path,
+    *,
+    target_version: str,
+    pkg_spec: str,
+    uv_executable: str,
+    index_url: str,
+    previous_version: str,
+    install_method: str,
+    request_id: str | None = None,
+) -> UpgradeRequest:
+    """Persist a request sentinel and return the resulting :class:`UpgradeRequest`.
+
+    *request_id* defaults to a fresh uuid4. Callers (the updater and
+    the CLI) generally don't pass it; tests do, so they can pin the
+    sentinel contents deterministically.
+    """
+    req = UpgradeRequest(
+        target_version=target_version,
+        pkg_spec=pkg_spec,
+        uv_executable=uv_executable,
+        index_url=index_url,
+        request_id=request_id or str(uuid.uuid4()),
+        requested_at=datetime.now(timezone.utc).isoformat(),
+        previous_version=previous_version,
+        install_method=install_method,
+    )
+    _atomic_write_json(upgrade_request_path(config_dir), req.to_dict())
+    return req
+
+
+def read_upgrade_request(config_dir: Path) -> UpgradeRequest | None:
+    """Read and return the request sentinel, or ``None`` if absent.
+
+    Does not delete the file — the worker is responsible for cleanup
+    once it has written its result. Used by tests + (eventually) any
+    diagnostic CLI that wants to inspect a stuck dispatch.
+    """
+    path = upgrade_request_path(config_dir)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    try:
+        return UpgradeRequest(
+            target_version=str(data["target_version"]),
+            pkg_spec=str(data["pkg_spec"]),
+            uv_executable=str(data["uv_executable"]),
+            index_url=str(data["index_url"]),
+            request_id=str(data["request_id"]),
+            requested_at=str(data["requested_at"]),
+            previous_version=str(data["previous_version"]),
+            install_method=str(data["install_method"]),
+        )
+    except (KeyError, TypeError):
+        return None
+
+
+def clear_upgrade_request(config_dir: Path) -> None:
+    upgrade_request_path(config_dir).unlink(missing_ok=True)
+
+
+def read_upgrade_result(config_dir: Path) -> UpgradeResult | None:
+    """Read and return the worker's result sentinel, or ``None`` if absent.
+
+    Lifecycle parallels the upgrade marker in :mod:`updater`: the
+    runtime reads the result on the post-restart inspection and then
+    deletes it via :func:`clear_upgrade_result` so a stale result from
+    a prior upgrade can't leak into the next one.
+    """
+    path = upgrade_result_path(config_dir)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    try:
+        return UpgradeResult(
+            request_id=str(data["request_id"]),
+            target_version=str(data["target_version"]),
+            succeeded=bool(data["succeeded"]),
+            returncode=(int(data["returncode"]) if data.get("returncode") is not None else None),
+            stdout_tail=str(data.get("stdout_tail", "")),
+            stderr_tail=str(data.get("stderr_tail", "")),
+            finished_at=str(data["finished_at"]),
+            error=(str(data["error"]) if data.get("error") is not None else None),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def clear_upgrade_result(config_dir: Path) -> None:
+    upgrade_result_path(config_dir).unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Package spec
+# ---------------------------------------------------------------------------
+
+
+def detect_installed_extras() -> list[str]:
+    """Return the list of extras the running watcher install has.
+
+    Best-effort: we only care about the ``windows-service`` extra
+    today. On any platform other than Windows (including all CI
+    runners) we return an empty list so this function is a no-op.
+
+    Detection strategy: probe the dist's ``Provides-Extra`` metadata
+    *and* check whether ``pywin32`` is importable in the current
+    interpreter. The two together are stable across pip / uv install
+    histories — extras tracking is notoriously inconsistent in dist
+    metadata across package managers, so we treat "the extra was
+    advertised AND its dependency satisfied" as the signal that the
+    operator wanted it.
+    """
+    if sys.platform != "win32":
+        return []
+
+    extras: list[str] = []
+    try:
+        dist = distribution(PACKAGE_NAME)
+    except PackageNotFoundError:
+        return extras
+
+    advertised: list[str] = []
+    metadata = dist.metadata
+    for key, value in metadata.items():
+        if key == "Provides-Extra" and isinstance(value, str):
+            advertised.append(value.strip())
+
+    if WINDOWS_SERVICE_EXTRA in advertised:
+        try:
+            import pywin32  # type: ignore[import-not-found]  # noqa: F401
+
+            extras.append(WINDOWS_SERVICE_EXTRA)
+        except Exception:
+            try:
+                import win32service  # type: ignore[import-not-found]  # noqa: F401
+
+                extras.append(WINDOWS_SERVICE_EXTRA)
+            except Exception:
+                pass
+
+    return extras
+
+
+def build_pkg_spec(
+    method: InstallMethod,
+    *,
+    target_version: str | None = None,
+    extras: list[str] | None = None,
+) -> str:
+    """Produce the ``data-hub-watcher[extras]==X.Y.Z`` spec for ``uv``/``pip``.
+
+    Used by both the in-process upgrade path and the worker so the two
+    paths can never disagree on what gets reinstalled. The Windows
+    service install historically broke after a self-update because the
+    in-process path passed bare ``data-hub-watcher==X.Y.Z`` — silently
+    dropping the ``[windows-service]`` extra and uninstalling
+    ``pywin32``. Rebuilding the spec via this helper closes that gap.
+    """
+    if method in (InstallMethod.EDITABLE, InstallMethod.UNKNOWN):
+        raise ValueError(f"Cannot build a package spec for install method {method.value!r}")
+
+    if extras:
+        # Sort for deterministic output so the rendered worker script
+        # is byte-identical across runs (matters for the golden-string
+        # test and for change detection in the dropped script).
+        extras_part = f"[{','.join(sorted(extras))}]"
+    else:
+        extras_part = ""
+    spec = f"{PACKAGE_NAME}{extras_part}"
+    if target_version:
+        spec = f"{spec}=={target_version}"
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# PowerShell worker template
+# ---------------------------------------------------------------------------
+
+
+# The worker does the bare minimum needed to break the file-lock loop:
+#   1. Stop the service (releases Scripts\python.exe).
+#   2. Run `uv tool install --reinstall` capturing stdout/stderr.
+#   3. Write a result sentinel so the post-restart event has the
+#      subprocess output to attach to UPDATE_SUCCEEDED / UPDATE_FAILED.
+#   4. Start the service again so the new wheel takes effect.
+#
+# Everything is wrapped in try/finally so a crash inside `uv` still
+# produces a result sentinel and still attempts to restart the service —
+# leaving the host with a stopped service after a botched upgrade would
+# be the worst possible failure mode.
+#
+# Logging is duplicated to a rolling text log under ~/.data-hub so an
+# operator on the lab PC can debug a stuck task without relying on the
+# Task Scheduler History pane (which is off by default on most fleet
+# images).
+WORKER_SCRIPT_TEMPLATE = """\
+# data-hub-watcher upgrade worker (auto-generated; do not edit by hand)
+# Generated: {generated_at}
+$ErrorActionPreference = "Stop"
+
+$ServiceName  = "{service_name}"
+$RequestPath  = "{request_path}"
+$ResultPath   = "{result_path}"
+$LogPath      = "{log_path}"
+$MarkerPath   = "{marker_path}"
+
+function Write-Log($msg) {{
+    $ts = (Get-Date).ToUniversalTime().ToString("o")
+    $line = "$ts $msg"
+    Add-Content -LiteralPath $LogPath -Value $line -ErrorAction SilentlyContinue
+}}
+
+function Write-ResultJson($payload) {{
+    $tmp = "$ResultPath.tmp"
+    $payload | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $tmp -Encoding UTF8
+    Move-Item -LiteralPath $tmp -Destination $ResultPath -Force
+}}
+
+function Tail-Text($text, $maxLen) {{
+    if (-not $text) {{ return "" }}
+    if ($text.Length -le $maxLen) {{ return $text }}
+    return $text.Substring($text.Length - $maxLen)
+}}
+
+Write-Log "upgrade-worker starting"
+
+if (-not (Test-Path -LiteralPath $RequestPath)) {{
+    Write-Log "no request sentinel at $RequestPath; nothing to do"
+    exit 0
+}}
+
+try {{
+    $request = Get-Content -LiteralPath $RequestPath -Raw | ConvertFrom-Json
+}} catch {{
+    Write-Log "failed to parse request sentinel: $_"
+    exit 1
+}}
+
+$RequestId = [string]$request.request_id
+$Target    = [string]$request.target_version
+$PkgSpec   = [string]$request.pkg_spec
+$UvExe     = [string]$request.uv_executable
+$IndexUrl  = [string]$request.index_url
+
+Write-Log "request_id=$RequestId target=$Target pkg_spec=$PkgSpec uv=$UvExe"
+
+$stdoutTail  = ""
+$stderrTail  = ""
+$returncode  = $null
+$succeeded   = $false
+$errorText   = $null
+
+try {{
+    Write-Log "stopping service $ServiceName"
+    try {{
+        Stop-Service -Name $ServiceName -Force -ErrorAction Stop
+        Write-Log "service stopped"
+    }} catch {{
+        Write-Log "stop-service failed (continuing): $_"
+    }}
+
+    # Give Windows a moment to fully release Scripts\\python.exe even
+    # after the service control manager reports the service as stopped.
+    Start-Sleep -Seconds 2
+
+    $uvArgs = @("tool", "install", "--reinstall")
+    if ($Target) {{
+        $uvArgs += @("--index-url", $IndexUrl)
+    }}
+    $uvArgs += @($PkgSpec)
+
+    Write-Log "running: $UvExe $($uvArgs -join ' ')"
+
+    $stdoutFile = [System.IO.Path]::GetTempFileName()
+    $stderrFile = [System.IO.Path]::GetTempFileName()
+    try {{
+        $proc = Start-Process -FilePath $UvExe -ArgumentList $uvArgs `
+            -RedirectStandardOutput $stdoutFile `
+            -RedirectStandardError $stderrFile `
+            -NoNewWindow -Wait -PassThru
+        $returncode = $proc.ExitCode
+        $stdout = Get-Content -LiteralPath $stdoutFile -Raw -ErrorAction SilentlyContinue
+        $stderr = Get-Content -LiteralPath $stderrFile -Raw -ErrorAction SilentlyContinue
+        $stdoutTail = Tail-Text $stdout 1000
+        $stderrTail = Tail-Text $stderr 1000
+        $succeeded = ($returncode -eq 0)
+        Write-Log "uv exited $returncode"
+        # Always echo uv's output to the worker log so an operator
+        # tailing it on the lab PC sees the install transcript even
+        # if the result sentinel is later consumed / cleared. We
+        # split on lines so each entry has its own UTC timestamp,
+        # which makes interleaving with surrounding log lines
+        # readable.
+        if ($stdout) {{
+            foreach ($line in ($stdout -split "`r?`n")) {{
+                if ($line) {{ Write-Log "uv stdout: $line" }}
+            }}
+        }}
+        if ($stderr) {{
+            foreach ($line in ($stderr -split "`r?`n")) {{
+                if ($line) {{ Write-Log "uv stderr: $line" }}
+            }}
+        }}
+    }} finally {{
+        Remove-Item -LiteralPath $stdoutFile -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $stderrFile -Force -ErrorAction SilentlyContinue
+    }}
+}} catch {{
+    $errorText = "$_"
+    Write-Log "worker raised: $errorText"
+}} finally {{
+    $payload = @{{
+        request_id     = $RequestId
+        target_version = $Target
+        succeeded      = $succeeded
+        returncode     = $returncode
+        stdout_tail    = $stdoutTail
+        stderr_tail    = $stderrTail
+        finished_at    = (Get-Date).ToUniversalTime().ToString("o")
+        error          = $errorText
+    }}
+    try {{
+        Write-ResultJson $payload
+        Write-Log "wrote result sentinel"
+    }} catch {{
+        Write-Log "failed to write result sentinel: $_"
+    }}
+
+    Remove-Item -LiteralPath $RequestPath -Force -ErrorAction SilentlyContinue
+
+    Write-Log "starting service $ServiceName"
+    try {{
+        Start-Service -Name $ServiceName -ErrorAction Stop
+        Write-Log "service started"
+    }} catch {{
+        Write-Log "start-service failed: $_"
+    }}
+}}
+
+Write-Log "upgrade-worker exiting"
+"""
+
+
+def render_worker_script(
+    *,
+    service_name: str,
+    request_path: Path,
+    result_path: Path,
+    log_path: Path,
+    marker_path: Path,
+    generated_at: str | None = None,
+) -> str:
+    """Render :data:`WORKER_SCRIPT_TEMPLATE` with concrete paths.
+
+    Pure string templating so the rendering is unit-testable on POSIX.
+    The actual ``uv`` path is not baked in — the worker reads it from
+    the request sentinel so a post-install relocation of ``uv.exe``
+    doesn't require regenerating the script.
+    """
+    return WORKER_SCRIPT_TEMPLATE.format(
+        generated_at=(generated_at or datetime.now(timezone.utc).isoformat()),
+        service_name=service_name,
+        request_path=str(request_path),
+        result_path=str(result_path),
+        log_path=str(log_path),
+        marker_path=str(marker_path),
+    )
+
+
+def write_worker_script(
+    config_dir: Path,
+    *,
+    service_name: str,
+    generated_at: str | None = None,
+) -> Path:
+    """Render the worker script and drop it under *config_dir*.
+
+    Returns the resulting path so callers (the service installer) can
+    hand it to ``schtasks`` as the action target.
+    """
+    from data_hub_watcher.updater import upgrade_marker_path
+
+    script_path = upgrade_worker_script_path(config_dir)
+    script = render_worker_script(
+        service_name=service_name,
+        request_path=upgrade_request_path(config_dir),
+        result_path=upgrade_result_path(config_dir),
+        log_path=upgrade_worker_log_path(config_dir),
+        marker_path=upgrade_marker_path(config_dir),
+        generated_at=generated_at,
+    )
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    script_path.write_text(script, encoding="utf-8")
+    return script_path

--- a/watcher/src/data_hub_watcher/upgrade_worker.py
+++ b/watcher/src/data_hub_watcher/upgrade_worker.py
@@ -385,7 +385,6 @@ $ServiceName  = "{service_name}"
 $RequestPath  = "{request_path}"
 $ResultPath   = "{result_path}"
 $LogPath      = "{log_path}"
-$MarkerPath   = "{marker_path}"
 
 function Write-Log($msg) {{
     $ts = (Get-Date).ToUniversalTime().ToString("o")
@@ -446,11 +445,13 @@ try {{
     # after the service control manager reports the service as stopped.
     Start-Sleep -Seconds 2
 
-    $uvArgs = @("tool", "install", "--reinstall")
-    if ($Target) {{
-        $uvArgs += @("--index-url", $IndexUrl)
-    }}
-    $uvArgs += @($PkgSpec)
+    # `--index-url` is always passed because the worker is only ever
+    # triggered for a pinned target version (the dispatch-side guards
+    # in ``_apply_via_worker`` and ``_dispatch_self_update_via_worker``
+    # both refuse to write a request without one). Mirrors
+    # ``build_upgrade_command``'s argv shape exactly so the worker and
+    # the in-process path produce equivalent uv invocations.
+    $uvArgs = @("tool", "install", "--reinstall", "--index-url", $IndexUrl, $PkgSpec)
 
     Write-Log "running: $UvExe $($uvArgs -join ' ')"
 
@@ -530,7 +531,6 @@ def render_worker_script(
     request_path: Path,
     result_path: Path,
     log_path: Path,
-    marker_path: Path,
     generated_at: str | None = None,
 ) -> str:
     """Render :data:`WORKER_SCRIPT_TEMPLATE` with concrete paths.
@@ -539,6 +539,11 @@ def render_worker_script(
     The actual ``uv`` path is not baked in — the worker reads it from
     the request sentinel so a post-install relocation of ``uv.exe``
     doesn't require regenerating the script.
+
+    The ``.upgrade-in-progress`` marker is intentionally not handed to
+    the worker: its full lifecycle (write before dispatch, evaluate
+    and clear on the next process start) lives on the Python side in
+    :mod:`data_hub_watcher.updater` and :mod:`data_hub_watcher.runtime`.
     """
     return WORKER_SCRIPT_TEMPLATE.format(
         generated_at=(generated_at or datetime.now(timezone.utc).isoformat()),
@@ -546,7 +551,6 @@ def render_worker_script(
         request_path=str(request_path),
         result_path=str(result_path),
         log_path=str(log_path),
-        marker_path=str(marker_path),
     )
 
 
@@ -561,15 +565,12 @@ def write_worker_script(
     Returns the resulting path so callers (the service installer) can
     hand it to ``schtasks`` as the action target.
     """
-    from data_hub_watcher.updater import upgrade_marker_path
-
     script_path = upgrade_worker_script_path(config_dir)
     script = render_worker_script(
         service_name=service_name,
         request_path=upgrade_request_path(config_dir),
         result_path=upgrade_result_path(config_dir),
         log_path=upgrade_worker_log_path(config_dir),
-        marker_path=upgrade_marker_path(config_dir),
         generated_at=generated_at,
     )
     script_path.parent.mkdir(parents=True, exist_ok=True)

--- a/watcher/tests/test_cli_self_update.py
+++ b/watcher/tests/test_cli_self_update.py
@@ -1,0 +1,259 @@
+"""Tests for the ``data-hub-watcher self-update`` CLI command.
+
+The self-update command branches based on platform + install method:
+
+* POSIX or Windows pip install: spawn ``uv``/``pip`` inline via
+  ``run_upgrade`` and surface the captured output.
+* Windows uv-tool install: route through the SYSTEM-owned scheduled
+  task to break the ``Scripts\\python.exe`` lock that would otherwise
+  cause the in-process reinstall to fail with ``Access is denied``.
+
+These tests pin the dispatch contract so a regression in the routing
+logic surfaces here rather than as an inscrutable error on a real
+lab PC.
+"""
+
+from __future__ import annotations
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from data_hub_watcher import cli as cli_module
+from data_hub_watcher.models import (
+    InstrumentConfig,
+    RunDetectionConfig,
+    WatcherConfig,
+    WatcherUpdateInfoResponse,
+)
+from data_hub_watcher.self_update import InstallMethod
+from data_hub_watcher.upgrade_worker import (
+    UPGRADE_REQUEST_FILENAME,
+    read_upgrade_request,
+)
+
+
+def _make_config(tmp_path: Path) -> WatcherConfig:
+    watch_dir = tmp_path / "data"
+    watch_dir.mkdir()
+    (watch_dir / "RUN001_sample.csv").write_text("a,b\n1,2\n")
+    return WatcherConfig(
+        version=1,
+        environment="staging",
+        watcher_id="w-test",
+        instrument=InstrumentConfig(
+            id="test-instrument",
+            watch_directory=watch_dir,
+            file_patterns=["*.csv"],
+            run_detection=RunDetectionConfig(pattern=r"^([^_]+)", recursive=False),
+        ),
+    )
+
+
+@pytest.fixture
+def configured(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Patch the CLI's config + client so we exercise just the upgrade logic.
+
+    Returns the per-test config dir we route ``DEFAULT_CONFIG_DIR`` at
+    so individual tests can read back the request sentinel from disk.
+    """
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("# placeholder, content is mocked away\n")
+    cfg = _make_config(tmp_path)
+
+    monkeypatch.setattr(cli_module, "resolve_config_path", lambda _override: config_path)
+    monkeypatch.setattr(cli_module, "load_config", lambda _p: cfg)
+    monkeypatch.setattr(cli_module, "env_file_path", lambda _env: tmp_path / ".env.staging")
+
+    # Stub the API client so /update-check returns a known target.
+    fake_client = MagicMock(name="DataHubClient")
+    fake_client.get_update_info.return_value = WatcherUpdateInfoResponse(
+        latest_version="9.9.9",
+        channel="stable",
+        mandatory=False,
+    )
+    monkeypatch.setattr(cli_module, "DataHubClient", lambda *_a, **_kw: fake_client)
+
+    # Reroute the well-known config dir into the per-test tmp dir so
+    # the sentinels the dispatch writes don't pollute the real
+    # ``~/.data-hub`` of whoever runs the suite.
+    config_dir = tmp_path / ".data-hub"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(cli_module, "DEFAULT_CONFIG_DIR", config_dir)
+
+    return config_dir
+
+
+class TestSelfUpdateWindowsUvToolWorkerDispatch:
+    """On Windows uv-tool installs, ``self-update`` writes a sentinel + triggers schtasks."""
+
+    def _force_windows_uv_tool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(cli_module, "detect_install_method", lambda: InstallMethod.UV_TOOL)
+        monkeypatch.setattr(
+            cli_module,
+            "_resolve_uv_executable",
+            lambda override=None, prefix=None: ("/fake/bin/uv.exe", ["/fake/bin/uv.exe"]),
+        )
+
+    def test_writes_sentinel_and_triggers_task_on_happy_path(
+        self,
+        configured: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._force_windows_uv_tool(monkeypatch)
+        # Pretend the [windows-service] extra is installed so the
+        # rendered pkg_spec preserves it (closes the historical
+        # regression where pywin32 silently disappeared after a
+        # reinstall).
+        import data_hub_watcher.upgrade_worker as worker_module
+
+        monkeypatch.setattr(worker_module, "detect_installed_extras", lambda: ["windows-service"])
+        # Pretend the scheduled task is registered.
+        import data_hub_watcher.scheduled_task as st_module
+
+        monkeypatch.setattr(st_module, "task_exists", lambda **_kw: True)
+        trigger_calls: list[None] = []
+        monkeypatch.setattr(
+            st_module,
+            "trigger_upgrade_task",
+            lambda **_kw: trigger_calls.append(None),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli_module.cli, ["self-update"])
+
+        assert result.exit_code == 0, result.output
+        assert "Dispatching upgrade" in result.output
+        assert "9.9.9" in result.output
+        assert "Upgrade dispatched" in result.output
+        # Sentinel must be on disk with the right pkg_spec.
+        req = read_upgrade_request(configured)
+        assert req is not None
+        assert req.target_version == "9.9.9"
+        assert req.pkg_spec == "data-hub-watcher[windows-service]==9.9.9"
+        assert req.uv_executable == "/fake/bin/uv.exe"
+        assert trigger_calls == [None]
+
+    def test_refuses_with_actionable_error_when_task_missing(
+        self,
+        configured: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._force_windows_uv_tool(monkeypatch)
+        import data_hub_watcher.scheduled_task as st_module
+
+        monkeypatch.setattr(st_module, "task_exists", lambda **_kw: False)
+        # If the dispatch silently fell back to the in-process path,
+        # we'd hit `run_upgrade` and try to actually reinstall — fail
+        # loudly here so the test catches that regression.
+        monkeypatch.setattr(
+            cli_module,
+            "run_upgrade",
+            lambda *a, **kw: pytest.fail(
+                "self-update must NOT call in-process run_upgrade on Windows uv-tool"
+            ),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli_module.cli, ["self-update"])
+
+        assert result.exit_code != 0
+        # Operator must see exactly which command to run next.
+        assert "service reinstall" in result.output
+        # No request sentinel should have been written when the
+        # pre-flight check failed.
+        assert not (configured / UPGRADE_REQUEST_FILENAME).exists()
+
+    def test_refuses_when_uv_executable_cannot_be_located(
+        self,
+        configured: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(cli_module, "detect_install_method", lambda: InstallMethod.UV_TOOL)
+        monkeypatch.setattr(
+            cli_module,
+            "_resolve_uv_executable",
+            lambda override=None, prefix=None: (None, [r"C:\Users\lab\.local\bin\uv.exe"]),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli_module.cli, ["self-update"])
+
+        assert result.exit_code != 0
+        assert "uv" in result.output.lower()
+        assert r"C:\Users\lab\.local\bin\uv.exe" in result.output
+
+    def test_schtasks_failure_rolls_back_sentinels(
+        self,
+        configured: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from data_hub_watcher.scheduled_task import ScheduledTaskError
+
+        self._force_windows_uv_tool(monkeypatch)
+        import data_hub_watcher.scheduled_task as st_module
+
+        monkeypatch.setattr(st_module, "task_exists", lambda **_kw: True)
+
+        def boom(**_kw: Any) -> None:
+            raise ScheduledTaskError(
+                "schtasks /Run failed",
+                argv=["schtasks.exe", "/Run", "/TN", "DataHubWatcherUpgrade"],
+                stderr="ERROR: Access is denied.",
+                returncode=1,
+            )
+
+        monkeypatch.setattr(st_module, "trigger_upgrade_task", boom)
+
+        runner = CliRunner()
+        result = runner.invoke(cli_module.cli, ["self-update"])
+
+        assert result.exit_code != 0
+        assert "scheduled task" in result.output.lower()
+        # Sentinels must be cleaned up so a retry isn't gated on a
+        # stale request file from the failed dispatch.
+        assert not (configured / UPGRADE_REQUEST_FILENAME).exists()
+
+
+class TestSelfUpdatePosixStillUsesInProcess:
+    def test_posix_uv_tool_uses_run_upgrade_inline(
+        self,
+        configured: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Mac/Linux uv-tool installs are not affected by the file-lock
+        # issue, so the inline subprocess path stays in place. The
+        # dispatch helper should never be reached.
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(cli_module, "detect_install_method", lambda: InstallMethod.UV_TOOL)
+
+        import subprocess
+
+        monkeypatch.setattr(
+            cli_module,
+            "run_upgrade",
+            lambda method, target_version=None: subprocess.CompletedProcess(
+                args=["uv"], returncode=0, stdout="ok\n", stderr=""
+            ),
+        )
+        # If dispatch helper somehow fired, it would try to call
+        # `_resolve_uv_executable`; replacing with a sentinel that
+        # explodes makes a regression visible.
+        import data_hub_watcher.scheduled_task as st_module
+
+        monkeypatch.setattr(
+            st_module,
+            "trigger_upgrade_task",
+            lambda **_kw: pytest.fail("POSIX uv-tool must not route through the worker"),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli_module.cli, ["self-update"])
+
+        assert result.exit_code == 0, result.output
+        assert "Upgrade to 9.9.9 complete" in result.output

--- a/watcher/tests/test_cli_service_reinstall.py
+++ b/watcher/tests/test_cli_service_reinstall.py
@@ -155,6 +155,70 @@ class TestServiceReinstallHappyPath:
         fake_service_module.start_service.assert_not_called()
 
 
+class TestServiceReinstallMarkedForDeletion:
+    """Lock in the recovery from Windows error 1072 ("marked for deletion").
+
+    DeleteService is asynchronous: a Services console (services.msc) or
+    AV agent holding an open handle keeps the service alive long enough
+    that a back-to-back ``CreateService`` fails. We must (a) actually
+    call ``wait_for_service_removed`` between uninstall and install,
+    and (b) surface a clear, actionable message when the wait times out
+    instead of letting the operator see the raw 1072 error.
+    """
+
+    def test_reinstall_polls_between_uninstall_and_install(
+        self,
+        windows_platform: None,
+        fake_service_module: MagicMock,
+        configured_path: Path,
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / ".env.staging").write_text("")
+
+        manager = MagicMock()
+        manager.attach_mock(fake_service_module.uninstall_service, "uninstall_service")
+        manager.attach_mock(
+            fake_service_module.wait_for_service_removed,
+            "wait_for_service_removed",
+        )
+        manager.attach_mock(fake_service_module.install_service, "install_service")
+
+        runner = CliRunner()
+        result = runner.invoke(cli_module.cli, ["service", "reinstall"])
+
+        assert result.exit_code == 0, result.output
+        call_names = [c[0] for c in manager.mock_calls]
+        # The poll MUST happen after uninstall and before install,
+        # otherwise the "marked for deletion" race is unfixed.
+        assert call_names.index("uninstall_service") < call_names.index("wait_for_service_removed")
+        assert call_names.index("wait_for_service_removed") < call_names.index("install_service")
+
+    def test_marked_for_deletion_timeout_raises_actionable_error(
+        self,
+        windows_platform: None,
+        fake_service_module: MagicMock,
+        configured_path: Path,
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / ".env.staging").write_text("")
+        fake_service_module.wait_for_service_removed.return_value = False
+
+        runner = CliRunner()
+        result = runner.invoke(cli_module.cli, ["service", "reinstall"])
+
+        assert result.exit_code != 0
+        # Operators should see exactly what to do — the raw "(1072,
+        # 'CreateService', ...)" error is what motivated this guard, so
+        # the message must mention services.msc and the manual recovery
+        # path. Don't pin the entire string; just the actionable bits.
+        assert "marked for deletion" in result.output
+        assert "services.msc" in result.output
+        # And install/start must NOT have run -- otherwise we'd produce
+        # the original confusing 1072 error on top of our nice message.
+        fake_service_module.install_service.assert_not_called()
+        fake_service_module.start_service.assert_not_called()
+
+
 class TestServiceReinstallPlatformGuard:
     def test_non_windows_platform_exits_one(
         self,

--- a/watcher/tests/test_runtime.py
+++ b/watcher/tests/test_runtime.py
@@ -14,13 +14,15 @@ wiring contract per `upload_mode` so any future drift fails loudly:
 """
 
 from __future__ import annotations
+import json
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 from unittest.mock import MagicMock
 
 import pytest
 
 from data_hub_watcher.constants import HEARTBEAT_INTERVAL_SECONDS
+from data_hub_watcher.events import EventType
 from data_hub_watcher.heartbeat import HeartbeatLoop, WatcherCounters
 from data_hub_watcher.models import InstrumentConfig, RunDetectionConfig, WatcherConfig
 from data_hub_watcher.monitor import FileMonitor
@@ -29,9 +31,14 @@ from data_hub_watcher.runtime import (
     ShutdownReason,
     build_runtime,
     classify_shutdown,
+    start_runtime,
 )
 from data_hub_watcher.state import StateDB
-from data_hub_watcher.updater import Updater
+from data_hub_watcher.updater import Updater, write_upgrade_marker
+from data_hub_watcher.upgrade_worker import (
+    UpgradeResult,
+    upgrade_result_path,
+)
 from data_hub_watcher.uploader import Uploader
 
 
@@ -290,5 +297,283 @@ class TestClassifyShutdown:
                 classify_shutdown(rt, role="Watcher").stopped_message
                 == "Watcher restarting for auto-update"
             )
+        finally:
+            rt.state_db.close()
+
+
+class TestStartRuntimePostUpgradeMerge:
+    """Post-restart event evaluation merges the worker's result sentinel.
+
+    The Windows uv-tool worker writes ``.upgrade-result.json`` with the
+    captured ``uv`` stdout/stderr/returncode. ``start_runtime`` reads
+    both the marker AND the result, merging the worker fields into the
+    emitted ``UPDATE_SUCCEEDED`` / ``UPDATE_FAILED`` event so the
+    dashboard sees the same level of detail it used to get from the
+    in-process subprocess.
+    """
+
+    def _make_runtime_with_reporter(self, tmp_path: Path) -> tuple[Any, MagicMock]:
+        cfg = _make_config(tmp_path, upload_mode="auto")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=tmp_path / "state.sqlite")
+        # Replace the real reporter with a mock so we can inspect
+        # which events were queued without round-tripping the API
+        # client.
+        mock_reporter = MagicMock()
+        rt.reporter = mock_reporter
+        # Stop monitor + heartbeat from really starting since this
+        # test only cares about the pre-startup event evaluation.
+        rt.monitor = MagicMock()
+        rt.heartbeat = MagicMock()
+        rt.detector = MagicMock()
+        return rt, mock_reporter
+
+    def _patch_default_config_dir(self, monkeypatch: pytest.MonkeyPatch, target: Path) -> None:
+        import data_hub_watcher.runtime as rt_module
+
+        monkeypatch.setattr(rt_module, "DEFAULT_CONFIG_DIR", target)
+
+    def test_success_merges_worker_result_into_event(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Pretend we just restarted into the upgraded version:
+        # write the marker, drop a successful result sentinel,
+        # invoke start_runtime, and assert the emitted event
+        # carries the worker fields.
+        config_dir = tmp_path / ".data-hub"
+        config_dir.mkdir()
+        self._patch_default_config_dir(monkeypatch, config_dir)
+        # Pretend we're on Windows so the "result missing" branch
+        # behaves correctly even though that branch is exercised in
+        # a separate test.
+        monkeypatch.setattr("data_hub_watcher.runtime.sys.platform", "win32")
+
+        # Marker says "we asked for 9.9.9". The current version
+        # comes from importlib.metadata; pin both ends to the same
+        # value so evaluate_upgrade_marker classifies it as success.
+        from data_hub_watcher.constants import WATCHER_VERSION
+
+        write_upgrade_marker(
+            config_dir,
+            target_version=WATCHER_VERSION,
+            previous_version="0.1.4",
+        )
+        # Worker drops the result sentinel after `uv` exits.
+        result = UpgradeResult(
+            request_id="abcd-1234",
+            target_version=WATCHER_VERSION,
+            succeeded=True,
+            returncode=0,
+            stdout_tail="installed 17 packages",
+            stderr_tail="",
+            finished_at="2026-05-04T22:30:00+00:00",
+            error=None,
+        )
+        upgrade_result_path(config_dir).write_text(json.dumps(result.to_dict()), encoding="utf-8")
+
+        rt, mock_reporter = self._make_runtime_with_reporter(tmp_path)
+        try:
+            start_runtime(rt, started_message="Watcher started on test")
+
+            queued = [c.args[0] for c in mock_reporter.queue_event.call_args_list]
+            update_events = [e for e in queued if e.event_type is EventType.UPDATE_SUCCEEDED]
+            assert len(update_events) == 1
+            details = update_events[0].details
+            assert details["target_version"] == WATCHER_VERSION
+            assert details["previous_version"] == "0.1.4"
+            assert details["via_worker"] is True
+            assert details["worker_returncode"] == 0
+            assert details["worker_stdout_tail"] == "installed 17 packages"
+            assert details["worker_request_id"] == "abcd-1234"
+        finally:
+            rt.state_db.close()
+
+        # Sentinel must have been consumed so the next restart
+        # doesn't re-emit it.
+        assert not upgrade_result_path(config_dir).exists()
+
+    def test_failure_with_worker_result_carries_returncode_and_stderr(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = tmp_path / ".data-hub"
+        config_dir.mkdir()
+        self._patch_default_config_dir(monkeypatch, config_dir)
+
+        # Marker says we tried to install 99.99.99 but the running
+        # version is whatever WATCHER_VERSION resolves to — that
+        # mismatch is what makes evaluate_upgrade_marker classify
+        # this as a failure.
+        write_upgrade_marker(
+            config_dir,
+            target_version="99.99.99",
+            previous_version="0.1.4",
+        )
+        result = UpgradeResult(
+            request_id="abcd",
+            target_version="99.99.99",
+            succeeded=False,
+            returncode=2,
+            stdout_tail="",
+            stderr_tail="error: Access is denied. (os error 5)",
+            finished_at="2026-05-04T22:30:00+00:00",
+            error=None,
+        )
+        upgrade_result_path(config_dir).write_text(json.dumps(result.to_dict()), encoding="utf-8")
+
+        rt, mock_reporter = self._make_runtime_with_reporter(tmp_path)
+        try:
+            start_runtime(rt, started_message="Watcher started on test")
+
+            queued = [c.args[0] for c in mock_reporter.queue_event.call_args_list]
+            failures = [e for e in queued if e.event_type is EventType.UPDATE_FAILED]
+            assert len(failures) == 1
+            details = failures[0].details
+            assert details["target_version"] == "99.99.99"
+            assert details["worker_returncode"] == 2
+            assert "Access is denied" in details["worker_stderr_tail"]
+            assert details["via_worker"] is True
+            # `worker_result_missing` must NOT be set when we have
+            # a real result sentinel — that flag is only for the
+            # "worker crashed before writing" case.
+            assert "worker_result_missing" not in details
+        finally:
+            rt.state_db.close()
+
+    def test_worker_failure_overrides_apparent_marker_success(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The most important regression guard: a partial install where
+        # uv exits non-zero AFTER updating enough Python source to
+        # fool the marker version comparison must STILL surface as
+        # UPDATE_FAILED with the actual installer error. Historically
+        # this masqueraded as success because we trusted the marker
+        # version comparison alone.
+        from data_hub_watcher.constants import WATCHER_VERSION
+
+        config_dir = tmp_path / ".data-hub"
+        config_dir.mkdir()
+        self._patch_default_config_dir(monkeypatch, config_dir)
+
+        # Marker says success (version comparison would match).
+        write_upgrade_marker(
+            config_dir,
+            target_version=WATCHER_VERSION,
+            previous_version="0.1.4",
+        )
+        # But the worker reports failure with a real uv error message.
+        result = UpgradeResult(
+            request_id="abcd",
+            target_version=WATCHER_VERSION,
+            succeeded=False,
+            returncode=2,
+            stdout_tail="Installed 17 packages",
+            stderr_tail=(
+                "error: failed to remove directory `C:\\...\\Scripts`: "
+                "Access is denied. (os error 5)"
+            ),
+            finished_at="2026-05-04T22:30:00+00:00",
+            error=None,
+        )
+        upgrade_result_path(config_dir).write_text(json.dumps(result.to_dict()), encoding="utf-8")
+
+        rt, mock_reporter = self._make_runtime_with_reporter(tmp_path)
+        try:
+            start_runtime(rt, started_message="Watcher started on test")
+
+            queued = [c.args[0] for c in mock_reporter.queue_event.call_args_list]
+            # Must emit UPDATE_FAILED, NOT UPDATE_SUCCEEDED, even
+            # though the version comparison would have said success.
+            failures = [e for e in queued if e.event_type is EventType.UPDATE_FAILED]
+            successes = [e for e in queued if e.event_type is EventType.UPDATE_SUCCEEDED]
+            assert len(failures) == 1
+            assert len(successes) == 0
+            details = failures[0].details
+            # The reason should be derived from the worker's
+            # stderr — the actual uv error, not the generic marker
+            # classification.
+            assert "Access is denied" in details["reason"] or "denied" in details["reason"].lower()
+            assert details["worker_returncode"] == 2
+            assert "Access is denied" in details["worker_stderr_tail"]
+            # The marker's own classification is preserved so the
+            # dashboard can show both signals when they disagree.
+            assert details["marker_succeeded"] is True
+            assert "marker_reason" in details
+        finally:
+            rt.state_db.close()
+
+    def test_worker_warning_flag_set_when_success_with_dirty_stderr(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # uv occasionally prints deprecation/info warnings to stderr
+        # even on a clean install. The worker reports success in that
+        # case but we still want the dashboard to flag the event so
+        # an operator can investigate the warning text.
+        from data_hub_watcher.constants import WATCHER_VERSION
+
+        config_dir = tmp_path / ".data-hub"
+        config_dir.mkdir()
+        self._patch_default_config_dir(monkeypatch, config_dir)
+
+        write_upgrade_marker(
+            config_dir,
+            target_version=WATCHER_VERSION,
+            previous_version="0.1.4",
+        )
+        result = UpgradeResult(
+            request_id="abcd",
+            target_version=WATCHER_VERSION,
+            succeeded=True,
+            returncode=3,  # non-zero but worker overrode succeeded=True
+            stdout_tail="installed",
+            stderr_tail="warning: deprecated index format",
+            finished_at="2026-05-04T22:30:00+00:00",
+            error=None,
+        )
+        upgrade_result_path(config_dir).write_text(json.dumps(result.to_dict()), encoding="utf-8")
+
+        rt, mock_reporter = self._make_runtime_with_reporter(tmp_path)
+        try:
+            start_runtime(rt, started_message="Watcher started on test")
+            queued = [c.args[0] for c in mock_reporter.queue_event.call_args_list]
+            successes = [e for e in queued if e.event_type is EventType.UPDATE_SUCCEEDED]
+            assert len(successes) == 1
+            details = successes[0].details
+            # Soft warning flag so the dashboard can surface "look
+            # at this even though it succeeded".
+            assert details.get("worker_warning") is True
+            assert "deprecated" in details["worker_stderr_tail"]
+        finally:
+            rt.state_db.close()
+
+    def test_failure_without_worker_result_flags_missing_on_windows(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Worker crashed between Stop-Service and writing the result
+        # sentinel — the marker is on disk but no result. On Windows
+        # this should set `worker_result_missing=True` so the
+        # operator knows to look at the upgrade-worker log, not at
+        # the in-process subprocess output (which doesn't exist).
+        config_dir = tmp_path / ".data-hub"
+        config_dir.mkdir()
+        self._patch_default_config_dir(monkeypatch, config_dir)
+        monkeypatch.setattr("data_hub_watcher.runtime.sys.platform", "win32")
+
+        write_upgrade_marker(
+            config_dir,
+            target_version="99.99.99",
+            previous_version="0.1.4",
+        )
+        # No result sentinel.
+
+        rt, mock_reporter = self._make_runtime_with_reporter(tmp_path)
+        try:
+            start_runtime(rt, started_message="Watcher started on test")
+
+            queued = [c.args[0] for c in mock_reporter.queue_event.call_args_list]
+            failures = [e for e in queued if e.event_type is EventType.UPDATE_FAILED]
+            assert len(failures) == 1
+            details = failures[0].details
+            assert details.get("worker_result_missing") is True
+            # No worker fields since there's no sentinel to merge from.
+            assert "worker_returncode" not in details
         finally:
             rt.state_db.close()

--- a/watcher/tests/test_runtime.py
+++ b/watcher/tests/test_runtime.py
@@ -29,6 +29,7 @@ from data_hub_watcher.monitor import FileMonitor
 from data_hub_watcher.run_detector import RunDetector
 from data_hub_watcher.runtime import (
     ShutdownReason,
+    _summarize_worker_failure,
     build_runtime,
     classify_shutdown,
     start_runtime,
@@ -577,3 +578,121 @@ class TestStartRuntimePostUpgradeMerge:
             assert "worker_returncode" not in details
         finally:
             rt.state_db.close()
+
+
+class TestSummarizeWorkerFailure:
+    """Direct coverage for the dashboard-headline picker.
+
+    The full stderr_tail is always preserved on the event details, so
+    this helper only chooses the one-liner reason. The selection
+    priority is:
+
+    1. The first ``error: <msg>`` (uv's own convention).
+    2. The first stderr line containing ``error`` / ``failed`` /
+       ``denied`` (covers tools that don't follow uv's convention,
+       e.g. PowerShell traps echoed to stderr by the worker).
+    3. The worker's PowerShell-trap ``error`` field.
+    4. ``uv exited <N>`` if all we have is a non-zero returncode.
+    """
+
+    def _result(
+        self,
+        *,
+        stderr: str = "",
+        returncode: int | None = 1,
+        error: str | None = None,
+    ) -> UpgradeResult:
+        return UpgradeResult(
+            request_id="rid",
+            target_version="9.9.9",
+            succeeded=False,
+            returncode=returncode,
+            stdout_tail="",
+            stderr_tail=stderr,
+            finished_at="2026-05-04T22:30:00+00:00",
+            error=error,
+        )
+
+    def test_picks_uv_error_prefix_line(self) -> None:
+        # uv's actual headline lives behind the ``error:`` prefix.
+        # We must surface it verbatim (truncated to 200) rather than
+        # the surrounding informational chatter.
+        result = self._result(
+            stderr=(
+                "Resolved 17 packages in 12ms\n"
+                "Prepared 17 packages in 800ms\n"
+                "error: failed to remove directory `C:\\...\\Scripts`: "
+                "Access is denied. (os error 5)\n"
+                "Suggestion: stop the service and retry.\n"
+            )
+        )
+        assert _summarize_worker_failure(result) == (
+            "error: failed to remove directory `C:\\...\\Scripts`: Access is denied. (os error 5)"
+        )
+
+    def test_uv_error_prefix_takes_priority_over_substring_match(self) -> None:
+        # Without the prefix-anchoring, the historical substring
+        # heuristic would pick "Resolution failed for 17 packages"
+        # because it appears first and contains "failed". The
+        # ``error:`` line further down is the actual diagnostic and
+        # must win.
+        result = self._result(
+            stderr=(
+                "Resolution failed for 17 packages (this is informational)\n"
+                "error: HTTP 503 from upstream index\n"
+            )
+        )
+        assert _summarize_worker_failure(result) == "error: HTTP 503 from upstream index"
+
+    def test_falls_back_to_substring_when_no_uv_error_prefix(self) -> None:
+        # Worker captured a PowerShell trap or Windows API error that
+        # didn't go through uv's `error:` formatter. The historical
+        # heuristic still fires so we don't fall through to the
+        # generic "uv exited N" message.
+        result = self._result(
+            stderr="Stop-Service : Access is denied (CategoryInfo: PermissionDenied)\n"
+        )
+        assert _summarize_worker_failure(result).startswith("Stop-Service")
+        assert "Access is denied" in _summarize_worker_failure(result)
+
+    def test_skips_innocuous_substring_match_when_better_line_follows(self) -> None:
+        # An informational line that mentions "no errors so far" must
+        # NOT be picked as the headline when a real ``error:`` line
+        # is also present. This is the regression the prefix-anchor
+        # exists to prevent.
+        result = self._result(
+            stderr=("Pre-flight: no errors so far\nerror: PyPI returned 503 Service Unavailable\n")
+        )
+        assert _summarize_worker_failure(result) == ("error: PyPI returned 503 Service Unavailable")
+
+    def test_caps_long_lines_at_200_chars(self) -> None:
+        long_msg = "x" * 500
+        result = self._result(stderr=f"error: {long_msg}\n")
+        summary = _summarize_worker_failure(result)
+        # Cap is enforced so the dashboard one-liner doesn't blow
+        # up; the full 500-char tail is still on the event details.
+        assert len(summary) == 200
+        assert summary.startswith("error: ")
+
+    def test_uses_worker_exception_field_when_stderr_empty(self) -> None:
+        # PowerShell trapped before uv could even start (e.g. ENOENT
+        # on the binary). The worker stamps the exception text into
+        # `error` and we surface that as the headline.
+        result = self._result(stderr="", error="Cannot find path 'uv.exe'")
+        assert _summarize_worker_failure(result) == ("worker exception: Cannot find path 'uv.exe'")
+
+    def test_falls_back_to_returncode_when_no_other_signal(self) -> None:
+        result = self._result(stderr="", returncode=137)
+        assert _summarize_worker_failure(result) == "uv exited 137"
+
+    def test_returns_generic_text_when_all_signals_empty(self) -> None:
+        # No stderr, no error, returncode is 0 (worker reported
+        # failure with succeeded=False but no useful diagnostics).
+        # We still need *some* string for the dashboard message.
+        result = self._result(stderr="", returncode=0, error=None)
+        assert _summarize_worker_failure(result) == "worker reported failure"
+
+    def test_non_upgrade_result_returns_generic_text(self) -> None:
+        # Defensive: callers shouldn't pass non-UpgradeResult values,
+        # but the helper must not raise when they do.
+        assert _summarize_worker_failure(object()) == "worker reported failure"

--- a/watcher/tests/test_scheduled_task.py
+++ b/watcher/tests/test_scheduled_task.py
@@ -1,0 +1,248 @@
+"""Unit tests for `data_hub_watcher.scheduled_task`.
+
+The wrappers live behind ``schtasks.exe`` so we mock ``subprocess.run``
+and assert on the argv we pass — the goal is to lock in the install
+flags (``/RU SYSTEM``, ``/RL HIGHEST``, ``/F``, etc.) and the
+"task already absent" tolerance for ``/Delete`` so a regression here
+shows up as a clear test failure rather than as a stuck or
+double-registered task on a real lab PC.
+"""
+
+from __future__ import annotations
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from data_hub_watcher import scheduled_task as st
+from data_hub_watcher.scheduled_task import (
+    UPGRADE_TASK_NAME,
+    ScheduledTaskError,
+    install_upgrade_task,
+    task_exists,
+    trigger_upgrade_task,
+    uninstall_upgrade_task,
+)
+
+
+def _completed(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["schtasks.exe"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+# ---------------------------------------------------------------------------
+# install_upgrade_task
+# ---------------------------------------------------------------------------
+
+
+class TestInstallUpgradeTask:
+    def test_passes_critical_flags(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            captured["cmd"] = cmd
+            return _completed(returncode=0)
+
+        monkeypatch.setattr(st.subprocess, "run", fake_run)
+
+        install_upgrade_task(Path(r"C:\data-hub\upgrade-worker.ps1"))
+
+        cmd = captured["cmd"]
+        assert cmd[0] == "schtasks.exe"
+        assert "/Create" in cmd
+        # Task name must match the module constant — that's what
+        # `trigger_upgrade_task` and the docs all assume.
+        assert cmd[cmd.index("/TN") + 1] == UPGRADE_TASK_NAME
+        # Run as SYSTEM so the worker can stop/start the service.
+        assert cmd[cmd.index("/RU") + 1] == "SYSTEM"
+        # Highest privileges so a future move to a less-privileged
+        # principal can't silently demote us.
+        assert cmd[cmd.index("/RL") + 1] == "HIGHEST"
+        # /F overwrites an existing task with the same name so a
+        # `service reinstall` is idempotent.
+        assert "/F" in cmd
+        # The action must reference the script path verbatim so a
+        # post-install relocation of the script breaks loudly rather
+        # than silently running stale code.
+        action = cmd[cmd.index("/TR") + 1]
+        assert r"C:\data-hub\upgrade-worker.ps1" in action
+        assert "powershell.exe" in action.lower()
+        assert "-ExecutionPolicy Bypass" in action
+        assert "-NoProfile" in action
+
+    def test_raises_with_diagnostic_payload_on_schtasks_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # When `schtasks /Create` fails (e.g. the operator ran
+        # `service install` from a non-Administrator shell), the
+        # caller needs the captured stderr + returncode to attach to
+        # the dashboard event. Lock in the typed-error contract.
+        monkeypatch.setattr(
+            st.subprocess,
+            "run",
+            lambda cmd, **kw: _completed(returncode=1, stderr="ERROR: Access is denied."),
+        )
+
+        with pytest.raises(ScheduledTaskError) as excinfo:
+            install_upgrade_task(Path(r"C:\data-hub\upgrade-worker.ps1"))
+
+        assert "schtasks /Create failed" in str(excinfo.value)
+        assert excinfo.value.returncode == 1
+        assert "Access is denied" in excinfo.value.stderr
+
+    def test_raises_when_schtasks_not_on_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(cmd: list[str], **kwargs: Any) -> Any:
+            raise FileNotFoundError("schtasks.exe")
+
+        monkeypatch.setattr(st.subprocess, "run", boom)
+        with pytest.raises(ScheduledTaskError, match="not found"):
+            install_upgrade_task(Path(r"C:\data-hub\upgrade-worker.ps1"))
+
+
+# ---------------------------------------------------------------------------
+# trigger_upgrade_task
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerUpgradeTask:
+    def test_invokes_schtasks_run_with_default_task_name(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            captured["cmd"] = cmd
+            return _completed(returncode=0)
+
+        monkeypatch.setattr(st.subprocess, "run", fake_run)
+        trigger_upgrade_task()
+
+        assert captured["cmd"][0] == "schtasks.exe"
+        assert captured["cmd"][1] == "/Run"
+        assert captured["cmd"][captured["cmd"].index("/TN") + 1] == UPGRADE_TASK_NAME
+
+    def test_raises_on_failure_with_stderr_payload(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Most common failure mode: the task isn't registered (because
+        # an old fleet PC auto-updated into the new code without
+        # running `service install`). The error must include the
+        # captured stderr so the dashboard event reads usefully.
+        monkeypatch.setattr(
+            st.subprocess,
+            "run",
+            lambda cmd, **kw: _completed(
+                returncode=1,
+                stderr="ERROR: The system cannot find the file specified.",
+            ),
+        )
+        with pytest.raises(ScheduledTaskError) as excinfo:
+            trigger_upgrade_task()
+        assert "schtasks /Run failed" in str(excinfo.value)
+        assert "cannot find" in excinfo.value.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# uninstall_upgrade_task
+# ---------------------------------------------------------------------------
+
+
+class TestUninstallUpgradeTask:
+    def test_returns_quietly_on_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            captured["cmd"] = cmd
+            return _completed(returncode=0)
+
+        monkeypatch.setattr(st.subprocess, "run", fake_run)
+        uninstall_upgrade_task()
+        assert "/Delete" in captured["cmd"]
+        assert "/F" in captured["cmd"]
+
+    def test_silently_ignores_missing_task(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A half-installed or already-uninstalled host must not block
+        # `service uninstall`. The error message variant we observe in
+        # practice is 'ERROR: The system cannot find the file specified'.
+        monkeypatch.setattr(
+            st.subprocess,
+            "run",
+            lambda cmd, **kw: _completed(
+                returncode=1,
+                stderr="ERROR: The system cannot find the file specified.",
+            ),
+        )
+        # Must NOT raise.
+        uninstall_upgrade_task()
+
+    def test_silently_ignores_does_not_exist_phrasing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Some Windows variants return a slightly different phrasing.
+        # Both should be classified as "already absent".
+        monkeypatch.setattr(
+            st.subprocess,
+            "run",
+            lambda cmd, **kw: _completed(
+                returncode=1,
+                stderr="ERROR: The specified task name does not exist.",
+            ),
+        )
+        uninstall_upgrade_task()
+
+    def test_raises_for_unknown_failures(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # An access-denied / RPC error etc. must surface as a clear
+        # error so an operator knows why a `service uninstall` left
+        # the host in an unclean state.
+        monkeypatch.setattr(
+            st.subprocess,
+            "run",
+            lambda cmd, **kw: _completed(
+                returncode=1,
+                stderr="ERROR: Access is denied.",
+            ),
+        )
+        with pytest.raises(ScheduledTaskError, match="Delete"):
+            uninstall_upgrade_task()
+
+
+# ---------------------------------------------------------------------------
+# task_exists
+# ---------------------------------------------------------------------------
+
+
+class TestTaskExists:
+    def test_returns_true_when_query_succeeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            st.subprocess,
+            "run",
+            lambda cmd, **kw: _completed(returncode=0, stdout="task info..."),
+        )
+        assert task_exists() is True
+
+    def test_returns_false_when_query_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            st.subprocess,
+            "run",
+            lambda cmd, **kw: _completed(
+                returncode=1,
+                stderr="ERROR: The system cannot find the file specified.",
+            ),
+        )
+        assert task_exists() is False
+
+    def test_propagates_subprocess_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # If schtasks.exe itself can't be invoked, callers (the
+        # service startup path) need to know — silently returning
+        # False would mask a much bigger problem with the host.
+        def boom(cmd: list[str], **kwargs: Any) -> Any:
+            raise FileNotFoundError("schtasks.exe")
+
+        monkeypatch.setattr(st.subprocess, "run", boom)
+        with pytest.raises(ScheduledTaskError):
+            task_exists()

--- a/watcher/tests/test_self_update.py
+++ b/watcher/tests/test_self_update.py
@@ -253,6 +253,31 @@ class TestBuildUpgradeCommand:
         with pytest.raises(ValueError, match="Cannot build an upgrade command"):
             build_upgrade_command(method, target_version="0.3.0")
 
+    def test_extras_are_preserved_in_pkg_spec(self) -> None:
+        # Regression guard: the original PowerShell output that
+        # surfaced the Windows-uv-tool failure mode also revealed
+        # that the in-process upgrade silently dropped pywin32 — the
+        # ``[windows-service]`` extra wasn't carried through. The
+        # ``extras`` parameter exists exactly so callers (the worker
+        # path and a future hardened in-process path) can preserve
+        # it.
+        cmd = build_upgrade_command(
+            InstallMethod.UV_TOOL,
+            target_version="0.3.0",
+            uv_executable="/usr/local/bin/uv",
+            extras=["windows-service"],
+        )
+        assert cmd[-1] == "data-hub-watcher[windows-service]==0.3.0"
+
+    def test_extras_are_sorted_for_pip(self) -> None:
+        cmd = build_upgrade_command(
+            InstallMethod.PIP,
+            target_version="0.3.0",
+            python_executable="python",
+            extras=["zeta", "alpha"],
+        )
+        assert cmd[-1] == "data-hub-watcher[alpha,zeta]==0.3.0"
+
     def test_uv_tool_uses_path_lookup_when_no_override(self) -> None:
         # Without an explicit `uv_executable` the builder must fall back
         # to `shutil.which("uv")`. Patching it here also guards against a

--- a/watcher/tests/test_service.py
+++ b/watcher/tests/test_service.py
@@ -217,10 +217,16 @@ class TestInstallService:
     """
 
     def test_install_passes_expected_kwargs_to_win32serviceutil(
-        self, service_module: ModuleType
+        self,
+        service_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         win32serviceutil = sys.modules["win32serviceutil"]
         sys.modules["winreg"].OpenKey.return_value = MagicMock()
+        # The upgrade-worker registration is exercised in its own
+        # test below; this test only cares about the SCM kwargs and
+        # would otherwise try to invoke the real `schtasks.exe`.
+        monkeypatch.setattr(service_module, "_install_upgrade_worker", lambda: None)
 
         service_module.install_service(Path("c.yaml"), Path("e.env"))
 
@@ -243,6 +249,7 @@ class TestInstallService:
         sys.modules["winreg"].OpenKey.return_value = MagicMock()
         store_calls: list[tuple[Path, Path]] = []
         recovery_calls: list[None] = []
+        worker_calls: list[None] = []
 
         monkeypatch.setattr(
             service_module,
@@ -254,11 +261,197 @@ class TestInstallService:
             "_configure_recovery",
             lambda: recovery_calls.append(None),
         )
+        monkeypatch.setattr(
+            service_module,
+            "_install_upgrade_worker",
+            lambda: worker_calls.append(None),
+        )
 
         service_module.install_service(Path("c.yaml"), Path("e.env"))
 
         assert store_calls == [(Path("c.yaml"), Path("e.env"))]
         assert recovery_calls == [None]
+        # Critical regression guard: `install_service` must always
+        # register the upgrade worker. A fleet PC installed without
+        # it would silently fall back to the broken in-process
+        # upgrade path on the next auto-update tick.
+        assert worker_calls == [None]
+
+
+class TestInstallUpgradeWorker:
+    """The upgrade-worker scheduled task is wired in alongside the SCM bits.
+
+    These tests exercise the small ``_install_upgrade_worker`` /
+    ``_uninstall_upgrade_worker`` helpers directly, mocking out the
+    schtasks + filesystem side-effects so we assert on the call
+    contract rather than touching the real system.
+    """
+
+    def test_install_writes_script_and_registers_task(
+        self,
+        service_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        # Redirect the well-known config dir into a temp dir so the
+        # rendered script lands somewhere we can inspect.
+        monkeypatch.setattr(service_module, "DEFAULT_CONFIG_DIR", tmp_path)
+
+        install_calls: list[Path] = []
+        monkeypatch.setattr(
+            "data_hub_watcher.scheduled_task.install_upgrade_task",
+            lambda script_path: install_calls.append(script_path),
+        )
+
+        service_module._install_upgrade_worker()
+
+        # Script is on disk under the patched config dir.
+        from data_hub_watcher.upgrade_worker import upgrade_worker_script_path
+
+        script_path = upgrade_worker_script_path(tmp_path)
+        assert script_path.exists()
+        assert "Stop-Service" in script_path.read_text(encoding="utf-8")
+        # Task installer was handed the same path.
+        assert install_calls == [script_path]
+
+    def test_uninstall_removes_task_and_script(
+        self,
+        service_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(service_module, "DEFAULT_CONFIG_DIR", tmp_path)
+
+        from data_hub_watcher.upgrade_worker import upgrade_worker_script_path
+
+        script_path = upgrade_worker_script_path(tmp_path)
+        script_path.parent.mkdir(parents=True, exist_ok=True)
+        script_path.write_text("# stub", encoding="utf-8")
+
+        uninstall_calls: list[None] = []
+        monkeypatch.setattr(
+            "data_hub_watcher.scheduled_task.uninstall_upgrade_task",
+            lambda: uninstall_calls.append(None),
+        )
+
+        service_module._uninstall_upgrade_worker()
+
+        assert uninstall_calls == [None]
+        assert not script_path.exists()
+
+    def test_uninstall_swallows_scheduled_task_errors(
+        self,
+        service_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        # A half-installed host or one where Task Scheduler refuses to
+        # talk to us must not block ``service uninstall`` — leaving
+        # the host with a partially-uninstalled service is strictly
+        # worse than silently missing the worker cleanup.
+        monkeypatch.setattr(service_module, "DEFAULT_CONFIG_DIR", tmp_path)
+
+        from data_hub_watcher.scheduled_task import ScheduledTaskError
+
+        def boom() -> None:
+            raise ScheduledTaskError("nope", argv=["schtasks.exe"], stderr="rpc dead")
+
+        monkeypatch.setattr(
+            "data_hub_watcher.scheduled_task.uninstall_upgrade_task",
+            boom,
+        )
+        # Must not raise.
+        service_module._uninstall_upgrade_worker()
+
+
+class TestRepairUpgradeWorkerOnStartup:
+    """The startup self-repair re-installs the task when it goes missing.
+
+    Lab PCs that auto-update into the worker-aware code without an
+    explicit ``service install`` first won't have the task registered.
+    The startup hook fixes this on the next service tick so the next
+    auto-update can succeed.
+    """
+
+    def test_repair_skipped_when_task_already_registered(
+        self,
+        service_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        sm = MagicMock(name="servicemanager")
+        monkeypatch.setattr("data_hub_watcher.scheduled_task.task_exists", lambda: True)
+        install_calls: list[Path] = []
+        monkeypatch.setattr(
+            "data_hub_watcher.scheduled_task.install_upgrade_task",
+            lambda script_path: install_calls.append(script_path),
+        )
+
+        service_module._repair_upgrade_worker_if_missing(sm)
+
+        assert install_calls == []
+
+    def test_repair_re_registers_when_task_missing(
+        self,
+        service_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(service_module, "DEFAULT_CONFIG_DIR", tmp_path)
+        sm = MagicMock(name="servicemanager")
+        monkeypatch.setattr("data_hub_watcher.scheduled_task.task_exists", lambda: False)
+        install_calls: list[Path] = []
+        monkeypatch.setattr(
+            "data_hub_watcher.scheduled_task.install_upgrade_task",
+            lambda script_path: install_calls.append(script_path),
+        )
+
+        service_module._repair_upgrade_worker_if_missing(sm)
+
+        from data_hub_watcher.upgrade_worker import upgrade_worker_script_path
+
+        assert install_calls == [upgrade_worker_script_path(tmp_path)]
+        assert upgrade_worker_script_path(tmp_path).exists()
+
+    def test_repair_swallows_query_errors(
+        self,
+        service_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # If we can't even query Task Scheduler we should NOT block
+        # service startup — the host should keep running its current
+        # version and surface the issue via LogWarningMsg + the next
+        # auto-update event.
+        from data_hub_watcher.scheduled_task import ScheduledTaskError
+
+        sm = MagicMock(name="servicemanager")
+
+        def boom() -> bool:
+            raise ScheduledTaskError("rpc dead")
+
+        monkeypatch.setattr("data_hub_watcher.scheduled_task.task_exists", boom)
+        # Must not raise.
+        service_module._repair_upgrade_worker_if_missing(sm)
+        sm.LogWarningMsg.assert_called_once()
+
+    def test_repair_swallows_install_failures(
+        self,
+        service_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        from data_hub_watcher.scheduled_task import ScheduledTaskError
+
+        monkeypatch.setattr(service_module, "DEFAULT_CONFIG_DIR", tmp_path)
+        sm = MagicMock(name="servicemanager")
+        monkeypatch.setattr("data_hub_watcher.scheduled_task.task_exists", lambda: False)
+
+        def boom(script_path: Path) -> None:
+            raise ScheduledTaskError("Access is denied")
+
+        monkeypatch.setattr("data_hub_watcher.scheduled_task.install_upgrade_task", boom)
+        # Must not raise even when re-registration fails.
+        service_module._repair_upgrade_worker_if_missing(sm)
+        sm.LogWarningMsg.assert_called_once()
 
 
 # --- _configure_recovery actions + non-crash failure flag --------------------
@@ -335,16 +528,25 @@ class TestServiceLifecycle:
     ) -> None:
         win32serviceutil = sys.modules["win32serviceutil"]
         delete_calls: list[None] = []
+        worker_calls: list[None] = []
         monkeypatch.setattr(
             service_module,
             "_delete_paths_from_registry",
             lambda: delete_calls.append(None),
+        )
+        monkeypatch.setattr(
+            service_module,
+            "_uninstall_upgrade_worker",
+            lambda: worker_calls.append(None),
         )
 
         service_module.uninstall_service()
 
         win32serviceutil.StopService.assert_called_once_with(service_module.SERVICE_NAME)
         assert delete_calls == [None]
+        # Uninstall must also tear down the upgrade worker so a
+        # subsequent reinstall starts from a clean slate.
+        assert worker_calls == [None]
         win32serviceutil.RemoveService.assert_called_once_with(service_module.SERVICE_NAME)
 
     def test_uninstall_swallows_stop_errors(
@@ -355,6 +557,7 @@ class TestServiceLifecycle:
         win32serviceutil = sys.modules["win32serviceutil"]
         win32serviceutil.StopService.side_effect = RuntimeError("not running")
         monkeypatch.setattr(service_module, "_delete_paths_from_registry", lambda: None)
+        monkeypatch.setattr(service_module, "_uninstall_upgrade_worker", lambda: None)
 
         # Even if StopService raises (e.g. service already stopped or
         # doesn't exist), uninstall must still proceed to RemoveService.
@@ -635,6 +838,16 @@ class _LoopHarness:
             service_module,
             "_read_paths_from_registry",
             lambda: (self.config_path, self.env_path),
+        )
+
+        # Stub out the upgrade-worker self-repair so existing
+        # ``_run_service_loop`` tests don't try to invoke ``schtasks.exe``
+        # — that helper has its own dedicated test class above.
+        self.repair_calls: list[Any] = []
+        monkeypatch.setattr(
+            service_module,
+            "_repair_upgrade_worker_if_missing",
+            lambda sm: self.repair_calls.append(sm),
         )
 
         # Patch source modules of the lazy imports inside _run_service_loop.

--- a/watcher/tests/test_service.py
+++ b/watcher/tests/test_service.py
@@ -81,11 +81,27 @@ def _make_win32_fakes() -> dict[str, ModuleType]:
     win32serviceutil = MagicMock(name="win32serviceutil")
     servicemanager = MagicMock(name="servicemanager")
 
+    # ``pywintypes.error`` is the base SCM exception type. The real class
+    # is ``(winerror, funcname, strerror)`` and exposes ``.winerror`` as
+    # an attribute. Using a real subclass of Exception (rather than a
+    # MagicMock) means the service module's ``except pywintypes.error``
+    # actually catches it instead of letting it through as a plain Mock.
+    class _PyWinError(Exception):
+        def __init__(self, winerror: int, funcname: str = "", strerror: str = "") -> None:
+            super().__init__(winerror, funcname, strerror)
+            self.winerror = winerror
+            self.funcname = funcname
+            self.strerror = strerror
+
+    pywintypes = MagicMock(name="pywintypes")
+    pywintypes.error = _PyWinError
+
     return {
         "winreg": winreg,
         "win32service": ws,
         "win32serviceutil": win32serviceutil,
         "servicemanager": servicemanager,
+        "pywintypes": pywintypes,
     }
 
 
@@ -355,6 +371,146 @@ class TestServiceLifecycle:
         win32serviceutil = sys.modules["win32serviceutil"]
         service_module.stop_service()
         win32serviceutil.StopService.assert_called_once_with(service_module.SERVICE_NAME)
+
+
+# --- wait_for_service_removed -----------------------------------------------
+
+
+class TestWaitForServiceRemoved:
+    """Polls SCM until DeleteService finalises.
+
+    The SCM marks the service for deletion synchronously but only
+    finishes the delete once every open handle is closed.  Without the
+    poll, ``service reinstall`` races into ``CreateService`` and dies
+    with the inscrutable error 1072 ("marked for deletion") whenever a
+    Services console (services.msc) or AV agent has the service open on
+    the host.
+    """
+
+    @staticmethod
+    def _patch_clock(monkeypatch: pytest.MonkeyPatch, service_module: ModuleType) -> list[float]:
+        """Replace ``time.monotonic`` / ``time.sleep`` with a deterministic clock.
+
+        Returns the list backing the clock so individual tests can
+        observe how many "ticks" the loop ran for.
+        """
+        clock = [0.0]
+
+        def fake_monotonic() -> float:
+            return clock[0]
+
+        def fake_sleep(seconds: float) -> None:
+            clock[0] += seconds
+
+        monkeypatch.setattr(service_module.time, "monotonic", fake_monotonic)
+        monkeypatch.setattr(service_module.time, "sleep", fake_sleep)
+        return clock
+
+    def test_returns_true_immediately_when_service_does_not_exist(
+        self,
+        service_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ws = sys.modules["win32service"]
+        pywintypes = sys.modules["pywintypes"]
+        ws.OpenSCManager.return_value = MagicMock(name="scm")
+        ws.OpenService.side_effect = pywintypes.error(1060, "OpenService", "does not exist")
+
+        clock = self._patch_clock(monkeypatch, service_module)
+        result = service_module.wait_for_service_removed(timeout_seconds=5.0)
+
+        assert result is True
+        assert ws.OpenService.call_count == 1
+        # No retries needed -> no time spent waiting.
+        assert clock[0] == 0.0
+        # SCM handle must be closed even on the fast-path success.
+        ws.CloseServiceHandle.assert_called_once_with(ws.OpenSCManager.return_value)
+
+    def test_polls_until_service_disappears(
+        self,
+        service_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ws = sys.modules["win32service"]
+        pywintypes = sys.modules["pywintypes"]
+        scm_handle = MagicMock(name="scm")
+        svc_handle = MagicMock(name="svc")
+        ws.OpenSCManager.return_value = scm_handle
+
+        # Three "still marked for deletion" responses, then the service
+        # is finally gone. The loop must close its OpenService handle on
+        # each successful open so it doesn't itself become the thing
+        # holding deletion open.
+        responses: list[Any] = [
+            svc_handle,
+            svc_handle,
+            svc_handle,
+            pywintypes.error(1060, "OpenService", "does not exist"),
+        ]
+
+        def open_service(*_args: Any, **_kwargs: Any) -> Any:
+            r = responses.pop(0)
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+        ws.OpenService.side_effect = open_service
+
+        self._patch_clock(monkeypatch, service_module)
+        result = service_module.wait_for_service_removed(
+            timeout_seconds=10.0, poll_interval_seconds=0.5
+        )
+
+        assert result is True
+        assert ws.OpenService.call_count == 4
+        # Service handle closed once per successful open (3) + SCM
+        # handle closed once at the end = 4 total.
+        close_targets = [c.args[0] for c in ws.CloseServiceHandle.call_args_list]
+        assert close_targets.count(svc_handle) == 3
+        assert close_targets.count(scm_handle) == 1
+
+    def test_returns_false_after_timeout(
+        self,
+        service_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ws = sys.modules["win32service"]
+        ws.OpenSCManager.return_value = MagicMock(name="scm")
+        # Service stays openable forever -> we should give up cleanly.
+        ws.OpenService.return_value = MagicMock(name="svc")
+
+        self._patch_clock(monkeypatch, service_module)
+        result = service_module.wait_for_service_removed(
+            timeout_seconds=2.0, poll_interval_seconds=0.5
+        )
+
+        assert result is False
+        # SCM handle must still be released so we don't leak it back to
+        # the caller (who will likely retry).
+        assert any(
+            c.args[0] is ws.OpenSCManager.return_value for c in ws.CloseServiceHandle.call_args_list
+        )
+
+    def test_unrelated_pywin_error_propagates(
+        self,
+        service_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Access denied (5) is the kind of error operators need to see —
+        # silently swallowing it would mask a permissions problem.
+        ws = sys.modules["win32service"]
+        pywintypes = sys.modules["pywintypes"]
+        ws.OpenSCManager.return_value = MagicMock(name="scm")
+        ws.OpenService.side_effect = pywintypes.error(5, "OpenService", "Access is denied")
+
+        self._patch_clock(monkeypatch, service_module)
+
+        with pytest.raises(pywintypes.error) as excinfo:
+            service_module.wait_for_service_removed(timeout_seconds=2.0)
+
+        assert excinfo.value.winerror == 5
+        # Even on the error path the SCM handle must be released.
+        ws.CloseServiceHandle.assert_called_once_with(ws.OpenSCManager.return_value)
 
 
 # --- query_service_status ----------------------------------------------------

--- a/watcher/tests/test_updater.py
+++ b/watcher/tests/test_updater.py
@@ -478,6 +478,52 @@ class TestUpdaterOnTick:
         # marker evaluation, not emitted here.
         assert EventType.UPDATE_SUCCEEDED not in emitted
 
+    def test_subprocess_output_is_logged_at_info_even_on_success(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # Defence in depth: a partial install can update some Python
+        # files (fooling the post-restart marker comparison) while
+        # uv exits with a non-zero code or prints a meaningful
+        # warning to stderr. Even on the apparent-success path we
+        # MUST mirror the captured output to ``watcher.log`` so an
+        # operator can recover the actual installer transcript when
+        # the dashboard event is misleading. Historically this gap
+        # is what made the "Scripts directory locked" failure
+        # invisible until someone ran the upgrade by hand.
+        runner = MagicMock(
+            return_value=subprocess.CompletedProcess(
+                args=["uv"],
+                returncode=0,
+                stdout="Installed 17 packages\n+ data-hub-watcher==9.9.9",
+                stderr="warning: index format is deprecated",
+            )
+        )
+        h = _make_updater(tmp_path, upgrade_runner=runner)
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.detect_install_method",
+            lambda: InstallMethod.UV_TOOL,
+        )
+
+        h.counters.last_files_uploaded = 0
+        with caplog.at_level("INFO", logger="data_hub_watcher.updater"):
+            h.updater.on_tick()
+            h.updater.on_tick()
+            h.updater.on_tick()
+
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        assert "Installed 17 packages" in log_text
+        # stderr is logged separately so a regression that only
+        # captured one stream surfaces here.
+        assert "warning: index format is deprecated" in log_text
+        # On success we still emit the "requesting service restart"
+        # line — these tests are specifically that the output is
+        # *also* logged.
+        assert "requesting service restart" in log_text
+
     def test_failed_upgrade_subprocess_emits_update_failed(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -867,3 +913,275 @@ class TestUpdaterAsyncDispatch:
         assert done.wait(timeout=2.0)
         assert seen_threads == ["upgrade-worker"]
         assert seen_threads[0] != threading.current_thread().name
+
+
+# ---------------------------------------------------------------------------
+# Updater worker-dispatch branch (Windows uv-tool)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdaterWorkerDispatch:
+    """On Windows uv-tool installs ``_apply`` routes through the worker.
+
+    Locks in the contract: the in-process subprocess path must NOT
+    fire (it would just re-hit the ``Scripts\\python.exe`` lock issue
+    that motivated this whole change), the request sentinel must
+    land on disk with the right pkg_spec, and ``schtasks /Run``
+    failures must surface as ``UPDATE_FAILED`` rather than a silent
+    no-op.
+    """
+
+    def _force_windows_uv_tool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("data_hub_watcher.updater.sys.platform", "win32")
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.detect_install_method",
+            lambda: InstallMethod.UV_TOOL,
+        )
+        monkeypatch.setattr(
+            "data_hub_watcher.updater._resolve_uv_executable",
+            lambda override=None, prefix=None: ("/fake/bin/uv.exe", ["/fake/bin/uv.exe"]),
+        )
+        # Pretend pywin32 is installed so the extras detection picks
+        # up the [windows-service] extra, exercising the regression
+        # where pywin32 used to silently disappear after a reinstall.
+        # The function is imported into the ``updater`` namespace, so
+        # we patch it there rather than at the source module.
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.detect_installed_extras",
+            lambda: ["windows-service"],
+        )
+
+    def test_writes_request_sentinel_and_triggers_task(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from data_hub_watcher.upgrade_worker import (
+            read_upgrade_request,
+        )
+
+        runner = MagicMock()  # must not be called on the worker path
+        h = _make_updater(tmp_path, upgrade_runner=runner)
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+
+        self._force_windows_uv_tool(monkeypatch)
+
+        trigger_calls: list[None] = []
+        monkeypatch.setattr(
+            "data_hub_watcher.scheduled_task.trigger_upgrade_task",
+            lambda **_kw: trigger_calls.append(None),
+        )
+
+        h.counters.last_files_uploaded = 0
+        h.updater.on_tick()
+        h.updater.on_tick()
+        result = h.updater.on_tick()
+
+        assert result is not None
+        assert result.attempted is True
+        # Worker dispatch leaves succeeded=None; the real outcome is
+        # surfaced from the post-restart event evaluation, not here.
+        assert result.succeeded is None
+        assert result.extra.get("via_worker") is True
+
+        # Request sentinel must be on disk with the right spec.
+        req = read_upgrade_request(tmp_path / ".data-hub")
+        assert req is not None
+        assert req.target_version == "9.9.9"
+        assert req.pkg_spec == "data-hub-watcher[windows-service]==9.9.9"
+        assert req.uv_executable == "/fake/bin/uv.exe"
+        assert req.install_method == "uv-tool"
+
+        # Marker is also on disk so the post-restart evaluation can
+        # tell whether the new version actually loaded.
+        assert (tmp_path / ".data-hub" / UPGRADE_MARKER_FILENAME).exists()
+        # schtasks /Run was triggered exactly once.
+        assert trigger_calls == [None]
+        # Critical: the in-process subprocess path must NOT fire on
+        # Windows uv-tool — that would re-hit the lock issue the
+        # whole change is designed to avoid.
+        runner.assert_not_called()
+        h.request_restart.assert_not_called()
+
+        # UPDATE_STARTED must have been queued so the dashboard shows
+        # the dispatch even if the worker takes the service down
+        # before the next heartbeat would normally flush.
+        emitted = [c.args[0] for c in h.reporter.queue_event.call_args_list]
+        types = [e.event_type for e in emitted]
+        assert EventType.UPDATE_STARTED in types
+        # The success / final-failure event is deferred to the
+        # post-restart marker evaluation, never emitted from here.
+        assert EventType.UPDATE_SUCCEEDED not in types
+
+    def test_uv_not_found_surfaces_update_failed_without_started(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Same invariant as the in-process path: a missing uv binary
+        # must NOT emit UPDATE_STARTED, must NOT write the marker,
+        # and must surface a single UPDATE_FAILED with the candidates
+        # we probed so the operator can drop a binary in the right
+        # place.
+        h = _make_updater(tmp_path)
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+
+        monkeypatch.setattr("data_hub_watcher.updater.sys.platform", "win32")
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.detect_install_method",
+            lambda: InstallMethod.UV_TOOL,
+        )
+        monkeypatch.setattr(
+            "data_hub_watcher.updater._resolve_uv_executable",
+            lambda override=None, prefix=None: (None, [r"C:\Users\lab\.local\bin\uv.exe"]),
+        )
+
+        trigger_calls: list[None] = []
+        monkeypatch.setattr(
+            "data_hub_watcher.scheduled_task.trigger_upgrade_task",
+            lambda **_kw: trigger_calls.append(None),
+        )
+
+        h.counters.last_files_uploaded = 0
+        h.updater.on_tick()
+        h.updater.on_tick()
+        result = h.updater.on_tick()
+
+        assert result is not None
+        assert result.attempted is True
+        assert result.succeeded is False
+        assert trigger_calls == []
+        assert not (tmp_path / ".data-hub" / UPGRADE_MARKER_FILENAME).exists()
+
+        emitted = [c.args[0] for c in h.reporter.queue_event.call_args_list]
+        types = [e.event_type for e in emitted]
+        assert EventType.UPDATE_STARTED not in types
+        update_failed = [e for e in emitted if e.event_type is EventType.UPDATE_FAILED]
+        assert len(update_failed) == 1
+        details = update_failed[0].details
+        assert details["reason"] == "uv executable not found"
+        assert details["attempted_subprocess"] is False
+        assert details["via_worker"] is True
+        assert details["candidates_tried"] == [r"C:\Users\lab\.local\bin\uv.exe"]
+
+    def test_schtasks_failure_clears_sentinels_and_emits_update_failed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Most likely cause: the scheduled task isn't registered (a
+        # fleet PC that auto-updated into worker-aware code without
+        # re-running ``service install``). The dispatch must:
+        #   1. Clear its own request sentinel + marker so the next
+        #      tick can try again from a clean slate.
+        #   2. Surface UPDATE_FAILED with a reason that points at
+        #      the recovery command.
+        #   3. NOT call request_restart (the worker is what stops
+        #      the service; without it firing we must stay alive).
+        from data_hub_watcher.scheduled_task import ScheduledTaskError
+        from data_hub_watcher.upgrade_worker import (
+            UPGRADE_REQUEST_FILENAME,
+            UPGRADE_RESULT_FILENAME,
+        )
+
+        h = _make_updater(tmp_path)
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+        self._force_windows_uv_tool(monkeypatch)
+
+        def boom(**_kw: Any) -> None:
+            raise ScheduledTaskError(
+                "schtasks /Run failed for 'DataHubWatcherUpgrade'",
+                argv=["schtasks.exe", "/Run", "/TN", "DataHubWatcherUpgrade"],
+                stderr="ERROR: The system cannot find the file specified.",
+                returncode=1,
+            )
+
+        monkeypatch.setattr("data_hub_watcher.scheduled_task.trigger_upgrade_task", boom)
+
+        h.counters.last_files_uploaded = 0
+        h.updater.on_tick()
+        h.updater.on_tick()
+        result = h.updater.on_tick()
+
+        assert result is not None
+        assert result.attempted is True
+        assert result.succeeded is False
+        assert "scheduled task" in result.reason
+        # Sentinels must be cleared so the next tick isn't gated on
+        # a stale request file from a failed dispatch.
+        assert not (tmp_path / ".data-hub" / UPGRADE_REQUEST_FILENAME).exists()
+        assert not (tmp_path / ".data-hub" / UPGRADE_MARKER_FILENAME).exists()
+        # And of course there's no result sentinel — the worker
+        # never ran.
+        assert not (tmp_path / ".data-hub" / UPGRADE_RESULT_FILENAME).exists()
+
+        h.request_restart.assert_not_called()
+
+        emitted = [c.args[0] for c in h.reporter.queue_event.call_args_list]
+        update_failed = [e for e in emitted if e.event_type is EventType.UPDATE_FAILED]
+        assert len(update_failed) == 1
+        details = update_failed[0].details
+        assert details["via_worker"] is True
+        assert details["attempted_subprocess"] is False
+        assert "schtasks_stderr" in details
+        assert details["schtasks_returncode"] == 1
+        assert "service reinstall" in details["reason"]
+
+    def test_posix_uv_tool_still_uses_in_process_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The worker dispatch is gated on Windows specifically. POSIX
+        # uv-tool installs continue to use the inline subprocess
+        # because they don't have the file-lock issue and the inline
+        # path gives the dashboard live UPDATE_STARTED -> succeeded
+        # event pairing without an extra hop.
+        runner = MagicMock(return_value=_success_completed_process())
+        h = _make_updater(tmp_path, upgrade_runner=runner)
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+
+        monkeypatch.setattr("data_hub_watcher.updater.sys.platform", "linux")
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.detect_install_method",
+            lambda: InstallMethod.UV_TOOL,
+        )
+        # If anything tried to dispatch through the worker, this
+        # would explode loudly rather than passing silently.
+        monkeypatch.setattr(
+            "data_hub_watcher.scheduled_task.trigger_upgrade_task",
+            lambda **_kw: pytest.fail("POSIX uv-tool must not route through the worker"),
+        )
+
+        h.counters.last_files_uploaded = 0
+        h.updater.on_tick()
+        h.updater.on_tick()
+        result = h.updater.on_tick()
+
+        assert result is not None
+        assert result.attempted is True
+        assert result.succeeded is True
+        runner.assert_called_once()
+        h.request_restart.assert_called_once_with("9.9.9")
+
+    def test_windows_pip_install_still_uses_in_process_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Windows pip-installed watchers don't have the lock issue
+        # because pip rewrites individual files in site-packages
+        # rather than recreating Scripts\\. They keep using the
+        # inline subprocess path.
+        runner = MagicMock(return_value=_success_completed_process())
+        h = _make_updater(tmp_path, upgrade_runner=runner)
+        h.client.get_update_info.return_value = _info(latest="9.9.9")
+
+        monkeypatch.setattr("data_hub_watcher.updater.sys.platform", "win32")
+        monkeypatch.setattr(
+            "data_hub_watcher.updater.detect_install_method",
+            lambda: InstallMethod.PIP,
+        )
+        monkeypatch.setattr(
+            "data_hub_watcher.scheduled_task.trigger_upgrade_task",
+            lambda **_kw: pytest.fail("Windows pip installs must not route through the worker"),
+        )
+
+        h.counters.last_files_uploaded = 0
+        h.updater.on_tick()
+        h.updater.on_tick()
+        result = h.updater.on_tick()
+
+        assert result is not None
+        assert result.succeeded is True
+        runner.assert_called_once()

--- a/watcher/tests/test_upgrade_worker.py
+++ b/watcher/tests/test_upgrade_worker.py
@@ -259,7 +259,6 @@ class TestRenderWorkerScript:
             request_path=tmp_path / ".upgrade-request.json",
             result_path=tmp_path / ".upgrade-result.json",
             log_path=tmp_path / "upgrade-worker.log",
-            marker_path=tmp_path / ".upgrade-in-progress",
             generated_at="2026-05-04T22:30:00+00:00",
         )
 
@@ -321,6 +320,34 @@ class TestRenderWorkerScript:
         contents = path.read_text(encoding="utf-8")
         assert "Stop-Service" in contents
         assert "DataHubWatcher" in contents
+
+    def test_no_marker_path_baked_into_template(self, tmp_path: Path) -> None:
+        # The ``.upgrade-in-progress`` marker is owned end-to-end on
+        # the Python side (written before dispatch in ``updater``,
+        # consumed in ``runtime.start_runtime``). The worker has no
+        # business touching it — leaking ``$MarkerPath`` into the
+        # rendered script invites a future change to start mutating
+        # it from PowerShell, which would race with the post-restart
+        # evaluation. Pin the contract here.
+        script = self._render(tmp_path)
+        assert "$MarkerPath" not in script
+        assert ".upgrade-in-progress" not in script
+
+    def test_uv_invocation_always_passes_index_url(self, tmp_path: Path) -> None:
+        # The dispatch-side code (``_apply_via_worker`` /
+        # ``_dispatch_self_update_via_worker``) only ever writes a
+        # request sentinel for a pinned target version, so the worker
+        # is guaranteed to have an index URL to forward. Mirroring
+        # ``build_upgrade_command``'s argv shape unconditionally keeps
+        # the two install paths byte-equivalent and means a future
+        # change to one needs to update the other — rather than
+        # silently drifting because a conditional in the worker
+        # was a no-op for the only call site that ever hit it.
+        script = self._render(tmp_path)
+        assert "--index-url" in script
+        # No conditional gating the index-url addition; the args list
+        # is constructed in a single literal.
+        assert "if ($Target)" not in script
 
     def test_uv_stdout_and_stderr_are_echoed_to_worker_log(self, tmp_path: Path) -> None:
         # Regression guard against the symptom that prompted this

--- a/watcher/tests/test_upgrade_worker.py
+++ b/watcher/tests/test_upgrade_worker.py
@@ -1,0 +1,359 @@
+"""Unit tests for `data_hub_watcher.upgrade_worker`.
+
+The worker module is the fixed contract between the service / CLI
+(which write the request sentinel) and the SYSTEM-owned PowerShell
+worker (which reads it). These tests pin the JSON shape, the package
+spec computation, and the rendered worker template so a regression
+that breaks the contract surfaces here rather than as a stuck
+``schtasks`` execution on a real lab PC.
+"""
+
+from __future__ import annotations
+import json
+from pathlib import Path
+
+import pytest
+
+from data_hub_watcher.self_update import InstallMethod
+from data_hub_watcher.upgrade_worker import (
+    UPGRADE_REQUEST_FILENAME,
+    UPGRADE_RESULT_FILENAME,
+    UPGRADE_WORKER_SCRIPT_FILENAME,
+    UpgradeResult,
+    build_pkg_spec,
+    clear_upgrade_request,
+    clear_upgrade_result,
+    read_upgrade_request,
+    read_upgrade_result,
+    render_worker_script,
+    upgrade_request_path,
+    upgrade_result_path,
+    upgrade_worker_script_path,
+    write_upgrade_request,
+    write_worker_script,
+)
+
+# ---------------------------------------------------------------------------
+# Sentinel round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestUpgradeRequestRoundTrip:
+    def test_write_then_read_preserves_fields(self, tmp_path: Path) -> None:
+        req = write_upgrade_request(
+            tmp_path,
+            target_version="0.3.0",
+            pkg_spec="data-hub-watcher[windows-service]==0.3.0",
+            uv_executable=r"C:\Users\lab\.local\bin\uv.exe",
+            index_url="https://pypi.org/simple/",
+            previous_version="0.1.4",
+            install_method="uv-tool",
+            request_id="test-id-1234",
+        )
+
+        loaded = read_upgrade_request(tmp_path)
+        assert loaded == req
+        assert loaded is not None
+        assert loaded.request_id == "test-id-1234"
+        assert loaded.pkg_spec == "data-hub-watcher[windows-service]==0.3.0"
+        assert loaded.uv_executable == r"C:\Users\lab\.local\bin\uv.exe"
+
+    def test_request_id_defaults_to_uuid_when_absent(self, tmp_path: Path) -> None:
+        req = write_upgrade_request(
+            tmp_path,
+            target_version="0.3.0",
+            pkg_spec="data-hub-watcher==0.3.0",
+            uv_executable="uv",
+            index_url="https://pypi.org/simple/",
+            previous_version="0.1.0",
+            install_method="uv-tool",
+        )
+        assert req.request_id
+        # uuid4 is 36 chars (32 hex + 4 dashes); the exact format is
+        # less important than "not the literal default placeholder".
+        assert len(req.request_id) == 36
+
+    def test_read_returns_none_when_file_absent(self, tmp_path: Path) -> None:
+        assert read_upgrade_request(tmp_path) is None
+
+    def test_read_returns_none_for_corrupt_json(self, tmp_path: Path) -> None:
+        upgrade_request_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+        upgrade_request_path(tmp_path).write_text("not-json", encoding="utf-8")
+        assert read_upgrade_request(tmp_path) is None
+
+    def test_read_returns_none_for_missing_required_fields(self, tmp_path: Path) -> None:
+        upgrade_request_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+        upgrade_request_path(tmp_path).write_text(
+            json.dumps({"target_version": "0.3.0"}), encoding="utf-8"
+        )
+        assert read_upgrade_request(tmp_path) is None
+
+    def test_clear_is_idempotent(self, tmp_path: Path) -> None:
+        clear_upgrade_request(tmp_path)
+        clear_upgrade_request(tmp_path)
+
+    def test_write_overwrites_existing_request(self, tmp_path: Path) -> None:
+        # Two consecutive dispatches (e.g. CLI invocation while the
+        # auto-updater also fired) must leave the file consistent
+        # rather than torn — the atomic-write contract is what makes
+        # the worker's read race-free.
+        write_upgrade_request(
+            tmp_path,
+            target_version="0.2.0",
+            pkg_spec="data-hub-watcher==0.2.0",
+            uv_executable="uv",
+            index_url="https://pypi.org/simple/",
+            previous_version="0.1.0",
+            install_method="uv-tool",
+            request_id="first",
+        )
+        write_upgrade_request(
+            tmp_path,
+            target_version="0.3.0",
+            pkg_spec="data-hub-watcher==0.3.0",
+            uv_executable="uv",
+            index_url="https://pypi.org/simple/",
+            previous_version="0.1.0",
+            install_method="uv-tool",
+            request_id="second",
+        )
+        latest = read_upgrade_request(tmp_path)
+        assert latest is not None
+        assert latest.request_id == "second"
+        assert latest.target_version == "0.3.0"
+
+
+class TestUpgradeResultRoundTrip:
+    def test_write_then_read_success(self, tmp_path: Path) -> None:
+        result = UpgradeResult(
+            request_id="test-id",
+            target_version="0.3.0",
+            succeeded=True,
+            returncode=0,
+            stdout_tail="installed 17 packages",
+            stderr_tail="",
+            finished_at="2026-05-04T22:30:00+00:00",
+            error=None,
+        )
+        path = upgrade_result_path(tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(result.to_dict()), encoding="utf-8")
+
+        loaded = read_upgrade_result(tmp_path)
+        assert loaded == result
+
+    def test_read_returns_none_when_absent(self, tmp_path: Path) -> None:
+        assert read_upgrade_result(tmp_path) is None
+
+    def test_read_returns_none_for_corrupt_json(self, tmp_path: Path) -> None:
+        upgrade_result_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+        upgrade_result_path(tmp_path).write_text("not-json", encoding="utf-8")
+        assert read_upgrade_result(tmp_path) is None
+
+    def test_read_handles_null_returncode(self, tmp_path: Path) -> None:
+        # The PowerShell worker writes returncode=null when `uv` itself
+        # raised before producing an exit code (e.g. ENOENT on the binary).
+        # Round-trip must preserve the null rather than coercing to 0,
+        # because 0 would mean "success" and dramatically change the
+        # event semantics.
+        path = upgrade_result_path(tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "request_id": "x",
+                    "target_version": "0.3.0",
+                    "succeeded": False,
+                    "returncode": None,
+                    "stdout_tail": "",
+                    "stderr_tail": "",
+                    "finished_at": "2026-05-04T22:30:00+00:00",
+                    "error": "uv not found",
+                }
+            ),
+            encoding="utf-8",
+        )
+        loaded = read_upgrade_result(tmp_path)
+        assert loaded is not None
+        assert loaded.succeeded is False
+        assert loaded.returncode is None
+        assert loaded.error == "uv not found"
+
+    def test_clear_is_idempotent(self, tmp_path: Path) -> None:
+        clear_upgrade_result(tmp_path)
+        clear_upgrade_result(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# build_pkg_spec
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPkgSpec:
+    def test_uv_tool_with_no_extras_pinned(self) -> None:
+        assert (
+            build_pkg_spec(InstallMethod.UV_TOOL, target_version="0.3.0")
+            == "data-hub-watcher==0.3.0"
+        )
+
+    def test_uv_tool_with_windows_service_extra(self) -> None:
+        # The whole point of this helper: a fleet PC originally
+        # installed with `[windows-service]` must keep getting it on
+        # every reinstall, otherwise pywin32 disappears and the
+        # service can't start.
+        assert (
+            build_pkg_spec(
+                InstallMethod.UV_TOOL,
+                target_version="0.3.0",
+                extras=["windows-service"],
+            )
+            == "data-hub-watcher[windows-service]==0.3.0"
+        )
+
+    def test_pip_with_extras(self) -> None:
+        assert (
+            build_pkg_spec(
+                InstallMethod.PIP,
+                target_version="0.3.0",
+                extras=["windows-service"],
+            )
+            == "data-hub-watcher[windows-service]==0.3.0"
+        )
+
+    def test_extras_are_sorted(self) -> None:
+        # Sorted output keeps the rendered worker script byte-stable
+        # so we can use a content hash for "did the script change?"
+        # checks down the line, and so the golden test below isn't
+        # sensitive to dict-iteration order.
+        assert (
+            build_pkg_spec(
+                InstallMethod.UV_TOOL,
+                target_version="0.3.0",
+                extras=["zeta", "alpha"],
+            )
+            == "data-hub-watcher[alpha,zeta]==0.3.0"
+        )
+
+    def test_no_target_version_omits_pin(self) -> None:
+        assert build_pkg_spec(InstallMethod.UV_TOOL) == "data-hub-watcher"
+        assert (
+            build_pkg_spec(InstallMethod.UV_TOOL, extras=["windows-service"])
+            == "data-hub-watcher[windows-service]"
+        )
+
+    @pytest.mark.parametrize("method", [InstallMethod.EDITABLE, InstallMethod.UNKNOWN])
+    def test_unsupported_methods_raise(self, method: InstallMethod) -> None:
+        with pytest.raises(ValueError, match="Cannot build a package spec"):
+            build_pkg_spec(method, target_version="0.3.0")
+
+
+# ---------------------------------------------------------------------------
+# Worker script template
+# ---------------------------------------------------------------------------
+
+
+class TestRenderWorkerScript:
+    def _render(self, tmp_path: Path) -> str:
+        return render_worker_script(
+            service_name="DataHubWatcher",
+            request_path=tmp_path / ".upgrade-request.json",
+            result_path=tmp_path / ".upgrade-result.json",
+            log_path=tmp_path / "upgrade-worker.log",
+            marker_path=tmp_path / ".upgrade-in-progress",
+            generated_at="2026-05-04T22:30:00+00:00",
+        )
+
+    def test_includes_critical_lifecycle_steps(self, tmp_path: Path) -> None:
+        script = self._render(tmp_path)
+        # Must stop the service before running uv (releases Scripts\python.exe).
+        assert "Stop-Service" in script
+        # Must start the service again so the new wheel is loaded.
+        assert "Start-Service" in script
+        # Must invoke uv with the reinstall flag so the venv is rebuilt.
+        assert "tool" in script and "install" in script and "--reinstall" in script
+        # Must write the result sentinel so the post-restart event has
+        # the subprocess output to attach.
+        assert "$ResultPath" in script
+        # Must clean up the request sentinel so a stale request doesn't
+        # re-dispatch on a future task run.
+        assert "Remove-Item" in script and "$RequestPath" in script
+
+    def test_baked_in_paths_are_absolute_strings(self, tmp_path: Path) -> None:
+        script = self._render(tmp_path)
+        assert str(tmp_path / ".upgrade-request.json") in script
+        assert str(tmp_path / ".upgrade-result.json") in script
+        assert str(tmp_path / "upgrade-worker.log") in script
+        assert "DataHubWatcher" in script
+
+    def test_uv_executable_is_read_from_request_not_baked(self, tmp_path: Path) -> None:
+        # The uv path lives in the request sentinel rather than being
+        # baked into the worker script so a post-install relocation of
+        # uv.exe doesn't require regenerating the script. Lock that
+        # contract here.
+        script = self._render(tmp_path)
+        assert r"C:\Users\lab\.local\bin\uv.exe" not in script
+        assert "$UvExe" in script
+        assert "request.uv_executable" in script
+
+    def test_writes_to_log_path(self, tmp_path: Path) -> None:
+        script = self._render(tmp_path)
+        assert "$LogPath" in script
+        assert "Add-Content" in script
+
+    def test_uses_finally_to_restart_service_on_failure(self, tmp_path: Path) -> None:
+        # If uv crashes, the worker MUST still write the result sentinel
+        # AND attempt to restart the service. Without the finally block
+        # the host would be left with a stopped service after a botched
+        # upgrade — strictly worse than the original problem.
+        script = self._render(tmp_path)
+        # The finally block contains both Write-ResultJson and Start-Service.
+        finally_idx = script.find("} finally {")
+        assert finally_idx != -1, "worker must wrap uv invocation in try/finally"
+        finally_block = script[finally_idx:]
+        assert "Write-ResultJson" in finally_block
+        assert "Start-Service" in finally_block
+
+    def test_write_worker_script_drops_file_at_expected_path(self, tmp_path: Path) -> None:
+        path = write_worker_script(tmp_path, service_name="DataHubWatcher")
+        assert path == upgrade_worker_script_path(tmp_path)
+        assert path.exists()
+        assert path.name == UPGRADE_WORKER_SCRIPT_FILENAME
+        contents = path.read_text(encoding="utf-8")
+        assert "Stop-Service" in contents
+        assert "DataHubWatcher" in contents
+
+    def test_uv_stdout_and_stderr_are_echoed_to_worker_log(self, tmp_path: Path) -> None:
+        # Regression guard against the symptom that prompted this
+        # change: the previous in-process upgrade attempts produced
+        # no record of uv's actual stderr anywhere on the lab PC,
+        # so an operator had no way to tell a "Scripts directory is
+        # locked" failure from a "PyPI was down" failure. The
+        # worker MUST mirror uv's full output to the worker log so
+        # tailing the log on the host always shows the install
+        # transcript, even if the result sentinel is later
+        # consumed/cleared.
+        script = self._render(tmp_path)
+        # Both stdout and stderr lines are written via Write-Log so
+        # they pick up the same UTC timestamp prefix as the rest of
+        # the worker's events.
+        assert "uv stdout:" in script
+        assert "uv stderr:" in script
+        # The split must happen on either CR-LF or LF so the
+        # transcript reads correctly regardless of which line ending
+        # uv emits on the host.
+        assert "`r?`n" in script or "\\r?\\n" in script
+
+
+# ---------------------------------------------------------------------------
+# Filename constants
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_filenames_are_dotfiles_under_config_dir(tmp_path: Path) -> None:
+    # The lifecycle helpers in `runtime` and the `__main__` block on
+    # the service rely on these filenames; pin them so a casual rename
+    # surfaces here rather than as a silent dispatch failure.
+    assert upgrade_request_path(tmp_path).name == UPGRADE_REQUEST_FILENAME
+    assert upgrade_result_path(tmp_path).name == UPGRADE_RESULT_FILENAME
+    assert UPGRADE_REQUEST_FILENAME.startswith(".")
+    assert UPGRADE_RESULT_FILENAME.startswith(".")


### PR DESCRIPTION
## Summary

Fixes the long-standing failure where `data-hub-watcher self-update` and the in-process auto-updater both hit `Access is denied. (os error 5)` on Windows uv-tool installs. The root cause is structural: `uv tool install --reinstall` recreates `Scripts\python.exe` while the running service holds an exclusive lock on it. No amount of retrying or running-as-Administrator can fix that — the upgrade subprocess has to live in a process tree that doesn't include the locked interpreter.

This PR introduces an out-of-process worker driven by Windows Task Scheduler. The watcher writes a request sentinel, triggers a SYSTEM-owned `DataHubWatcherUpgrade` Scheduled Task, and lets the worker stop the service, run `uv`, drop a result sentinel, and restart the service. POSIX uv-tool and Windows pip installs are unchanged — they don't have the lock issue and the inline subprocess path gives the dashboard live event pairing.

A secondary fix: the previous in-process path silently dropped the `[windows-service]` extra on every reinstall, which uninstalled `pywin32` and would have broken the service on the very next restart. The new `build_pkg_spec` helper preserves extras across both code paths.

### What's new

- **`data_hub_watcher.upgrade_worker`** — sentinel dataclasses (`UpgradeRequest`, `UpgradeResult`), atomic JSON read/write helpers, `build_pkg_spec` (preserves `[windows-service]`), `detect_installed_extras`, and the PowerShell worker template + renderer.
- **`data_hub_watcher.scheduled_task`** — thin `schtasks.exe` wrappers (`install_upgrade_task` / `trigger_upgrade_task` / `uninstall_upgrade_task` / `task_exists`) with a typed `ScheduledTaskError`.
- **Service install/uninstall** drops the worker script under `~/.data-hub/upgrade-worker.ps1` and registers/removes the task.
- **`_run_service_loop` self-heal** — every service startup checks for the task and lazily re-registers it if missing, so fleet PCs that auto-update into v0.2.0 fix themselves on the next service tick without operator action.
- **`Updater._apply` branches** on `sys.platform == "win32" and method is UV_TOOL` between the in-process path and the new worker dispatch. The worker path resolves `uv`, builds the pkg spec with extras, writes the request sentinel + marker, and triggers the task.
- **`cli.self_update`** dispatches the same way; pre-flight checks (uv resolvable? task registered?) raise actionable `ClickException`s rather than silently falling back to the broken path.
- **Post-restart event evaluation** in `runtime.py` now reads the worker's result sentinel and merges `worker_returncode` / `worker_stdout_tail` / `worker_stderr_tail` into the emitted `update_succeeded`/`update_failed` events. The worker's `succeeded` flag is treated as authoritative — a partial install that fools the marker version comparison still surfaces `update_failed` with the actual uv error, with `marker_succeeded` / `marker_reason` preserved so disagreements between the two signals are visible.
- **Installer transcript is logged in two places** — the worker echoes uv's stdout/stderr line-by-line to `~/.data-hub/upgrade-worker.log`, and the in-process path now logs the subprocess output to `watcher.log` regardless of return code. The historical "no errors surfaced" failure mode (where uv exited non-zero on a partial install but only the generic 'expected X, running Y' marker reason reached the dashboard) is now recoverable from the lab PC even after the result sentinel is consumed.

### What stays the same

- POSIX (Linux/macOS) and Windows pip install paths use the existing inline subprocess flow.
- The on-disk `.upgrade-in-progress` marker semantics, the event taxonomy (`UPDATE_STARTED` / `UPDATE_SUCCEEDED` / `UPDATE_FAILED`), and the activity-window guard for auto-updates are unchanged.
- Editable / `uv sync` checkouts continue to be refused.

### Operator impact

Lab PCs already running an older watcher build need a one-time `data-hub-watcher service reinstall` from an Administrator shell after they auto-update into v0.2.0 — that is what registers the new Scheduled Task. The startup self-heal covers most cases without operator intervention; the troubleshooting docs walk through the explicit recovery for the rest.

Bumps watcher to **0.2.0**. Docs (`upgrading-the-watcher.md`, `installing-a-watcher.md`) rewritten to cover the new flow, with troubleshooting entries for missing tasks, missing result sentinels, where to find the install transcript, and the "worker reported failure even though the marker says success" case.

## Test plan

Automated coverage (327 watcher tests, all passing):

- [x] `test_upgrade_worker.py` — sentinel round-trips, `build_pkg_spec` with/without extras, golden-string check on the rendered PowerShell, and the new "uv stdout/stderr is echoed to the worker log" assertion.
- [x] `test_scheduled_task.py` — argv shape for `install_upgrade_task` (`/RU SYSTEM`, `/RL HIGHEST`, `/F`), `task_exists` returns / propagates correctly, `uninstall_upgrade_task` is silent on missing task and loud on real failures.
- [x] `test_service.py` — `install_service` calls `_install_upgrade_worker`, `uninstall_service` calls `_uninstall_upgrade_worker`, the new `_repair_upgrade_worker_if_missing` startup hook re-registers a missing task and swallows transient `schtasks` failures.
- [x] `test_updater.py` — Windows uv-tool routes through the worker (writes request sentinel with `[windows-service]` extra, calls `trigger_upgrade_task`, never invokes the inline runner); POSIX uv-tool and Windows pip still use the inline path; `schtasks /Run` failures clear sentinels and emit a specific `update_failed` reason.
- [x] `test_cli_self_update.py` — happy path writes the sentinel and triggers the task; missing task / missing uv / `schtasks` failures all surface as actionable click errors and do NOT fall back to the broken in-process path.
- [x] `test_runtime.py` — post-restart evaluation merges the worker result into success and failure events; **worker `succeeded=False` overrides marker success** (the regression guard for the silent installer-error case); soft `worker_warning` flag fires when the worker reports success with non-empty stderr.
- [x] `make check-all` is clean.

Manual verification on a real Windows lab PC (next):

- [ ] On a PC that auto-updated into v0.2.0 from v0.1.x: confirm the startup self-heal registers `DataHubWatcherUpgrade` (visible in `taskschd.msc`).
- [ ] Run `data-hub-watcher self-update` against a new server target: confirm the CLI exits with "Upgrade dispatched", the service cycles `Stopped → Running`, and the dashboard shows `update_started` → `update_succeeded` with the worker fields populated.
- [ ] Force a failure (e.g. point at a non-existent version): confirm the dashboard shows `update_failed` with the actual `uv` error in `worker_stderr_tail`, not the generic "expected X, running Y" reason.
- [ ] Tail `~/.data-hub/upgrade-worker.log` during an upgrade: confirm uv's full transcript is mirrored line by line.

Made with [Cursor](https://cursor.com)