### PR TITLE
Watcher: Resolve auto-update sentinel paths via the registry, not DEFAULT_CONFIG_DIR

### DIFF
--- a/watcher/src/data_hub_watcher/runtime.py
+++ b/watcher/src/data_hub_watcher/runtime.py
@@ -52,6 +52,21 @@ class WatcherRuntime:
     monitor: FileMonitor
     heartbeat: HeartbeatLoop
     updater: Updater
+    # Directory the upgrade machinery uses for its on-disk sentinels
+    # (``.upgrade-request.json`` / ``.upgrade-result.json`` / the
+    # ``.upgrade-in-progress`` marker). The CLI and the Windows service
+    # resolve this differently: the CLI runs as the operator user, so
+    # ``DEFAULT_CONFIG_DIR`` resolves to ``~/.data-hub`` and is correct;
+    # the service runs as LocalSystem, where ``~`` is the SYSTEM profile
+    # rather than the operator's home, so the service reads its config
+    # path from the registry and threads ``config_path.parent`` through
+    # here. Without that handoff the service would write sentinels to
+    # ``C:\Windows\System32\config\systemprofile\.data-hub\`` while the
+    # SYSTEM-owned upgrade worker (whose paths are baked in at install
+    # time as the operator user) reads from the operator's profile —
+    # the two never meet, the worker logs "no request sentinel", and
+    # every auto-update tick silently no-ops.
+    config_dir: Path
     # Set when the in-process updater has successfully installed a new
     # watcher version and wants the main loop to exit non-zero so the
     # Windows SCM (or a foreground operator running ``watch``) restarts
@@ -177,6 +192,7 @@ def build_runtime(
     client: DataHubClient,
     cfg: WatcherConfig,
     db_path: Path,
+    config_dir: Path | None = None,
 ) -> WatcherRuntime:
     """Construct the full runtime graph from a validated config.
 
@@ -184,9 +200,18 @@ def build_runtime(
     CLI does this explicitly via a click error, and the service does it
     via a registry lookup. We assert here as a safety net so a silent
     misconfiguration becomes a loud crash.
+
+    *config_dir* is the directory used by the auto-update machinery
+    for its on-disk sentinels. Defaults to ``DEFAULT_CONFIG_DIR`` for
+    the CLI ``watch`` entrypoint (where ``~`` resolves to the operator's
+    home). The Windows service must pass an explicit value derived from
+    its registry-stored config path — see the field-level comment on
+    :class:`WatcherRuntime` for why.
     """
     if not cfg.watcher_id:
         raise ValueError("cfg.watcher_id must be set before building the runtime")
+
+    effective_config_dir = config_dir if config_dir is not None else DEFAULT_CONFIG_DIR
 
     inst = cfg.instrument
     watcher_id = cfg.watcher_id
@@ -214,7 +239,7 @@ def build_runtime(
         counters=counters,
         state_db=state_db,
         cfg=cfg,
-        config_dir=DEFAULT_CONFIG_DIR,
+        config_dir=effective_config_dir,
         request_upgrade_restart=_request_upgrade_restart,
     )
 
@@ -291,6 +316,7 @@ def build_runtime(
         monitor=monitor,
         heartbeat=heartbeat,
         updater=updater,
+        config_dir=effective_config_dir,
         shutdown_event=shutdown_event,
         upgrade_restart_event=upgrade_restart_event,
     )
@@ -315,7 +341,7 @@ def start_runtime(rt: WatcherRuntime, *, started_message: str) -> None:
         )
     )
 
-    outcome = evaluate_upgrade_marker(DEFAULT_CONFIG_DIR)
+    outcome = evaluate_upgrade_marker(rt.config_dir)
     if outcome.found:
         # Out-of-process upgrades (the Windows uv-tool worker) drop a
         # ``.upgrade-result.json`` sentinel alongside the marker. The
@@ -327,7 +353,7 @@ def start_runtime(rt: WatcherRuntime, *, started_message: str) -> None:
         # and the actual installer error never surfaced to the
         # dashboard. Trust the worker's ``succeeded`` flag whenever
         # it's present.
