### PR TITLE
CI: Allow deploy role to update S3 event notifications, bump action versions

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: us-west-1
@@ -48,7 +48,7 @@ jobs:
           docker push "${IMAGE_URI}"
           echo "IMAGE_URI=${IMAGE_URI}" >> "$GITHUB_ENV"
 
-      - uses: aws-actions/setup-sam@v2
+      - uses: aws-actions/setup-sam@v3
 
       - name: Deploy SAM stack
         working-directory: infra

--- a/.github/workflows/publish-watcher.yml
+++ b/.github/workflows/publish-watcher.yml
@@ -45,9 +45,9 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v8
 
       # Refuse to publish unless the git tag and the package version line
       # up — guards against shipping `watcher-v0.3.0` from a repo whose
@@ -69,7 +69,7 @@ jobs:
       - name: List built artifacts
         run: ls -la dist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -91,7 +91,7 @@ jobs:
       # short-lived API token at the index.
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -109,7 +109,7 @@ jobs:
     needs: [build, publish]
     runs-on: ubuntu-latest
     steps:
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.12"
 

--- a/.github/workflows/publish-watcher.yml
+++ b/.github/workflows/publish-watcher.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
 
       # Refuse to publish unless the git tag and the package version line
       # up — guards against shipping `watcher-v0.3.0` from a repo whose
@@ -109,7 +109,7 @@ jobs:
     needs: [build, publish]
     runs-on: ubuntu-latest
     steps:
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -28,8 +28,8 @@ jobs:
   python-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8
 
       - name: Install dependencies
         run: uv sync --all-packages

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
         run: uv sync --all-packages

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           node-version: 24
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install Node.js packages
         run: npm ci

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -51,13 +51,13 @@ jobs:
       AUTH_GOOGLE_SECRET: stub
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v8
 
       - name: Install Node.js packages
         run: npm ci

--- a/.github/workflows/typescript-lint.yml
+++ b/.github/workflows/typescript-lint.yml
@@ -25,9 +25,9 @@ jobs:
       run:
         working-directory: web-app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/typescript-test.yml
+++ b/.github/workflows/typescript-test.yml
@@ -43,9 +43,9 @@ jobs:
       AUTH_GOOGLE_SECRET: stub
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/docs/ci-and-deployment.md
+++ b/docs/ci-and-deployment.md
@@ -192,7 +192,7 @@ On pushes to `staging` or `production`, the **Deploy Lambda** workflow:
 
 Secrets (`DATA_HUB_API_KEY`, `SLACK_WEBHOOK_URL`, etc.) are stored in GitHub environment secrets scoped to each environment.
 
-> **Note:** The CI deploy role has intentionally narrow permissions — enough to push a new container image and update the existing CloudFormation stack, but _not_ enough to create the stack from scratch or to add/remove S3 buckets, Lambda functions, or S3 event triggers. Initial stack creation and infrastructure-level changes (e.g., adding a new instrument trigger) must be performed by an admin with broader AWS permissions. Once the stack exists, routine image-update deploys through CI work without issue.
+> **Note:** The CI deploy role has intentionally narrow permissions — enough to push a new container image, update the existing CloudFormation stack, and modify the data buckets' S3 event notifications (so new instrument triggers roll out via CI), but _not_ enough to create the stack from scratch or to add/remove S3 buckets or Lambda functions. Initial stack creation and structural infrastructure changes must be performed by an admin with broader AWS permissions. Once the stack exists, routine image-update deploys and new-trigger rollouts through CI work without issue.
 
 #### Local deployment
 

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -289,9 +289,11 @@ Resources:
                   - !Sub "arn:aws:s3:::arcadia-data-hub-archives-${Environment}/*"
 
   # ---- IAM: GitHub Actions deploy role ----
-  # Scoped for routine image-update deploys only.  Initial stack creation and
-  # infrastructure changes (new buckets, Lambda functions, S3 event triggers)
-  # require broader permissions — run those from an admin session.
+  # Scoped for routine image-update deploys plus in-place updates to the
+  # existing data buckets' S3 event notifications (so new instrument triggers
+  # roll out via CI). Initial stack creation and structural changes — adding
+  # new buckets or Lambda functions — still require broader permissions and
+  # must be run from an admin session.
 
   GitHubActionsDeployRole:
     Type: AWS::IAM::Role
@@ -366,6 +368,18 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:s3:::aws-sam-cli-managed-default-samclisourcebucket-*"
                   - !Sub "arn:aws:s3:::aws-sam-cli-managed-default-samclisourcebucket-*/*"
+              # Updating S3 event notifications (e.g., adding a new instrument
+              # trigger to RawDataBucket) requires Get/PutBucketNotification on
+              # the bucket itself. Scoped to the three data buckets this stack
+              # owns so CI can roll out new triggers without an admin deploy.
+              - Effect: Allow
+                Action:
+                  - s3:GetBucketNotification
+                  - s3:PutBucketNotification
+                Resource:
+                  - !Sub "arn:aws:s3:::arcadia-data-hub-raw-${Environment}"
+                  - !Sub "arn:aws:s3:::arcadia-data-hub-processed-${Environment}"
+                  - !Sub "arn:aws:s3:::arcadia-data-hub-archives-${Environment}"
               - Effect: Allow
                 Action:
                   - iam:GetRole


### PR DESCRIPTION
## Summary

Unblocks the `deploy-lambda` workflow on infra changes that touch `RawDataBucket.NotificationConfiguration` (e.g. adding a new instrument trigger), which previously required an admin `sam deploy`. Also clears the GitHub Actions Node 20 deprecation warnings across every workflow ahead of GitHub forcing Node 24 in June.

## Changes

- `infra/template.yaml` — adds `s3:GetBucketNotification` / `s3:PutBucketNotification` to the SAM deploy role, scoped to the three stack-owned data buckets (`raw`, `processed`, `archives`). The previous deploy of #56 (Epson V700 Scanner) failed on exactly this permission. Updates the role's banner comment to reflect the new capability.
- `docs/ci-and-deployment.md` — updates the "narrow permissions" note to call out that S3 notification changes now flow through CI.

## Breaking changes

None.

## Driveby changes

Bumped action plugins to their latest stable major versions everywhere they appear (six workflow files):

| Action | Old | New |
| --- | --- | --- |
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v5 | v6 |
| `astral-sh/setup-uv` | v6 | v8 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `aws-actions/configure-aws-credentials` | v4 | v6 |
| `aws-actions/setup-sam` | v2 | v3 |

`aws-actions/amazon-ecr-login` and `pypa/gh-action-pypi-publish` are already on their current tags.

## Testing

- [x] `make check-all` passes locally
- [ ] First post-merge `deploy-lambda` run on `staging` succeeds (confirms the permission unblocks the rolled-back Epson V700 changeset and that the bumped actions still work end-to-end)
- [x] `python-lint`, `python-test`, `typescript-lint`, `typescript-test` runs on this PR pass on the bumped action versions
- [ ] Next `publish-watcher` release (or a manual dispatch from `staging`) succeeds with the bumped `upload-artifact@v7` / `download-artifact@v8`

> **Rollout note:** This same changeset both grants the new IAM permission *and* re-applies the Epson V700 notification update that originally failed. CloudFormation should apply the IAM update before re-trying the bucket update within the same changeset, but if the next CI run still trips on `s3:PutBucketNotification`, a one-time admin `sam deploy` will land it; CI is self-sufficient from then on.