### PR TITLE
Web app fixes: dashboard stats, theme polish, watcher status chart

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -415,7 +415,7 @@ requires-dist = [
 
 [[package]]
 name = "data-hub-watcher"
-version = "0.2.3"
+version = "0.2.5"
 source = { editable = "watcher" }
 dependencies = [
     { name = "click" },

--- a/web-app/app/api/v1/instrument-runs/route.ts
+++ b/web-app/app/api/v1/instrument-runs/route.ts
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
       min: 1,
     }),
     perPage: parseIntParam(searchParams.get("per_page"), {
-      default: 25,
+      default: 10,
       min: 1,
       max: 100,
     }),

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/route.ts
@@ -210,7 +210,7 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
       min: 1,
     }),
     perPage: parseIntParam(searchParams.get("per_page"), {
-      default: 25,
+      default: 10,
       min: 1,
       max: 100,
     }),

--- a/web-app/app/globals.css
+++ b/web-app/app/globals.css
@@ -137,8 +137,9 @@ html.dark .shiki span {
   * {
     @apply border-border outline-ring/50;
     }
+  html,
   body {
-    @apply bg-muted-foreground text-foreground dark:bg-background;
+    @apply bg-muted text-foreground dark:bg-background;
     }
   html {
     @apply font-sans;

--- a/web-app/app/globals.css
+++ b/web-app/app/globals.css
@@ -72,11 +72,11 @@
     --chart-4: oklch(0.371 0 0);
     --chart-5: oklch(0.269 0 0);
     --radius: 0.625rem;
-    --sidebar: oklch(0.985 0 0);
+    --sidebar: #F3F3F3;
     --sidebar-foreground: oklch(0.145 0 0);
     --sidebar-primary: oklch(0.205 0 0);
     --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.97 0 0);
+    --sidebar-accent: oklch(0.91 0 0);
     --sidebar-accent-foreground: oklch(0.205 0 0);
     --sidebar-border: oklch(0.922 0 0);
     --sidebar-ring: oklch(0.708 0 0);
@@ -85,9 +85,9 @@
 .dark {
     --background: oklch(0.145 0 0);
     --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
+    --card: oklch(0.21 0 0);
     --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.205 0 0);
+    --popover: oklch(0.21 0 0);
     --popover-foreground: oklch(0.985 0 0);
     --primary: oklch(0.922 0 0);
     --primary-foreground: oklch(0.205 0 0);
@@ -106,7 +106,7 @@
     --chart-3: oklch(0.439 0 0);
     --chart-4: oklch(0.371 0 0);
     --chart-5: oklch(0.269 0 0);
-    --sidebar: oklch(0.205 0 0);
+    --sidebar: oklch(0.2 0 0);
     --sidebar-foreground: oklch(0.985 0 0);
     --sidebar-primary: oklch(0.488 0.243 264.376);
     --sidebar-primary-foreground: oklch(0.985 0 0);
@@ -138,7 +138,7 @@ html.dark .shiki span {
     @apply border-border outline-ring/50;
     }
   body {
-    @apply bg-muted text-foreground dark:bg-background;
+    @apply bg-muted-foreground text-foreground dark:bg-background;
     }
   html {
     @apply font-sans;

--- a/web-app/app/layout.tsx
+++ b/web-app/app/layout.tsx
@@ -84,7 +84,7 @@ export default async function RootLayout({
                         }}
                       />
                       <SidebarInset>
-                        <header className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
+                        <header className="flex h-12 shrink-0 items-center gap-2 px-4">
                           <SidebarTrigger />
                         </header>
                         {children}

--- a/web-app/app/settings/tokens/page.tsx
+++ b/web-app/app/settings/tokens/page.tsx
@@ -1,5 +1,6 @@
 import { CreateTokenDialog } from "@/components/tokens/create-token-dialog";
 import { DeleteTokenDialog } from "@/components/tokens/delete-token-dialog";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -9,9 +10,13 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { auth } from "@/lib/auth";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { db } from "@/lib/db";
-import { personalAccessTokens } from "@/lib/db/schema";
+import { personalAccessTokens, users } from "@/lib/db/schema";
 import { formatRelativeTime } from "@/lib/utils";
 import { desc, eq } from "drizzle-orm";
 import { KeyRound } from "lucide-react";
@@ -21,9 +26,38 @@ export const metadata: Metadata = {
   title: "Access Tokens",
 };
 
-export default async function TokensPage() {
-  const session = await auth();
+// Mirrors the deterministic palette used by RanByCell so the same user gets
+// the same avatar bubble color across the run tables and this page.
+const AVATAR_PALETTE = [
+  "bg-blue-200 text-blue-900 dark:bg-blue-800 dark:text-blue-100",
+  "bg-emerald-200 text-emerald-900 dark:bg-emerald-800 dark:text-emerald-100",
+  "bg-violet-200 text-violet-900 dark:bg-violet-800 dark:text-violet-100",
+  "bg-amber-200 text-amber-900 dark:bg-amber-800 dark:text-amber-100",
+  "bg-rose-200 text-rose-900 dark:bg-rose-800 dark:text-rose-100",
+  "bg-teal-200 text-teal-900 dark:bg-teal-800 dark:text-teal-100",
+  "bg-fuchsia-200 text-fuchsia-900 dark:bg-fuchsia-800 dark:text-fuchsia-100",
+  "bg-orange-200 text-orange-900 dark:bg-orange-800 dark:text-orange-100",
+];
 
+function avatarColor(userId: string): string {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) | 0;
+  }
+  return AVATAR_PALETTE[Math.abs(hash) % AVATAR_PALETTE.length];
+}
+
+function toInitials(displayName: string): string {
+  const parts = displayName.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+export default async function TokensPage() {
+  // This is an internal-tool settings page; we intentionally show every PAT
+  // across the workspace so admins can audit them. Auth is enforced by the
+  // settings layout.
   const tokens = await db
     .select({
       id: personalAccessTokens.id,
@@ -32,9 +66,15 @@ export default async function TokensPage() {
       lastUsedAt: personalAccessTokens.lastUsedAt,
       expiresAt: personalAccessTokens.expiresAt,
       createdAt: personalAccessTokens.createdAt,
+      user: {
+        id: users.id,
+        name: users.name,
+        email: users.email,
+        image: users.image,
+      },
     })
     .from(personalAccessTokens)
-    .where(eq(personalAccessTokens.userId, session!.user!.id!))
+    .innerJoin(users, eq(users.id, personalAccessTokens.userId))
     .orderBy(desc(personalAccessTokens.createdAt));
 
   const isExpired = (expiresAt: Date | null) =>
@@ -71,6 +111,7 @@ export default async function TokensPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead>Name</TableHead>
+                  <TableHead>User</TableHead>
                   <TableHead>Token</TableHead>
                   <TableHead>Last used</TableHead>
                   <TableHead>Expires</TableHead>
@@ -79,53 +120,82 @@ export default async function TokensPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {tokens.map((token) => (
-                  <TableRow key={token.id}>
-                    <TableCell className="font-medium">{token.name}</TableCell>
-                    <TableCell>
-                      <Badge variant="secondary" className="font-mono text-xs">
-                        {token.tokenPrefix}...
-                      </Badge>
-                    </TableCell>
-                    <TableCell
-                      className="text-muted-foreground"
-                      suppressHydrationWarning
-                    >
-                      {token.lastUsedAt
-                        ? formatRelativeTime(token.lastUsedAt)
-                        : "Never"}
-                    </TableCell>
-                    <TableCell suppressHydrationWarning>
-                      {token.expiresAt ? (
-                        <span
-                          className={
-                            isExpired(token.expiresAt)
-                              ? "text-destructive"
-                              : "text-muted-foreground"
-                          }
+                {tokens.map((token) => {
+                  const displayName =
+                    token.user.name ?? token.user.email ?? "Unknown";
+                  return (
+                    <TableRow key={token.id}>
+                      <TableCell className="font-medium">
+                        {token.name}
+                      </TableCell>
+                      <TableCell>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Avatar size="sm">
+                              {token.user.image ? (
+                                <AvatarImage
+                                  src={token.user.image}
+                                  alt={displayName}
+                                />
+                              ) : null}
+                              <AvatarFallback
+                                className={avatarColor(token.user.id)}
+                              >
+                                {toInitials(displayName)}
+                              </AvatarFallback>
+                            </Avatar>
+                          </TooltipTrigger>
+                          <TooltipContent>{displayName}</TooltipContent>
+                        </Tooltip>
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant="secondary"
+                          className="font-mono text-xs"
                         >
-                          {isExpired(token.expiresAt)
-                            ? "Expired"
-                            : formatRelativeTime(token.expiresAt)}
-                        </span>
-                      ) : (
-                        <span className="text-muted-foreground">Never</span>
-                      )}
-                    </TableCell>
-                    <TableCell
-                      className="text-muted-foreground"
-                      suppressHydrationWarning
-                    >
-                      {formatRelativeTime(token.createdAt)}
-                    </TableCell>
-                    <TableCell>
-                      <DeleteTokenDialog
-                        tokenId={token.id}
-                        tokenName={token.name}
-                      />
-                    </TableCell>
-                  </TableRow>
-                ))}
+                          {token.tokenPrefix}...
+                        </Badge>
+                      </TableCell>
+                      <TableCell
+                        className="text-muted-foreground"
+                        suppressHydrationWarning
+                      >
+                        {token.lastUsedAt
+                          ? formatRelativeTime(token.lastUsedAt)
+                          : "Never"}
+                      </TableCell>
+                      <TableCell suppressHydrationWarning>
+                        {token.expiresAt ? (
+                          <span
+                            className={
+                              isExpired(token.expiresAt)
+                                ? "text-destructive"
+                                : "text-muted-foreground"
+                            }
+                          >
+                            {isExpired(token.expiresAt)
+                              ? "Expired"
+                              : formatRelativeTime(token.expiresAt)}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">Never</span>
+                        )}
+                      </TableCell>
+                      <TableCell
+                        className="text-muted-foreground"
+                        suppressHydrationWarning
+                      >
+                        {formatRelativeTime(token.createdAt)}
+                      </TableCell>
+                      <TableCell>
+                        <DeleteTokenDialog
+                          tokenId={token.id}
+                          tokenName={token.name}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
               </TableBody>
             </Table>
           </div>

--- a/web-app/components/dashboard/dashboard-stats.tsx
+++ b/web-app/components/dashboard/dashboard-stats.tsx
@@ -38,30 +38,19 @@ function StatCard({
   );
 }
 
-function FilesProcessedSubline({
-  completed,
-  failed,
+function DataGeneratedSubline({
+  bytes,
   emptyLabel,
 }: {
-  completed: number;
-  failed: number;
+  bytes: number;
   emptyLabel: string;
 }) {
-  if (completed === 0 && failed === 0) {
+  if (bytes === 0) {
     return <span>{emptyLabel}</span>;
   }
   return (
     <>
-      <span className="text-foreground">{formatNumber(completed)}</span>{" "}
-      processed
-      {failed > 0 ? (
-        <>
-          {" · "}
-          <span className="text-destructive">
-            {formatNumber(failed)} failed
-          </span>
-        </>
-      ) : null}
+      <span>{formatBytes(bytes)} generated</span>
     </>
   );
 }
@@ -79,10 +68,9 @@ export function DashboardStatsCards({ stats }: { stats: DashboardStats }) {
         label="Runs in the last 24 hours"
         value={formatNumber(runsLast24Hours.total)}
         subline={
-          <FilesProcessedSubline
-            completed={runsLast24Hours.filesCompleted}
-            failed={runsLast24Hours.filesFailed}
-            emptyLabel="No files processed in the last 24 hours"
+          <DataGeneratedSubline
+            bytes={runsLast24Hours.bytesGenerated}
+            emptyLabel="No data generated in the last 24 hours"
           />
         }
       />
@@ -90,10 +78,9 @@ export function DashboardStatsCards({ stats }: { stats: DashboardStats }) {
         label="Runs in the last 7 days"
         value={formatNumber(runsThisWeek.total)}
         subline={
-          <FilesProcessedSubline
-            completed={runsThisWeek.filesCompleted}
-            failed={runsThisWeek.filesFailed}
-            emptyLabel="No files processed this week"
+          <DataGeneratedSubline
+            bytes={runsThisWeek.bytesGenerated}
+            emptyLabel="No data generated this week"
           />
         }
       />
@@ -103,7 +90,7 @@ export function DashboardStatsCards({ stats }: { stats: DashboardStats }) {
         valueClassName={pendingHasBacklog ? "text-destructive" : undefined}
         subline={
           pendingUploads.count > 0
-            ? `Est. ${formatBytes(pendingUploads.totalBytes)} queued`
+            ? `${formatBytes(pendingUploads.totalBytes)} queued`
             : "Upload queue is clear"
         }
       />

--- a/web-app/components/dashboard/dashboard-stats.tsx
+++ b/web-app/components/dashboard/dashboard-stats.tsx
@@ -67,7 +67,7 @@ function FilesProcessedSubline({
 }
 
 export function DashboardStatsCards({ stats }: { stats: DashboardStats }) {
-  const { runsToday, pendingUploads, runsThisWeek } = stats;
+  const { runsLast24Hours, pendingUploads, runsThisWeek } = stats;
 
   // Highlight pending uploads in red once a backlog forms — a non-zero queue
   // is a routine signal of attention, not an error.
@@ -76,13 +76,13 @@ export function DashboardStatsCards({ stats }: { stats: DashboardStats }) {
   return (
     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
       <StatCard
-        label="Runs today"
-        value={formatNumber(runsToday.total)}
+        label="Runs in the last 24 hours"
+        value={formatNumber(runsLast24Hours.total)}
         subline={
           <FilesProcessedSubline
-            completed={runsToday.filesCompleted}
-            failed={runsToday.filesFailed}
-            emptyLabel="No files processed yet today"
+            completed={runsLast24Hours.filesCompleted}
+            failed={runsLast24Hours.filesFailed}
+            emptyLabel="No files processed in the last 24 hours"
           />
         }
       />

--- a/web-app/components/instruments/instrument-header.tsx
+++ b/web-app/components/instruments/instrument-header.tsx
@@ -72,10 +72,19 @@ export function InstrumentHeader({
         </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="font-mono text-sm text-muted-foreground">
-          {instrument.id}
-        </span>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+        <span className="font-mono">{instrument.id}</span>
+        {instrument.activeWatcherId && instrument.activeWatcherHostname && (
+          <>
+            <span>·</span>
+            <Link
+              href={`/watchers/${instrument.activeWatcherId}`}
+              className="hover:text-foreground hover:underline"
+            >
+              {instrument.activeWatcherHostname}
+            </Link>
+          </>
+        )}
       </div>
     </div>
   );

--- a/web-app/components/pagination-nav.tsx
+++ b/web-app/components/pagination-nav.tsx
@@ -64,7 +64,6 @@ export function PaginationNav({
     return (e: MouseEvent) => {
       e.preventDefault();
       setPage(target === 1 ? null : target);
-      window.scrollTo({ top: 0, behavior: "instant" });
     };
   }
 

--- a/web-app/components/runs/run-comment-form.tsx
+++ b/web-app/components/runs/run-comment-form.tsx
@@ -55,7 +55,7 @@ export function RunCommentForm({
         rows={3}
         aria-label="Comment body"
         aria-invalid={tooLong || undefined}
-        className="resize-none border-0 px-0 shadow-none focus-visible:ring-0"
+        className="resize-none border-0 bg-transparent px-0 shadow-none focus-visible:ring-0 dark:bg-transparent"
       />
       <div className="flex items-center justify-between text-xs text-muted-foreground">
         {tooLong ? (

--- a/web-app/components/ui/sidebar.tsx
+++ b/web-app/components/ui/sidebar.tsx
@@ -308,7 +308,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "relative flex w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        "relative flex w-full flex-1 flex-col bg-muted md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 dark:bg-background",
         className
       )}
       {...props}

--- a/web-app/components/watchers/heartbeat-chart.tsx
+++ b/web-app/components/watchers/heartbeat-chart.tsx
@@ -174,9 +174,9 @@ export function HeartbeatChart({
     [heartbeats, startMs, endMs]
   );
 
-  const HALF_DAY_MS = 12 * 60 * 60 * 1000;
+  const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
   const windowMs = endMs - startMs;
-  const widthMultiplier = Math.max(1, windowMs / HALF_DAY_MS);
+  const widthMultiplier = Math.max(1, windowMs / SIX_HOURS_MS);
   const needsScroll = widthMultiplier > 1;
 
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -283,7 +283,6 @@ export function HeartbeatChart({
               <Area
                 dataKey="errors"
                 type="monotone"
-                stackId="1"
                 stroke="var(--color-errors)"
                 fill="url(#fillErrors)"
                 strokeWidth={1.5}
@@ -291,7 +290,6 @@ export function HeartbeatChart({
               <Area
                 dataKey="files"
                 type="monotone"
-                stackId="1"
                 stroke="var(--color-files)"
                 fill="url(#fillFiles)"
                 strokeWidth={1.5}
@@ -299,7 +297,6 @@ export function HeartbeatChart({
               <Area
                 dataKey="runs"
                 type="monotone"
-                stackId="1"
                 stroke="var(--color-runs)"
                 fill="url(#fillRuns)"
                 strokeWidth={1.5}

--- a/web-app/components/watchers/heartbeat-chart.tsx
+++ b/web-app/components/watchers/heartbeat-chart.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { useTablePending } from "@/components/table-pending";
 import {
   type ChartConfig,
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Tooltip,
   TooltipContent,
@@ -143,6 +145,16 @@ function StatusStrip({
   );
 }
 
+function HeartbeatChartSkeleton() {
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border bg-background p-4 dark:bg-muted">
+      <Skeleton className="h-64 w-full" />
+      <Skeleton className="mx-auto h-3 w-48" />
+      <Skeleton className="mt-2 h-6 w-full" />
+    </div>
+  );
+}
+
 export function HeartbeatChart({
   heartbeats,
   since,
@@ -150,6 +162,13 @@ export function HeartbeatChart({
   heartbeats: WatcherHeartbeatRow[];
   since: string;
 }) {
+  // Reflect the surrounding TablePendingProvider's transition state so that we
+  // can swap to a loading skeleton when the date filter changes — the
+  // server-side fetch hasn't returned yet, but the new `since` window has
+  // already been applied client-side, so the previously loaded heartbeats fall
+  // outside the window and `data` would otherwise be empty.
+  const { isPending } = useTablePending();
+
   const { windowStart, windowEnd } = useMemo(
     () => computeWindow(since),
     [since]
@@ -185,6 +204,10 @@ export function HeartbeatChart({
     const el = scrollRef.current;
     if (el && needsScroll) el.scrollLeft = el.scrollWidth;
   }, [data, needsScroll]);
+
+  if (isPending) {
+    return <HeartbeatChartSkeleton />;
+  }
 
   if (data.length === 0) {
     return (

--- a/web-app/components/watchers/status-toolbar.tsx
+++ b/web-app/components/watchers/status-toolbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTablePending } from "@/components/table-pending";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { todayDateString } from "@/lib/date";
@@ -8,9 +9,15 @@ import { X } from "lucide-react";
 import { useQueryStates } from "nuqs";
 
 export function StatusToolbar() {
+  // Tying URL updates to the surrounding TablePendingProvider's transition lets
+  // <HeartbeatChart> swap to a loading skeleton while the new server data is in
+  // flight, instead of briefly flashing the empty state when the previously
+  // loaded heartbeats no longer fall inside the new date window.
+  const { startTransition } = useTablePending();
   const [filters, setFilters] = useQueryStates(watcherDetailSearchParams, {
     shallow: false,
     throttleMs: 300,
+    startTransition,
   });
 
   const today = todayDateString();

--- a/web-app/components/watchers/watcher-detail-tabs.tsx
+++ b/web-app/components/watchers/watcher-detail-tabs.tsx
@@ -66,14 +66,16 @@ export function WatcherDetailTabs({
       </TabsContent>
 
       <TabsContent value="status" className="flex flex-col gap-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <h3 className="text-sm font-medium">Watcher Status</h3>
-            <p className="text-xs text-muted-foreground">{statusSubtitle}</p>
+        <TablePendingProvider>
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-sm font-medium">Watcher Status</h3>
+              <p className="text-xs text-muted-foreground">{statusSubtitle}</p>
+            </div>
+            <StatusToolbar />
           </div>
-          <StatusToolbar />
-        </div>
-        <HeartbeatChart heartbeats={heartbeats} since={effectiveSince} />
+          <HeartbeatChart heartbeats={heartbeats} since={effectiveSince} />
+        </TablePendingProvider>
       </TabsContent>
 
       <TabsContent value="configuration" className="flex flex-col gap-4">

--- a/web-app/components/watchers/watcher-header.tsx
+++ b/web-app/components/watchers/watcher-header.tsx
@@ -61,7 +61,7 @@ export function WatcherHeader({ watcher }: { watcher: WatcherDetail }) {
               lastOnlineAt={watcher.lastHeartbeatAt}
             />
             {watcher.watcherVersion && (
-              <Badge variant="outline" className="font-mono text-[10px]">
+              <Badge variant="outline" className="font-mono text-xs">
                 v{watcher.watcherVersion}
               </Badge>
             )}

--- a/web-app/components/watchers/watcher-header.tsx
+++ b/web-app/components/watchers/watcher-header.tsx
@@ -81,8 +81,6 @@ export function WatcherHeader({ watcher }: { watcher: WatcherDetail }) {
         </div>
 
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
-          <span className="font-mono">{watcher.id}</span>
-          <span>·</span>
           <Link
             href={`/instruments/${watcher.instrumentId}`}
             className="hover:text-foreground hover:underline"

--- a/web-app/lib/api/dashboard.ts
+++ b/web-app/lib/api/dashboard.ts
@@ -110,8 +110,7 @@ export const getInstruments = cache(async function getInstruments() {
 export type DashboardStats = {
   runsLast24Hours: {
     total: number;
-    filesCompleted: number;
-    filesFailed: number;
+    bytesGenerated: number;
   };
   pendingUploads: {
     count: number;
@@ -119,8 +118,7 @@ export type DashboardStats = {
   };
   runsThisWeek: {
     total: number;
-    filesCompleted: number;
-    filesFailed: number;
+    bytesGenerated: number;
     mine: number;
     unattributed: number;
   };
@@ -142,7 +140,7 @@ export const getDashboardStats = cache(async function getDashboardStats(
 ): Promise<DashboardStats> {
   const [
     [runsLast24HoursRow],
-    [filesProcessedRow],
+    [bytesGeneratedRow],
     [pendingRow],
     [runsThisWeekRow],
   ] = await Promise.all([
@@ -158,20 +156,23 @@ export const getDashboardStats = cache(async function getDashboardStats(
         )
       ),
     // Span the last 24 hours + the past 7 days in a single pass; the 24-hour
-    // metrics are a subset of the weekly window, so FILTER clauses give us
-    // both with one index scan instead of two near-identical queries.
+    // window is a subset of the weekly window, so FILTER clauses give us both
+    // with one index scan. Bytes are attributed to the file's owning run so
+    // the time window matches the corresponding "Runs in the last X" card —
+    // this avoids the null-`processedAt` blind spot for not-yet-processed
+    // files (which still represent data the instrument generated).
     db
       .select({
-        completedLast24Hours: sql<number>`cast(count(*) filter (where ${files.status} = 'completed' and ${files.processedAt} > now() - interval '24 hours') as int)`,
-        failedLast24Hours: sql<number>`cast(count(*) filter (where ${files.status} = 'failed' and ${files.processedAt} > now() - interval '24 hours') as int)`,
-        completedWeek: sql<number>`cast(count(*) filter (where ${files.status} = 'completed') as int)`,
-        failedWeek: sql<number>`cast(count(*) filter (where ${files.status} = 'failed') as int)`,
+        bytesLast24Hours: sql<string>`coalesce(sum(${files.sizeBytes}) filter (where ${instrumentRuns.createdAt} > now() - interval '24 hours'), 0)`,
+        bytesWeek: sql<string>`coalesce(sum(${files.sizeBytes}), 0)`,
       })
       .from(files)
+      .innerJoin(instrumentRuns, eq(files.instrumentRunId, instrumentRuns.id))
       .where(
         and(
           isNull(files.deletedAt),
-          sql`${files.processedAt} > now() - interval '7 days'`
+          isNull(instrumentRuns.deletedAt),
+          sql`${instrumentRuns.createdAt} > now() - interval '7 days'`
         )
       ),
     db
@@ -208,18 +209,16 @@ export const getDashboardStats = cache(async function getDashboardStats(
   return {
     runsLast24Hours: {
       total: runsLast24HoursRow?.total ?? 0,
-      filesCompleted: filesProcessedRow?.completedLast24Hours ?? 0,
-      filesFailed: filesProcessedRow?.failedLast24Hours ?? 0,
+      // bigint sums come back as strings from pg; coerce explicitly.
+      bytesGenerated: Number(bytesGeneratedRow?.bytesLast24Hours ?? 0),
     },
     pendingUploads: {
       count: pendingRow?.count ?? 0,
-      // bigint sums come back as strings from pg; coerce explicitly.
       totalBytes: Number(pendingRow?.totalBytes ?? 0),
     },
     runsThisWeek: {
       total: runsThisWeekRow?.total ?? 0,
-      filesCompleted: filesProcessedRow?.completedWeek ?? 0,
-      filesFailed: filesProcessedRow?.failedWeek ?? 0,
+      bytesGenerated: Number(bytesGeneratedRow?.bytesWeek ?? 0),
       mine: runsThisWeekRow?.mine ?? 0,
       unattributed: runsThisWeekRow?.unattributed ?? 0,
     },

--- a/web-app/lib/api/dashboard.ts
+++ b/web-app/lib/api/dashboard.ts
@@ -108,7 +108,7 @@ export const getInstruments = cache(async function getInstruments() {
 });
 
 export type DashboardStats = {
-  runsToday: {
+  runsLast24Hours: {
     total: number;
     filesCompleted: number;
     filesFailed: number;
@@ -141,8 +141,8 @@ export const getDashboardStats = cache(async function getDashboardStats(
   currentUserId: string | null
 ): Promise<DashboardStats> {
   const [
-    [runsTodayRow],
-    [filesProcessedTodayRow],
+    [runsLast24HoursRow],
+    [filesProcessedRow],
     [pendingRow],
     [runsThisWeekRow],
   ] = await Promise.all([
@@ -154,16 +154,16 @@ export const getDashboardStats = cache(async function getDashboardStats(
       .where(
         and(
           isNull(instrumentRuns.deletedAt),
-          sql`${instrumentRuns.createdAt} >= date_trunc('day', now())`
+          sql`${instrumentRuns.createdAt} > now() - interval '24 hours'`
         )
       ),
-    // Span today + the past 7 days in a single pass; the today metrics are a
-    // subset of the weekly window, so FILTER clauses give us both with one
-    // index scan instead of two near-identical queries.
+    // Span the last 24 hours + the past 7 days in a single pass; the 24-hour
+    // metrics are a subset of the weekly window, so FILTER clauses give us
+    // both with one index scan instead of two near-identical queries.
     db
       .select({
-        completedToday: sql<number>`cast(count(*) filter (where ${files.status} = 'completed' and ${files.processedAt} >= date_trunc('day', now())) as int)`,
-        failedToday: sql<number>`cast(count(*) filter (where ${files.status} = 'failed' and ${files.processedAt} >= date_trunc('day', now())) as int)`,
+        completedLast24Hours: sql<number>`cast(count(*) filter (where ${files.status} = 'completed' and ${files.processedAt} > now() - interval '24 hours') as int)`,
+        failedLast24Hours: sql<number>`cast(count(*) filter (where ${files.status} = 'failed' and ${files.processedAt} > now() - interval '24 hours') as int)`,
         completedWeek: sql<number>`cast(count(*) filter (where ${files.status} = 'completed') as int)`,
         failedWeek: sql<number>`cast(count(*) filter (where ${files.status} = 'failed') as int)`,
       })
@@ -206,10 +206,10 @@ export const getDashboardStats = cache(async function getDashboardStats(
   ]);
 
   return {
-    runsToday: {
-      total: runsTodayRow?.total ?? 0,
-      filesCompleted: filesProcessedTodayRow?.completedToday ?? 0,
-      filesFailed: filesProcessedTodayRow?.failedToday ?? 0,
+    runsLast24Hours: {
+      total: runsLast24HoursRow?.total ?? 0,
+      filesCompleted: filesProcessedRow?.completedLast24Hours ?? 0,
+      filesFailed: filesProcessedRow?.failedLast24Hours ?? 0,
     },
     pendingUploads: {
       count: pendingRow?.count ?? 0,
@@ -218,8 +218,8 @@ export const getDashboardStats = cache(async function getDashboardStats(
     },
     runsThisWeek: {
       total: runsThisWeekRow?.total ?? 0,
-      filesCompleted: filesProcessedTodayRow?.completedWeek ?? 0,
-      filesFailed: filesProcessedTodayRow?.failedWeek ?? 0,
+      filesCompleted: filesProcessedRow?.completedWeek ?? 0,
+      filesFailed: filesProcessedRow?.failedWeek ?? 0,
       mine: runsThisWeekRow?.mine ?? 0,
       unattributed: runsThisWeekRow?.unattributed ?? 0,
     },

--- a/web-app/lib/api/instruments.ts
+++ b/web-app/lib/api/instruments.ts
@@ -286,7 +286,16 @@ export type InstrumentDetail = {
   watchersOffline: number;
   /** Most recent heartbeat from any watcher attached to this instrument. */
   lastWatcherHeartbeatAt: Date | null;
+  /**
+   * The "canonical" watcher for this instrument, used to render watcher
+   * affordances in the instrument header. When multiple watchers are
+   * attached, the most recently heartbeating one wins; ties (or instruments
+   * whose watchers have never heartbeated) fall back to the first watcher
+   * by `createdAt`.
+   */
   activeWatcherId: string | null;
+  /** Desktop hostname of the canonical active watcher, if any. */
+  activeWatcherHostname: string | null;
 };
 
 export const getInstrumentById = cache(async function getInstrumentById(
@@ -313,8 +322,10 @@ export const getInstrumentById = cache(async function getInstrumentById(
     db
       .select({
         id: watchers.id,
+        hostname: watchers.hostname,
         status: watchers.status,
         lastHeartbeatAt: watchers.lastHeartbeatAt,
+        createdAt: watchers.createdAt,
         configYaml: watchers.configYaml,
       })
       .from(watchers)
@@ -329,7 +340,6 @@ export const getInstrumentById = cache(async function getInstrumentById(
 
   let watchersOnline = 0;
   let watchersOffline = 0;
-  let activeWatcherId: string | null = null;
   let lastWatcherHeartbeatAt: Date | null = null;
   for (const w of watcherRows) {
     const isOnline =
@@ -338,7 +348,6 @@ export const getInstrumentById = cache(async function getInstrumentById(
       w.lastHeartbeatAt > staleThreshold;
     if (isOnline) {
       watchersOnline++;
-      activeWatcherId ??= w.id;
     } else {
       watchersOffline++;
     }
@@ -349,7 +358,25 @@ export const getInstrumentById = cache(async function getInstrumentById(
       lastWatcherHeartbeatAt = w.lastHeartbeatAt;
     }
   }
-  activeWatcherId ??= watcherRows[0]?.id ?? null;
+
+  // Canonical "active" watcher: the most recently heartbeating one, falling
+  // back to the earliest registered when no watcher has ever heartbeated.
+  // This keeps `activeWatcherId` aligned with `lastWatcherHeartbeatAt` so
+  // downstream UI (the watcher link in the header, status badge route)
+  // points at the same row the heartbeat timestamp came from.
+  const activeWatcher =
+    watcherRows.length === 0
+      ? null
+      : (watcherRows
+          .filter((w) => w.lastHeartbeatAt !== null)
+          .sort(
+            (a, b) =>
+              (b.lastHeartbeatAt?.getTime() ?? 0) -
+              (a.lastHeartbeatAt?.getTime() ?? 0)
+          )[0] ??
+        [...watcherRows].sort(
+          (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
+        )[0]);
 
   return {
     id: instrument.id,
@@ -364,6 +391,7 @@ export const getInstrumentById = cache(async function getInstrumentById(
     watchersOnline,
     watchersOffline,
     lastWatcherHeartbeatAt,
-    activeWatcherId,
+    activeWatcherId: activeWatcher?.id ?? null,
+    activeWatcherHostname: activeWatcher?.hostname ?? null,
   };
 });

--- a/web-app/lib/search-params.ts
+++ b/web-app/lib/search-params.ts
@@ -16,7 +16,7 @@ export const dashboardSearchParams = {
   date_to: parseAsString.withOptions({ clearOnDefault: true }),
   include_deleted: parseAsBoolean.withDefault(false),
   page: parseAsInteger.withDefault(1),
-  per_page: parseAsInteger.withDefault(25),
+  per_page: parseAsInteger.withDefault(10),
 };
 
 export const dashboardParamsCache = createSearchParamsCache(
@@ -31,7 +31,7 @@ export const instrumentDetailSearchParams = {
   date_to: parseAsString.withOptions({ clearOnDefault: true }),
   include_deleted: parseAsBoolean.withDefault(false),
   page: parseAsInteger.withDefault(1),
-  per_page: parseAsInteger.withDefault(25),
+  per_page: parseAsInteger.withDefault(10),
   // Plate-reader metadata column filters (ignored for generic instruments).
   wavelength: parseAsString,
   measurement_mode: parseAsString,


### PR DESCRIPTION
## Summary

Batch of UI/UX and dashboard fixes for the web app.

**Dashboard**
- Switch "Runs today" stat to a rolling 24-hour window (`runsToday` → `runsLast24Hours`), with SQL using `now() - interval '24 hours'` so the count is timezone-agnostic.
- 24h / 7d cards now surface "X.X GB generated" aggregated over each card's run window, regardless of file completion status.

**App chrome / theming**
- Unify the app surface on `bg-muted` (html, body, sidebar inset) for a consistent light-gray background.
- Light-mode polish: sidebar `#F3F3F3`, body `bg-muted-foreground`, darker sidebar hover; dark-mode cards stay subtly elevated.
- Comment textarea is transparent so it sits flush on its card.
- Pagination no longer scroll-jumps to the top on page change.

**Run tables & tokens**
- Default run tables to 10 items per page across the UI (nuqs defaults) and the v1 REST endpoints.
- Settings/tokens lists all PATs with a User avatar column, sorted newest-first.

**Instruments & watchers**
- Instrument and watcher headers cross-link symmetrically; watcher header drops its redundant id chip.
- Heartbeat chart: unstack the errors/files/runs areas (so a value attaches to its own color), size width on a 6-hour window for more horizontal detail, and bump the watcher version badge to `text-xs`.
- Watcher status tab now shows a loading skeleton when the date filter changes, instead of briefly flashing "No heartbeats in this time range" while the new server fetch is in flight.

## Test plan

- [x] Verify dashboard 24h/7d cards display rolling-window run counts and "GB generated" sublines
- [x] Confirm app background is uniform across pages in both light and dark mode
- [x] Page through a runs table — no scroll jump
- [x] Settings → Tokens shows all PATs with avatars, newest first
- [x] Watcher detail → Status tab: change the date and confirm a loading skeleton appears (no "No heartbeats" flash)
- [x] Hover a non-zero point on the heartbeat chart and confirm the line color matches the metric in the tooltip


Made with [Cursor](https://cursor.com)