-        worker_result = read_upgrade_result(DEFAULT_CONFIG_DIR)
+        worker_result = read_upgrade_result(rt.config_dir)
 
         worker_failed = worker_result is not None and not worker_result.succeeded
         worker_warned = (
@@ -432,8 +458,8 @@ def start_runtime(rt: WatcherRuntime, *, started_message: str) -> None:
         # inspection so a stale result from a prior upgrade can't
         # leak into the next one. Mirrors the marker's "consumed on
         # read" lifecycle in ``evaluate_upgrade_marker``.
-        clear_upgrade_result(DEFAULT_CONFIG_DIR)
-        clear_upgrade_request(DEFAULT_CONFIG_DIR)
+        clear_upgrade_result(rt.config_dir)
+        clear_upgrade_request(rt.config_dir)
 
     # Rebuild in-memory run state from the local DB before any file
     # events fire. Without this, every restart starts with an empty

--- a/watcher/src/data_hub_watcher/service.py
+++ b/watcher/src/data_hub_watcher/service.py
@@ -85,11 +85,20 @@ def install_service(config_path: Path, env_path: Path) -> None:
 
     _store_paths_in_registry(config_path, env_path)
     _configure_recovery()
-    _install_upgrade_worker()
+    # The worker template bakes its sentinel paths in at render time,
+    # so we render against the operator's chosen config directory
+    # (``config_path.parent``) rather than the import-time
+    # ``DEFAULT_CONFIG_DIR``. The two are equivalent for default
+    # installs but diverge when an operator passes a custom
+    # ``--config-path``, and — critically — diverge between the
+    # operator's user account and the LocalSystem account the service
+    # itself runs under. The matching read side in ``_run_service_loop``
+    # consults the registry for the same reason.
+    _install_upgrade_worker(config_path.parent)
     logger.info("Service '%s' installed successfully", SERVICE_NAME)
 
 
-def _install_upgrade_worker() -> None:
+def _install_upgrade_worker(config_dir: Path) -> None:
     """Drop the upgrade-worker PowerShell script and register the task.
 
     Splits cleanly from ``install_service`` so unit tests can patch
@@ -98,13 +107,19 @@ def _install_upgrade_worker() -> None:
     ``win32serviceutil`` to test). Failure here is logged but
     re-raised so the operator running ``service install`` sees a clear
     error rather than a silently-broken auto-update path.
+
+    *config_dir* must be the directory the running watcher service will
+    later use for its sentinels — the worker template bakes the
+    request/result paths in at render time, so a mismatch here results
+    in the worker reading from one directory while the service writes
+    to another (and the auto-update silently no-ops every tick).
     """
     from data_hub_watcher.scheduled_task import install_upgrade_task
     from data_hub_watcher.upgrade_worker import write_worker_script
 
-    script_path = write_worker_script(DEFAULT_CONFIG_DIR, service_name=SERVICE_NAME)
+    script_path = write_worker_script(config_dir, service_name=SERVICE_NAME)
     install_upgrade_task(script_path)
-    logger.info("Upgrade worker script + scheduled task registered")
+    logger.info("Upgrade worker script + scheduled task registered under %s", config_dir)
 
 
 def _store_paths_in_registry(config_path: Path, env_path: Path) -> None:
@@ -233,13 +248,26 @@ def uninstall_service() -> None:
     except Exception:
         pass  # already stopped or doesn't exist
 
-    _uninstall_upgrade_worker()
+    # Try the registry first so we clean up the worker script in the
+    # operator's actual config directory rather than wherever
+    # ``DEFAULT_CONFIG_DIR`` happens to resolve in this process
+    # (it'd be wrong, e.g., if uninstall is invoked from an elevated
+    # ``runas /user:SYSTEM`` shell). If the registry read fails we fall
+    # back to ``DEFAULT_CONFIG_DIR`` so a partially-broken install
+    # doesn't block uninstall — leaving the script behind is harmless
+    # without the matching scheduled task.
+    try:
+        config_path, _env_path = _read_paths_from_registry()
+        worker_config_dir = config_path.parent
+    except OSError:
+        worker_config_dir = DEFAULT_CONFIG_DIR
+    _uninstall_upgrade_worker(worker_config_dir)
     _delete_paths_from_registry()
     win32serviceutil.RemoveService(SERVICE_NAME)
     logger.info("Service '%s' removed", SERVICE_NAME)
 
 
-def _uninstall_upgrade_worker() -> None:
+def _uninstall_upgrade_worker(config_dir: Path) -> None:
     """Best-effort removal of the upgrade-worker scheduled task + script.
 
     Idempotent (the underlying ``schtasks /Delete`` swallows
@@ -258,7 +286,7 @@ def _uninstall_upgrade_worker() -> None:
     except ScheduledTaskError as exc:
         logger.warning("Could not remove upgrade scheduled task: %s", exc)
 
-    script_path = upgrade_worker_script_path(DEFAULT_CONFIG_DIR)
+    script_path = upgrade_worker_script_path(config_dir)
     try:
         script_path.unlink(missing_ok=True)
     except OSError as exc:
@@ -371,7 +399,7 @@ def query_service_status() -> dict[str, Any]:
         ws.CloseServiceHandle(hscm)
 
 
-def _repair_upgrade_worker_if_missing(sm: Any) -> None:
+def _repair_upgrade_worker_if_missing(sm: Any, config_dir: Path) -> None:
     """Re-install the upgrade scheduled task on startup if it has gone missing.
 
     Lab PCs that auto-update into the version that introduced the
@@ -381,6 +409,16 @@ def _repair_upgrade_worker_if_missing(sm: Any) -> None:
     startup means the host self-heals on the very next service restart
     (which the auto-updater triggers anyway), without any operator
     intervention.
+
+    *config_dir* must be the operator's resolved config directory (the
+    parent of the registry-stored config path) — NOT
+    ``DEFAULT_CONFIG_DIR``, because under the LocalSystem account the
+    service runs as the latter resolves to
+    ``C:\\Windows\\System32\\config\\systemprofile\\.data-hub`` rather
+    than the operator's ``~\\.data-hub``. Rendering the worker template
+    against the wrong directory bakes in a sentinel path the running
+    service will never actually write to, which silently breaks every
+    subsequent auto-update.
 
     Failures are logged via the Windows event log but do not raise:
     a host that can't register the task should still be able to run
