### PR TITLE
Runs: Surface actual on-instrument acquisition time (`acquired_at`)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -415,7 +415,7 @@ requires-dist = [
 
 [[package]]
 name = "data-hub-watcher"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "watcher" }
 dependencies = [
     { name = "click" },

--- a/watcher/pyproject.toml
+++ b/watcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-hub-watcher"
-version = "0.2.5"
+version = "0.2.6"
 description = "File-watcher agent for lab instrument PCs that ingests data into Data Hub."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/watcher/src/data_hub_watcher/run_detector.py
+++ b/watcher/src/data_hub_watcher/run_detector.py
@@ -67,6 +67,17 @@ class RunState:
     # every call. On a failed PATCH the cursor is left untouched so the
     # next stable file's PATCH carries the backlog plus the new entry.
     patched_file_count: int = 0
+    # Last `acquired_at` value (seconds since epoch) we successfully sent
+    # to the API for this run. Used so `_update_run` only PATCHes the
+    # field when a later-stabilising file reveals an earlier creation
+    # time than what the server already knows.
+    acquired_at_sent: float | None = None
+
+
+def _run_acquired_at(files: list[FileInfo]) -> float | None:
+    """Earliest known on-disk creation time across *files*, or None."""
+    times = [f.file_created_at for f in files if f.file_created_at]
+    return min(times) if times else None
 
 
 class RunDetector:
@@ -249,17 +260,21 @@ class RunDetector:
         self._state_db.record_detected_files(run.run_id, rows)
 
     def _report_new_run(self, run: RunState) -> None:
-        payload = {
+        acquired = _run_acquired_at(run.files)
+        payload: dict[str, object] = {
             "run_id": run.run_id,
             "source": "watcher",
             "watcher_id": self._watcher_id,
             "detected_files": [self._file_payload(f) for f in run.files],
         }
+        if acquired is not None:
+            payload["acquired_at"] = datetime.fromtimestamp(acquired, tz=timezone.utc).isoformat()
         try:
             resp = self._client.report_run(self._instrument_id, payload)
             run.reported = True
             run.api_run_id = resp.id
             run.patched_file_count = len(run.files)
+            run.acquired_at_sent = acquired
             self._state_db.record_run_reported(run.run_id)
             self._persist_detected_files(run)
             self._counters.runs_reported += 1
@@ -308,15 +323,31 @@ class RunDetector:
         of the PATCH cursor).
         """
         new_files = run.files[run.patched_file_count :]
-        if not new_files:
+        # An out-of-order stable file may carry an older birthtime than
+        # anything we've sent so far; surface that to the server even if
+        # the file delta itself is empty (rare but possible).
+        acquired = _run_acquired_at(run.files)
+        earlier_acquired: float | None = (
+            acquired
+            if acquired is not None
+            and (run.acquired_at_sent is None or acquired < run.acquired_at_sent)
+            else None
+        )
+        if not new_files and earlier_acquired is None:
             return
 
-        payload = {
+        payload: dict[str, object] = {
             "detected_files": [self._file_payload(f) for f in new_files],
         }
+        if earlier_acquired is not None:
+            payload["acquired_at"] = datetime.fromtimestamp(
+                earlier_acquired, tz=timezone.utc
+            ).isoformat()
         try:
             self._client.update_run(self._instrument_id, run.run_id, payload)
             run.patched_file_count = len(run.files)
+            if earlier_acquired is not None:
+                run.acquired_at_sent = earlier_acquired
             self._persist_detected_files(run)
             logger.info(
                 "Updated run %s (sent %d new file(s), %d total)",
@@ -394,6 +425,11 @@ class RunDetector:
                 # is only written after a successful POST/PATCH — so the
                 # PATCH cursor starts at the end of the manifest.
                 patched_file_count=len(files),
+                # Equivalently, the server's `acquired_at` is the floor of
+                # what we've persisted in `detected_files`. Seeding the
+                # cursor here avoids a redundant PATCH on the first stable
+                # file after restart.
+                acquired_at_sent=_run_acquired_at(files),
             )
             count += 1
         if count:

--- a/watcher/tests/test_run_detector_hydration.py
+++ b/watcher/tests/test_run_detector_hydration.py
@@ -14,7 +14,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from data_hub_watcher.run_detector import RunDetector, file_created_at
+from data_hub_watcher.run_detector import (
+    FileInfo,
+    RunDetector,
+    _run_acquired_at,
+    file_created_at,
+)
 from data_hub_watcher.state import StateDB
 
 
@@ -371,3 +376,127 @@ class TestUpdateRunSendsDeltaOnly:
 
         rel_paths = {r.relative_path for r in state_db.get_detected_files_for_run("run-retry")}
         assert rel_paths == {"run-retry/a.nd2", "run-retry/b.nd2", "run-retry/c.nd2"}
+
+
+class TestAcquiredAt:
+    """Run-level `acquired_at` derived from min(file_created_at)."""
+
+    def test_run_acquired_at_skips_zero_and_returns_min(self) -> None:
+        files = [
+            FileInfo(
+                path=Path("/a"),
+                filename="a",
+                size_bytes=1,
+                file_created_at=1_700_000_500.0,
+            ),
+            FileInfo(
+                path=Path("/b"),
+                filename="b",
+                size_bytes=1,
+                file_created_at=0.0,
+            ),
+            FileInfo(
+                path=Path("/c"),
+                filename="c",
+                size_bytes=1,
+                file_created_at=1_699_999_900.0,
+            ),
+        ]
+        assert _run_acquired_at(files) == 1_699_999_900.0
+
+    def test_run_acquired_at_returns_none_when_all_missing(self) -> None:
+        files = [
+            FileInfo(path=Path("/a"), filename="a", size_bytes=1, file_created_at=0.0),
+        ]
+        assert _run_acquired_at(files) is None
+
+    def test_post_payload_includes_acquired_at_iso(
+        self, state_db: StateDB, watch_dir: Path
+    ) -> None:
+        """The POST /runs payload must include `acquired_at` (ISO 8601 UTC) when known."""
+        client = MagicMock()
+        client.report_run.return_value = MagicMock(id="api-run-id")
+        detector = _make_detector(watch_dir, state_db, client=client)
+
+        (watch_dir / "run-acq").mkdir()
+        f = watch_dir / "run-acq" / "data.nd2"
+        f.write_bytes(b"q" * 8)
+        detector.on_stable_file(f)
+
+        client.report_run.assert_called_once()
+        _, payload = client.report_run.call_args.args
+        assert isinstance(payload.get("acquired_at"), str)
+        assert payload["acquired_at"].endswith("+00:00")
+        # The run-level acquired_at equals the per-file file_created_at
+        # (single-file run), which is already exposed in detected_files[0].
+        assert payload["acquired_at"] == payload["detected_files"][0]["file_created_at"]
+
+    def test_patch_includes_earlier_acquired_at_when_later_file_predates(
+        self, state_db: StateDB, watch_dir: Path
+    ) -> None:
+        """If a later-stabilising file has an earlier birthtime, the PATCH must
+        carry an `acquired_at` field so the server can move the row earlier."""
+        client = MagicMock()
+        client.report_run.return_value = MagicMock(id="api-run-id")
+        detector = _make_detector(watch_dir, state_db, client=client)
+
+        run_dir = watch_dir / "run-earlier"
+        run_dir.mkdir()
+        f1 = run_dir / "a.nd2"
+        f1.write_bytes(b"a" * 10)
+        detector.on_stable_file(f1)
+
+        run = detector._runs["run-earlier"]
+        assert run.acquired_at_sent is not None
+        first_acquired = run.acquired_at_sent
+
+        # Inject a second stable file whose on-disk birthtime predates the
+        # first by an hour. Bypass `on_stable_file` so we control the
+        # FileInfo precisely without depending on platform birthtime
+        # behaviour.
+        f2 = run_dir / "b.nd2"
+        f2.write_bytes(b"b" * 20)
+        earlier = first_acquired - 3600.0
+        run.files.append(
+            FileInfo(
+                path=f2,
+                filename=f2.name,
+                size_bytes=20,
+                mtime=first_acquired,
+                file_created_at=earlier,
+            )
+        )
+        detector._update_run(run)
+
+        client.update_run.assert_called_once()
+        _, _, patch_payload = client.update_run.call_args.args
+        assert isinstance(patch_payload.get("acquired_at"), str)
+        # ISO-encoded earlier value matches the new floor.
+        from datetime import datetime, timezone
+
+        assert (
+            patch_payload["acquired_at"]
+            == datetime.fromtimestamp(earlier, tz=timezone.utc).isoformat()
+        )
+        assert run.acquired_at_sent == earlier
+
+    def test_patch_omits_acquired_at_when_floor_unchanged(
+        self, state_db: StateDB, watch_dir: Path
+    ) -> None:
+        """A later file with a *later* birthtime must not bump acquired_at."""
+        client = MagicMock()
+        client.report_run.return_value = MagicMock(id="api-run-id")
+        detector = _make_detector(watch_dir, state_db, client=client)
+
+        run_dir = watch_dir / "run-monotonic"
+        run_dir.mkdir()
+        f1 = run_dir / "a.nd2"
+        f1.write_bytes(b"a" * 10)
+        detector.on_stable_file(f1)
+        f2 = run_dir / "b.nd2"
+        f2.write_bytes(b"b" * 20)
+        detector.on_stable_file(f2)
+
+        client.update_run.assert_called_once()
+        _, _, patch_payload = client.update_run.call_args.args
+        assert "acquired_at" not in patch_payload

--- a/web-app/app/api/v1/instrument-runs/route.ts
+++ b/web-app/app/api/v1/instrument-runs/route.ts
@@ -26,6 +26,8 @@ export async function GET(request: NextRequest) {
     search: searchParams.get("search") ?? undefined,
     sort: searchParams.get("sort") ?? undefined,
     order: searchParams.get("order") ?? undefined,
+    dateFrom: searchParams.get("date_from") ?? undefined,
+    dateTo: searchParams.get("date_to") ?? undefined,
     page: parseIntParam(searchParams.get("page"), {
       default: 1,
       min: 1,

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/route.ts
@@ -6,11 +6,14 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
-import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
+import {
+  lookupRunByNaturalKey,
+  parseAcquiredAt,
+} from "@/lib/api/instrument-runs";
 import { db } from "@/lib/db";
 import { files, instrumentRuns } from "@/lib/db/schema";
 import { getPresignedDownloadUrl } from "@/lib/s3";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 
 type RouteContext = {
@@ -82,6 +85,7 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
     source: run.source,
     watcher_id: run.watcherId,
     created_at: run.createdAt,
+    acquired_at: run.acquiredAt,
     updated_at: run.updatedAt,
     deleted_at: run.deletedAt,
     metadata: run.metadata,
@@ -145,6 +149,20 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
       .where(eq(instrumentRuns.id, run.id));
   }
 
+  // Fold an incoming acquired_at into the row using LEAST so the run's
+  // acquisition time can only ever move earlier (e.g. a later-stabilising
+  // file with an older birthtime). Recomputed from detected_files when not
+  // supplied explicitly — see parseAcquiredAt.
+  const incomingAcquiredAt = parseAcquiredAt(body);
+  if (incomingAcquiredAt) {
+    await db
+      .update(instrumentRuns)
+      .set({
+        acquiredAt: sql`least(coalesce(${instrumentRuns.acquiredAt}, ${incomingAcquiredAt}), ${incomingAcquiredAt})`,
+      })
+      .where(eq(instrumentRuns.id, run.id));
+  }
+
   // Handle detected_files upsert (watcher reporting new files for a run).
   const detectedFiles = Array.isArray(body.detected_files)
     ? body.detected_files
@@ -189,6 +207,7 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
     watcher_id: updated!.watcherId,
     metadata: updated!.metadata,
     created_at: updated!.createdAt,
+    acquired_at: updated!.acquiredAt,
     updated_at: updated!.updatedAt,
     deleted_at: updated!.deletedAt,
   });

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/route.ts
@@ -153,12 +153,17 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
   // acquisition time can only ever move earlier (e.g. a later-stabilising
   // file with an older birthtime). Recomputed from detected_files when not
   // supplied explicitly — see parseAcquiredAt.
+  //
+  // Bind the ISO string + ::timestamptz cast: drizzle's sql tag has no
+  // PgColumn context here to coerce a JS Date for the postgres-js driver,
+  // which would otherwise throw ERR_INVALID_ARG_TYPE.
   const incomingAcquiredAt = parseAcquiredAt(body);
   if (incomingAcquiredAt) {
+    const iso = incomingAcquiredAt.toISOString();
     await db
       .update(instrumentRuns)
       .set({
-        acquiredAt: sql`least(coalesce(${instrumentRuns.acquiredAt}, ${incomingAcquiredAt}), ${incomingAcquiredAt})`,
+        acquiredAt: sql`least(coalesce(${instrumentRuns.acquiredAt}, ${iso}::timestamptz), ${iso}::timestamptz)`,
       })
       .where(eq(instrumentRuns.id, run.id));
   }

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/route.ts
@@ -5,12 +5,12 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
-import { buildRunListQuery } from "@/lib/api/instrument-runs";
+import { buildRunListQuery, parseAcquiredAt } from "@/lib/api/instrument-runs";
 import { parseIntParam } from "@/lib/api/validators";
 import { db } from "@/lib/db";
 import { files, instrumentRuns, instruments, watchers } from "@/lib/db/schema";
 import { sendSlackMessage } from "@/lib/slack";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 
 type RouteContext = {
@@ -70,6 +70,12 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   const watcherId =
     typeof body.watcher_id === "string" ? body.watcher_id : null;
 
+  // Parse the watcher-supplied acquired_at, falling back to the floor of
+  // any detected_files[].file_created_at when omitted. This is defense-in-
+  // depth: older watchers or future callers that send only file timestamps
+  // still get a meaningful run-level acquisition timestamp on insert.
+  const incomingAcquiredAt = parseAcquiredAt(body);
+
   // Validate watcher_id references an active watcher for this instrument.
   if (watcherId) {
     const [watcher] = await db
@@ -102,6 +108,7 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
       runId,
       source,
       watcherId,
+      acquiredAt: incomingAcquiredAt,
     })
     .onConflictDoNothing({
       target: [instrumentRuns.instrumentId, instrumentRuns.runId],
@@ -111,7 +118,9 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   const isNew = !!inserted;
 
   // If onConflictDoNothing fired, `inserted` is undefined — fetch the
-  // existing row by the natural key.
+  // existing row by the natural key. When the watcher POST races a
+  // lambda-created row, fold the watcher's acquired_at into the existing
+  // row using LEAST so it can only ever move earlier.
   const [run] = isNew
     ? await db
         .select()
@@ -128,6 +137,15 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
           )
         )
         .limit(1);
+
+  if (!isNew && incomingAcquiredAt) {
+    await db
+      .update(instrumentRuns)
+      .set({
+        acquiredAt: sql`least(coalesce(${instrumentRuns.acquiredAt}, ${incomingAcquiredAt}), ${incomingAcquiredAt})`,
+      })
+      .where(eq(instrumentRuns.id, run.id));
+  }
 
   // Watcher payloads may include detected files to bulk-insert alongside
   // the run. Duplicates (same run + relative_path) are silently skipped.

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/route.ts
@@ -139,10 +139,15 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
         .limit(1);
 
   if (!isNew && incomingAcquiredAt) {
+    // Bind the ISO string explicitly + cast to timestamptz: drizzle's
+    // sql tag has no PgColumn context here to coerce a JS Date for the
+    // postgres-js driver. See instrument-runs.ts dateFrom/dateTo for
+    // the same pattern.
+    const iso = incomingAcquiredAt.toISOString();
     await db
       .update(instrumentRuns)
       .set({
-        acquiredAt: sql`least(coalesce(${instrumentRuns.acquiredAt}, ${incomingAcquiredAt}), ${incomingAcquiredAt})`,
+        acquiredAt: sql`least(coalesce(${instrumentRuns.acquiredAt}, ${iso}::timestamptz), ${iso}::timestamptz)`,
       })
       .where(eq(instrumentRuns.id, run.id));
   }
@@ -239,6 +244,8 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
     search: searchParams.get("search") ?? undefined,
     sort: searchParams.get("sort") ?? undefined,
     order: searchParams.get("order") ?? undefined,
+    dateFrom: searchParams.get("date_from") ?? undefined,
+    dateTo: searchParams.get("date_to") ?? undefined,
     page: parseIntParam(searchParams.get("page"), {
       default: 1,
       min: 1,

--- a/web-app/components/dashboard/runs-table.tsx
+++ b/web-app/components/dashboard/runs-table.tsx
@@ -136,7 +136,11 @@ export function RunsTable({
                   />
                 </TableCell>
                 <TableCell className="text-right">
-                  <RelativeTime date={new Date(row.created_at).toISOString()} />
+                  <RelativeTime
+                    date={new Date(
+                      row.acquired_at ?? row.created_at
+                    ).toISOString()}
+                  />
                 </TableCell>
                 <TableCell className="py-1">
                   <RunRowActions row={row} />

--- a/web-app/components/dashboard/runs-table.tsx
+++ b/web-app/components/dashboard/runs-table.tsx
@@ -1,4 +1,5 @@
 import { RelativeTime } from "@/components/dashboard/relative-time";
+import { AcquiredColumnHeader } from "@/components/instruments/runs-table/acquired-column-header";
 import { RanByCell } from "@/components/instruments/runs-table/ran-by-cell";
 import { RawFileColumnHeader } from "@/components/instruments/runs-table/raw-file-column-header";
 import { RunIdLabel } from "@/components/instruments/runs-table/run-id-label";
@@ -72,7 +73,9 @@ export function RunsTable({
               <RawFileColumnHeader label="Size" />
             </TableHead>
             <TableHead>Ran By</TableHead>
-            <TableHead className="text-right">Created</TableHead>
+            <TableHead className="text-right">
+              <AcquiredColumnHeader />
+            </TableHead>
             <TableHead className="w-[132px]">
               <span className="sr-only">Actions</span>
             </TableHead>
@@ -177,7 +180,9 @@ export function RunsTableSkeleton() {
               <RawFileColumnHeader label="Size" />
             </TableHead>
             <TableHead>Ran By</TableHead>
-            <TableHead className="text-right">Created</TableHead>
+            <TableHead className="text-right">
+              <AcquiredColumnHeader />
+            </TableHead>
             <TableHead className="w-[132px]" />
           </TableRow>
         </TableHeader>

--- a/web-app/components/instruments/runs-table/acquired-column-header.tsx
+++ b/web-app/components/instruments/runs-table/acquired-column-header.tsx
@@ -1,0 +1,35 @@
+import { CircleHelp } from "lucide-react";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+// Column header for the acquisition-time column on every runs table. The
+// cell renders coalesce(acquired_at, created_at): when the watcher knows
+// the run's actual on-instrument acquisition time we surface that,
+// otherwise we fall back to when Data Hub learned about the run. The
+// tooltip makes the fallback explicit so a "runs from yesterday" filter
+// result isn't surprising.
+export function AcquiredColumnHeader() {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        type="button"
+        aria-label="About the Acquired column"
+        className="inline-flex h-8 cursor-help items-center gap-1.5 font-medium text-foreground"
+      >
+        Acquired
+        <CircleHelp
+          className="size-3 text-muted-foreground"
+          aria-hidden="true"
+        />
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        When the run was acquired on the instrument. Falls back to when Data Hub
+        first heard about it for older or Lambda-created runs.
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/web-app/components/instruments/runs-table/default-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/default-runs-table.tsx
@@ -103,7 +103,9 @@ export function DefaultRunsTable({
                 />
               </TableCell>
               <TableCell className="text-right">
-                <RelativeTime date={row.created_at.toISOString()} />
+                <RelativeTime
+                  date={(row.acquired_at ?? row.created_at).toISOString()}
+                />
               </TableCell>
               <TableCell className="py-1">
                 <RunRowActions row={row} />

--- a/web-app/components/instruments/runs-table/default-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/default-runs-table.tsx
@@ -12,6 +12,7 @@ import { runRowToRef } from "@/lib/runs/row-actions";
 import { cn, formatBytes } from "@/lib/utils";
 
 import type { RunsTableProps } from ".";
+import { AcquiredColumnHeader } from "./acquired-column-header";
 import { FilterableColumnHeader } from "./filterable-column-header";
 import { RanByCell } from "./ran-by-cell";
 import { RawFileColumnHeader } from "./raw-file-column-header";
@@ -49,7 +50,9 @@ export function DefaultRunsTable({
               options={ranByOptions}
             />
           </TableHead>
-          <TableHead className="text-right">Created</TableHead>
+          <TableHead className="text-right">
+            <AcquiredColumnHeader />
+          </TableHead>
           <TableHead className="w-[132px]">
             <span className="sr-only">Actions</span>
           </TableHead>

--- a/web-app/components/instruments/runs-table/epson-scanner-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/epson-scanner-runs-table.tsx
@@ -158,7 +158,9 @@ export function EpsonScannerRunsTable({
                 />
               </TableCell>
               <TableCell className="text-right">
-                <RelativeTime date={row.created_at.toISOString()} />
+                <RelativeTime
+                  date={(row.acquired_at ?? row.created_at).toISOString()}
+                />
               </TableCell>
               <TableCell className="py-1">
                 <RunRowActions row={row} />

--- a/web-app/components/instruments/runs-table/epson-scanner-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/epson-scanner-runs-table.tsx
@@ -18,6 +18,7 @@ import { runRowToRef } from "@/lib/runs/row-actions";
 import { cn, formatBytes } from "@/lib/utils";
 
 import type { RunRow } from ".";
+import { AcquiredColumnHeader } from "./acquired-column-header";
 import { FilterableColumnHeader } from "./filterable-column-header";
 import { MetadataFieldBadge, getMetadataField } from "./metadata-utils";
 import { RanByCell } from "./ran-by-cell";
@@ -88,7 +89,9 @@ export function EpsonScannerRunsTable({
               options={ranByOptions}
             />
           </TableHead>
-          <TableHead className="text-right">Created</TableHead>
+          <TableHead className="text-right">
+            <AcquiredColumnHeader />
+          </TableHead>
           <TableHead className="w-[132px]">
             <span className="sr-only">Actions</span>
           </TableHead>

--- a/web-app/components/instruments/runs-table/gel-doc-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/gel-doc-runs-table.tsx
@@ -195,7 +195,9 @@ export function GelDocRunsTable({
                 />
               </TableCell>
               <TableCell className="text-right">
-                <RelativeTime date={row.created_at.toISOString()} />
+                <RelativeTime
+                  date={(row.acquired_at ?? row.created_at).toISOString()}
+                />
               </TableCell>
               <TableCell className="py-1">
                 <RunRowActions row={row} />

--- a/web-app/components/instruments/runs-table/gel-doc-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/gel-doc-runs-table.tsx
@@ -19,6 +19,7 @@ import { runRowToRef } from "@/lib/runs/row-actions";
 import { cn, formatBytes } from "@/lib/utils";
 
 import type { RunRow } from ".";
+import { AcquiredColumnHeader } from "./acquired-column-header";
 import { FilterableColumnHeader } from "./filterable-column-header";
 import {
   MetadataFieldBadge,
@@ -102,7 +103,9 @@ export function GelDocRunsTable({
               options={ranByOptions}
             />
           </TableHead>
-          <TableHead className="text-right">Created</TableHead>
+          <TableHead className="text-right">
+            <AcquiredColumnHeader />
+          </TableHead>
           <TableHead className="w-[132px]">
             <span className="sr-only">Actions</span>
           </TableHead>

--- a/web-app/components/instruments/runs-table/hina-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/hina-runs-table.tsx
@@ -18,6 +18,7 @@ import { runRowToRef } from "@/lib/runs/row-actions";
 import { cn, formatBytes } from "@/lib/utils";
 
 import type { RunRow } from ".";
+import { AcquiredColumnHeader } from "./acquired-column-header";
 import { FilterableColumnHeader } from "./filterable-column-header";
 import {
   getMetadataArray,
@@ -87,7 +88,9 @@ export function HinaRunsTable({
               options={ranByOptions}
             />
           </TableHead>
-          <TableHead className="text-right">Created</TableHead>
+          <TableHead className="text-right">
+            <AcquiredColumnHeader />
+          </TableHead>
           <TableHead className="w-[132px]">
             <span className="sr-only">Actions</span>
           </TableHead>

--- a/web-app/components/instruments/runs-table/hina-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/hina-runs-table.tsx
@@ -160,7 +160,9 @@ export function HinaRunsTable({
                 />
               </TableCell>
               <TableCell className="text-right">
-                <RelativeTime date={row.created_at.toISOString()} />
+                <RelativeTime
+                  date={(row.acquired_at ?? row.created_at).toISOString()}
+                />
               </TableCell>
               <TableCell className="py-1">
                 <RunRowActions row={row} />

--- a/web-app/components/instruments/runs-table/plate-reader-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/plate-reader-runs-table.tsx
@@ -169,7 +169,9 @@ export function PlateReaderRunsTable({
                 />
               </TableCell>
               <TableCell className="text-right">
-                <RelativeTime date={row.created_at.toISOString()} />
+                <RelativeTime
+                  date={(row.acquired_at ?? row.created_at).toISOString()}
+                />
               </TableCell>
               <TableCell className="py-1">
                 <RunRowActions row={row} />

--- a/web-app/components/instruments/runs-table/plate-reader-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/plate-reader-runs-table.tsx
@@ -18,6 +18,7 @@ import { runRowToRef } from "@/lib/runs/row-actions";
 import { cn, formatBytes } from "@/lib/utils";
 
 import type { RunRow } from ".";
+import { AcquiredColumnHeader } from "./acquired-column-header";
 import { FilterableColumnHeader } from "./filterable-column-header";
 import {
   MetadataFieldBadge,
@@ -91,7 +92,9 @@ export function PlateReaderRunsTable({
               options={ranByOptions}
             />
           </TableHead>
-          <TableHead className="text-right">Created</TableHead>
+          <TableHead className="text-right">
+            <AcquiredColumnHeader />
+          </TableHead>
           <TableHead className="w-[132px]">
             <span className="sr-only">Actions</span>
           </TableHead>

--- a/web-app/components/instruments/runs-table/qpcr-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/qpcr-runs-table.tsx
@@ -14,6 +14,7 @@ import { runRowToRef } from "@/lib/runs/row-actions";
 import { cn, formatBytes } from "@/lib/utils";
 
 import type { RunRow } from ".";
+import { AcquiredColumnHeader } from "./acquired-column-header";
 import { FilterableColumnHeader } from "./filterable-column-header";
 import { MetadataArrayBadges, getMetadataArray } from "./metadata-utils";
 import { RanByCell } from "./ran-by-cell";
@@ -65,7 +66,9 @@ export function QpcrRunsTable({
               options={ranByOptions}
             />
           </TableHead>
-          <TableHead className="text-right">Created</TableHead>
+          <TableHead className="text-right">
+            <AcquiredColumnHeader />
+          </TableHead>
           <TableHead className="w-[132px]">
             <span className="sr-only">Actions</span>
           </TableHead>

--- a/web-app/components/instruments/runs-table/qpcr-runs-table.tsx
+++ b/web-app/components/instruments/runs-table/qpcr-runs-table.tsx
@@ -129,7 +129,9 @@ export function QpcrRunsTable({
                 />
               </TableCell>
               <TableCell className="text-right">
-                <RelativeTime date={row.created_at.toISOString()} />
+                <RelativeTime
+                  date={(row.acquired_at ?? row.created_at).toISOString()}
+                />
               </TableCell>
               <TableCell className="py-1">
                 <RunRowActions row={row} />

--- a/web-app/components/runs/run-header.tsx
+++ b/web-app/components/runs/run-header.tsx
@@ -66,7 +66,13 @@ export function RunHeader({
       </div>
 
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
-        <span>Created {formatDateTime(run.createdAt)}</span>
+        {run.acquiredAt && (
+          <>
+            <span>Run started {formatDateTime(run.acquiredAt)}</span>
+            <span className="text-muted-foreground/40">&middot;</span>
+          </>
+        )}
+        <span>Reported {formatDateTime(run.createdAt)}</span>
         <span className="text-muted-foreground/40">&middot;</span>
         <span>Updated {formatDateTime(run.updatedAt)}</span>
         {attributionsSlot && (

--- a/web-app/drizzle/0020_add_acquired_at.sql
+++ b/web-app/drizzle/0020_add_acquired_at.sql
@@ -1,0 +1,16 @@
+ALTER TABLE "instrument_runs" ADD COLUMN "acquired_at" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX "idx_instrument_runs_active_acquired_at" ON "instrument_runs" USING btree ("instrument_id",coalesce("acquired_at", "created_at") desc) WHERE "instrument_runs"."deleted_at" is null;--> statement-breakpoint
+-- One-time backfill from the per-file manifest. The watcher already
+-- captures st_birthtime / st_mtime in files.file_created_at, so existing
+-- runs can be assigned an acquired_at retroactively. Lambda-created runs
+-- and manual file uploads with no file_created_at remain NULL and the
+-- list query falls back to created_at via coalesce.
+UPDATE "instrument_runs" ir
+SET "acquired_at" = sub.min_created
+FROM (
+  SELECT "instrument_run_id", MIN("file_created_at") AS min_created
+  FROM "files"
+  WHERE "file_created_at" IS NOT NULL
+  GROUP BY "instrument_run_id"
+) sub
+WHERE ir."id" = sub."instrument_run_id" AND ir."acquired_at" IS NULL;

--- a/web-app/drizzle/meta/0020_snapshot.json
+++ b/web-app/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,1704 @@
+{
+  "id": "a3add94e-8831-4f87-905b-4f503c0a4671",
+  "prevId": "f2c8b5a9-1e4d-4a7b-9c3e-5b8d9f0a1c2e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archive_jobs": {
+      "name": "archive_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archive_bucket": {
+          "name": "archive_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_key": {
+          "name": "archive_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "archive_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_archive_jobs_inflight": {
+          "name": "uq_archive_jobs_inflight",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"archive_jobs\".\"status\" in ('pending', 'building')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_archive_jobs_run_fingerprint_status": {
+          "name": "idx_archive_jobs_run_fingerprint_status",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "archive_jobs_instrument_run_id_instrument_runs_id_fk": {
+          "name": "archive_jobs_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "archive_jobs_created_by_user_id_fk": {
+          "name": "archive_jobs_created_by_user_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "file_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raw'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_requested_at": {
+          "name": "upload_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_files_instrument_run_id_relative_path": {
+          "name": "uq_files_instrument_run_id_relative_path",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"relative_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_active_instrument_run_id_filename": {
+          "name": "uq_files_active_instrument_run_id_filename",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_s3_key": {
+          "name": "uq_files_s3_key",
+          "columns": [
+            {
+              "expression": "s3_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"s3_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_instrument_run_id": {
+          "name": "idx_files_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_status_instrument_run_id": {
+          "name": "idx_files_status_instrument_run_id",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_upload_queue": {
+          "name": "idx_files_upload_queue",
+          "columns": [
+            {
+              "expression": "upload_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"upload_requested_at\" is not null and \"files\".\"uploaded_at\" is null and \"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_metadata_gin": {
+          "name": "idx_files_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_instrument_run_id_instrument_runs_id_fk": {
+          "name": "files_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_runs": {
+      "name": "instrument_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "instrument_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lambda'"
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instrument_runs_instrument_id_created_at": {
+          "name": "idx_instrument_runs_instrument_id_created_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active": {
+          "name": "idx_instrument_runs_active",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active_acquired_at": {
+          "name": "idx_instrument_runs_active_acquired_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"acquired_at\", \"created_at\") desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_metadata_gin": {
+          "name": "idx_instrument_runs_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_runs_instrument_id_instruments_id_fk": {
+          "name": "instrument_runs_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_watcher_id_watchers_id_fk": {
+          "name": "instrument_runs_watcher_id_watchers_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_instrument_runs_instrument_id_run_id": {
+          "name": "uq_instrument_runs_instrument_id_run_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instrument_id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instruments": {
+      "name": "instruments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instrument_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instrument_type": {
+          "name": "instrument_type",
+          "type": "instrument_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_personal_access_tokens_user_id": {
+          "name": "idx_personal_access_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_user_id_fk": {
+          "name": "personal_access_tokens_user_id_user_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_attributions": {
+      "name": "run_attributions",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_attributions_run_id": {
+          "name": "idx_run_attributions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_attributions_user_id": {
+          "name": "idx_run_attributions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_attributions_run_id_instrument_runs_id_fk": {
+          "name": "run_attributions_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_attributions_user_id_user_id_fk": {
+          "name": "run_attributions_user_id_user_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_attributions_run_id_user_id_pk": {
+          "name": "run_attributions_run_id_user_id_pk",
+          "columns": [
+            "run_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_comments": {
+      "name": "run_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_run_comments_run_id_created_at": {
+          "name": "idx_run_comments_run_id_created_at",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_comments_user_id": {
+          "name": "idx_run_comments_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_comments_run_id_instrument_runs_id_fk": {
+          "name": "run_comments_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_comments_user_id_user_id_fk": {
+          "name": "run_comments_user_id_user_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_events": {
+      "name": "watcher_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "watcher_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_events_watcher_id_timestamp": {
+          "name": "idx_watcher_events_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_watcher_events_watcher_id_event_type": {
+          "name": "idx_watcher_events_watcher_id_event_type",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_events_watcher_id_watchers_id_fk": {
+          "name": "watcher_events_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_events",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_heartbeats": {
+      "name": "watcher_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_mode": {
+          "name": "upload_mode",
+          "type": "upload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_uploaded_since_last": {
+          "name": "files_uploaded_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "runs_reported_since_last": {
+          "name": "runs_reported_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_since_last": {
+          "name": "errors_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_heartbeats_watcher_id_timestamp": {
+          "name": "idx_watcher_heartbeats_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_heartbeats_watcher_id_watchers_id_fk": {
+          "name": "watcher_heartbeats_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_heartbeats",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watchers": {
+      "name": "watchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_info": {
+          "name": "os_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watcher_version": {
+          "name": "watcher_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_checksum": {
+          "name": "config_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_yaml": {
+          "name": "config_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "watcher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_watchers_active_instrument_id": {
+          "name": "uq_watchers_active_instrument_id",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"watchers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchers_instrument_id_instruments_id_fk": {
+          "name": "watchers_instrument_id_instruments_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.archive_job_status": {
+      "name": "archive_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "building",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.file_category": {
+      "name": "file_category",
+      "schema": "public",
+      "values": [
+        "raw",
+        "processed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "detected",
+        "upload_requested",
+        "uploaded",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.instrument_run_source": {
+      "name": "instrument_run_source",
+      "schema": "public",
+      "values": [
+        "lambda",
+        "watcher"
+      ]
+    },
+    "public.instrument_status": {
+      "name": "instrument_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "inactive"
+      ]
+    },
+    "public.instrument_type": {
+      "name": "instrument_type",
+      "schema": "public",
+      "values": [
+        "generic",
+        "plate_reader",
+        "gel_doc",
+        "qpcr",
+        "tape_station",
+        "hina_microscope",
+        "epson_v700_scanner"
+      ]
+    },
+    "public.upload_mode": {
+      "name": "upload_mode",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual"
+      ]
+    },
+    "public.watcher_event_type": {
+      "name": "watcher_event_type",
+      "schema": "public",
+      "values": [
+        "watcher_started",
+        "watcher_stopped",
+        "file_uploaded",
+        "upload_failed",
+        "run_reported",
+        "config_synced",
+        "error",
+        "update_started",
+        "update_succeeded",
+        "update_failed"
+      ]
+    },
+    "public.watcher_status": {
+      "name": "watcher_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "watching",
+        "stopped"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web-app/drizzle/meta/_journal.json
+++ b/web-app/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1778207440655,
       "tag": "0019_set_epson_scanner_type",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1778264446987,
+      "tag": "0020_add_acquired_at",
+      "breakpoints": true
     }
   ]
 }

--- a/web-app/lib/api/dashboard.ts
+++ b/web-app/lib/api/dashboard.ts
@@ -34,7 +34,7 @@ export const getInstrumentSummaries = cache(
         displayName: instruments.displayName,
         status: instruments.status,
         runCount: sql<number>`cast(count(distinct ${instrumentRuns.id}) filter (where ${instrumentRuns.deletedAt} is null) as int)`,
-        lastRunAt: sql<Date | null>`max(${instrumentRuns.createdAt}) filter (where ${instrumentRuns.deletedAt} is null)`,
+        lastRunAt: sql<Date | null>`max(coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt})) filter (where ${instrumentRuns.deletedAt} is null)`,
         filesPendingUpload: sql<number>`cast(count(distinct ${files.id}) filter (where ${files.status} in ('detected', 'upload_requested') and ${files.deletedAt} is null) as int)`,
       })
       .from(instruments)
@@ -152,7 +152,7 @@ export const getDashboardStats = cache(async function getDashboardStats(
       .where(
         and(
           isNull(instrumentRuns.deletedAt),
-          sql`${instrumentRuns.createdAt} > now() - interval '24 hours'`
+          sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '24 hours'`
         )
       ),
     // Span the last 24 hours + the past 7 days in a single pass; the 24-hour
@@ -160,10 +160,13 @@ export const getDashboardStats = cache(async function getDashboardStats(
     // with one index scan. Bytes are attributed to the file's owning run so
     // the time window matches the corresponding "Runs in the last X" card —
     // this avoids the null-`processedAt` blind spot for not-yet-processed
-    // files (which still represent data the instrument generated).
+    // files (which still represent data the instrument generated). Windows
+    // are anchored to the run's actual acquisition time when known so
+    // backfilled historical data doesn't pollute the "last 24h"/"this week"
+    // counts.
     db
       .select({
-        bytesLast24Hours: sql<string>`coalesce(sum(${files.sizeBytes}) filter (where ${instrumentRuns.createdAt} > now() - interval '24 hours'), 0)`,
+        bytesLast24Hours: sql<string>`coalesce(sum(${files.sizeBytes}) filter (where coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '24 hours'), 0)`,
         bytesWeek: sql<string>`coalesce(sum(${files.sizeBytes}), 0)`,
       })
       .from(files)
@@ -172,7 +175,7 @@ export const getDashboardStats = cache(async function getDashboardStats(
         and(
           isNull(files.deletedAt),
           isNull(instrumentRuns.deletedAt),
-          sql`${instrumentRuns.createdAt} > now() - interval '7 days'`
+          sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '7 days'`
         )
       ),
     db
@@ -201,7 +204,7 @@ export const getDashboardStats = cache(async function getDashboardStats(
       .where(
         and(
           isNull(instrumentRuns.deletedAt),
-          sql`${instrumentRuns.createdAt} > now() - interval '7 days'`
+          sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '7 days'`
         )
       ),
   ]);

--- a/web-app/lib/api/instrument-runs.ts
+++ b/web-app/lib/api/instrument-runs.ts
@@ -11,7 +11,7 @@ import {
   users,
 } from "@/lib/db/schema";
 import { getS3ObjectStream } from "@/lib/s3";
-import type { SQL } from "drizzle-orm";
+import type { AnyColumn, SQL } from "drizzle-orm";
 import {
   and,
   asc,
@@ -100,6 +100,7 @@ export async function lookupRunByNaturalKey(
       watcherId: instrumentRuns.watcherId,
       metadata: instrumentRuns.metadata,
       createdAt: instrumentRuns.createdAt,
+      acquiredAt: instrumentRuns.acquiredAt,
       updatedAt: instrumentRuns.updatedAt,
       deletedAt: instrumentRuns.deletedAt,
       instrumentDisplayName: instruments.displayName,
@@ -119,6 +120,42 @@ export async function lookupRunByNaturalKey(
 
   const byRun = await getAttributionsByRunIds([row.id]);
   return { ...row, attributions: byRun.get(row.id) ?? [] };
+}
+
+// ---------------------------------------------------------------------------
+// acquired_at parsing for create/update payloads.
+//
+// Watchers send `acquired_at` as ISO 8601 (UTC) at the run level; older
+// watchers (and the lambda) only send per-file `file_created_at` on
+// `detected_files[]`. Falling back to min(detected_files.file_created_at)
+// gives those callers a usable run-level timestamp without requiring a
+// client-side change.
+// ---------------------------------------------------------------------------
+
+export function parseAcquiredAt(body: Record<string, unknown>): Date | null {
+  if (typeof body.acquired_at === "string") {
+    const explicit = new Date(body.acquired_at);
+    if (!Number.isNaN(explicit.getTime())) return explicit;
+  }
+
+  const detected = Array.isArray(body.detected_files)
+    ? body.detected_files
+    : [];
+  let floor: number | null = null;
+  for (const f of detected) {
+    if (
+      f &&
+      typeof f === "object" &&
+      "file_created_at" in f &&
+      typeof (f as { file_created_at: unknown }).file_created_at === "string"
+    ) {
+      const t = new Date(
+        (f as { file_created_at: string }).file_created_at
+      ).getTime();
+      if (!Number.isNaN(t) && (floor === null || t < floor)) floor = t;
+    }
+  }
+  return floor === null ? null : new Date(floor);
 }
 
 // ---------------------------------------------------------------------------
@@ -165,10 +202,14 @@ const UNATTRIBUTED_SENTINEL = "unattributed";
 
 const MAX_PER_PAGE = 100;
 
-const ALLOWED_SORT_FIELDS: Record<
-  string,
-  (typeof instrumentRuns)["createdAt" | "updatedAt"]
-> = {
+// `acquired_at` sorts on coalesce(acquired_at, created_at) so runs that
+// pre-date the watcher backfill, or that came from the lambda (no
+// acquired_at), still order alongside watcher-reported runs. The matching
+// index is `idx_instrument_runs_active_acquired_at`.
+const acquiredOrCreatedSql = sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt})`;
+
+const ALLOWED_SORT_FIELDS: Record<string, SQL | AnyColumn> = {
+  acquired_at: acquiredOrCreatedSql,
   created_at: instrumentRuns.createdAt,
   updated_at: instrumentRuns.updatedAt,
 };
@@ -196,15 +237,20 @@ export async function buildRunListQuery(filters: RunListFilters) {
     conditions.push(eq(instrumentRuns.source, filters.source));
   }
 
+  // Date filters apply against coalesce(acquired_at, created_at) so a user
+  // filtering "runs from yesterday" sees runs whose data was acquired
+  // yesterday — even if the watcher only reported them to Data Hub today.
+  // Lambda runs and pre-backfill runs (acquired_at IS NULL) fall through to
+  // created_at via coalesce.
   if (filters.dateFrom) {
-    conditions.push(gte(instrumentRuns.createdAt, new Date(filters.dateFrom)));
+    conditions.push(gte(acquiredOrCreatedSql, new Date(filters.dateFrom)));
   }
   // dateTo is a date string (e.g. "2026-03-28") without a time component.
   // Advance by one day so the filter is inclusive of the entire selected day.
   if (filters.dateTo) {
     const end = new Date(filters.dateTo);
     end.setDate(end.getDate() + 1);
-    conditions.push(lte(instrumentRuns.createdAt, end));
+    conditions.push(lte(acquiredOrCreatedSql, end));
   }
 
   if (filters.search) {
@@ -348,9 +394,11 @@ export async function buildRunListQuery(filters: RunListFilters) {
     }
   );
 
+  // Default sort is the run's actual acquisition time (with fallback to
+  // created_at via coalesce inside acquiredOrCreatedSql), so backfilled and
+  // freshly-detected runs interleave correctly chronologically.
   const sortCol =
-    ALLOWED_SORT_FIELDS[filters.sort ?? "created_at"] ??
-    instrumentRuns.createdAt;
+    ALLOWED_SORT_FIELDS[filters.sort ?? "acquired_at"] ?? acquiredOrCreatedSql;
   const orderFn = filters.order === "asc" ? asc : desc;
 
   // Total count for pagination (runs only, no joins needed for the count).
@@ -371,6 +419,7 @@ export async function buildRunListQuery(filters: RunListFilters) {
       source: instrumentRuns.source,
       metadata: instrumentRuns.metadata,
       created_at: instrumentRuns.createdAt,
+      acquired_at: instrumentRuns.acquiredAt,
       updated_at: instrumentRuns.updatedAt,
       deleted_at: instrumentRuns.deletedAt,
       file_count: fileCount,

--- a/web-app/lib/api/instrument-runs.ts
+++ b/web-app/lib/api/instrument-runs.ts
@@ -12,18 +12,7 @@ import {
 } from "@/lib/db/schema";
 import { getS3ObjectStream } from "@/lib/s3";
 import type { AnyColumn, SQL } from "drizzle-orm";
-import {
-  and,
-  asc,
-  desc,
-  eq,
-  gte,
-  ilike,
-  inArray,
-  isNull,
-  lte,
-  sql,
-} from "drizzle-orm";
+import { and, asc, desc, eq, ilike, inArray, isNull, sql } from "drizzle-orm";
 
 // ---------------------------------------------------------------------------
 // Run attributions: users who claimed they ran a given run. Wire shape is
@@ -242,15 +231,24 @@ export async function buildRunListQuery(filters: RunListFilters) {
   // yesterday — even if the watcher only reported them to Data Hub today.
   // Lambda runs and pre-backfill runs (acquired_at IS NULL) fall through to
   // created_at via coalesce.
+  //
+  // NOTE: drizzle's `gte`/`lte` rely on the column's PgColumn mapper to
+  // serialize a JS Date for the postgres-js driver. With a raw SQL
+  // fragment as the LHS that mapper is bypassed, so the driver sees a
+  // Date and throws ERR_INVALID_ARG_TYPE. Bind ISO strings explicitly and
+  // cast on the Postgres side to keep this path on the index.
   if (filters.dateFrom) {
-    conditions.push(gte(acquiredOrCreatedSql, new Date(filters.dateFrom)));
+    const from = new Date(filters.dateFrom).toISOString();
+    conditions.push(sql`${acquiredOrCreatedSql} >= ${from}::timestamptz`);
   }
   // dateTo is a date string (e.g. "2026-03-28") without a time component.
   // Advance by one day so the filter is inclusive of the entire selected day.
   if (filters.dateTo) {
     const end = new Date(filters.dateTo);
     end.setDate(end.getDate() + 1);
-    conditions.push(lte(acquiredOrCreatedSql, end));
+    conditions.push(
+      sql`${acquiredOrCreatedSql} <= ${end.toISOString()}::timestamptz`
+    );
   }
 
   if (filters.search) {

--- a/web-app/lib/api/instruments.ts
+++ b/web-app/lib/api/instruments.ts
@@ -62,17 +62,23 @@ function mergeFilePatterns(configs: (string | null)[]): string[] {
 // constants) so each caller gets a fresh drizzle alias and the queries can
 // be composed independently.
 function buildRunCountSubquery() {
+  // `runsThisWeek` and `lastRunAt` are anchored to the run's true
+  // acquisition time when known so backfilled runs (where created_at is
+  // "today" but the data is older) don't pollute the recent-runs window
+  // or get reported as the most recent activity. Falls back to created_at
+  // for Lambda-only and pre-backfill runs where acquired_at is NULL.
   return db
     .select({
       instrumentId: instrumentRuns.instrumentId,
       count: sql<number>`cast(count(*) as int)`.as("run_count"),
       countThisWeek:
-        sql<number>`cast(count(*) filter (where ${instrumentRuns.createdAt} > now() - interval '7 days') as int)`.as(
+        sql<number>`cast(count(*) filter (where coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '7 days') as int)`.as(
           "run_count_this_week"
         ),
-      lastRunAt: sql<Date | null>`max(${instrumentRuns.createdAt})`.as(
-        "last_run_at"
-      ),
+      lastRunAt:
+        sql<Date | null>`max(coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}))`.as(
+          "last_run_at"
+        ),
     })
     .from(instrumentRuns)
     .where(isNull(instrumentRuns.deletedAt))

--- a/web-app/lib/api/sidebar.ts
+++ b/web-app/lib/api/sidebar.ts
@@ -29,9 +29,10 @@ export const getSidebarInstruments = cache(
     const lastRunSq = db
       .select({
         instrumentId: instrumentRuns.instrumentId,
-        lastRunAt: sql<Date | null>`max(${instrumentRuns.createdAt})`.as(
-          "last_run_at"
-        ),
+        lastRunAt:
+          sql<Date | null>`max(coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}))`.as(
+            "last_run_at"
+          ),
       })
       .from(instrumentRuns)
       .where(isNull(instrumentRuns.deletedAt))

--- a/web-app/lib/db/schema.ts
+++ b/web-app/lib/db/schema.ts
@@ -360,13 +360,21 @@ export const instrumentRuns = pgTable(
     // flat object; multi-valued properties use JSON arrays.
     metadata: jsonb("metadata").notNull().default({}),
     // When the run was first created (reported by watcher or auto-created by
-    // Lambda).
+    // Lambda) — i.e. when Data Hub learned about it.
     createdAt: timestamp("created_at", {
       withTimezone: true,
       mode: "date",
     })
       .notNull()
       .defaultNow(),
+    // When the run actually happened on the instrument PC, derived by the
+    // watcher from the minimum file creation time (st_birthtime where
+    // available, else mtime). NULL for Lambda-created runs and runs reported
+    // by older watchers; the UI and list queries fall back to created_at.
+    acquiredAt: timestamp("acquired_at", {
+      withTimezone: true,
+      mode: "date",
+    }),
     updatedAt: timestamp("updated_at", {
       withTimezone: true,
       mode: "date",
@@ -394,6 +402,14 @@ export const instrumentRuns = pgTable(
     ),
     index("idx_instrument_runs_active")
       .on(run.instrumentId, run.createdAt.desc())
+      .where(sql`${run.deletedAt} is null`),
+    // Supports the default list sort/filter on coalesce(acquired_at,
+    // created_at). Expression must match the buildRunListQuery sort key.
+    index("idx_instrument_runs_active_acquired_at")
+      .on(
+        run.instrumentId,
+        sql`coalesce(${run.acquiredAt}, ${run.createdAt}) desc`
+      )
       .where(sql`${run.deletedAt} is null`),
     index("idx_instrument_runs_metadata_gin").using("gin", run.metadata),
   ]

--- a/web-app/lib/mcp/tools.ts
+++ b/web-app/lib/mcp/tools.ts
@@ -151,9 +151,11 @@ export function registerTools(server: McpServer) {
           .optional()
           .describe("End date (inclusive, YYYY-MM-DD)"),
         sort: z
-          .enum(["created_at", "updated_at"])
+          .enum(["acquired_at", "created_at", "updated_at"])
           .optional()
-          .describe("Sort field (default: created_at)"),
+          .describe(
+            "Sort field (default: acquired_at — when the run actually happened on the instrument PC, falling back to created_at)"
+          ),
         order: z
           .enum(["asc", "desc"])
           .optional()

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -3456,9 +3456,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
-      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -3472,9 +3472,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -3488,9 +3488,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -3504,9 +3504,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
       ],
@@ -3520,9 +3520,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
       ],
@@ -3536,9 +3536,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
       ],
@@ -3552,9 +3552,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
       ],
@@ -3568,9 +3568,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -3584,9 +3584,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -10290,12 +10290,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -10364,9 +10364,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -10380,9 +10380,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -10391,7 +10391,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -11070,9 +11071,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -11238,9 +11239,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -13610,12 +13611,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
-      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.4",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -13629,14 +13630,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.4",
-        "@next/swc-darwin-x64": "16.2.4",
-        "@next/swc-linux-arm64-gnu": "16.2.4",
-        "@next/swc-linux-arm64-musl": "16.2.4",
-        "@next/swc-linux-x64-gnu": "16.2.4",
-        "@next/swc-linux-x64-musl": "16.2.4",
-        "@next/swc-win32-arm64-msvc": "16.2.4",
-        "@next/swc-win32-x64-msvc": "16.2.4",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -18465,6 +18466,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/web-app/tests/integration/instrument-runs.test.ts
+++ b/web-app/tests/integration/instrument-runs.test.ts
@@ -1,4 +1,3 @@
-import { buildRunListQuery } from "@/lib/api/instrument-runs";
 import { instruments } from "@/lib/db/schema";
 import {
   api,
@@ -532,18 +531,16 @@ describe("Run acquired_at", () => {
 
   // Regression: drizzle's `gte`/`lte` against a raw SQL fragment skips
   // the column-level Date->string coercion and crashes the postgres-js
-  // driver with ERR_INVALID_ARG_TYPE. The current implementation binds
-  // ISO strings explicitly and casts to timestamptz on the server.
-  it("buildRunListQuery date filters apply against coalesce(acquired_at, created_at)", async () => {
-    const result = await buildRunListQuery({
-      instrumentId,
-      dateFrom: "2009-01-01",
-      dateTo: "2010-12-31",
-      page: 1,
-      perPage: 100,
-      includeDeleted: false,
-    });
-    const ids = result.data.map((r) => r.run_id);
+  // driver with ERR_INVALID_ARG_TYPE. The implementation now binds ISO
+  // strings explicitly and casts to timestamptz on the server.
+  it("GET list date_from/date_to filter against coalesce(acquired_at, created_at)", async () => {
+    const res = await api(
+      `/api/v1/instruments/${instrumentId}/runs?date_from=2009-01-01&date_to=2010-12-31&per_page=100`,
+      { token }
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const ids = body.data.map((r: { run_id: string }) => r.run_id);
     expect(ids).toContain("sort-oldest");
     expect(ids).not.toContain("sort-newest");
   });

--- a/web-app/tests/integration/instrument-runs.test.ts
+++ b/web-app/tests/integration/instrument-runs.test.ts
@@ -346,10 +346,186 @@ describe("Run creation Slack notification", () => {
     expect(messages.length).toBe(1);
     expect(messages[0].text).toContain(instrumentDisplayName);
     expect(messages[0].text).toContain(runId);
-    expect(messages[0].text).toContain("source: lambda");
     expect(messages[0].text).toContain(
       `/instruments/${instrumentId}/runs/${runId}`
     );
     expect(messages[0].text).toContain("View in Data Hub");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Run acquisition time
+//
+// `acquired_at` is the run's actual on-instrument timestamp (min of the
+// constituent files' birthtimes). It is supplied by the watcher on POST
+// and may move earlier — never later — via subsequent PATCHes when an
+// out-of-order stable file reveals an earlier birthtime. The list query
+// also sorts and date-filters on coalesce(acquired_at, created_at).
+// ---------------------------------------------------------------------------
+
+describe("Run acquired_at", () => {
+  let token: string;
+  const instrumentId = "acquired-at-instrument";
+
+  beforeAll(async () => {
+    ({ token } = await seedTestUser());
+    const db = getTestDb();
+    await db.insert(instruments).values({
+      id: instrumentId,
+      displayName: "Acquired-At Instrument",
+      status: "active",
+    });
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  it("POST stores explicit acquired_at and returns it on GET detail", async () => {
+    const acquiredAt = "2025-01-15T08:30:00.000Z";
+    const res = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: {
+        run_id: "explicit-acquired",
+        source: "watcher",
+        acquired_at: acquiredAt,
+      },
+    });
+    expect(res.status).toBe(201);
+
+    const detail = await api(
+      `/api/v1/instruments/${instrumentId}/runs/explicit-acquired`,
+      { token }
+    );
+    const data = await detail.json();
+    expect(new Date(data.acquired_at).toISOString()).toBe(acquiredAt);
+  });
+
+  it("POST without acquired_at derives the floor from detected_files", async () => {
+    const res = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: {
+        run_id: "derived-acquired",
+        source: "watcher",
+        detected_files: [
+          {
+            relative_path: "later.csv",
+            filename: "later.csv",
+            size_bytes: 10,
+            file_created_at: "2025-02-01T12:00:00.000Z",
+          },
+          {
+            relative_path: "earliest.csv",
+            filename: "earliest.csv",
+            size_bytes: 20,
+            file_created_at: "2025-02-01T10:00:00.000Z",
+          },
+        ],
+      },
+    });
+    expect(res.status).toBe(201);
+
+    const detail = await api(
+      `/api/v1/instruments/${instrumentId}/runs/derived-acquired`,
+      { token }
+    );
+    const data = await detail.json();
+    expect(new Date(data.acquired_at).toISOString()).toBe(
+      "2025-02-01T10:00:00.000Z"
+    );
+  });
+
+  it("PATCH with an earlier acquired_at moves the value backward", async () => {
+    await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: {
+        run_id: "patch-earlier",
+        source: "watcher",
+        acquired_at: "2025-03-10T12:00:00.000Z",
+      },
+    });
+
+    const patch = await api(
+      `/api/v1/instruments/${instrumentId}/runs/patch-earlier`,
+      {
+        method: "PATCH",
+        token,
+        body: { acquired_at: "2025-03-10T08:00:00.000Z" },
+      }
+    );
+    expect(patch.status).toBe(200);
+    const data = await patch.json();
+    expect(new Date(data.acquired_at).toISOString()).toBe(
+      "2025-03-10T08:00:00.000Z"
+    );
+  });
+
+  it("PATCH with a later acquired_at is ignored (LEAST semantics)", async () => {
+    await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: {
+        run_id: "patch-later",
+        source: "watcher",
+        acquired_at: "2025-04-05T08:00:00.000Z",
+      },
+    });
+
+    const patch = await api(
+      `/api/v1/instruments/${instrumentId}/runs/patch-later`,
+      {
+        method: "PATCH",
+        token,
+        body: { acquired_at: "2025-04-05T20:00:00.000Z" },
+      }
+    );
+    expect(patch.status).toBe(200);
+    const data = await patch.json();
+    expect(new Date(data.acquired_at).toISOString()).toBe(
+      "2025-04-05T08:00:00.000Z"
+    );
+  });
+
+  it("GET list orders by coalesce(acquired_at, created_at) by default", async () => {
+    // Insert two backfilled runs whose acquired_at predates the runs
+    // already created in this describe block. The default sort (desc)
+    // should still place them after the current-day runs because their
+    // acquired_at is older — even though they were inserted later (so
+    // their created_at is newer).
+    const newest = "2030-01-01T00:00:00.000Z";
+    const oldest = "2010-01-01T00:00:00.000Z";
+
+    await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: {
+        run_id: "sort-newest",
+        source: "watcher",
+        acquired_at: newest,
+      },
+    });
+    await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: {
+        run_id: "sort-oldest",
+        source: "watcher",
+        acquired_at: oldest,
+      },
+    });
+
+    const res = await api(
+      `/api/v1/instruments/${instrumentId}/runs?per_page=100`,
+      { token }
+    );
+    const body = await res.json();
+    const ids: string[] = body.data.map((r: { run_id: string }) => r.run_id);
+    expect(ids.indexOf("sort-newest")).toBeLessThan(ids.indexOf("sort-oldest"));
+    // sort-newest should be first overall — its acquired_at (year 2030)
+    // is later than every other run's acquired_at OR created_at.
+    expect(ids[0]).toBe("sort-newest");
   });
 });

--- a/web-app/tests/integration/instrument-runs.test.ts
+++ b/web-app/tests/integration/instrument-runs.test.ts
@@ -1,3 +1,4 @@
+import { buildRunListQuery } from "@/lib/api/instrument-runs";
 import { instruments } from "@/lib/db/schema";
 import {
   api,
@@ -527,5 +528,23 @@ describe("Run acquired_at", () => {
     // sort-newest should be first overall — its acquired_at (year 2030)
     // is later than every other run's acquired_at OR created_at.
     expect(ids[0]).toBe("sort-newest");
+  });
+
+  // Regression: drizzle's `gte`/`lte` against a raw SQL fragment skips
+  // the column-level Date->string coercion and crashes the postgres-js
+  // driver with ERR_INVALID_ARG_TYPE. The current implementation binds
+  // ISO strings explicitly and casts to timestamptz on the server.
+  it("buildRunListQuery date filters apply against coalesce(acquired_at, created_at)", async () => {
+    const result = await buildRunListQuery({
+      instrumentId,
+      dateFrom: "2009-01-01",
+      dateTo: "2010-12-31",
+      page: 1,
+      perPage: 100,
+      includeDeleted: false,
+    });
+    const ids = result.data.map((r) => r.run_id);
+    expect(ids).toContain("sort-oldest");
+    expect(ids).not.toContain("sort-newest");
   });
 });


### PR DESCRIPTION
## Summary

Adds an `acquired_at` timestamp on `instrument_runs` populated by the watcher from the minimum `file_created_at` across a run's files. This lets backfilled runs (data that already existed on the PC when a watcher first connects) appear with their true acquisition time instead of "now". The list query default sort, date filter, and dashboard time windows switch to `coalesce(acquired_at, created_at)`, and the run detail header shows both "Run started" and "Reported".

## Changes

- **Schema**: nullable `instrument_runs.acquired_at TIMESTAMPTZ` plus `idx_instrument_runs_active_acquired_at` (partial expression index on `coalesce(acquired_at, created_at) desc`). Migration `0020_add_acquired_at.sql` includes a one-time backfill from `files.file_created_at`.
- **API**:
  - `POST /runs` accepts `acquired_at`, falls back to `min(detected_files[].file_created_at)`, and folds late watcher-vs-lambda race writes via `LEAST(coalesce(acquired_at, $1), $1)`.
  - `PATCH /runs/:id` applies the same `LEAST` semantics so the value can only move earlier; `GET`/`PATCH` responses now expose `acquired_at`.
- **Queries**: `buildRunListQuery` default sort and `dateFrom`/`dateTo` filter use `coalesce(acquired_at, created_at)`. `lookupRunByNaturalKey`, `dashboard.ts` (`lastRunAt`, 24h/7d windows), and `sidebar.ts` updated likewise. MCP `search_runs` sort enum extended.
- **Watcher**: `RunDetector` tracks `acquired_at_sent` on `RunState`, sends `acquired_at` (ISO UTC) on `_report_new_run`, and PATCHes only when a later-stable file reveals an earlier birthtime. Hydration seeds the cursor from the persisted manifest.
- **UI**: All seven run-list table variants render `row.acquired_at ?? row.created_at` in the existing "Created" cell. `RunHeader` shows "Run started …" (when present), "Reported …", "Updated …".
- **Tests**: New integration block in `instrument-runs.test.ts` covers explicit-POST, derived-from-files POST, earlier-PATCH, later-PATCH ignored, default coalesce sort. New `TestAcquiredAt` class in `test_run_detector_hydration.py` covers the helper, POST payload shape, the earlier-PATCH path, and the monotonic no-PATCH path.

## Breaking changes

None. `acquired_at` is nullable and all sort/filter call sites coalesce to `created_at` for runs predating the watcher backfill or coming from the Lambda. Existing API callers that omit `acquired_at` are unaffected.

## Driveby changes

- `npm audit fix` bump in `web-app/package-lock.json` (`0027c9d`, unrelated to this feature).

## Testing

- [x] `make check-all` (ruff, pyright, prettier, eslint, tsc) — clean.
- [x] `make py-test` — watcher unit tests, including new `TestAcquiredAt` cases.
- [x] `make fe-test` — `instrument-runs.test.ts` integration tests, including new `Run acquired_at` block.
- [x] Apply migration `0020_add_acquired_at.sql` against staging and spot-check that pre-existing runs have `acquired_at` populated from the file manifest.
- [x] Manual: run detail header shows both "Run started" and "Reported"; list "Created" column reflects acquisition time for watcher-reported runs and falls back to insert time for Lambda-only runs.
- [x] Manual: roll out updated watcher to a PC with historical files, confirm new runs POST with `acquired_at` and that out-of-order stable files PATCH it earlier.