### PR TITLE
InstantRaman: Add instrument type and Report Data spectrum viewer

### DIFF
--- a/docs/lambda.md
+++ b/docs/lambda.md
@@ -46,6 +46,7 @@ See [Run archives](run-archives.md) for the full flow, S3 bucket layout, cache s
 | Azure Cielo qPCR | `azure_cielo_qpcr` | `azure-cielo-qpcr` |
 | Epson V700 Scanner | `epson_v700_scanner` | `epson-v700-scanner` |
 | Hina Microscope | `hina_microscope` | `hina-microscope` |
+| InstantRaman | _(no Lambda processor)_ | `instant-raman` |
 | SpectraMax iD3 Plate Reader | `spectramax_plate_reader` | `spectramax-id3-plate-reader` |
 | SpectraMax iD5 Plate Reader | `spectramax_plate_reader` | `spectramax-id5-plate-reader` |
 

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -66,6 +66,26 @@ Resources:
       BucketName: !Sub "arcadia-data-hub-raw-${Environment}"
       VersioningConfiguration:
         Status: Enabled
+      # Allow the web app to fetch raw files from the browser via the
+      # `/api/v1/files/:id/download` 302-redirect to a presigned S3 URL.
+      # Image/PDF previews bypass CORS via `<img>`/`<iframe>`, but client-side
+      # `fetch()` (used e.g. for InstantRaman spectrum CSVs) requires the
+      # origin to be allowlisted so the browser exposes the response body.
+      CorsConfiguration:
+        CorsRules:
+          - AllowedMethods:
+              - GET
+              - HEAD
+            AllowedOrigins:
+              - "https://data-hub.arcadiascience.com"
+              - "https://*.vercel.app"
+              - "http://localhost:3000"
+            AllowedHeaders:
+              - "*"
+            ExposedHeaders:
+              - ETag
+              - Content-Length
+            MaxAge: 3600
       NotificationConfiguration:
         LambdaConfigurations:
           - Event: s3:ObjectCreated:*
@@ -163,6 +183,23 @@ Resources:
       BucketName: !Sub "arcadia-data-hub-processed-${Environment}"
       VersioningConfiguration:
         Status: Enabled
+      # See RawDataBucket for the CORS rationale — both buckets back the same
+      # `/api/v1/files/:id/download` endpoint so they need parity.
+      CorsConfiguration:
+        CorsRules:
+          - AllowedMethods:
+              - GET
+              - HEAD
+            AllowedOrigins:
+              - "https://data-hub.arcadiascience.com"
+              - "https://*.vercel.app"
+              - "http://localhost:3000"
+            AllowedHeaders:
+              - "*"
+            ExposedHeaders:
+              - ETag
+              - Content-Length
+            MaxAge: 3600
       Tags:
         - Key: project
           Value: arcadia-data-hub

--- a/packages/shared/src/data_hub_shared/constants.py
+++ b/packages/shared/src/data_hub_shared/constants.py
@@ -9,6 +9,7 @@ INSTRUMENT_ID_TO_NAME_MAP: dict[str, str] = {
     Instrument.AZURE_CIELO_QPCR.value: "Azure Cielo qPCR",
     Instrument.EPSON_V700_SCANNER.value: "Epson V700 Scanner",
     Instrument.HINA_MICROSCOPE.value: "Hina Microscope",
+    Instrument.INSTANT_RAMAN.value: "InstantRaman",
     Instrument.SPECTRAMAX_ID3_PLATE_READER.value: "SpectraMax iD3 Plate Reader",
     Instrument.SPECTRAMAX_ID5_PLATE_READER.value: "SpectraMax iD5 Plate Reader",
 }

--- a/packages/shared/src/data_hub_shared/enums.py
+++ b/packages/shared/src/data_hub_shared/enums.py
@@ -14,5 +14,6 @@ class Instrument(Enum):
     AZURE_CIELO_QPCR = "azure-cielo-qpcr"
     EPSON_V700_SCANNER = "epson-v700-scanner"
     HINA_MICROSCOPE = "hina-microscope"
+    INSTANT_RAMAN = "instant-raman"
     SPECTRAMAX_ID3_PLATE_READER = "spectramax-id3-plate-reader"
     SPECTRAMAX_ID5_PLATE_READER = "spectramax-id5-plate-reader"