@@ -417,7 +455,7 @@ def _repair_upgrade_worker_if_missing(sm: Any) -> None:
         "self-repair after auto-update into worker-aware code)."
     )
     try:
-        script_path = write_worker_script(DEFAULT_CONFIG_DIR, service_name=SERVICE_NAME)
+        script_path = write_worker_script(config_dir, service_name=SERVICE_NAME)
         install_upgrade_task(script_path)
     except (OSError, ScheduledTaskError) as exc:
         sm.LogWarningMsg(
@@ -467,8 +505,12 @@ def _run_service_loop(stop_event: threading.Event, sm: Any) -> None:
 
     sm.LogInfoMsg(f"{SERVICE_DISPLAY_NAME} starting")
 
-    _repair_upgrade_worker_if_missing(sm)
-
+    # Read registry paths BEFORE the upgrade-worker self-repair so
+    # both have a single source of truth for the operator's config
+    # directory. Doing the repair first would force it to fall back
+    # to ``DEFAULT_CONFIG_DIR`` — which under LocalSystem points at
+    # the SYSTEM profile, not the operator's profile, and would bake
+    # the wrong sentinel paths into the regenerated worker script.
     try:
         path, env_path = _read_paths_from_registry()
     except Exception as exc:
@@ -477,6 +519,8 @@ def _run_service_loop(stop_event: threading.Event, sm: Any) -> None:
             "Re-run 'data-hub-watcher service install'."
         )
         raise SystemExit(1) from exc
+
+    _repair_upgrade_worker_if_missing(sm, path.parent)
 
     # Mirror the CLI's ``load_env`` semantics: load the base
     # ``~/.data-hub/.env`` first (for any shared, non-secret values
@@ -525,7 +569,12 @@ def _run_service_loop(stop_event: threading.Event, sm: Any) -> None:
         raise SystemExit(1)
 
     db_path = path.parent / STATE_DB_FILENAME
-    rt = build_runtime(client=client, cfg=cfg, db_path=db_path)
+    # Pass the registry-resolved config directory through to the
+    # runtime so the auto-update sentinels land where the SYSTEM-owned
+    # upgrade worker (whose paths were baked in at install time
+    # against the same directory) actually reads from. See
+    # ``WatcherRuntime.config_dir`` for the gory details.
+    rt = build_runtime(client=client, cfg=cfg, db_path=db_path, config_dir=path.parent)
 
     # Step 2: sync config checksum (now that we have a reporter, any
     # failure surfaces as kind=config_sync_failed in the dashboard

--- a/watcher/tests/test_runtime.py
+++ b/watcher/tests/test_runtime.py
@@ -249,6 +249,70 @@ class TestBuildRuntimeErrors:
             build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
 
 
+class TestBuildRuntimeConfigDir:
+    """Plumbing of the explicit ``config_dir`` parameter through the runtime.
+
+    Regression guard for the auto-update silent no-op on Windows: the
+    Windows service runs as LocalSystem (so ``Path("~/.data-hub")``
+    inside the service process resolves to the SYSTEM profile, not
+    the operator's profile) but the upgrade worker has its sentinel
+    paths baked in at install time under the operator's profile.
+    Letting the running service fall back to ``DEFAULT_CONFIG_DIR``
+    rather than the registry-resolved directory caused the service to
+    write the request sentinel into a directory the worker never
+    reads from, so every auto-update tick fired ``update_started``
+    and the worker logged "no request sentinel" without doing
+    anything.
+    """
+
+    def test_explicit_config_dir_overrides_default(
+        self, tmp_path: Path, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Patch DEFAULT_CONFIG_DIR to a *different* path so we can
+        # tell apart "fell back to the default" from "honoured the
+        # explicit argument".
+        import data_hub_watcher.runtime as rt_module
+
+        wrong_dir = tmp_path / "system-profile"
+        right_dir = tmp_path / "operator-profile"
+        wrong_dir.mkdir()
+        right_dir.mkdir()
+        monkeypatch.setattr(rt_module, "DEFAULT_CONFIG_DIR", wrong_dir)
+
+        cfg = _make_config(tmp_path, upload_mode="auto")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path, config_dir=right_dir)
+        try:
+            assert rt.config_dir == right_dir
+            # The Updater MUST receive the same dir we passed in;
+            # this is what makes ``write_upgrade_request`` land in
+            # the directory the SYSTEM-owned worker reads from.
+            assert rt.updater._config_dir == right_dir
+        finally:
+            rt.state_db.close()
+
+    def test_omitted_config_dir_falls_back_to_module_default(
+        self, tmp_path: Path, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The CLI ``watch`` command relies on this fallback: it runs
+        # as the operator user, so ``DEFAULT_CONFIG_DIR`` resolves
+        # correctly and the CLI doesn't need to thread the argument
+        # through. Pin the behaviour so a future refactor doesn't
+        # silently make the argument required.
+        import data_hub_watcher.runtime as rt_module
+
+        fake_default = tmp_path / "operator-profile"
+        fake_default.mkdir()
+        monkeypatch.setattr(rt_module, "DEFAULT_CONFIG_DIR", fake_default)
+
+        cfg = _make_config(tmp_path, upload_mode="auto")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+        try:
+            assert rt.config_dir == fake_default
+            assert rt.updater._config_dir == fake_default
+        finally:
+            rt.state_db.close()
+
+
 class TestClassifyShutdown:
     """Pin the WATCHER_STOPPED message text shared by the CLI ``watch``
     command and the Windows service. Both call sites used to hard-code
@@ -578,6 +642,81 @@ class TestStartRuntimePostUpgradeMerge:
             assert "worker_returncode" not in details
         finally:
             rt.state_db.close()
+
+    def test_post_restart_inspection_uses_runtime_config_dir_not_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Regression guard for the Windows-service silent no-op:
+        # under LocalSystem ``DEFAULT_CONFIG_DIR`` resolves to the
+        # SYSTEM profile, but the upgrade marker / result / request
+        # all live in the operator's profile (where the worker reads
+        # from). ``start_runtime`` MUST consult ``rt.config_dir`` —
+        # not the module-level ``DEFAULT_CONFIG_DIR`` — so a service
+        # that's been threaded the right directory at construction
+        # time picks up its own marker.
+        from data_hub_watcher.constants import WATCHER_VERSION
+
+        wrong_dir = tmp_path / "system-profile-data-hub"
+        right_dir = tmp_path / "operator-profile-data-hub"
+        wrong_dir.mkdir()
+        right_dir.mkdir()
+
+        # Marker + result land in the *right* (registry-resolved)
+        # directory, mirroring what the running service writes when
+        # it calls ``write_upgrade_marker(rt.config_dir, ...)``.
+        write_upgrade_marker(
+            right_dir,
+            target_version=WATCHER_VERSION,
+            previous_version="0.1.4",
+        )
+        result = UpgradeResult(
+            request_id="rid",
+            target_version=WATCHER_VERSION,
+            succeeded=True,
+            returncode=0,
+            stdout_tail="installed 17 packages",
+            stderr_tail="",
+            finished_at="2026-05-06T11:54:22+00:00",
+            error=None,
+        )
+        upgrade_result_path(right_dir).write_text(json.dumps(result.to_dict()), encoding="utf-8")
+
+        # Patch ``DEFAULT_CONFIG_DIR`` to the *wrong* directory so
+        # an accidental fallback would silently miss the marker
+        # and emit no UPDATE_SUCCEEDED event at all.
+        self._patch_default_config_dir(monkeypatch, wrong_dir)
+        monkeypatch.setattr("data_hub_watcher.runtime.sys.platform", "win32")
+
+        cfg = _make_config(tmp_path, upload_mode="auto")
+        rt = build_runtime(
+            client=MagicMock(),
+            cfg=cfg,
+            db_path=tmp_path / "state.sqlite",
+            config_dir=right_dir,
+        )
+        mock_reporter = MagicMock()
+        rt.reporter = mock_reporter
+        rt.monitor = MagicMock()
+        rt.heartbeat = MagicMock()
+        rt.detector = MagicMock()
+        try:
+            start_runtime(rt, started_message="Service started on test")
+
+            queued = [c.args[0] for c in mock_reporter.queue_event.call_args_list]
+            successes = [e for e in queued if e.event_type is EventType.UPDATE_SUCCEEDED]
+            assert len(successes) == 1, (
+                "start_runtime fell back to DEFAULT_CONFIG_DIR — the marker in "
+                "the registry-resolved config_dir was missed entirely."
+            )
+            details = successes[0].details
+            assert details["worker_request_id"] == "rid"
+            assert details["worker_stdout_tail"] == "installed 17 packages"
+        finally:
+            rt.state_db.close()
+
+        # Sentinel must be consumed from the *right* directory; the
+        # wrong directory is irrelevant and unchanged.
+        assert not upgrade_result_path(right_dir).exists()
 
 
 class TestSummarizeWorkerFailure:

--- a/watcher/tests/test_service.py
+++ b/watcher/tests/test_service.py
@@ -226,7 +226,7 @@ class TestInstallService:
         # The upgrade-worker registration is exercised in its own
         # test below; this test only cares about the SCM kwargs and
         # would otherwise try to invoke the real `schtasks.exe`.
-        monkeypatch.setattr(service_module, "_install_upgrade_worker", lambda: None)
+        monkeypatch.setattr(service_module, "_install_upgrade_worker", lambda _config_dir: None)
 
         service_module.install_service(Path("c.yaml"), Path("e.env"))
 
@@ -249,7 +249,7 @@ class TestInstallService:
         sys.modules["winreg"].OpenKey.return_value = MagicMock()
         store_calls: list[tuple[Path, Path]] = []
         recovery_calls: list[None] = []
-        worker_calls: list[None] = []
+        worker_calls: list[Path] = []
 
         monkeypatch.setattr(
             service_module,
@@ -264,7 +264,7 @@ class TestInstallService:
         monkeypatch.setattr(
             service_module,
             "_install_upgrade_worker",
-            lambda: worker_calls.append(None),
+            lambda config_dir: worker_calls.append(config_dir),
         )
 
         service_module.install_service(Path("c.yaml"), Path("e.env"))
@@ -272,10 +272,15 @@ class TestInstallService:
         assert store_calls == [(Path("c.yaml"), Path("e.env"))]
         assert recovery_calls == [None]
         # Critical regression guard: `install_service` must always
-        # register the upgrade worker. A fleet PC installed without
-        # it would silently fall back to the broken in-process
-        # upgrade path on the next auto-update tick.
-        assert worker_calls == [None]
+        # register the upgrade worker, AND it must register it
+        # against the operator's chosen config directory rather than
+        # the import-time ``DEFAULT_CONFIG_DIR``. The latter resolves
+        # to the SYSTEM profile when the running service later writes
+        # sentinels (under LocalSystem), so a worker template baked
+        # against ``DEFAULT_CONFIG_DIR`` would read from one
+        # directory while the service writes to another and every
+        # auto-update tick would silently no-op.
+        assert worker_calls == [Path("c.yaml").parent]
 
 
 class TestInstallUpgradeWorker:
@@ -293,24 +298,33 @@ class TestInstallUpgradeWorker:
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        # Redirect the well-known config dir into a temp dir so the
-        # rendered script lands somewhere we can inspect.
-        monkeypatch.setattr(service_module, "DEFAULT_CONFIG_DIR", tmp_path)
-
         install_calls: list[Path] = []
         monkeypatch.setattr(
             "data_hub_watcher.scheduled_task.install_upgrade_task",
             lambda script_path: install_calls.append(script_path),
         )
 
-        service_module._install_upgrade_worker()
+        service_module._install_upgrade_worker(tmp_path)
 
-        # Script is on disk under the patched config dir.
+        # Script is on disk under the supplied config dir, NOT under
+        # ``DEFAULT_CONFIG_DIR`` — the explicit-config-dir contract
+        # is what makes the worker template consistent with the
+        # running service when the two execute under different user
+        # accounts (operator-user install vs LocalSystem service).
         from data_hub_watcher.upgrade_worker import upgrade_worker_script_path
 
         script_path = upgrade_worker_script_path(tmp_path)
         assert script_path.exists()
         assert "Stop-Service" in script_path.read_text(encoding="utf-8")
+        # The rendered template MUST bake in sentinel paths under
+        # the supplied config dir — anything else means the running
+        # service (which writes sentinels to its own resolved
+        # ``config_dir``) would write to a different directory than
+        # the worker reads from, and every auto-update silently
+        # no-ops with "no request sentinel".
+        rendered = script_path.read_text(encoding="utf-8")
+        assert str(tmp_path / ".upgrade-request.json") in rendered
+        assert str(tmp_path / ".upgrade-result.json") in rendered
         # Task installer was handed the same path.
         assert install_calls == [script_path]
 
@@ -320,8 +334,6 @@ class TestInstallUpgradeWorker:
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        monkeypatch.setattr(service_module, "DEFAULT_CONFIG_DIR", tmp_path)
-
         from data_hub_watcher.upgrade_worker import upgrade_worker_script_path
 
         script_path = upgrade_worker_script_path(tmp_path)
@@ -334,7 +346,7 @@ class TestInstallUpgradeWorker:
             lambda: uninstall_calls.append(None),
         )
 
-        service_module._uninstall_upgrade_worker()
+        service_module._uninstall_upgrade_worker(tmp_path)
 
         assert uninstall_calls == [None]
         assert not script_path.exists()
@@ -349,8 +361,6 @@ class TestInstallUpgradeWorker:
         # talk to us must not block ``service uninstall`` — leaving
         # the host with a partially-uninstalled service is strictly
         # worse than silently missing the worker cleanup.
-        monkeypatch.setattr(service_module, "DEFAULT_CONFIG_DIR", tmp_path)
-
         from data_hub_watcher.scheduled_task import ScheduledTaskError
 
         def boom() -> None:
@@ -361,7 +371,7 @@ class TestInstallUpgradeWorker:
             boom,
         )
         # Must not raise.
-        service_module._uninstall_upgrade_worker()
+        service_module._uninstall_upgrade_worker(tmp_path)
 
 
 class TestRepairUpgradeWorkerOnStartup:
@@ -377,6 +387,7 @@ class TestRepairUpgradeWorkerOnStartup:
         self,
         service_module: ModuleType,
         monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         sm = MagicMock(name="servicemanager")
         monkeypatch.setattr("data_hub_watcher.scheduled_task.task_exists", lambda: True)
@@ -386,7 +397,7 @@ class TestRepairUpgradeWorkerOnStartup:
             lambda script_path: install_calls.append(script_path),
         )
 
-        service_module._repair_upgrade_worker_if_missing(sm)
+        service_module._repair_upgrade_worker_if_missing(sm, tmp_path)
 
         assert install_calls == []
 
@@ -396,7 +407,6 @@ class TestRepairUpgradeWorkerOnStartup:
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        monkeypatch.setattr(service_module, "DEFAULT_CONFIG_DIR", tmp_path)
         sm = MagicMock(name="servicemanager")
         monkeypatch.setattr("data_hub_watcher.scheduled_task.task_exists", lambda: False)
         install_calls: list[Path] = []
@@ -405,17 +415,24 @@ class TestRepairUpgradeWorkerOnStartup:
             lambda script_path: install_calls.append(script_path),
         )
 
-        service_module._repair_upgrade_worker_if_missing(sm)
+        service_module._repair_upgrade_worker_if_missing(sm, tmp_path)
 
         from data_hub_watcher.upgrade_worker import upgrade_worker_script_path
 
+        # The repair must render against the supplied *config_dir*,
+        # not ``DEFAULT_CONFIG_DIR`` — this is the regression guard
+        # for the "service runs as LocalSystem so ~ resolves to the
+        # SYSTEM profile" failure mode.
         assert install_calls == [upgrade_worker_script_path(tmp_path)]
         assert upgrade_worker_script_path(tmp_path).exists()
+        rendered = upgrade_worker_script_path(tmp_path).read_text(encoding="utf-8")
+        assert str(tmp_path / ".upgrade-request.json") in rendered
 
     def test_repair_swallows_query_errors(
         self,
         service_module: ModuleType,
         monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         # If we can't even query Task Scheduler we should NOT block
         # service startup — the host should keep running its current
@@ -430,7 +447,7 @@ class TestRepairUpgradeWorkerOnStartup:
 
         monkeypatch.setattr("data_hub_watcher.scheduled_task.task_exists", boom)
         # Must not raise.
-        service_module._repair_upgrade_worker_if_missing(sm)
+        service_module._repair_upgrade_worker_if_missing(sm, tmp_path)
         sm.LogWarningMsg.assert_called_once()
 
     def test_repair_swallows_install_failures(
@@ -441,7 +458,6 @@ class TestRepairUpgradeWorkerOnStartup:
     ) -> None:
         from data_hub_watcher.scheduled_task import ScheduledTaskError
 
-        monkeypatch.setattr(service_module, "DEFAULT_CONFIG_DIR", tmp_path)
         sm = MagicMock(name="servicemanager")
         monkeypatch.setattr("data_hub_watcher.scheduled_task.task_exists", lambda: False)
 
@@ -450,7 +466,7 @@ class TestRepairUpgradeWorkerOnStartup:
 
         monkeypatch.setattr("data_hub_watcher.scheduled_task.install_upgrade_task", boom)
         # Must not raise even when re-registration fails.
-        service_module._repair_upgrade_worker_if_missing(sm)
+        service_module._repair_upgrade_worker_if_missing(sm, tmp_path)
         sm.LogWarningMsg.assert_called_once()
 
 
@@ -525,10 +541,13 @@ class TestServiceLifecycle:
         self,
         service_module: ModuleType,
         monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         win32serviceutil = sys.modules["win32serviceutil"]
         delete_calls: list[None] = []
-        worker_calls: list[None] = []
+        worker_calls: list[Path] = []
+        config_path = tmp_path / "config.yaml"
+        env_path = tmp_path / ".env.staging"
         monkeypatch.setattr(
             service_module,
             "_delete_paths_from_registry",
@@ -536,8 +555,13 @@ class TestServiceLifecycle:
         )
         monkeypatch.setattr(
             service_module,
+            "_read_paths_from_registry",
+            lambda: (config_path, env_path),
+        )
+        monkeypatch.setattr(
+            service_module,
             "_uninstall_upgrade_worker",
-            lambda: worker_calls.append(None),
+            lambda config_dir: worker_calls.append(config_dir),
         )
 
         service_module.uninstall_service()
@@ -545,19 +569,58 @@ class TestServiceLifecycle:
         win32serviceutil.StopService.assert_called_once_with(service_module.SERVICE_NAME)
         assert delete_calls == [None]
         # Uninstall must also tear down the upgrade worker so a
-        # subsequent reinstall starts from a clean slate.
-        assert worker_calls == [None]
+        # subsequent reinstall starts from a clean slate, AND it must
+        # do so against the registry-resolved config dir rather than
+        # whatever ``DEFAULT_CONFIG_DIR`` resolves to in the current
+        # process. Otherwise the script can be left behind under the
+        # operator's profile when uninstall happens to run under a
+        # different account.
+        assert worker_calls == [config_path.parent]
         win32serviceutil.RemoveService.assert_called_once_with(service_module.SERVICE_NAME)
+
+    def test_uninstall_falls_back_to_default_when_registry_missing(
+        self,
+        service_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A partial install (registry key gone but service still
+        # registered, or a pre-registry-storage build) must not block
+        # uninstall — fall back to ``DEFAULT_CONFIG_DIR`` so the
+        # cleanup is at least best-effort.
+        win32serviceutil = sys.modules["win32serviceutil"]
+        worker_calls: list[Path] = []
+        monkeypatch.setattr(service_module, "_delete_paths_from_registry", lambda: None)
+
+        def boom() -> tuple[Path, Path]:
+            raise OSError("registry key missing")
+
+        monkeypatch.setattr(service_module, "_read_paths_from_registry", boom)
+        monkeypatch.setattr(
+            service_module,
+            "_uninstall_upgrade_worker",
+            lambda config_dir: worker_calls.append(config_dir),
+        )
+
+        service_module.uninstall_service()
+
+        assert worker_calls == [service_module.DEFAULT_CONFIG_DIR]
+        win32serviceutil.RemoveService.assert_called_once()
 
     def test_uninstall_swallows_stop_errors(
         self,
         service_module: ModuleType,
         monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         win32serviceutil = sys.modules["win32serviceutil"]
         win32serviceutil.StopService.side_effect = RuntimeError("not running")
         monkeypatch.setattr(service_module, "_delete_paths_from_registry", lambda: None)
-        monkeypatch.setattr(service_module, "_uninstall_upgrade_worker", lambda: None)
+        monkeypatch.setattr(
+            service_module,
+            "_read_paths_from_registry",
+            lambda: (tmp_path / "config.yaml", tmp_path / ".env.staging"),
+        )
+        monkeypatch.setattr(service_module, "_uninstall_upgrade_worker", lambda _config_dir: None)
 
         # Even if StopService raises (e.g. service already stopped or
         # doesn't exist), uninstall must still proceed to RemoveService.
@@ -843,11 +906,11 @@ class _LoopHarness:
         # Stub out the upgrade-worker self-repair so existing
         # ``_run_service_loop`` tests don't try to invoke ``schtasks.exe``
         # — that helper has its own dedicated test class above.
-        self.repair_calls: list[Any] = []
+        self.repair_calls: list[tuple[Any, Path]] = []
         monkeypatch.setattr(
             service_module,
             "_repair_upgrade_worker_if_missing",
-            lambda sm: self.repair_calls.append(sm),
+            lambda sm, config_dir: self.repair_calls.append((sm, config_dir)),
         )
 
         # Patch source modules of the lazy imports inside _run_service_loop.


### PR DESCRIPTION
## Summary

Fixes the silent auto-update no-op observed on staging-pinned lab PCs running 0.2.0 → 0.2.1. The upgrade-worker scheduled task fires correctly, but bails immediately with `no request sentinel at C:\Users\<op>\.data-hub\.upgrade-request.json` while the dashboard never sees the matching `update_succeeded` / `update_failed`. Hourly retries pile up indefinitely and operators have to remote in to collect logs by hand because nothing useful reaches the API.

### Root cause

A process-context mismatch on \`DEFAULT_CONFIG_DIR\`. \`Path(\"~/.data-hub\").expanduser()\` is evaluated at module import time per-process and resolves against whichever account is running the process:

- **\`service install\` (operator user)** → renders the worker template with \`C:\Users\<op>\.data-hub\.upgrade-request.json\` baked in.
- **The running service (\`LocalSystem\`)** → \`~\` resolves to \`C:\Windows\System32\config\systemprofile\.data-hub\`, so \`Updater._apply_via_worker\` writes its request sentinel there.

The two never meet. The worker's path is fixed at install time and points at the user profile; the running service writes to the SYSTEM profile; the worker fires, sees no request file, exits.

The service already knows the operator's directory — \`install_service\` stores \`config_path\` / \`env_path\` in the registry, and \`_run_service_loop\` reads them back to locate \`config.yaml\` and \`watcher.db\`. We just weren't threading that path through to the upgrade machinery.

### What changes

- **\`WatcherRuntime\`** gains a \`config_dir\` field. **\`build_runtime\`** takes a matching keyword that defaults to \`DEFAULT_CONFIG_DIR\` so the CLI \`watch\` entrypoint (which runs as the operator user) needs no caller changes. **\`start_runtime\`** reads the marker / result / request sentinels from \`rt.config_dir\` instead of the import-time default.
- **\`_run_service_loop\`** reads the registry FIRST, then passes \`path.parent\` to both \`_repair_upgrade_worker_if_missing\` and \`build_runtime\`. Reordering matters: the previous order forced the startup self-repair to fall back to the SYSTEM-profile default, which would have re-baked the wrong path into a freshly regenerated worker script on every tick that lost the task.
- **\`install_service\`** passes \`config_path.parent\` to \`_install_upgrade_worker\` so the install-time render is robust to custom \`--config-path\` and to (hypothetically) a future install run by a different user account.
- **\`uninstall_service\`** reads the registry best-effort and threads the same dir through \`_uninstall_upgrade_worker\`; falls back to \`DEFAULT_CONFIG_DIR\` only on a partially-broken install where the registry key is gone.

### Tests

- \`TestBuildRuntimeConfigDir\` pins both halves of the contract: an explicit \`config_dir\` argument overrides \`DEFAULT_CONFIG_DIR\`, and omitting it falls back to the module default (the CLI's path).
- New \`test_post_restart_inspection_uses_runtime_config_dir_not_default\` is the headline regression guard — patches \`DEFAULT_CONFIG_DIR\` to a decoy directory and writes the marker + result in a different directory passed via \`config_dir\`, then asserts \`UPDATE_SUCCEEDED\` is emitted from the right directory. Without this fix the test fails because \`start_runtime\` would read from the patched default and miss the marker entirely.
- \`test_install_writes_script_and_registers_task\` / \`test_repair_re_registers_when_task_missing\` now assert that the rendered worker template contains the supplied config dir's sentinel paths, not the import-time default.
- \`test_uninstall_stops_clears_registry_and_removes\` asserts the registry-resolved dir is passed to \`_uninstall_upgrade_worker\`; \`test_uninstall_falls_back_to_default_when_registry_missing\` covers the partial-install case.

342 watcher tests pass; \`make check-all\` clean.

## Test plan

- [x] Full watcher pytest suite passes locally (342 tests, 17s).
- [x] \`make check-all\` clean (ruff format/lint, pyright, prettier, eslint, tsc).
- [ ] After merge → tag \`watcher-v0.2.2\` → publish to PyPI: confirm a staging-pinned lab PC running 0.2.1 stays stuck on 0.2.1 (because the bug this PR fixes is on the version they're running). The fix only takes effect after a one-time \`data-hub-watcher service reinstall\` from an Administrator shell — that's what re-renders the worker template against the registry-stored config dir.
- [ ] After the manual \`service reinstall\`: confirm the next hourly tick produces \`update_started\` → \`update_succeeded\` with \`worker_returncode: 0\` and \`worker_stdout_tail\` populated, and that the heartbeat reports \`watcher_version: \"0.2.2\"\`.
- [ ] Force a failure (e.g. point at a non-existent version): confirm \`update_failed\` carries the actual \`uv\` error in \`worker_stderr_tail\`, not the generic "expected X, running Y" reason.
- [ ] Tail \`~/.data-hub/upgrade-worker.log\` during the upgrade: confirm uv's full transcript is mirrored line by line and that the \"no request sentinel\" line is gone.

## Operator impact

Lab PCs already on 0.2.1 cannot auto-update past this bug — that's the whole reason this PR exists. After this lands and we tag a 0.2.2 release, every PC in the fleet needs a one-time \`data-hub-watcher service reinstall\` from an Administrator shell to re-register the scheduled task against the registry-resolved sentinel paths. From 0.2.2 forward the auto-update path is unblocked and self-healing again.

Made with [Cursor](https://cursor.com)