--- a/web-app/components/instruments/edit-instrument-dialog.tsx
+++ b/web-app/components/instruments/edit-instrument-dialog.tsx
@@ -33,6 +33,7 @@ const TYPE_LABELS: Record<string, string> = {
   tape_station: "TapeStation",
   hina_microscope: "Hina Microscope",
   epson_v700_scanner: "Epson V700 Scanner",
+  instant_raman: "InstantRaman",
 };
 
 const INSTRUMENT_TYPE_OPTIONS = VALID_INSTRUMENT_TYPES.map((value) => ({

--- a/web-app/components/runs/raman-report-section.tsx
+++ b/web-app/components/runs/raman-report-section.tsx
@@ -31,7 +31,7 @@ export function RamanReportSection({
       <h2 className="text-sm font-semibold">
         Report Data{" "}
         <span className="ml-1 font-mono text-xs font-normal text-muted-foreground">
-          {spectra.length} spectrum{spectra.length === 1 ? "" : "s"}
+          {spectra.length} {spectra.length === 1 ? "spectrum" : "spectra"}
         </span>
       </h2>
       <Card size="sm">

--- a/web-app/components/runs/raman-report-section.tsx
+++ b/web-app/components/runs/raman-report-section.tsx
@@ -1,0 +1,44 @@
+import { RamanSpectrumViewer } from "@/components/runs/raman-spectrum-viewer";
+import { Card, CardContent } from "@/components/ui/card";
+
+export type RamanSpectrumFileRef = {
+  fileId: number;
+  filename: string;
+};
+
+export function RamanReportSection({
+  spectra,
+}: {
+  spectra: RamanSpectrumFileRef[];
+}) {
+  if (spectra.length === 0) {
+    return (
+      <div className="flex flex-col gap-2">
+        <h2 className="text-sm font-semibold">Report Data</h2>
+        <Card size="sm">
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              No report data has been generated for this run.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h2 className="text-sm font-semibold">
+        Report Data{" "}
+        <span className="ml-1 font-mono text-xs font-normal text-muted-foreground">
+          {spectra.length} spectrum{spectra.length === 1 ? "" : "s"}
+        </span>
+      </h2>
+      <Card size="sm">
+        <CardContent>
+          <RamanSpectrumViewer spectra={spectra} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/web-app/components/runs/raman-spectrum-viewer.tsx
+++ b/web-app/components/runs/raman-spectrum-viewer.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import type { RamanSpectrumFileRef } from "@/components/runs/raman-report-section";
+import { Button } from "@/components/ui/button";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { parse } from "csv-parse/browser/esm/sync";
+import { AlertTriangle, Check, ChevronsUpDown } from "lucide-react";
+import { startTransition, useEffect, useMemo, useRef, useState } from "react";
+import { CartesianGrid, Legend, Line, LineChart, XAxis, YAxis } from "recharts";
+
+type SpectrumPoint = {
+  wavenumber: number;
+  intensity: number;
+  intensityDarkSubtracted: number;
+};
+
+const chartConfig = {
+  intensity: {
+    label: "Intensity",
+    color: "var(--color-chart-1)",
+  },
+  intensityDarkSubtracted: {
+    label: "Intensity (dark-subtracted)",
+    color: "var(--color-chart-2)",
+  },
+} satisfies ChartConfig;
+
+const CSV_HEADER_INTENSITY = "Intensity";
+const CSV_HEADER_DARK = "Intensity (dark-subtracted)";
+const CSV_HEADER_WAVENUMBER = "Wavenumber";
+
+async function fetchSpectrum(fileId: number): Promise<SpectrumPoint[]> {
+  // The download endpoint 302-redirects to a short-lived presigned S3 URL.
+  // The browser follows the redirect transparently, so the bytes flow
+  // directly from S3 to the user with zero Vercel Fast Origin Transfer.
+  const res = await fetch(`/api/v1/files/${fileId}/download`);
+  if (!res.ok) {
+    throw new Error(`Failed to load spectrum (HTTP ${res.status})`);
+  }
+  const text = await res.text();
+
+  const rows = parse(text, {
+    columns: true,
+    skip_empty_lines: true,
+    trim: true,
+  }) as Record<string, string>[];
+
+  if (rows.length === 0) {
+    throw new Error("Spectrum CSV is empty");
+  }
+  const first = rows[0];
+  if (
+    !(CSV_HEADER_WAVENUMBER in first) ||
+    !(CSV_HEADER_INTENSITY in first || CSV_HEADER_DARK in first)
+  ) {
+    throw new Error(
+      `CSV is missing expected columns (${CSV_HEADER_WAVENUMBER} + ${CSV_HEADER_INTENSITY}/${CSV_HEADER_DARK})`
+    );
+  }
+
+  return rows
+    .map<SpectrumPoint>((r) => ({
+      wavenumber: Number(r[CSV_HEADER_WAVENUMBER]),
+      intensity: Number(r[CSV_HEADER_INTENSITY]),
+      intensityDarkSubtracted: Number(r[CSV_HEADER_DARK]),
+    }))
+    .filter((p) => Number.isFinite(p.wavenumber));
+}
+
+function SpectrumPicker({
+  spectra,
+  selectedId,
+  onSelect,
+}: {
+  spectra: RamanSpectrumFileRef[];
+  selectedId: number | null;
+  onSelect: (fileId: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = spectra.find((s) => s.fileId === selectedId);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full max-w-md justify-between font-normal"
+        >
+          <span className="truncate">
+            {selected ? selected.filename : "Select a spectrum…"}
+          </span>
+          <ChevronsUpDown className="size-3.5 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput placeholder="Search spectra..." />
+          <CommandList>
+            <CommandEmpty>No spectra found.</CommandEmpty>
+            <CommandGroup>
+              {spectra.map((s) => {
+                const isSelected = s.fileId === selectedId;
+                return (
+                  <CommandItem
+                    key={s.fileId}
+                    value={s.filename}
+                    onSelect={() => {
+                      onSelect(s.fileId);
+                      setOpen(false);
+                    }}
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 size-4",
+                        isSelected ? "opacity-100" : "opacity-0"
+                      )}
+                    />
+                    <span className="truncate">{s.filename}</span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function SpectrumChart({ points }: { points: SpectrumPoint[] }) {
+  // Recharts performs best with stable, plain-array data; the upstream points
+  // are already in render-ready shape, but memoize to keep referential
+  // equality across unrelated parent renders (e.g. picker open/close).
+  const data = useMemo(() => points, [points]);
+
+  return (
+    <ChartContainer config={chartConfig} className="aspect-auto h-80 w-full">
+      <LineChart data={data} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" />
+        <XAxis
+          dataKey="wavenumber"
+          type="number"
+          domain={["dataMin", "dataMax"]}
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          tickFormatter={(v: number) => v.toFixed(0)}
+          label={{
+            value: "Wavenumber (cm\u207B\u00B9)",
+            position: "insideBottom",
+            offset: -2,
+            style: {
+              fontSize: 11,
+              fill: "var(--color-muted-foreground)",
+            },
+          }}
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          width={64}
+          tickFormatter={(v: number) =>
+            Math.abs(v) >= 1000 ? `${(v / 1000).toFixed(1)}k` : v.toFixed(0)
+          }
+        />
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              labelFormatter={(label) =>
+                typeof label === "number"
+                  ? `${label.toFixed(2)} cm\u207B\u00B9`
+                  : String(label)
+              }
+            />
+          }
+        />
+        <Legend
+          wrapperStyle={{ fontSize: 11, paddingTop: 4 }}
+          iconType="line"
+        />
+        <Line
+          name={chartConfig.intensity.label as string}
+          dataKey="intensity"
+          stroke="var(--color-intensity)"
+          strokeWidth={1.25}
+          dot={false}
+          isAnimationActive={false}
+        />
+        <Line
+          name={chartConfig.intensityDarkSubtracted.label as string}
+          dataKey="intensityDarkSubtracted"
+          stroke="var(--color-intensityDarkSubtracted)"
+          strokeWidth={1.25}
+          dot={false}
+          isAnimationActive={false}
+        />
+      </LineChart>
+    </ChartContainer>
+  );
+}
+
+type LoadState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; points: SpectrumPoint[] }
+  | { status: "error"; message: string };
+
+// Async-resolution result, tagged with the fileId it belongs to so we can
+// ignore it during render when the user has already moved on to a different
+// spectrum.
+type AsyncResult =
+  | { fileId: number; status: "ready"; points: SpectrumPoint[] }
+  | { fileId: number; status: "error"; message: string };
+
+export function RamanSpectrumViewer({
+  spectra,
+}: {
+  spectra: RamanSpectrumFileRef[];
+}) {
+  const [selectedId, setSelectedId] = useState<number | null>(
+    () => spectra[0]?.fileId ?? null
+  );
+  // Bumped on retry to invalidate the cache entry and re-run the load effect
+  // even when `selectedId` hasn't changed.
+  const [retryNonce, setRetryNonce] = useState(0);
+  // Only async resolutions (fetch success/failure) write to React state; all
+  // synchronous transitions (idle / loading / cache-hit ready) are derived
+  // during render. This avoids `react-hooks/set-state-in-effect` warnings.
+  const [asyncResult, setAsyncResult] = useState<AsyncResult | null>(null);
+
+  // Per-mount cache so toggling between already-loaded spectra is instant
+  // and never re-hits S3.
+  const cacheRef = useRef<Map<number, SpectrumPoint[]>>(new Map());
+
+  const state: LoadState = useMemo(() => {
+    if (selectedId == null) return { status: "idle" };
+    const cached = cacheRef.current.get(selectedId);
+    if (cached) return { status: "ready", points: cached };
+    if (asyncResult && asyncResult.fileId === selectedId) {
+      return asyncResult.status === "ready"
+        ? { status: "ready", points: asyncResult.points }
+        : { status: "error", message: asyncResult.message };
+    }
+    return { status: "loading" };
+    // `retryNonce` participates so a retry that clears the cache entry forces
+    // a fresh derivation back to "loading" before the next fetch resolves.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedId, asyncResult, retryNonce]);
+
+  useEffect(() => {
+    if (selectedId == null) return;
+    if (cacheRef.current.has(selectedId)) return;
+
+    let cancelled = false;
+    fetchSpectrum(selectedId)
+      .then((points) => {
+        cacheRef.current.set(selectedId, points);
+        if (cancelled) return;
+        // Rendering ~2k points to recharts is the heavy part of this update;
+        // a transition lets the picker close stay snappy.
+        startTransition(() => {
+          setAsyncResult({ fileId: selectedId, status: "ready", points });
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message =
+          err instanceof Error ? err.message : "Failed to load spectrum";
+        setAsyncResult({ fileId: selectedId, status: "error", message });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId, retryNonce]);
+
+  function handleRetry() {
+    if (selectedId == null) return;
+    cacheRef.current.delete(selectedId);
+    setAsyncResult(null);
+    setRetryNonce((n) => n + 1);
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SpectrumPicker
+        spectra={spectra}
+        selectedId={selectedId}
+        onSelect={setSelectedId}
+      />
+      {state.status === "loading" && (
+        <Skeleton className="h-80 w-full" aria-label="Loading spectrum" />
+      )}
+      {state.status === "error" && (
+        <div className="flex h-80 flex-col items-center justify-center gap-3 rounded-md border border-dashed bg-muted/20 p-6 text-center">
+          <AlertTriangle className="size-6 text-muted-foreground" aria-hidden />
+          <p className="text-sm text-muted-foreground">{state.message}</p>
+          <Button variant="outline" size="sm" onClick={handleRetry}>
+            Retry
+          </Button>
+        </div>
+      )}
+      {state.status === "ready" && <SpectrumChart points={state.points} />}
+    </div>
+  );
+}

--- a/web-app/components/runs/raman-spectrum-viewer.tsx
+++ b/web-app/components/runs/raman-spectrum-viewer.tsx
@@ -22,11 +22,18 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { cn } from "@/lib/utils";
 import { parse } from "csv-parse/browser/esm/sync";
-import { AlertTriangle, Check, ChevronsUpDown } from "lucide-react";
+import {
+  AlertTriangle,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsUpDown,
+} from "lucide-react";
 import { startTransition, useEffect, useMemo, useRef, useState } from "react";
-import { CartesianGrid, Legend, Line, LineChart, XAxis, YAxis } from "recharts";
+import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
 
 type SpectrumPoint = {
   wavenumber: number;
@@ -34,16 +41,23 @@ type SpectrumPoint = {
   intensityDarkSubtracted: number;
 };
 
+type Series = "intensity" | "intensityDarkSubtracted";
+
+// Two distinguishable shades of blue: lighter for the raw signal, deeper for
+// the corrected signal so the dark-subtracted line reads as the primary
+// series when both are visible.
 const chartConfig = {
   intensity: {
     label: "Intensity",
-    color: "var(--color-chart-1)",
+    color: "#93c5fd", // tailwind blue-300
   },
   intensityDarkSubtracted: {
     label: "Intensity (dark-subtracted)",
-    color: "var(--color-chart-2)",
+    color: "#2563eb", // tailwind blue-600
   },
 } satisfies ChartConfig;
+
+const ALL_SERIES: Series[] = ["intensity", "intensityDarkSubtracted"];
 
 const CSV_HEADER_INTENSITY = "Intensity";
 const CSV_HEADER_DARK = "Intensity (dark-subtracted)";
@@ -152,15 +166,63 @@ function SpectrumPicker({
   );
 }
 
-function SpectrumChart({ points }: { points: SpectrumPoint[] }) {
+function SeriesToggle({
+  visible,
+  onChange,
+}: {
+  visible: Series[];
+  onChange: (next: Series[]) => void;
+}) {
+  return (
+    <ToggleGroup
+      type="multiple"
+      size="sm"
+      value={visible}
+      onValueChange={(next) => {
+        // Don't let the user deselect every series — that would leave an
+        // empty chart with no obvious way to recover.
+        if (next.length === 0) return;
+        onChange(next as Series[]);
+      }}
+      aria-label="Series visibility"
+    >
+      {ALL_SERIES.map((key) => (
+        <ToggleGroupItem key={key} value={key} className="gap-1.5 text-xs">
+          <span
+            aria-hidden
+            className="size-2.5 rounded-sm"
+            style={{ backgroundColor: chartConfig[key].color }}
+          />
+          {chartConfig[key].label}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  );
+}
+
+function SpectrumChart({
+  points,
+  visible,
+}: {
+  points: SpectrumPoint[];
+  visible: Series[];
+}) {
   // Recharts performs best with stable, plain-array data; the upstream points
   // are already in render-ready shape, but memoize to keep referential
   // equality across unrelated parent renders (e.g. picker open/close).
   const data = useMemo(() => points, [points]);
+  const showIntensity = visible.includes("intensity");
+  const showDark = visible.includes("intensityDarkSubtracted");
 
   return (
     <ChartContainer config={chartConfig} className="aspect-auto h-80 w-full">
-      <LineChart data={data} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+      <LineChart
+        data={data}
+        // Bottom margin makes room for the X-axis title sitting below the
+        // tick labels; the legend lives outside the chart now, so the chart
+        // owns only the axes.
+        margin={{ top: 8, right: 16, bottom: 28, left: 0 }}
+      >
         <CartesianGrid vertical={false} strokeDasharray="3 3" />
         <XAxis
           dataKey="wavenumber"
@@ -173,7 +235,7 @@ function SpectrumChart({ points }: { points: SpectrumPoint[] }) {
           label={{
             value: "Wavenumber (cm\u207B\u00B9)",
             position: "insideBottom",
-            offset: -2,
+            offset: -16,
             style: {
               fontSize: 11,
               fill: "var(--color-muted-foreground)",
@@ -200,26 +262,26 @@ function SpectrumChart({ points }: { points: SpectrumPoint[] }) {
             />
           }
         />
-        <Legend
-          wrapperStyle={{ fontSize: 11, paddingTop: 4 }}
-          iconType="line"
-        />
-        <Line
-          name={chartConfig.intensity.label as string}
-          dataKey="intensity"
-          stroke="var(--color-intensity)"
-          strokeWidth={1.25}
-          dot={false}
-          isAnimationActive={false}
-        />
-        <Line
-          name={chartConfig.intensityDarkSubtracted.label as string}
-          dataKey="intensityDarkSubtracted"
-          stroke="var(--color-intensityDarkSubtracted)"
-          strokeWidth={1.25}
-          dot={false}
-          isAnimationActive={false}
-        />
+        {showIntensity && (
+          <Line
+            name={chartConfig.intensity.label as string}
+            dataKey="intensity"
+            stroke={chartConfig.intensity.color}
+            strokeWidth={1.25}
+            dot={false}
+            isAnimationActive={false}
+          />
+        )}
+        {showDark && (
+          <Line
+            name={chartConfig.intensityDarkSubtracted.label as string}
+            dataKey="intensityDarkSubtracted"
+            stroke={chartConfig.intensityDarkSubtracted.color}
+            strokeWidth={1.25}
+            dot={false}
+            isAnimationActive={false}
+          />
+        )}
       </LineChart>
     </ChartContainer>
   );
@@ -246,6 +308,7 @@ export function RamanSpectrumViewer({
   const [selectedId, setSelectedId] = useState<number | null>(
     () => spectra[0]?.fileId ?? null
   );
+  const [visible, setVisible] = useState<Series[]>(ALL_SERIES);
   // Bumped on retry to invalidate the cache entry and re-run the load effect
   // even when `selectedId` hasn't changed.
   const [retryNonce, setRetryNonce] = useState(0);
@@ -253,6 +316,25 @@ export function RamanSpectrumViewer({
   // synchronous transitions (idle / loading / cache-hit ready) are derived
   // during render. This avoids `react-hooks/set-state-in-effect` warnings.
   const [asyncResult, setAsyncResult] = useState<AsyncResult | null>(null);
+
+  const currentIndex = useMemo(
+    () =>
+      selectedId == null
+        ? -1
+        : spectra.findIndex((s) => s.fileId === selectedId),
+    [spectra, selectedId]
+  );
+  const canGoPrev = currentIndex > 0;
+  const canGoNext = currentIndex >= 0 && currentIndex < spectra.length - 1;
+
+  function goPrev() {
+    if (!canGoPrev) return;
+    setSelectedId(spectra[currentIndex - 1].fileId);
+  }
+  function goNext() {
+    if (!canGoNext) return;
+    setSelectedId(spectra[currentIndex + 1].fileId);
+  }
 
   // Per-mount cache so toggling between already-loaded spectra is instant
   // and never re-hits S3.
@@ -308,12 +390,37 @@ export function RamanSpectrumViewer({
   }
 
   return (
-    <div className="flex flex-col gap-4">
-      <SpectrumPicker
-        spectra={spectra}
-        selectedId={selectedId}
-        onSelect={setSelectedId}
-      />
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-2">
+        <SpectrumPicker
+          spectra={spectra}
+          selectedId={selectedId}
+          onSelect={setSelectedId}
+        />
+        <div className="flex items-center gap-1">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={goPrev}
+            disabled={!canGoPrev}
+            aria-label="Previous spectrum"
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={goNext}
+            disabled={!canGoNext}
+            aria-label="Next spectrum"
+          >
+            <ChevronRight className="size-4" />
+          </Button>
+        </div>
+      </div>
+      <div className="flex justify-end">
+        <SeriesToggle visible={visible} onChange={setVisible} />
+      </div>
       {state.status === "loading" && (
         <Skeleton className="h-80 w-full" aria-label="Loading spectrum" />
       )}
@@ -326,7 +433,9 @@ export function RamanSpectrumViewer({
           </Button>
         </div>
       )}
-      {state.status === "ready" && <SpectrumChart points={state.points} />}
+      {state.status === "ready" && (
+        <SpectrumChart points={state.points} visible={visible} />
+      )}
     </div>
   );
 }

--- a/web-app/components/runs/variants/index.tsx
+++ b/web-app/components/runs/variants/index.tsx
@@ -4,6 +4,7 @@ import { DefaultRunDetail } from "./default-run-detail";
 import { EpsonScannerRunDetail } from "./epson-scanner-run-detail";
 import { GelDocRunDetail } from "./gel-doc-run-detail";
 import { HinaMicroscopeRunDetail } from "./hina-microscope-run-detail";
+import { InstantRamanRunDetail } from "./instant-raman-run-detail";
 import { PlateReaderRunDetail } from "./plate-reader-run-detail";
 import { QpcrRunDetail } from "./qpcr-run-detail";
 import { TapeStationRunDetail } from "./tape-station-run-detail";
@@ -24,6 +25,8 @@ export function RunDetailVariant(props: RunDetailVariantProps) {
       return <HinaMicroscopeRunDetail {...props} />;
     case "epson_v700_scanner":
       return <EpsonScannerRunDetail {...props} />;
+    case "instant_raman":
+      return <InstantRamanRunDetail {...props} />;
     default:
       return <DefaultRunDetail {...props} />;
   }

--- a/web-app/components/runs/variants/instant-raman-run-detail.tsx
+++ b/web-app/components/runs/variants/instant-raman-run-detail.tsx
@@ -1,0 +1,56 @@
+import { DeleteRunDialog } from "@/components/runs/delete-run-dialog";
+import { RamanReportSection } from "@/components/runs/raman-report-section";
+import { RestoreRunButton } from "@/components/runs/restore-run-button";
+import type { RunDetailProps } from "@/components/runs/run-detail";
+import { RunDetail } from "@/components/runs/run-detail";
+
+export function InstantRamanRunDetail({
+  run,
+  files,
+  instrumentId,
+  runId,
+  attributionsSlot,
+}: RunDetailProps) {
+  const isDeleted = run.deletedAt !== null;
+  const activeFileCount = files.filter((f) => f.deletedAt === null).length;
+  const hasProcessedFiles =
+    files.filter((f) => f.category === "processed" && f.deletedAt === null)
+      .length > 0;
+
+  // Within an InstantRaman run we treat every active CSV as a Raman spectrum.
+  // Non-conforming files surface an inline error in the chart area rather than
+  // being silently filtered out, so users always see what's available.
+  const spectra = files
+    .filter((f) => f.deletedAt === null && /\.csv$/i.test(f.filename))
+    .map((f) => ({ fileId: f.id, filename: f.filename }))
+    .sort((a, b) => a.filename.localeCompare(b.filename));
+
+  return (
+    <>
+      <RunDetail.Header run={run} attributionsSlot={attributionsSlot}>
+        {!isDeleted && (
+          <DeleteRunDialog
+            instrumentId={instrumentId}
+            runId={runId}
+            fileCount={activeFileCount}
+            hasProcessedFiles={hasProcessedFiles}
+          />
+        )}
+        {isDeleted && (
+          <RestoreRunButton instrumentId={instrumentId} runId={runId} />
+        )}
+      </RunDetail.Header>
+
+      <RunDetail.FilesMetadataLayout>
+        <RunDetail.Files
+          files={files}
+          instrumentId={instrumentId}
+          runId={runId}
+          isDeleted={isDeleted}
+        />
+      </RunDetail.FilesMetadataLayout>
+
+      <RamanReportSection spectra={spectra} />
+    </>
+  );
+}

--- a/web-app/drizzle/0021_instant_raman_type.sql
+++ b/web-app/drizzle/0021_instant_raman_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."instrument_type" ADD VALUE 'instant_raman';

--- a/web-app/drizzle/meta/0021_snapshot.json
+++ b/web-app/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,1705 @@
+{
+  "id": "f2cb32f9-dd57-4afd-9ab4-88f97c9eb0d2",
+  "prevId": "a3add94e-8831-4f87-905b-4f503c0a4671",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archive_jobs": {
+      "name": "archive_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archive_bucket": {
+          "name": "archive_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_key": {
+          "name": "archive_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "archive_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_archive_jobs_inflight": {
+          "name": "uq_archive_jobs_inflight",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"archive_jobs\".\"status\" in ('pending', 'building')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_archive_jobs_run_fingerprint_status": {
+          "name": "idx_archive_jobs_run_fingerprint_status",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "archive_jobs_instrument_run_id_instrument_runs_id_fk": {
+          "name": "archive_jobs_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "archive_jobs_created_by_user_id_fk": {
+          "name": "archive_jobs_created_by_user_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "file_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raw'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_requested_at": {
+          "name": "upload_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_files_instrument_run_id_relative_path": {
+          "name": "uq_files_instrument_run_id_relative_path",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"relative_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_active_instrument_run_id_filename": {
+          "name": "uq_files_active_instrument_run_id_filename",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_s3_key": {
+          "name": "uq_files_s3_key",
+          "columns": [
+            {
+              "expression": "s3_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"s3_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_instrument_run_id": {
+          "name": "idx_files_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_status_instrument_run_id": {
+          "name": "idx_files_status_instrument_run_id",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_upload_queue": {
+          "name": "idx_files_upload_queue",
+          "columns": [
+            {
+              "expression": "upload_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"upload_requested_at\" is not null and \"files\".\"uploaded_at\" is null and \"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_metadata_gin": {
+          "name": "idx_files_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_instrument_run_id_instrument_runs_id_fk": {
+          "name": "files_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_runs": {
+      "name": "instrument_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "instrument_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lambda'"
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instrument_runs_instrument_id_created_at": {
+          "name": "idx_instrument_runs_instrument_id_created_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active": {
+          "name": "idx_instrument_runs_active",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active_acquired_at": {
+          "name": "idx_instrument_runs_active_acquired_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"acquired_at\", \"created_at\") desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_metadata_gin": {
+          "name": "idx_instrument_runs_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_runs_instrument_id_instruments_id_fk": {
+          "name": "instrument_runs_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_watcher_id_watchers_id_fk": {
+          "name": "instrument_runs_watcher_id_watchers_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_instrument_runs_instrument_id_run_id": {
+          "name": "uq_instrument_runs_instrument_id_run_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instrument_id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instruments": {
+      "name": "instruments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instrument_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instrument_type": {
+          "name": "instrument_type",
+          "type": "instrument_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_personal_access_tokens_user_id": {
+          "name": "idx_personal_access_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_user_id_fk": {
+          "name": "personal_access_tokens_user_id_user_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_attributions": {
+      "name": "run_attributions",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_attributions_run_id": {
+          "name": "idx_run_attributions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_attributions_user_id": {
+          "name": "idx_run_attributions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_attributions_run_id_instrument_runs_id_fk": {
+          "name": "run_attributions_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_attributions_user_id_user_id_fk": {
+          "name": "run_attributions_user_id_user_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_attributions_run_id_user_id_pk": {
+          "name": "run_attributions_run_id_user_id_pk",
+          "columns": [
+            "run_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_comments": {
+      "name": "run_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_run_comments_run_id_created_at": {
+          "name": "idx_run_comments_run_id_created_at",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_comments_user_id": {
+          "name": "idx_run_comments_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_comments_run_id_instrument_runs_id_fk": {
+          "name": "run_comments_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_comments_user_id_user_id_fk": {
+          "name": "run_comments_user_id_user_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_events": {
+      "name": "watcher_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "watcher_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_events_watcher_id_timestamp": {
+          "name": "idx_watcher_events_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_watcher_events_watcher_id_event_type": {
+          "name": "idx_watcher_events_watcher_id_event_type",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_events_watcher_id_watchers_id_fk": {
+          "name": "watcher_events_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_events",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_heartbeats": {
+      "name": "watcher_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_mode": {
+          "name": "upload_mode",
+          "type": "upload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_uploaded_since_last": {
+          "name": "files_uploaded_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "runs_reported_since_last": {
+          "name": "runs_reported_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_since_last": {
+          "name": "errors_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_heartbeats_watcher_id_timestamp": {
+          "name": "idx_watcher_heartbeats_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_heartbeats_watcher_id_watchers_id_fk": {
+          "name": "watcher_heartbeats_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_heartbeats",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watchers": {
+      "name": "watchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_info": {
+          "name": "os_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watcher_version": {
+          "name": "watcher_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_checksum": {
+          "name": "config_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_yaml": {
+          "name": "config_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "watcher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_watchers_active_instrument_id": {
+          "name": "uq_watchers_active_instrument_id",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"watchers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchers_instrument_id_instruments_id_fk": {
+          "name": "watchers_instrument_id_instruments_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.archive_job_status": {
+      "name": "archive_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "building",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.file_category": {
+      "name": "file_category",
+      "schema": "public",
+      "values": [
+        "raw",
+        "processed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "detected",
+        "upload_requested",
+        "uploaded",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.instrument_run_source": {
+      "name": "instrument_run_source",
+      "schema": "public",
+      "values": [
+        "lambda",
+        "watcher"
+      ]
+    },
+    "public.instrument_status": {
+      "name": "instrument_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "inactive"
+      ]
+    },
+    "public.instrument_type": {
+      "name": "instrument_type",
+      "schema": "public",
+      "values": [
+        "generic",
+        "plate_reader",
+        "gel_doc",
+        "qpcr",
+        "tape_station",
+        "hina_microscope",
+        "epson_v700_scanner",
+        "instant_raman"
+      ]
+    },
+    "public.upload_mode": {
+      "name": "upload_mode",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual"
+      ]
+    },
+    "public.watcher_event_type": {
+      "name": "watcher_event_type",
+      "schema": "public",
+      "values": [
+        "watcher_started",
+        "watcher_stopped",
+        "file_uploaded",
+        "upload_failed",
+        "run_reported",
+        "config_synced",
+        "error",
+        "update_started",
+        "update_succeeded",
+        "update_failed"
+      ]
+    },
+    "public.watcher_status": {
+      "name": "watcher_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "watching",
+        "stopped"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web-app/drizzle/meta/_journal.json
+++ b/web-app/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1778264446987,
       "tag": "0020_add_acquired_at",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1778878800000,
+      "tag": "0021_instant_raman_type",
+      "breakpoints": true
     }
   ]
 }

--- a/web-app/lib/api/instrument-runs.ts
+++ b/web-app/lib/api/instrument-runs.ts
@@ -803,6 +803,7 @@ export async function getInstrumentFilterOptions(
       };
     case "generic":
     case "tape_station":
+    case "instant_raman":
       return { kind: "default" };
   }
 }

--- a/web-app/lib/db/schema.ts
+++ b/web-app/lib/db/schema.ts
@@ -58,6 +58,7 @@ export const instrumentTypeEnum = pgEnum("instrument_type", [
   "tape_station",
   "hina_microscope",
   "epson_v700_scanner",
+  "instant_raman",
 ]);
 
 export const VALID_INSTRUMENT_TYPES = instrumentTypeEnum.enumValues;


### PR DESCRIPTION
## Summary

- Adds `instant_raman` to the `instrument_type` enum (Drizzle migration `0021_instant_raman_type.sql` + snapshot/journal, `lib/db/schema.ts`, `edit-instrument-dialog` label, shared `Instrument` enum + name map, `docs/lambda.md` table).
- New `InstantRamanRunDetail` variant that filters the run's CSVs in place and renders a "Report Data" section with a searchable Popover+Command spectrum picker (`raman-report-section.tsx`) and a Recharts `LineChart` viewer (`raman-spectrum-viewer.tsx`) plotting Wavenumber vs `Intensity` and `Intensity (dark-subtracted)` (toggleable via the chart legend).
- Spectrum CSVs are fetched and parsed client-side using `csv-parse/browser/esm/sync` via the existing `/api/v1/files/:id/download` 302-redirect to a presigned S3 URL — bytes go browser ↔ S3 directly with zero Vercel Fast Origin Transfer. A per-mount `Map` cache keeps spectrum switching instant after the first load.
- Adds `CorsConfiguration` to `RawDataBucket` and `ProcessedDataBucket` in `infra/template.yaml` so the browser can read the response body when following the redirect to S3 (image/PDF previews already worked because `<img>`/`<iframe>` ignore CORS). Allowed origins: `data-hub.arcadiascience.com`, `*.vercel.app`, `localhost:3000`.

## Test plan

- [x] `make sam-deploy ENV=staging` lands the new CORS rules on `arcadia-data-hub-raw-staging` / `arcadia-data-hub-processed-staging`.
- [x] Drizzle migration `0021_instant_raman_type` runs cleanly against staging Postgres.
- [x] Create an `instant-raman` instrument, upload a Raman spectrum CSV (e.g. `A10-Site_0.csv`), open its run detail page.
- [x] Confirm the picker lists the CSV(s), the chart renders both lines, and the Network tab shows the spectrum body coming from `*.s3.*.amazonaws.com` (not Vercel).
- [x] Toggle Intensity / Intensity (dark-subtracted) via the legend; switch between spectra and verify the second selection is instant (cache hit).
- [x] Existing instrument variants (plate reader, gel doc, qPCR, tape station, Hina microscope, Epson scanner, generic) still render their normal Report Data section.

Made with [Cursor](https://cursor.com)