### PR TITLE
Watcher: Speed up initial scan, parallelize uploads, eliminate StateDB lock contention

### DIFF
--- a/watcher/src/data_hub_watcher/models.py
+++ b/watcher/src/data_hub_watcher/models.py
@@ -41,6 +41,14 @@ class InstrumentConfig(BaseModel):
     enabled: bool = True
     upload_mode: Literal["auto", "manual"] = "auto"
     stability_period_seconds: int = Field(default=5, ge=1, le=300)
+    # Maximum number of files to upload concurrently for a single
+    # detected run (auto mode) or queue poll. The default of 4 balances
+    # S3 throughput against lab-PC network and CPU budgets; instruments
+    # on slow shared uplinks can dial it down to 1 and high-bandwidth
+    # microscopy hosts can push toward the cap. New field, defaulted
+    # for backward compatibility -- existing config YAMLs need no
+    # migration.
+    upload_parallelism: int = Field(default=4, ge=1, le=32)
     run_detection: RunDetectionConfig
 
     @field_validator("id")

--- a/watcher/src/data_hub_watcher/monitor.py
+++ b/watcher/src/data_hub_watcher/monitor.py
@@ -202,7 +202,9 @@ class FileMonitor:
 
         ``OSError`` from a deleted/unreadable directory is logged and
         skipped so a single transient permission glitch doesn't
-        abort the whole scan.
+        abort the whole scan. Per-entry ``is_dir`` failures are also
+        logged: a silently-skipped subdirectory means the scan never
+        descends into it, which can mask whole runs from the watcher.
         """
         stack: list[Path] = [root]
         while stack:
@@ -216,10 +218,21 @@ class FileMonitor:
                 for entry in it:
                     if self._recursive:
                         try:
-                            if entry.is_dir(follow_symlinks=False):
-                                stack.append(Path(entry.path))
-                                continue
-                        except OSError:
+                            is_dir = entry.is_dir(follow_symlinks=False)
+                        except OSError as exc:
+                            # Don't silently drop: an unreadable
+                            # subdirectory here means we'll never
+                            # descend into it and the operator has no
+                            # way to find out without comparing
+                            # uploads against on-disk reality.
+                            logger.warning(
+                                "is_dir() failed for %s: %s; skipping entry",
+                                entry.path,
+                                exc,
+                            )
+                            continue
+                        if is_dir:
+                            stack.append(Path(entry.path))
                             continue
                     yield entry
 

--- a/watcher/src/data_hub_watcher/monitor.py
+++ b/watcher/src/data_hub_watcher/monitor.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 import fnmatch
 import logging
 import os
+import re
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -28,6 +29,31 @@ from data_hub_watcher.events import EventReporter
 from data_hub_watcher.state import StateDB
 
 logger = logging.getLogger(__name__)
+
+# ~1 second tolerance applied to stat-based dedup matches in the
+# initial scan. Mirrors the SQL ``ABS(mtime - ?) < 1.0`` predicate used
+# by ``StateDB.has_stat_match`` -- keep the two in sync.
+_STAT_MTIME_TOLERANCE = 1.0
+
+
+def _compile_pattern_matcher(file_patterns: list[str]) -> Callable[[str], bool]:
+    """Return a fast ``filename -> bool`` matcher for *file_patterns*.
+
+    Pre-compiles the user-facing fnmatch globs (e.g. ``["*.csv",
+    "*.txt"]``) into a single anchored regex so the hot paths
+    (per-file initial-scan filter, per-event watchdog filter) only do
+    one regex match instead of one ``fnmatch.fnmatch`` call per
+    pattern. ``fnmatch.translate`` already produces anchored regexes,
+    so combining them with ``|`` is safe.
+    """
+    if not file_patterns:
+        # An empty pattern list rejects everything -- mirrors the
+        # behaviour of ``any(... for pat in [])`` which is False.
+        return lambda _name: False
+
+    combined = "|".join(f"(?:{fnmatch.translate(pat)})" for pat in file_patterns)
+    regex = re.compile(combined)
+    return lambda name: regex.match(name) is not None
 
 
 @dataclass
@@ -46,28 +72,27 @@ class _EventHandler(FileSystemEventHandler):
 
     def __init__(
         self,
-        file_patterns: list[str],
+        matches: Callable[[str], bool],
         on_event: Callable[[Path], None],
         recursive: bool,
     ) -> None:
         super().__init__()
-        self._patterns = file_patterns
+        # Pre-compiled matcher shared with the FileMonitor so we
+        # don't pay fnmatch translation cost per event.
+        self._matches = matches
         self._on_event = on_event
         self._recursive = recursive
-
-    def _matches(self, path: Path) -> bool:
-        return any(fnmatch.fnmatch(path.name, pat) for pat in self._patterns)
 
     def on_created(self, event: FileSystemEvent) -> None:
         if isinstance(event, FileCreatedEvent) and not event.is_directory:
             p = Path(str(event.src_path))
-            if self._matches(p):
+            if self._matches(p.name):
                 self._on_event(p)
 
     def on_modified(self, event: FileSystemEvent) -> None:
         if isinstance(event, FileModifiedEvent) and not event.is_directory:
             p = Path(str(event.src_path))
-            if self._matches(p):
+            if self._matches(p.name):
                 self._on_event(p)
 
 
@@ -104,6 +129,11 @@ class FileMonitor:
     ) -> None:
         self._watch_dir = watch_directory
         self._patterns = file_patterns
+        # Compile the patterns once and reuse for both the initial scan
+        # and the watchdog event handler. Hot-path scans of large
+        # directories used to do ``len(file_patterns)`` fnmatch calls
+        # per file; this is one regex match instead.
+        self._matches_name = _compile_pattern_matcher(file_patterns)
         self._stability_period = stability_period
         self._on_stable = on_stable_file
         self._state_db = state_db
@@ -128,7 +158,7 @@ class FileMonitor:
         """Run the initial scan, start the watchdog observer, and begin the stability checker."""
         self._initial_scan()
 
-        handler = _EventHandler(self._patterns, self._enqueue, self._recursive)
+        handler = _EventHandler(self._matches_name, self._enqueue, self._recursive)
         self._observer.schedule(handler, str(self._watch_dir), recursive=self._recursive)
         self._observer.start()
 
@@ -157,6 +187,60 @@ class FileMonitor:
     # initial scan
     # ------------------------------------------------------------------
 
+    def _iter_dir_entries(self, root: Path) -> Iterator[os.DirEntry[str]]:
+        """Yield ``os.DirEntry`` objects under *root*, optionally recursively.
+
+        ``os.scandir`` returns ``DirEntry`` objects that cache the
+        result of one ``lstat`` syscall per entry: ``is_file()`` and
+        ``stat()`` then come from cache rather than triggering more
+        syscalls. The previous ``Path.rglob('*') + entry.is_file() +
+        entry.stat()`` chain costs three stats per file on Windows
+        network shares (~hundreds of microseconds each) -- this is
+        one. Walking via an explicit stack avoids the recursion-depth
+        cap on deeply nested run trees and keeps a single open
+        ``scandir`` handle per directory at a time.
+
+        ``OSError`` from a deleted/unreadable directory is logged and
+        skipped so a single transient permission glitch doesn't
+        abort the whole scan.
+        """
+        stack: list[Path] = [root]
+        while stack:
+            current = stack.pop()
+            try:
+                it = os.scandir(current)
+            except OSError as exc:
+                logger.warning("scandir failed for %s: %s", current, exc)
+                continue
+            with it:
+                for entry in it:
+                    if self._recursive:
+                        try:
+                            if entry.is_dir(follow_symlinks=False):
+                                stack.append(Path(entry.path))
+                                continue
+                        except OSError:
+                            continue
+                    yield entry
+
+    def _load_dedup_index(self) -> dict[str, list[tuple[int, float]]]:
+        """Bulk-load the union of upload + detected stat keys keyed by relative path.
+
+        One ``SELECT`` per table replaces what used to be two ``SELECT``
+        s per scanned file. Multiple rows can exist for the same
+        relative path (re-uploads with different content / mtime), so
+        the value is a list of ``(size_bytes, mtime)`` tuples and
+        membership is checked with the same ~1s mtime tolerance the
+        SQL ``has_stat_match`` predicate uses (see
+        :data:`_STAT_MTIME_TOLERANCE`).
+        """
+        index: dict[str, list[tuple[int, float]]] = {}
+        for rel_path, size_bytes, mtime in self._state_db.iter_uploaded_stat_keys():
+            index.setdefault(rel_path, []).append((size_bytes, mtime))
+        for rel_path, size_bytes, mtime in self._state_db.iter_detected_stat_keys():
+            index.setdefault(rel_path, []).append((size_bytes, mtime))
+        return index
+
     def _initial_scan(self) -> None:
         """Walk the directory for existing files and enqueue unuploaded ones.
 
@@ -177,6 +261,16 @@ class FileMonitor:
         and `uploaded_files` stays empty — without this, every restart
         would re-POST / PATCH the full manifest.
         See also: `StateDB.has_detected_stat_match`.
+
+        Implementation notes
+        --------------------
+        The scan walks via :meth:`_iter_dir_entries` (a thin
+        ``os.scandir`` wrapper) and consults a single in-memory
+        dedup index built up front by :meth:`_load_dedup_index`.
+        Together they replace the previous "one ``Path.is_file()`` +
+        one ``entry.stat()`` + two SQL ``SELECT`` s per file" pattern
+        with "one cached ``DirEntry.stat()`` + one Python dict lookup"
+        -- typically a 5-10x speedup on lab-PC sized trees.
         """
         logger.info(
             "Initial scan starting (dir=%s, patterns=%s, recursive=%s)…",
@@ -184,36 +278,43 @@ class FileMonitor:
             self._patterns,
             self._recursive,
         )
-        iterator = self._watch_dir.rglob("*") if self._recursive else self._watch_dir.iterdir()
+        dedup_index = self._load_dedup_index()
         total = 0
         queued = 0
         skipped = 0
-        for entry in iterator:
-            if not entry.is_file():
+        for entry in self._iter_dir_entries(self._watch_dir):
+            try:
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+            except OSError:
                 continue
-            if not any(fnmatch.fnmatch(entry.name, pat) for pat in self._patterns):
+            if not self._matches_name(entry.name):
                 continue
             total += 1
             try:
-                st = entry.stat()
+                # ``DirEntry.stat()`` is cached after the first call,
+                # so this and a subsequent ``entry.stat()`` in
+                # ``_enqueue`` (via ``stat_result=st`` below) share the
+                # same syscall.
+                st = entry.stat(follow_symlinks=False)
             except OSError:
                 continue
+            entry_path = Path(entry.path)
             try:
-                rel_path = entry.relative_to(self._watch_dir).as_posix()
+                rel_path = entry_path.relative_to(self._watch_dir).as_posix()
             except ValueError:
                 # Symlinks or oddities outside the watch dir: fall back to
                 # basename so the lookup degrades gracefully instead of
                 # raising.
                 rel_path = entry.name
-            if self._state_db.has_stat_match(
-                rel_path, st.st_size, st.st_mtime
-            ) or self._state_db.has_detected_stat_match(rel_path, st.st_size, st.st_mtime):
+            if _stat_in_dedup_index(dedup_index, rel_path, st.st_size, st.st_mtime):
                 skipped += 1
                 continue
             # Pass `st` through so `_enqueue` doesn't issue a redundant
-            # stat() syscall — halves the stat cost on initial scans of
-            # large directories.
-            self._enqueue(entry, stat_result=st)
+            # stat() syscall. ``DirEntry.stat()`` returns the same
+            # ``os.stat_result`` shape as ``Path.stat()`` so the call
+            # site doesn't care which producer it came from.
+            self._enqueue(entry_path, stat_result=st)
             queued += 1
             if total % 100 == 0:
                 logger.info(
@@ -324,3 +425,26 @@ class FileMonitor:
                         path=str(path),
                         error=str(exc),
                     )
+
+
+def _stat_in_dedup_index(
+    index: dict[str, list[tuple[int, float]]],
+    relative_path: str,
+    size_bytes: int,
+    mtime: float,
+) -> bool:
+    """Return True if *index* contains a matching ``(size, mtime)`` for *relative_path*.
+
+    Mirrors the ``ABS(mtime - ?) < 1.0`` tolerance that
+    :meth:`StateDB.has_stat_match` and
+    :meth:`StateDB.has_detected_stat_match` apply in SQL so the bulk
+    lookup behaves identically to the per-row helpers it replaces in
+    the initial-scan hot path.
+    """
+    candidates = index.get(relative_path)
+    if not candidates:
+        return False
+    for cand_size, cand_mtime in candidates:
+        if cand_size == size_bytes and abs(cand_mtime - mtime) < _STAT_MTIME_TOLERANCE:
+            return True
+    return False

--- a/watcher/src/data_hub_watcher/runtime.py
+++ b/watcher/src/data_hub_watcher/runtime.py
@@ -253,6 +253,9 @@ def build_runtime(
         instrument_id=inst.id,
         watcher_id=watcher_id,
         watch_directory=inst.watch_directory,
+        # Per-instrument knob, defaulted on the model so older configs
+        # transparently inherit the new parallel-upload behaviour.
+        upload_parallelism=inst.upload_parallelism,
     )
 
     detector = RunDetector(

--- a/watcher/src/data_hub_watcher/state.py
+++ b/watcher/src/data_hub_watcher/state.py
@@ -2,14 +2,31 @@
 
 Stores which files have been uploaded (for dedup) and which runs have
 been reported (for crash recovery).  Uses WAL mode for safe concurrent
-reads from the heartbeat thread.
+reads from background threads without blocking writes.
+
+Threading model
+---------------
+Each thread that touches the database gets its own
+:class:`sqlite3.Connection` lazily on first access. SQLite is
+fully thread-safe per connection but a single connection cannot be
+shared across threads without serialising every call -- which is what
+the previous process-wide ``threading.Lock`` was doing and what was
+defeating WAL mode for parallel readers (and, with the upcoming
+parallel uploader pool, parallel writers too).
+
+Reads run unlocked: WAL lets multiple readers proceed against the
+last-committed snapshot while a writer is in progress. Writes take
+``_write_lock`` so only one Python thread at a time issues an
+``INSERT/UPDATE/DELETE`` -- combined with ``PRAGMA busy_timeout`` this
+gives us cooperative serialisation without ever surfacing
+``database is locked`` to callers.
 """
 
 from __future__ import annotations
 import logging
 import sqlite3
 import threading
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -50,73 +67,138 @@ class StateDB:
 
     def __init__(self, db_path: Path) -> None:
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        # check_same_thread=False is required because the heartbeat and
-        # stability-checker threads also read from this DB.
-        self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
-        # WAL mode allows concurrent reads from background threads while
-        # the main thread writes, without blocking.
-        self._conn.execute("PRAGMA journal_mode=WAL")
-        self._conn.execute("PRAGMA synchronous=NORMAL")
-        self._lock = threading.Lock()
+        self._db_path = db_path
+        # Per-thread connection storage. Each thread that calls into this
+        # StateDB gets its own sqlite3 handle the first time it touches
+        # the ``_conn`` property (see below). Sharing a single handle
+        # across threads serialises every call on Python's lock and
+        # nullifies WAL's concurrent-read benefit.
+        self._local = threading.local()
+        # All opened connections, so ``close()`` can reach handles that
+        # belong to threads other than the closer.
+        self._connections: list[sqlite3.Connection] = []
+        self._connections_lock = threading.Lock()
+        # Serialises concurrent writers from this Python process so we
+        # never surface ``database is locked`` to callers. SQLite itself
+        # only allows one writer at a time; this lock just makes the
+        # contention happen in user space (cheap) instead of at the
+        # SQLite layer (busy-wait + retry storms).
+        self._write_lock = threading.Lock()
+        # Eagerly materialise the main-thread connection so DDL runs
+        # exactly once at construction time -- subsequent worker threads
+        # see the schema already in place when they open their handles.
         self._create_tables()
 
+    # ------------------------------------------------------------------
+    # connection plumbing
+    # ------------------------------------------------------------------
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        """Return the current thread's sqlite3 connection, opening one if needed.
+
+        Exposed as a property (rather than a private helper) so existing
+        callers and tests that historically reached for ``state_db._conn``
+        keep working unchanged. The underlying handle is now per-thread,
+        which is the behavioural difference -- but every call site only
+        used it on the main thread, so the change is invisible.
+        """
+        conn = getattr(self._local, "conn", None)
+        if conn is not None:
+            return conn
+
+        # ``check_same_thread=False`` is no longer strictly needed (each
+        # connection is used by exactly one thread) but keeping it set
+        # tolerates the rare test that constructs a StateDB on the main
+        # thread and immediately uses its handle from a child thread
+        # before the child has triggered its own lazy init.
+        conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+        # WAL is a database-file property and persists once enabled, but
+        # the other PRAGMAs are per-connection and have to be set on
+        # every handle.
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        # 64 MiB page cache (negative => kibibytes) and a 256 MiB mmap
+        # window. On lab PCs with millions of historical upload rows,
+        # these turn the bulk-load scans (``iter_uploaded_stat_keys`` /
+        # ``iter_detected_stat_keys``) into mostly in-memory work.
+        conn.execute("PRAGMA cache_size=-65536")
+        conn.execute("PRAGMA temp_store=MEMORY")
+        conn.execute("PRAGMA mmap_size=268435456")
+        # If two writer threads race, the loser waits up to 5 s for the
+        # winner's transaction to commit instead of immediately raising
+        # ``database is locked``. Combined with ``_write_lock`` above
+        # this is belt-and-suspenders -- the lock makes contention
+        # cooperative; ``busy_timeout`` covers the case where a worker
+        # bypasses the lock (e.g. via the ``_conn`` property in a test).
+        conn.execute("PRAGMA busy_timeout=5000")
+
+        self._local.conn = conn
+        with self._connections_lock:
+            self._connections.append(conn)
+        return conn
+
     def _create_tables(self) -> None:
-        self._conn.executescript(
-            """
-            CREATE TABLE IF NOT EXISTS uploaded_files (
-                filename   TEXT NOT NULL,
-                sha256     TEXT NOT NULL,
-                uploaded_at TEXT NOT NULL,
-                s3_key     TEXT NOT NULL,
-                PRIMARY KEY (filename, sha256, s3_key)
-            );
+        with self._write_lock:
+            self._conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS uploaded_files (
+                    filename   TEXT NOT NULL,
+                    sha256     TEXT NOT NULL,
+                    uploaded_at TEXT NOT NULL,
+                    s3_key     TEXT NOT NULL,
+                    PRIMARY KEY (filename, sha256, s3_key)
+                );
 
-            CREATE TABLE IF NOT EXISTS runs (
-                run_id      TEXT PRIMARY KEY,
-                reported_at TEXT NOT NULL,
-                uploaded_at TEXT
-            );
+                CREATE TABLE IF NOT EXISTS runs (
+                    run_id      TEXT PRIMARY KEY,
+                    reported_at TEXT NOT NULL,
+                    uploaded_at TEXT
+                );
 
-            CREATE TABLE IF NOT EXISTS detected_files (
-                run_id        TEXT NOT NULL,
-                relative_path TEXT NOT NULL,
-                filename      TEXT NOT NULL,
-                size_bytes    INTEGER NOT NULL,
-                mtime         REAL NOT NULL,
-                PRIMARY KEY (run_id, relative_path)
-            );
+                CREATE TABLE IF NOT EXISTS detected_files (
+                    run_id        TEXT NOT NULL,
+                    relative_path TEXT NOT NULL,
+                    filename      TEXT NOT NULL,
+                    size_bytes    INTEGER NOT NULL,
+                    mtime         REAL NOT NULL,
+                    PRIMARY KEY (run_id, relative_path)
+                );
 
-            CREATE INDEX IF NOT EXISTS idx_detected_files_stat
-                ON detected_files (relative_path, size_bytes, mtime);
-            """
-        )
-        # Additive migration: older state DBs predate the stat-based initial
-        # scan and have no size/mtime/relative_path columns. Add them as
-        # nullable so legacy rows remain valid; has_stat_match simply misses
-        # them and the scan falls back to enqueuing (uploader-side dedup
-        # prevents re-upload).
-        #
-        # relative_path is keyed instead of just `filename` so same-named
-        # files in different subdirectories (common in recursive watches)
-        # don't collide on the cheap stat check.
-        cols = {row[1] for row in self._conn.execute("PRAGMA table_info(uploaded_files)")}
-        if "size_bytes" not in cols:
-            self._conn.execute("ALTER TABLE uploaded_files ADD COLUMN size_bytes INTEGER")
-        if "mtime" not in cols:
-            self._conn.execute("ALTER TABLE uploaded_files ADD COLUMN mtime REAL")
-        if "relative_path" not in cols:
-            self._conn.execute("ALTER TABLE uploaded_files ADD COLUMN relative_path TEXT")
-        self._conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_uploaded_files_stat "
-            "ON uploaded_files (relative_path, size_bytes, mtime)"
-        )
-        # detected_files predates the file_created_at column; add it as
-        # nullable so legacy rows survive the migration. New rows always
-        # populate it (record_detected_files passes the value through).
-        detected_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(detected_files)")}
-        if "file_created_at" not in detected_cols:
-            self._conn.execute("ALTER TABLE detected_files ADD COLUMN file_created_at REAL")
-        self._conn.commit()
+                CREATE INDEX IF NOT EXISTS idx_detected_files_stat
+                    ON detected_files (relative_path, size_bytes, mtime);
+                """
+            )
+            # Additive migration: older state DBs predate the stat-based
+            # initial scan and have no size/mtime/relative_path columns.
+            # Add them as nullable so legacy rows remain valid;
+            # has_stat_match simply misses them and the scan falls back
+            # to enqueuing (uploader-side dedup prevents re-upload).
+            #
+            # relative_path is keyed instead of just `filename` so
+            # same-named files in different subdirectories (common in
+            # recursive watches) don't collide on the cheap stat check.
+            cols = {row[1] for row in self._conn.execute("PRAGMA table_info(uploaded_files)")}
+            if "size_bytes" not in cols:
+                self._conn.execute("ALTER TABLE uploaded_files ADD COLUMN size_bytes INTEGER")
+            if "mtime" not in cols:
+                self._conn.execute("ALTER TABLE uploaded_files ADD COLUMN mtime REAL")
+            if "relative_path" not in cols:
+                self._conn.execute("ALTER TABLE uploaded_files ADD COLUMN relative_path TEXT")
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_uploaded_files_stat "
+                "ON uploaded_files (relative_path, size_bytes, mtime)"
+            )
+            # detected_files predates the file_created_at column; add it
+            # as nullable so legacy rows survive the migration. New rows
+            # always populate it (record_detected_files passes the value
+            # through).
+            detected_cols = {
+                row[1] for row in self._conn.execute("PRAGMA table_info(detected_files)")
+            }
+            if "file_created_at" not in detected_cols:
+                self._conn.execute("ALTER TABLE detected_files ADD COLUMN file_created_at REAL")
+            self._conn.commit()
 
     # ------------------------------------------------------------------
     # uploaded_files
@@ -125,7 +207,7 @@ class StateDB:
     def prune_uploaded_files(self, days: int = 90) -> int:
         """Delete upload records older than *days*. Returns rows removed."""
         cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
-        with self._lock:
+        with self._write_lock:
             cur = self._conn.execute("DELETE FROM uploaded_files WHERE uploaded_at < ?", (cutoff,))
             self._conn.commit()
         removed = cur.rowcount
@@ -140,12 +222,11 @@ class StateDB:
         be uploaded to different S3 destinations (e.g. different runs that
         produce identically-named output files).
         """
-        with self._lock:
-            cur = self._conn.execute(
-                "SELECT 1 FROM uploaded_files WHERE filename = ? AND sha256 = ? AND s3_key = ?",
-                (filename, sha256, s3_key),
-            )
-            return cur.fetchone() is not None
+        cur = self._conn.execute(
+            "SELECT 1 FROM uploaded_files WHERE filename = ? AND sha256 = ? AND s3_key = ?",
+            (filename, sha256, s3_key),
+        )
+        return cur.fetchone() is not None
 
     def has_stat_match(self, relative_path: str, size_bytes: int, mtime: float) -> bool:
         """Cheap identity check for the initial scan.
@@ -158,15 +239,39 @@ class StateDB:
         The mtime comparison uses a ~1s tolerance to absorb filesystem
         timestamp resolution differences (FAT = 2s, NTFS = 100ns, ext4 = ns)
         and minor float rounding between Python versions / platforms.
+
+        Production hot paths (notably ``FileMonitor._initial_scan``)
+        use :meth:`iter_uploaded_stat_keys` to bulk-load every key in a
+        single ``SELECT`` and check membership in Python -- one query
+        for the whole scan instead of one per file. This per-row
+        helper remains for ad-hoc lookups and for the
+        ``test_monitor_initial_scan`` unit suite that drives it
+        directly.
         """
-        with self._lock:
-            cur = self._conn.execute(
-                "SELECT 1 FROM uploaded_files "
-                "WHERE relative_path = ? AND size_bytes = ? AND ABS(mtime - ?) < 1.0 "
-                "LIMIT 1",
-                (relative_path, size_bytes, mtime),
-            )
-            return cur.fetchone() is not None
+        cur = self._conn.execute(
+            "SELECT 1 FROM uploaded_files "
+            "WHERE relative_path = ? AND size_bytes = ? AND ABS(mtime - ?) < 1.0 "
+            "LIMIT 1",
+            (relative_path, size_bytes, mtime),
+        )
+        return cur.fetchone() is not None
+
+    def iter_uploaded_stat_keys(self) -> Iterator[tuple[str, int, float]]:
+        """Yield ``(relative_path, size_bytes, mtime)`` for every upload row.
+
+        Bulk-load helper used by :meth:`FileMonitor._initial_scan` so
+        the scan can build an in-memory dedup index in a single SQL
+        round trip rather than issuing one ``SELECT`` per scanned file.
+        Legacy rows that predate the stat columns (any of the three
+        being NULL) are filtered out -- they would never match the
+        scan's tolerance check anyway.
+        """
+        cur = self._conn.execute(
+            "SELECT relative_path, size_bytes, mtime FROM uploaded_files "
+            "WHERE relative_path IS NOT NULL AND size_bytes IS NOT NULL AND mtime IS NOT NULL"
+        )
+        for row in cur:
+            yield row[0], row[1], row[2]
 
     def record_upload(
         self,
@@ -179,7 +284,7 @@ class StateDB:
         mtime: float,
     ) -> None:
         now = datetime.now(timezone.utc).isoformat()
-        with self._lock:
+        with self._write_lock:
             self._conn.execute(
                 "INSERT OR REPLACE INTO uploaded_files "
                 "(filename, sha256, uploaded_at, s3_key, relative_path, size_bytes, mtime) "
@@ -211,7 +316,7 @@ class StateDB:
         ]
         if not rows:
             return
-        with self._lock:
+        with self._write_lock:
             self._conn.executemany(
                 "INSERT OR REPLACE INTO detected_files "
                 "(run_id, relative_path, filename, size_bytes, mtime, file_created_at) "
@@ -229,26 +334,42 @@ class StateDB:
         uploaded yet (manual mode).
 
         Uses the same ~1s mtime tolerance as `has_stat_match` for
-        consistency across filesystem timestamp resolutions.
+        consistency across filesystem timestamp resolutions. As with
+        ``has_stat_match``, the production initial-scan path uses
+        :meth:`iter_detected_stat_keys` to bulk-load instead of calling
+        this per file.
         """
-        with self._lock:
-            cur = self._conn.execute(
-                "SELECT 1 FROM detected_files "
-                "WHERE relative_path = ? AND size_bytes = ? AND ABS(mtime - ?) < 1.0 "
-                "LIMIT 1",
-                (relative_path, size_bytes, mtime),
-            )
-            return cur.fetchone() is not None
+        cur = self._conn.execute(
+            "SELECT 1 FROM detected_files "
+            "WHERE relative_path = ? AND size_bytes = ? AND ABS(mtime - ?) < 1.0 "
+            "LIMIT 1",
+            (relative_path, size_bytes, mtime),
+        )
+        return cur.fetchone() is not None
+
+    def iter_detected_stat_keys(self) -> Iterator[tuple[str, int, float]]:
+        """Yield ``(relative_path, size_bytes, mtime)`` for every detected-file row.
+
+        Bulk-load counterpart to :meth:`iter_uploaded_stat_keys` for the
+        ``detected_files`` table. Excludes rows with NULL stat columns
+        (none should exist today, but the guard keeps the helper safe
+        if a future migration introduces them).
+        """
+        cur = self._conn.execute(
+            "SELECT relative_path, size_bytes, mtime FROM detected_files "
+            "WHERE relative_path IS NOT NULL AND size_bytes IS NOT NULL AND mtime IS NOT NULL"
+        )
+        for row in cur:
+            yield row[0], row[1], row[2]
 
     def get_detected_files_for_run(self, run_id: str) -> list[DetectedFileRecord]:
         """Return the persisted file manifest for *run_id*, ordered by path."""
-        with self._lock:
-            cur = self._conn.execute(
-                "SELECT relative_path, filename, size_bytes, mtime, file_created_at "
-                "FROM detected_files WHERE run_id = ? ORDER BY relative_path",
-                (run_id,),
-            )
-            rows = cur.fetchall()
+        cur = self._conn.execute(
+            "SELECT relative_path, filename, size_bytes, mtime, file_created_at "
+            "FROM detected_files WHERE run_id = ? ORDER BY relative_path",
+            (run_id,),
+        )
+        rows = cur.fetchall()
         return [
             DetectedFileRecord(
                 relative_path=row[0],
@@ -269,21 +390,19 @@ class StateDB:
         after which their manifest will be recorded and future restarts
         will skip them.
         """
-        with self._lock:
-            cur = self._conn.execute("SELECT DISTINCT run_id FROM detected_files ORDER BY run_id")
-            return [row[0] for row in cur.fetchall()]
+        cur = self._conn.execute("SELECT DISTINCT run_id FROM detected_files ORDER BY run_id")
+        return [row[0] for row in cur.fetchall()]
 
     # ------------------------------------------------------------------
     # runs
     # ------------------------------------------------------------------
 
     def get_run(self, run_id: str) -> RunRecord | None:
-        with self._lock:
-            cur = self._conn.execute(
-                "SELECT run_id, reported_at, uploaded_at FROM runs WHERE run_id = ?",
-                (run_id,),
-            )
-            row = cur.fetchone()
+        cur = self._conn.execute(
+            "SELECT run_id, reported_at, uploaded_at FROM runs WHERE run_id = ?",
+            (run_id,),
+        )
+        row = cur.fetchone()
         if row is None:
             return None
         return RunRecord(run_id=row[0], reported_at=row[1], uploaded_at=row[2])
@@ -295,7 +414,7 @@ class StateDB:
         (e.g. a retry after a previous partial failure).
         """
         now = datetime.now(timezone.utc).isoformat()
-        with self._lock:
+        with self._write_lock:
             self._conn.execute(
                 "INSERT OR REPLACE INTO runs (run_id, reported_at, uploaded_at) "
                 "VALUES (?, ?, (SELECT uploaded_at FROM runs WHERE run_id = ?))",
@@ -310,16 +429,15 @@ class StateDB:
         window: we don't want to take down the watcher in the middle of
         an actively-running experiment.
         """
-        with self._lock:
-            cur = self._conn.execute("SELECT MAX(reported_at) FROM runs")
-            row = cur.fetchone()
+        cur = self._conn.execute("SELECT MAX(reported_at) FROM runs")
+        row = cur.fetchone()
         if row is None or row[0] is None:
             return None
         return str(row[0])
 
     def record_run_uploaded(self, run_id: str) -> None:
         now = datetime.now(timezone.utc).isoformat()
-        with self._lock:
+        with self._write_lock:
             self._conn.execute(
                 "UPDATE runs SET uploaded_at = ? WHERE run_id = ?",
                 (now, run_id),
@@ -331,5 +449,29 @@ class StateDB:
     # ------------------------------------------------------------------
 
     def close(self) -> None:
-        with self._lock:
-            self._conn.close()
+        """Close every per-thread sqlite3 handle opened by this StateDB.
+
+        Safe to call from any thread: we snapshot the connection list
+        under ``_connections_lock`` and close each one outside the
+        lock. Connections opened after this call (e.g. a stray late
+        write attempt) will simply re-open against the file -- there
+        is no "is closed" flag because the watcher's shutdown sequence
+        guarantees the runtime threads have already joined before
+        ``close()`` runs.
+        """
+        with self._connections_lock:
+            conns = list(self._connections)
+            self._connections.clear()
+        for conn in conns:
+            try:
+                conn.close()
+            except sqlite3.Error as exc:
+                # A best-effort close: if a connection is already closed
+                # or in a bad state, log and move on so we still close
+                # the rest. Re-raising would leave handles dangling.
+                logger.warning("Error closing StateDB connection: %s", exc)
+        # Drop the thread-local handle so any subsequent _conn access
+        # from this thread re-initialises rather than reusing a closed
+        # connection.
+        if hasattr(self._local, "conn"):
+            del self._local.conn

--- a/watcher/src/data_hub_watcher/state.py
+++ b/watcher/src/data_hub_watcher/state.py
@@ -26,12 +26,32 @@ from __future__ import annotations
 import logging
 import sqlite3
 import threading
+import weakref
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+class _PerThreadHandle:
+    """Owns a single ``sqlite3.Connection`` for the thread that opened it.
+
+    Stored only in :class:`threading.local` so the holder is reachable
+    exclusively through the owning thread's per-thread storage. When
+    that thread terminates CPython clears its slice of the
+    ``threading.local`` dict, drops the last strong reference to the
+    holder, and the :func:`weakref.finalize` registered against it by
+    :meth:`StateDB._conn` fires -- closing the connection and removing
+    it from :attr:`StateDB._connections` so short-lived upload workers
+    don't accumulate sqlite handles for the lifetime of the watcher.
+    """
+
+    __slots__ = ("conn", "__weakref__")
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self.conn = conn
 
 
 @dataclass
@@ -74,9 +94,14 @@ class StateDB:
         # across threads serialises every call on Python's lock and
         # nullifies WAL's concurrent-read benefit.
         self._local = threading.local()
-        # All opened connections, so ``close()`` can reach handles that
-        # belong to threads other than the closer.
-        self._connections: list[sqlite3.Connection] = []
+        # Live per-thread connections, used so ``close()`` can reach
+        # handles that belong to threads other than the closer. Stored
+        # as a ``set`` (not a list) for O(1) removal by the per-thread
+        # weakref finaliser when an upload-worker thread dies; without
+        # that pruning, every short-lived ThreadPoolExecutor worker
+        # would leak an open sqlite handle for the lifetime of the
+        # watcher process.
+        self._connections: set[sqlite3.Connection] = set()
         self._connections_lock = threading.Lock()
         # Serialises concurrent writers from this Python process so we
         # never surface ``database is locked`` to callers. SQLite itself
@@ -103,9 +128,9 @@ class StateDB:
         which is the behavioural difference -- but every call site only
         used it on the main thread, so the change is invisible.
         """
-        conn = getattr(self._local, "conn", None)
-        if conn is not None:
-            return conn
+        holder = getattr(self._local, "holder", None)
+        if holder is not None:
+            return holder.conn
 
         # ``check_same_thread=False`` is no longer strictly needed (each
         # connection is used by exactly one thread) but keeping it set
@@ -133,10 +158,43 @@ class StateDB:
         # bypasses the lock (e.g. via the ``_conn`` property in a test).
         conn.execute("PRAGMA busy_timeout=5000")
 
-        self._local.conn = conn
+        # Hold the handle behind a per-thread wrapper so the finaliser
+        # registered just below has something to watch other than the
+        # connection itself -- registering finalize() on the connection
+        # would race with ``sqlite3.Connection.__del__`` and confuse the
+        # "already-closed" detection.
+        holder = _PerThreadHandle(conn)
+        self._local.holder = holder
         with self._connections_lock:
-            self._connections.append(conn)
+            self._connections.add(conn)
+        # When this thread terminates, CPython clears the per-thread
+        # slice of ``self._local``, the holder loses its last strong
+        # reference, and this finaliser closes the connection and
+        # removes it from ``_connections``. The result: an upload
+        # ThreadPoolExecutor that spawns -> dies -> spawns again on
+        # every batch no longer accumulates a sqlite handle per worker
+        # per batch for the watcher's lifetime.
+        weakref.finalize(holder, self._reap_connection, conn)
         return conn
+
+    def _reap_connection(self, conn: sqlite3.Connection) -> None:
+        """Drop *conn* from the live set and best-effort close it.
+
+        Invoked from a :func:`weakref.finalize` callback when the
+        owning thread's :class:`threading.local` storage is reclaimed.
+        Idempotent against an explicit :meth:`close` -- if the
+        connection has already been closed there, ``conn.close()`` is
+        a no-op and the ``discard`` simply finds nothing to remove.
+        """
+        with self._connections_lock:
+            self._connections.discard(conn)
+        try:
+            conn.close()
+        except sqlite3.Error:
+            # Already closed (e.g. close() ran first) or otherwise in a
+            # bad state. We've removed it from the live set so there is
+            # nothing left to clean up.
+            pass
 
     def _create_tables(self) -> None:
         with self._write_lock:
@@ -451,7 +509,7 @@ class StateDB:
     def close(self) -> None:
         """Close every per-thread sqlite3 handle opened by this StateDB.
 
-        Safe to call from any thread: we snapshot the connection list
+        Safe to call from any thread: we snapshot the connection set
         under ``_connections_lock`` and close each one outside the
         lock. Connections opened after this call (e.g. a stray late
         write attempt) will simply re-open against the file -- there
@@ -470,8 +528,10 @@ class StateDB:
                 # or in a bad state, log and move on so we still close
                 # the rest. Re-raising would leave handles dangling.
                 logger.warning("Error closing StateDB connection: %s", exc)
-        # Drop the thread-local handle so any subsequent _conn access
+        # Drop the thread-local holder so any subsequent _conn access
         # from this thread re-initialises rather than reusing a closed
-        # connection.
-        if hasattr(self._local, "conn"):
-            del self._local.conn
+        # connection. The other threads' holders (and their dead
+        # connections) are reaped lazily by the per-thread finaliser
+        # registered in ``_conn``.
+        if hasattr(self._local, "holder"):
+            del self._local.holder

--- a/watcher/src/data_hub_watcher/uploader.py
+++ b/watcher/src/data_hub_watcher/uploader.py
@@ -10,7 +10,9 @@ watcher does not need AWS credentials.
 from __future__ import annotations
 import logging
 import mimetypes
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor, wait
 from pathlib import Path
 
 import requests as http_requests
@@ -66,6 +68,13 @@ class Uploader:
         Watcher identity for queue polling.
     watch_directory:
         Root watch directory for resolving relative paths in queue mode.
+    upload_parallelism:
+        Maximum number of files to upload concurrently within a single
+        :meth:`upload_files` batch. Defaults to 1 (fully serial) so
+        unit tests and call sites that don't pass an explicit value
+        keep their previous behaviour. Production wiring (see
+        ``runtime.build_runtime``) reads this from the per-instrument
+        config.
     """
 
     def __init__(
@@ -78,6 +87,7 @@ class Uploader:
         instrument_id: str,
         watcher_id: str,
         watch_directory: Path,
+        upload_parallelism: int = 1,
     ) -> None:
         self._client = client
         self._state_db = state_db
@@ -86,12 +96,33 @@ class Uploader:
         self._instrument_id = instrument_id
         self._watcher_id = watcher_id
         self._watch_dir = watch_directory
+        if upload_parallelism < 1:
+            raise ValueError(f"upload_parallelism must be >= 1, got {upload_parallelism}")
+        self._parallelism = upload_parallelism
         # Track consecutive upload-queue poll failures so the watcher
         # surfaces a ``kind=upload_queue_poll_failed`` event on the
         # 1st failure and every 10th repeat. The unthrottled case
         # would emit one event per heartbeat tick during an outage,
         # crowding out other signals on the dashboard.
+        # Mutated only from the heartbeat thread (manual mode), so
+        # not under any explicit lock.
         self._consecutive_queue_poll_failures = 0
+        # Single ``requests.Session`` shared across every S3 PUT
+        # (parallel or serial). Keeps TLS connections alive between
+        # presigned URLs that target the same S3 bucket -- avoids
+        # paying the handshake cost on every file in a multi-file
+        # run. ``requests.Session`` is documented as thread-safe for
+        # concurrent ``put`` calls; the urllib3 connection pool
+        # underneath grows on demand up to ``pool_maxsize`` which we
+        # let default (10).
+        self._s3_session = http_requests.Session()
+        # Counter mutations from upload worker threads are protected
+        # by the GIL on the underlying ``int`` increment, but use an
+        # explicit lock anyway so we can later move to ``threading.
+        # Lock``-free atomics or ``itertools.count`` without a behaviour
+        # change. Cheap enough at the per-file cadence that the
+        # serialisation cost is negligible.
+        self._counters_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # Auto-mode: upload a batch of files for a reported run
@@ -102,11 +133,47 @@ class Uploader:
 
         Called by `RunDetector` immediately after a successful run report
         (auto mode only).  Returns the number of files successfully uploaded.
+
+        When ``upload_parallelism > 1`` the per-file
+        :meth:`_upload_single` calls run in a short-lived
+        :class:`~concurrent.futures.ThreadPoolExecutor`. The pool is
+        scoped to a single batch (created and torn down per call) so
+        idle worker threads don't outlive the run -- watcher hosts are
+        long-lived and an always-on pool would just be holding socket
+        FDs and Python frames around for nothing between runs.
         """
-        succeeded = 0
-        for info in files:
-            if self._upload_single(info.path, run_id):
-                succeeded += 1
+        if not files:
+            # Avoid spinning up a pool for a (rare) empty manifest;
+            # also preserves the existing "succeeded == len(files)"
+            # check below which would mark the run uploaded with
+            # zero work.
+            self._state_db.record_run_uploaded(run_id)
+            return 0
+
+        # Upper-bound parallelism by the actual file count so a small
+        # batch doesn't allocate more threads than it can use.
+        max_workers = min(self._parallelism, len(files))
+
+        if max_workers <= 1:
+            # Fast path: avoid the pool's overhead (thread spin-up,
+            # ``Future`` wrapping) when there's nothing to parallelise.
+            # Behaviour-identical to the previous serial loop.
+            succeeded = sum(1 for info in files if self._upload_single(info.path, run_id))
+        else:
+            with ThreadPoolExecutor(
+                max_workers=max_workers,
+                thread_name_prefix="uploader",
+            ) as pool:
+                futures = [pool.submit(self._upload_single, info.path, run_id) for info in files]
+                # ``wait`` (rather than ``as_completed``) keeps the
+                # success count deterministic without caring about
+                # completion order. Any exception raised inside
+                # ``_upload_single`` would already have been caught
+                # and translated into a ``False`` return by the
+                # function's own error-handling, so we can safely
+                # treat ``future.result()`` as boolean.
+                wait(futures)
+                succeeded = sum(1 for f in futures if f.result())
 
         if succeeded == len(files):
             self._state_db.record_run_uploaded(run_id)
@@ -176,35 +243,70 @@ class Uploader:
     # Presigned PUT helper
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _put_to_presigned_url(url: str, path: Path, content_type: str | None) -> None:
-        """HTTP PUT a file's bytes to a presigned S3 URL."""
+    def _put_to_presigned_url(self, url: str, path: Path, content_type: str | None) -> None:
+        """HTTP PUT a file's bytes to a presigned S3 URL.
+
+        Reuses ``self._s3_session`` so successive PUTs to the same S3
+        bucket share TLS connections. Method (rather than static) so
+        the parallel-upload path inherits the session without each
+        call having to thread it through.
+        """
         headers: dict[str, str] = {}
         if content_type:
             headers["Content-Type"] = content_type
 
         with open(path, "rb") as fh:
-            resp = http_requests.put(url, data=fh, headers=headers, timeout=300)
+            resp = self._s3_session.put(url, data=fh, headers=headers, timeout=300)
         resp.raise_for_status()
 
     # ------------------------------------------------------------------
     # Single-file upload with retry
     # ------------------------------------------------------------------
 
+    def _bump_errors(self) -> None:
+        """Increment the shared error counter under ``_counters_lock``.
+
+        Centralised so worker threads inside the parallel-upload pool
+        never race the heartbeat thread reading these values for its
+        per-tick payload.
+        """
+        with self._counters_lock:
+            self._counters.errors += 1
+
+    def _bump_files_uploaded(self) -> None:
+        """Increment the shared success counter under ``_counters_lock``."""
+        with self._counters_lock:
+            self._counters.files_uploaded += 1
+
     def _upload_single(self, path: Path, run_id: str) -> bool:
         """Upload one file via a presigned URL, notify the API, and record in StateDB.
 
         Returns `True` on success, `False` after all retries exhausted.
+
+        Concurrency note
+        ----------------
+        ``file_sha256(path)`` and ``client.request_upload_url(...)``
+        run on a tiny 2-thread pool so the (CPU+IO bound) hash and the
+        (network bound) presigned-URL request fully overlap. On a
+        multi-GiB instrument file with a slow API, this halves the
+        critical-path latency before the actual S3 PUT can start. The
+        pool is created per call -- short-lived overhead is dwarfed by
+        the time savings on any non-trivial file.
         """
         content_type = _guess_content_type(path)
-        sha = file_sha256(path)
         stat = path.stat()
         rel_path = _relative_path(path, self._watch_dir)
 
-        # Request a presigned upload URL from the API. This also creates or
-        # locates the server-side file record.
-        try:
-            presigned = self._client.request_upload_url(
+        # Kick off both the SHA-256 and the presigned-URL request in
+        # parallel. ``ThreadPoolExecutor(2)`` is plenty: hashing is
+        # CPU/IO with mostly-released GIL via hashlib's C
+        # implementation, and the request thread blocks on the
+        # network. Resolve both before branching so the rest of the
+        # method behaves exactly as the old serial version.
+        with ThreadPoolExecutor(max_workers=2, thread_name_prefix="upload-prep") as prep:
+            sha_future = prep.submit(file_sha256, path)
+            presign_future = prep.submit(
+                self._client.request_upload_url,
                 self._instrument_id,
                 run_id,
                 path.name,
@@ -212,17 +314,45 @@ class Uploader:
                 size_bytes=stat.st_size,
                 file_created_at_ts=file_created_at(stat),
             )
-        except ApiError as exc:
-            logger.error("Failed to get presigned URL for %s: %s", path.name, exc.message)
-            self._counters.errors += 1
-            self._reporter.queue_event(
-                WatcherEvent(
-                    event_type=EventType.UPLOAD_FAILED,
-                    message=f"Presigned URL request failed: {path.name}",
-                    details={"error": exc.message},
+
+            try:
+                presigned = presign_future.result()
+            except ApiError as exc:
+                # Wait for the hash to finish (cancellation is best-effort
+                # for already-running futures) before exiting the
+                # ``with`` block, otherwise the pool blocks on shutdown.
+                sha_future.cancel()
+                try:
+                    sha_future.result()
+                except Exception:
+                    pass
+                logger.error("Failed to get presigned URL for %s: %s", path.name, exc.message)
+                self._bump_errors()
+                self._reporter.queue_event(
+                    WatcherEvent(
+                        event_type=EventType.UPLOAD_FAILED,
+                        message=f"Presigned URL request failed: {path.name}",
+                        details={"error": exc.message},
+                    )
                 )
-            )
-            return False
+                return False
+
+            try:
+                sha = sha_future.result()
+            except Exception as exc:
+                # Hashing failed (e.g. the file vanished mid-stream).
+                # Treat as an upload failure so the file is retried
+                # rather than silently dropped.
+                logger.error("Failed to hash %s: %s", path.name, exc)
+                self._bump_errors()
+                self._reporter.queue_event(
+                    WatcherEvent(
+                        event_type=EventType.UPLOAD_FAILED,
+                        message=f"Hashing failed: {path.name}",
+                        details={"error": str(exc)},
+                    )
+                )
+                return False
 
         s3_key = presigned.s3_key
         s3_bucket = presigned.s3_bucket
@@ -274,7 +404,7 @@ class Uploader:
                     details={"s3_key": s3_key, "error": str(last_exc)},
                 )
             )
-            self._counters.errors += 1
+            self._bump_errors()
             return False
 
         # Notify API — treat a failed PATCH as an upload failure so the file
@@ -291,7 +421,7 @@ class Uploader:
             )
         except ApiError as exc:
             logger.error("PATCH /files/%d failed: %s", file_id, exc.message)
-            self._counters.errors += 1
+            self._bump_errors()
             self._reporter.queue_event(
                 WatcherEvent(
                     event_type=EventType.UPLOAD_FAILED,
@@ -309,7 +439,7 @@ class Uploader:
             size_bytes=stat.st_size,
             mtime=stat.st_mtime,
         )
-        self._counters.files_uploaded += 1
+        self._bump_files_uploaded()
         self._reporter.queue_event(
             WatcherEvent(
                 event_type=EventType.FILE_UPLOADED,

--- a/watcher/src/data_hub_watcher/uploader.py
+++ b/watcher/src/data_hub_watcher/uploader.py
@@ -16,6 +16,7 @@ from concurrent.futures import ThreadPoolExecutor, wait
 from pathlib import Path
 
 import requests as http_requests
+from requests.adapters import HTTPAdapter
 
 from data_hub_watcher.api_client import ApiError, DataHubClient
 from data_hub_watcher.constants import (
@@ -112,10 +113,27 @@ class Uploader:
         # presigned URLs that target the same S3 bucket -- avoids
         # paying the handshake cost on every file in a multi-file
         # run. ``requests.Session`` is documented as thread-safe for
-        # concurrent ``put`` calls; the urllib3 connection pool
-        # underneath grows on demand up to ``pool_maxsize`` which we
-        # let default (10).
+        # concurrent ``put`` calls.
         self._s3_session = http_requests.Session()
+        # Size the urllib3 pool to match ``upload_parallelism`` so we
+        # never trip the "Connection pool is full, discarding
+        # connection" warning that the default ``pool_maxsize=10``
+        # produces once parallelism exceeds 10 -- which the model
+        # explicitly allows (``ge=1, le=32``). Discarded connections
+        # defeat the keep-alive optimisation this session exists for.
+        # ``pool_connections`` controls the number of *host* pools;
+        # presigned S3 PUTs typically hit a single bucket-host so one
+        # is enough, but matching ``pool_maxsize`` is harmless and
+        # leaves room for cross-bucket fan-out if a future config does
+        # that. ``pool_block=False`` (the default) preserves the prior
+        # behaviour of spinning up a transient connection if the pool
+        # is momentarily exhausted instead of blocking the worker.
+        adapter = HTTPAdapter(
+            pool_connections=upload_parallelism,
+            pool_maxsize=upload_parallelism,
+        )
+        self._s3_session.mount("https://", adapter)
+        self._s3_session.mount("http://", adapter)
         # Counter mutations from upload worker threads are protected
         # by the GIL on the underlying ``int`` increment, but use an
         # explicit lock anyway so we can later move to ``threading.
@@ -200,7 +218,13 @@ class Uploader:
             queue = self._client.get_upload_queue(self._watcher_id)
         except ApiError as exc:
             logger.warning("Failed to fetch upload queue: %s", exc.message)
-            self._counters.errors += 1
+            # Route through the shared helper so every error increment
+            # (whether emitted from the heartbeat thread here or from
+            # an upload-pool worker in ``_upload_single``) goes through
+            # the same lock. Inconsistent locking would race the
+            # heartbeat reader against parallel-upload writers and
+            # surface as off-by-one error totals.
+            self._bump_errors()
             self._consecutive_queue_poll_failures += 1
             # Emit on first failure, then every 10th, so a sustained
             # outage stays visible without flooding the queue.
@@ -234,7 +258,7 @@ class Uploader:
                         details={"file_id": qf.id, "expected_path": str(local_path)},
                     )
                 )
-                self._counters.errors += 1
+                self._bump_errors()
                 continue
 
             self._upload_single(local_path, qf.run_id)

--- a/watcher/src/data_hub_watcher/util.py
+++ b/watcher/src/data_hub_watcher/util.py
@@ -9,17 +9,27 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 
+# 1 MiB read buffer for streamed hashing. The previous 8 KiB value
+# came from CPython's example in the hashlib docs and is fine for
+# small files, but instrument outputs are routinely multi-GiB and at
+# 8 KiB that's hundreds of thousands of ``read()`` syscalls per file.
+# 1 MiB cuts the syscall count by 128x and lets the kernel readahead
+# stream the file efficiently. Memory is bounded (one buffer
+# allocation per active hash), and on the parallel-upload path each
+# worker thread holds at most one buffer at a time.
+HASH_CHUNK_SIZE = 1 << 20
+
 
 def file_sha256(path: Path) -> str:
     """Return the hex SHA-256 digest of *path*.
 
-    Streams the file in 8 KiB chunks so we don't load multi-GiB
-    instrument outputs into memory. Lives here rather than next to the
-    uploader so callers don't have to import the full upload module
-    just to hash a file.
+    Streams the file in :data:`HASH_CHUNK_SIZE`-byte chunks so we don't
+    load multi-GiB instrument outputs into memory. Lives here rather
+    than next to the uploader so callers don't have to import the full
+    upload module just to hash a file.
     """
     h = hashlib.sha256()
     with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
+        for chunk in iter(lambda: f.read(HASH_CHUNK_SIZE), b""):
             h.update(chunk)
     return h.hexdigest()

--- a/watcher/tests/test_monitor_initial_scan.py
+++ b/watcher/tests/test_monitor_initial_scan.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from data_hub_watcher.monitor import FileMonitor
+from data_hub_watcher.monitor import FileMonitor, _stat_in_dedup_index
 from data_hub_watcher.state import StateDB
 
 
@@ -393,3 +393,177 @@ class TestDetectedFilesApi:
 
         assert ids == ["run-1", "run-2"]
         assert "run-legacy" not in ids
+
+
+class TestBulkLoadIterators:
+    """The new bulk-load helpers backing the rewritten initial scan.
+
+    These are what let the scan replace the old per-file
+    ``has_stat_match`` / ``has_detected_stat_match`` SELECTs with a
+    single SELECT per table. The scan-level test below proves we
+    actually use them; these tests pin down the iterator semantics
+    in isolation.
+    """
+
+    def test_iter_uploaded_stat_keys_excludes_legacy_rows(self, state_db: StateDB) -> None:
+        # Real row with stat columns populated.
+        state_db.record_upload(
+            "fresh.nd2",
+            "sha-fresh",
+            "s3/fresh.nd2",
+            relative_path="fresh.nd2",
+            size_bytes=1024,
+            mtime=1_700_000_000.0,
+        )
+        # Legacy row predating the stat columns -- relative_path is NULL.
+        # Bulk loaders must skip these so the in-memory dedup index
+        # never contains entries that can't possibly match a scanned file.
+        state_db._conn.execute(
+            "INSERT INTO uploaded_files (filename, sha256, uploaded_at, s3_key) "
+            "VALUES (?, ?, ?, ?)",
+            ("legacy.nd2", "sha-legacy", "2025-01-01T00:00:00+00:00", "s3/legacy.nd2"),
+        )
+        state_db._conn.commit()
+
+        keys = list(state_db.iter_uploaded_stat_keys())
+        assert keys == [("fresh.nd2", 1024, 1_700_000_000.0)]
+
+    def test_iter_detected_stat_keys_returns_all_present_rows(self, state_db: StateDB) -> None:
+        state_db.record_detected_files(
+            "run-1",
+            [
+                ("run-1/a.nd2", "a.nd2", 100, 1.0, None),
+                ("run-1/b.nd2", "b.nd2", 200, 2.0, None),
+            ],
+        )
+
+        keys = sorted(state_db.iter_detected_stat_keys())
+        assert keys == [("run-1/a.nd2", 100, 1.0), ("run-1/b.nd2", 200, 2.0)]
+
+
+class TestStatInDedupIndex:
+    """Pure-Python tolerance check used by the scan to skip dedup'd files."""
+
+    def test_exact_match(self) -> None:
+        index = {"a.nd2": [(1024, 1_700_000_000.0)]}
+        assert _stat_in_dedup_index(index, "a.nd2", 1024, 1_700_000_000.0) is True
+
+    def test_within_mtime_tolerance(self) -> None:
+        index = {"a.nd2": [(1024, 1_700_000_000.0)]}
+        assert _stat_in_dedup_index(index, "a.nd2", 1024, 1_700_000_000.5) is True
+
+    def test_outside_mtime_tolerance(self) -> None:
+        index = {"a.nd2": [(1024, 1_700_000_000.0)]}
+        assert _stat_in_dedup_index(index, "a.nd2", 1024, 1_700_000_100.0) is False
+
+    def test_size_mismatch(self) -> None:
+        index = {"a.nd2": [(1024, 1_700_000_000.0)]}
+        assert _stat_in_dedup_index(index, "a.nd2", 2048, 1_700_000_000.0) is False
+
+    def test_path_not_in_index(self) -> None:
+        index = {"a.nd2": [(1024, 1_700_000_000.0)]}
+        assert _stat_in_dedup_index(index, "b.nd2", 1024, 1_700_000_000.0) is False
+
+    def test_picks_correct_entry_among_multiple(self) -> None:
+        # Same relative path, different (size, mtime) tuples -- the
+        # uploaded_files PK is (filename, sha256, s3_key) so the same
+        # path can legitimately have multiple rows after a re-upload.
+        index = {
+            "a.nd2": [
+                (1024, 1_700_000_000.0),
+                (2048, 1_700_000_500.0),
+            ]
+        }
+        assert _stat_in_dedup_index(index, "a.nd2", 2048, 1_700_000_500.0) is True
+        assert _stat_in_dedup_index(index, "a.nd2", 4096, 1_700_000_500.0) is False
+
+
+class TestInitialScanBulkLoad:
+    """Regression guard: the rewritten scan must NOT issue per-file SELECTs.
+
+    The old loop ran ``has_stat_match`` and ``has_detected_stat_match``
+    once per file -- on a 50k-file lab tree that's 100k SQL round
+    trips through a process-wide lock. The rewrite replaces those with
+    one bulk SELECT per table via ``iter_*_stat_keys``.
+
+    We assert the new behaviour by counting how many times those
+    helpers are invoked across a 50-file scan. The number must be
+    exactly one each, regardless of how many files end up matching or
+    being enqueued.
+    """
+
+    def test_initial_scan_bulk_loads_exactly_once_per_table(
+        self, state_db: StateDB, watch_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for i in range(50):
+            (watch_dir / f"file-{i:03d}.nd2").write_bytes(b"x" * 64)
+
+        # Pre-populate dedup so half the files are skipped -- exercises
+        # both the "in index" and "not in index" branches without
+        # changing the per-table SELECT count.
+        for i in range(0, 50, 2):
+            f = watch_dir / f"file-{i:03d}.nd2"
+            st = f.stat()
+            state_db.record_upload(
+                f.name,
+                f"sha-{i}",
+                f"s3/{f.name}",
+                relative_path=f.name,
+                size_bytes=st.st_size,
+                mtime=st.st_mtime,
+            )
+
+        uploaded_calls = 0
+        detected_calls = 0
+        original_uploaded = state_db.iter_uploaded_stat_keys
+        original_detected = state_db.iter_detected_stat_keys
+
+        def counting_uploaded() -> object:
+            nonlocal uploaded_calls
+            uploaded_calls += 1
+            return original_uploaded()
+
+        def counting_detected() -> object:
+            nonlocal detected_calls
+            detected_calls += 1
+            return original_detected()
+
+        monkeypatch.setattr(state_db, "iter_uploaded_stat_keys", counting_uploaded)
+        monkeypatch.setattr(state_db, "iter_detected_stat_keys", counting_detected)
+
+        # The per-row helpers (``has_stat_match`` /
+        # ``has_detected_stat_match``) must not be touched by the scan
+        # any more -- if they are, our claim of "one SELECT per table"
+        # is a lie.
+        has_stat_calls = 0
+        has_detected_calls = 0
+        original_has_stat = state_db.has_stat_match
+        original_has_detected = state_db.has_detected_stat_match
+
+        def counting_has_stat(*args: object, **kwargs: object) -> bool:
+            nonlocal has_stat_calls
+            has_stat_calls += 1
+            return original_has_stat(*args, **kwargs)  # type: ignore[arg-type]
+
+        def counting_has_detected(*args: object, **kwargs: object) -> bool:
+            nonlocal has_detected_calls
+            has_detected_calls += 1
+            return original_has_detected(*args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(state_db, "has_stat_match", counting_has_stat)
+        monkeypatch.setattr(state_db, "has_detected_stat_match", counting_has_detected)
+
+        monitor = _make_monitor(watch_dir, state_db)
+        monitor._initial_scan()
+
+        assert uploaded_calls == 1, f"expected exactly one bulk SELECT, got {uploaded_calls}"
+        assert detected_calls == 1, f"expected exactly one bulk SELECT, got {detected_calls}"
+        assert has_stat_calls == 0, (
+            f"per-row has_stat_match must not be used in the scan, got {has_stat_calls}"
+        )
+        assert has_detected_calls == 0, (
+            f"per-row has_detected_stat_match must not be used, got {has_detected_calls}"
+        )
+        # And the actual scan output must still be correct: 25 enqueued,
+        # 25 skipped (every other file was pre-recorded above).
+        assert len(monitor._pending) == 25

--- a/watcher/tests/test_monitor_initial_scan.py
+++ b/watcher/tests/test_monitor_initial_scan.py
@@ -567,3 +567,116 @@ class TestInitialScanBulkLoad:
         # And the actual scan output must still be correct: 25 enqueued,
         # 25 skipped (every other file was pre-recorded above).
         assert len(monitor._pending) == 25
+
+
+class TestIterDirEntriesErrorLogging:
+    """Per-entry ``OSError`` surfaces in the log instead of being dropped.
+
+    The walker previously swallowed ``OSError`` from
+    ``entry.is_dir()`` silently, which meant a permission-denied
+    subdirectory was invisible to operators: the scan never descended
+    into it and there was no log line to explain why. The fix logs a
+    warning per failing entry.
+    """
+
+    def test_scandir_failure_is_logged(
+        self,
+        state_db: StateDB,
+        watch_dir: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Make ``os.scandir`` blow up on the watch directory so we hit
+        # the outer ``OSError`` branch. We restrict the failure to the
+        # exact path we care about so unrelated pytest internals
+        # (which also call scandir) keep working.
+        real_scandir = os.scandir
+
+        def failing_scandir(path: object) -> object:
+            if str(path) == str(watch_dir):
+                raise PermissionError(13, "Permission denied", str(watch_dir))
+            return real_scandir(path)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(os, "scandir", failing_scandir)
+
+        monitor = _make_monitor(watch_dir, state_db)
+        with caplog.at_level("WARNING", logger="data_hub_watcher.monitor"):
+            monitor._initial_scan()
+
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("scandir failed for" in m for m in msgs), (
+            f"Expected scandir-failure warning, got log records: {msgs}"
+        )
+
+    def test_is_dir_failure_is_logged_and_entry_skipped(
+        self,
+        state_db: StateDB,
+        watch_dir: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Create a real subdirectory inside ``watch_dir`` and rig the
+        # corresponding ``DirEntry.is_dir`` call to raise. We can't
+        # easily produce a real ``is_dir`` failure on a sane
+        # filesystem, so we wrap ``os.scandir`` to yield ``DirEntry``-
+        # alike objects that raise on ``is_dir()``.
+        bad_dir = watch_dir / "bad"
+        bad_dir.mkdir()
+        (watch_dir / "ok.nd2").write_bytes(b"x" * 8)
+
+        real_scandir = os.scandir
+
+        class _ExplodingEntry:
+            """Forwards everything to a real DirEntry except is_dir(), which raises."""
+
+            def __init__(self, real: os.DirEntry[str]) -> None:
+                self._real = real
+                self.name = real.name
+                self.path = real.path
+
+            def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+                raise PermissionError(13, "is_dir denied", self.path)
+
+            def is_file(self, *, follow_symlinks: bool = True) -> bool:
+                return self._real.is_file(follow_symlinks=follow_symlinks)
+
+            def stat(self, *, follow_symlinks: bool = True) -> os.stat_result:
+                return self._real.stat(follow_symlinks=follow_symlinks)
+
+        class _PatchedScandirContext:
+            def __init__(self, root: str) -> None:
+                self._it = real_scandir(root)
+
+            def __enter__(self) -> object:
+                return self
+
+            def __exit__(self, *exc: object) -> None:
+                self._it.__exit__(*exc)  # type: ignore[arg-type]
+
+            def __iter__(self) -> object:
+                return self
+
+            def __next__(self) -> object:
+                entry = next(self._it)
+                # Wrap only the bad subdirectory; everything else
+                # passes through untouched so ``ok.nd2`` still enqueues.
+                if entry.name == "bad":
+                    return _ExplodingEntry(entry)
+                return entry
+
+        def patched_scandir(path: object) -> object:
+            return _PatchedScandirContext(str(path))
+
+        monkeypatch.setattr(os, "scandir", patched_scandir)
+
+        monitor = _make_monitor(watch_dir, state_db, recursive=True)
+        with caplog.at_level("WARNING", logger="data_hub_watcher.monitor"):
+            monitor._initial_scan()
+
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("is_dir() failed for" in m for m in msgs), (
+            f"Expected is_dir-failure warning, got log records: {msgs}"
+        )
+        # And the healthy peer file at the same level must still
+        # enqueue -- one bad subdirectory must not abort the scan.
+        assert len(monitor._pending) == 1

--- a/watcher/tests/test_run_detection_config.py
+++ b/watcher/tests/test_run_detection_config.py
@@ -1,11 +1,19 @@
-"""Unit tests for ``RunDetectionConfig`` validation."""
+"""Unit tests for ``RunDetectionConfig`` validation.
+
+Also covers the ``InstrumentConfig.upload_parallelism`` field added
+alongside the parallel-upload optimisation -- it lives here rather
+than in its own file because the existing ``RunDetectionConfig``
+suite is the closest neighbour and the field is a small additive
+concern.
+"""
 
 from __future__ import annotations
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
 
-from data_hub_watcher.models import RunDetectionConfig
+from data_hub_watcher.models import InstrumentConfig, RunDetectionConfig
 
 
 class TestRunDetectionConfigValidation:
@@ -40,3 +48,55 @@ class TestRunDetectionConfigValidation:
     def test_non_capturing_groups_do_not_count(self) -> None:
         cfg = RunDetectionConfig(pattern=r"(?:^|/)(\d{8}_\d{6}_\d{3})/")
         assert cfg.pattern == r"(?:^|/)(\d{8}_\d{6}_\d{3})/"
+
+
+def _make_instrument(
+    tmp_path: Path,
+    *,
+    upload_parallelism: int | None = None,
+) -> InstrumentConfig:
+    watch_dir = tmp_path / "data"
+    watch_dir.mkdir()
+    (watch_dir / "RUN001_sample.csv").write_text("a,b\n1,2\n")
+    kwargs: dict[str, object] = {
+        "id": "test-instrument",
+        "watch_directory": watch_dir,
+        "file_patterns": ["*.csv"],
+        "run_detection": RunDetectionConfig(pattern=r"^([^_]+)", recursive=False),
+    }
+    if upload_parallelism is not None:
+        kwargs["upload_parallelism"] = upload_parallelism
+    return InstrumentConfig(**kwargs)  # type: ignore[arg-type]
+
+
+class TestUploadParallelism:
+    """Validation rules for ``InstrumentConfig.upload_parallelism``.
+
+    Defaulted so existing config YAMLs (which won't mention the
+    field) keep working unchanged. Bounded to a sensible range so a
+    typo can't accidentally spawn 10 000 worker threads on a lab PC.
+    """
+
+    def test_defaults_to_four(self, tmp_path: Path) -> None:
+        cfg = _make_instrument(tmp_path)
+        assert cfg.upload_parallelism == 4
+
+    def test_explicit_minimum_of_one(self, tmp_path: Path) -> None:
+        cfg = _make_instrument(tmp_path, upload_parallelism=1)
+        assert cfg.upload_parallelism == 1
+
+    def test_explicit_maximum_of_thirty_two(self, tmp_path: Path) -> None:
+        cfg = _make_instrument(tmp_path, upload_parallelism=32)
+        assert cfg.upload_parallelism == 32
+
+    def test_zero_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ValidationError, match="greater than or equal to 1"):
+            _make_instrument(tmp_path, upload_parallelism=0)
+
+    def test_negative_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ValidationError, match="greater than or equal to 1"):
+            _make_instrument(tmp_path, upload_parallelism=-3)
+
+    def test_above_cap_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ValidationError, match="less than or equal to 32"):
+            _make_instrument(tmp_path, upload_parallelism=64)

--- a/watcher/tests/test_state_db_concurrency.py
+++ b/watcher/tests/test_state_db_concurrency.py
@@ -1,0 +1,197 @@
+"""Concurrency tests for the thread-local ``StateDB`` connection model.
+
+The optimisation switches ``StateDB`` from a single ``sqlite3.Connection``
+guarded by a process-wide ``threading.Lock`` to per-thread lazy
+connections plus a write-only lock. This unlocks parallel uploaders
+(see ``Uploader.upload_files`` with ``upload_parallelism > 1``) but
+introduces real multi-threaded SQLite usage that the previous
+single-thread model masked.
+
+These tests pin down the new invariants:
+- Concurrent writers from many threads never raise
+  ``sqlite3.OperationalError("database is locked")``.
+- Reads can run concurrently with writes (WAL semantics).
+- The final row count after parallel inserts equals the number of
+  inserts attempted (no silent loss).
+- ``close()`` cleans up every thread's connection, including ones
+  opened by threads that no longer exist.
+"""
+
+from __future__ import annotations
+import sqlite3
+import threading
+from collections.abc import Generator
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import pytest
+
+from data_hub_watcher.state import StateDB
+
+
+@pytest.fixture()
+def state_db(tmp_path: Path) -> Generator[StateDB, None, None]:
+    db = StateDB(tmp_path / "concurrency.db")
+    yield db
+    db.close()
+
+
+class TestParallelWriters:
+    """Many threads writing to ``uploaded_files`` in parallel."""
+
+    def test_no_database_locked_errors_under_contention(self, state_db: StateDB) -> None:
+        """40 threads x 25 inserts each must complete without OperationalError.
+
+        Pre-thread-local-connections this would frequently raise
+        ``database is locked`` once the per-process ``_lock`` was
+        replaced by SQLite's own busy detection -- the
+        ``busy_timeout=5000`` PRAGMA + ``_write_lock`` together must
+        prevent that.
+        """
+        per_worker = 25
+        worker_count = 40
+
+        def worker(worker_id: int) -> int:
+            for i in range(per_worker):
+                state_db.record_upload(
+                    f"w{worker_id}-{i}.nd2",
+                    f"sha-{worker_id}-{i}",
+                    f"s3/w{worker_id}/{i}.nd2",
+                    relative_path=f"w{worker_id}/{i}.nd2",
+                    size_bytes=1024 + i,
+                    mtime=1_700_000_000.0 + worker_id,
+                )
+            return per_worker
+
+        with ThreadPoolExecutor(max_workers=worker_count) as pool:
+            futures = [pool.submit(worker, w) for w in range(worker_count)]
+            results = [f.result() for f in as_completed(futures)]
+
+        assert sum(results) == worker_count * per_worker
+        # Cross-check via the bulk-load iterator: every insert is
+        # represented in the final dump.
+        keys = list(state_db.iter_uploaded_stat_keys())
+        assert len(keys) == worker_count * per_worker
+
+    def test_concurrent_reads_during_writes(self, state_db: StateDB) -> None:
+        """Reader threads must observe consistent snapshots while writers run.
+
+        WAL mode lets readers proceed against the last-committed
+        snapshot without blocking writers. Pre-rewrite the
+        process-wide lock would have serialised every reader behind
+        every writer -- the test would still pass, but slowly. We
+        assert the readers complete (no exceptions, no corrupted
+        rows) which covers the correctness side; the throughput win
+        is observable in the parallel-upload integration scenario.
+        """
+        stop = threading.Event()
+        write_errors: list[BaseException] = []
+        read_errors: list[BaseException] = []
+
+        def writer() -> None:
+            i = 0
+            try:
+                while not stop.is_set():
+                    state_db.record_upload(
+                        f"writer-{i}.nd2",
+                        f"sha-{i}",
+                        f"s3/writer/{i}.nd2",
+                        relative_path=f"writer/{i}.nd2",
+                        size_bytes=1024,
+                        mtime=1_700_000_000.0 + i,
+                    )
+                    i += 1
+            except BaseException as exc:
+                write_errors.append(exc)
+
+        def reader() -> int:
+            count = 0
+            try:
+                while not stop.is_set():
+                    # Both helpers should be safe to call from any
+                    # thread now that each opens its own connection
+                    # lazily on first access.
+                    _ = list(state_db.iter_uploaded_stat_keys())
+                    _ = state_db.is_uploaded("writer-0.nd2", "sha-0", "s3/writer/0.nd2")
+                    count += 1
+            except BaseException as exc:
+                read_errors.append(exc)
+            return count
+
+        threads = [
+            threading.Thread(target=writer, name="writer", daemon=True),
+            threading.Thread(target=reader, name="reader-1", daemon=True),
+            threading.Thread(target=reader, name="reader-2", daemon=True),
+        ]
+        for t in threads:
+            t.start()
+        # Brief contention window; long enough to exercise interleaving
+        # without slowing the test suite noticeably.
+        threading.Event().wait(0.4)
+        stop.set()
+        for t in threads:
+            t.join(timeout=5.0)
+            assert not t.is_alive(), f"{t.name} did not stop in time"
+
+        assert write_errors == [], f"writer raised: {write_errors!r}"
+        assert read_errors == [], f"reader raised: {read_errors!r}"
+
+
+class TestPerThreadConnections:
+    """The connection cache is keyed per-thread, not per-process."""
+
+    def test_distinct_threads_get_distinct_connections(self, state_db: StateDB) -> None:
+        # Touch the property on the main thread to materialise its
+        # connection.
+        main_conn = state_db._conn
+        worker_conn: sqlite3.Connection | None = None
+
+        def grab_conn() -> None:
+            nonlocal worker_conn
+            worker_conn = state_db._conn
+
+        t = threading.Thread(target=grab_conn)
+        t.start()
+        t.join(timeout=2.0)
+
+        assert worker_conn is not None
+        assert worker_conn is not main_conn
+
+    def test_same_thread_reuses_its_connection(self, state_db: StateDB) -> None:
+        first = state_db._conn
+        second = state_db._conn
+        assert first is second
+
+
+class TestClose:
+    """``close()`` must reach connections opened by other threads."""
+
+    def test_close_shuts_down_all_thread_connections(self, tmp_path: Path) -> None:
+        db = StateDB(tmp_path / "close.db")
+        # Open connections from several threads.
+        opened: list[sqlite3.Connection] = []
+        opened_lock = threading.Lock()
+
+        def open_one() -> None:
+            conn = db._conn
+            with opened_lock:
+                opened.append(conn)
+
+        threads = [threading.Thread(target=open_one) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=2.0)
+
+        # Plus the main-thread connection (from __init__'s
+        # ``_create_tables``).
+        assert len(opened) == 5
+
+        db.close()
+
+        # Every captured connection must now refuse further use; the
+        # exact exception type is sqlite3.ProgrammingError on closed
+        # handles.
+        for conn in opened:
+            with pytest.raises(sqlite3.ProgrammingError):
+                conn.execute("SELECT 1")

--- a/watcher/tests/test_state_db_concurrency.py
+++ b/watcher/tests/test_state_db_concurrency.py
@@ -18,8 +18,10 @@ These tests pin down the new invariants:
 """
 
 from __future__ import annotations
+import gc
 import sqlite3
 import threading
+import weakref
 from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -195,3 +197,139 @@ class TestClose:
         for conn in opened:
             with pytest.raises(sqlite3.ProgrammingError):
                 conn.execute("SELECT 1")
+
+
+class TestThreadDeathReclamation:
+    """Connections owned by terminated threads must be reaped.
+
+    The optimisation spawns a fresh ``ThreadPoolExecutor`` per upload
+    batch; each worker opens its own ``sqlite3.Connection`` on first
+    StateDB access. Without lifecycle plumbing those handles would
+    pile up in ``StateDB._connections`` (and in the kernel FD table)
+    for the entire watcher process lifetime -- hours-to-days on a
+    busy lab PC. The per-thread ``weakref.finalize`` callback in
+    ``StateDB._conn`` is what prevents that. These tests pin its
+    behaviour.
+    """
+
+    def test_connections_are_dropped_when_owning_thread_dies(self, state_db: StateDB) -> None:
+        """After short-lived workers exit, only the main thread's handle remains.
+
+        We open one ``StateDB`` connection per worker (the workers
+        write a row so the handle is fully materialised), join the
+        workers, then drive the GC. The watcher's ``_connections``
+        set must drop back down to just the main-thread connection
+        eagerly cached at construction time.
+        """
+        # Materialise the main thread's connection (already opened by
+        # ``_create_tables``, but make the expectation explicit).
+        _ = state_db._conn
+
+        def worker(worker_id: int) -> None:
+            state_db.record_upload(
+                f"tt-{worker_id}.nd2",
+                f"sha-tt-{worker_id}",
+                f"s3/tt/{worker_id}.nd2",
+                relative_path=f"tt/{worker_id}.nd2",
+                size_bytes=1024,
+                mtime=1_700_000_000.0 + worker_id,
+            )
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5.0)
+            assert not t.is_alive()
+
+        # Threading-local data is reclaimed when the thread is joined,
+        # but the actual ``_PerThreadHandle`` may still be sitting on
+        # the GC's young-generation freelist. A single ``gc.collect``
+        # is enough to fire the ``weakref.finalize`` callbacks.
+        gc.collect()
+
+        with state_db._connections_lock:
+            remaining = set(state_db._connections)
+
+        # Exactly one connection should remain: the main thread's.
+        # We don't rely on ``len`` to point at a specific handle --
+        # we assert membership against the live main-thread handle so
+        # the test stays robust to incidental allocations elsewhere.
+        assert state_db._conn in remaining
+        assert len(remaining) == 1, (
+            f"Expected only the main-thread handle to remain, got {len(remaining)} live connections"
+        )
+
+    def test_thread_local_holder_is_garbage_collected_after_thread_dies(
+        self, state_db: StateDB
+    ) -> None:
+        """The per-thread holder is the linchpin of the reaper.
+
+        We weak-ref the holder rather than the connection itself
+        because the connection is briefly kept alive by the
+        ``weakref.finalize`` callback's closed-over reference. A live
+        holder == a still-leaked entry; a dead holder == reaper
+        already ran.
+        """
+        holder_refs: list[weakref.ref[object]] = []
+        holder_refs_lock = threading.Lock()
+
+        def worker() -> None:
+            _ = state_db._conn
+            holder = state_db._local.holder  # type: ignore[attr-defined]
+            with holder_refs_lock:
+                holder_refs.append(weakref.ref(holder))
+
+        threads = [threading.Thread(target=worker) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5.0)
+
+        gc.collect()
+
+        live_holders = [ref() for ref in holder_refs if ref() is not None]
+        assert live_holders == [], (
+            f"Expected all per-thread holders to be GC'd; {len(live_holders)} still alive"
+        )
+
+    def test_pool_workers_do_not_leak_handles_across_batches(self, state_db: StateDB) -> None:
+        """Simulate the per-batch ``ThreadPoolExecutor`` pattern.
+
+        ``Uploader.upload_files`` constructs a new pool per call.
+        With ``upload_parallelism=4`` and 10 batches the unfixed code
+        would accumulate ~40 stale connections; the fix keeps the
+        live count bounded regardless of batch count.
+        """
+        batches = 10
+        per_batch = 4
+
+        def worker(batch: int, worker_id: int) -> None:
+            state_db.record_upload(
+                f"b{batch}-w{worker_id}.nd2",
+                f"sha-b{batch}-w{worker_id}",
+                f"s3/b{batch}/w{worker_id}.nd2",
+                relative_path=f"b{batch}/w{worker_id}.nd2",
+                size_bytes=512,
+                mtime=1_700_000_000.0 + batch,
+            )
+
+        for batch in range(batches):
+            with ThreadPoolExecutor(max_workers=per_batch) as pool:
+                futures = [pool.submit(worker, batch, w) for w in range(per_batch)]
+                for f in futures:
+                    f.result()
+
+        gc.collect()
+
+        with state_db._connections_lock:
+            remaining = len(state_db._connections)
+
+        # Upper bound: the main-thread handle plus a small slack for
+        # any GC scheduling oddities. Concrete number doesn't matter
+        # as long as it isn't O(batches * per_batch) -- the pre-fix
+        # code would land at exactly 41 here.
+        assert remaining <= 2, (
+            f"Per-batch worker connections leaked: {remaining} live "
+            f"after {batches} batches of {per_batch} workers"
+        )

--- a/watcher/tests/test_uploader.py
+++ b/watcher/tests/test_uploader.py
@@ -9,6 +9,7 @@ from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
+from requests.adapters import HTTPAdapter
 
 from data_hub_watcher.api_client import ApiError
 from data_hub_watcher.events import EventReporter
@@ -462,3 +463,128 @@ class TestUploadFilesParallelism:
     ) -> None:
         with pytest.raises(ValueError, match="upload_parallelism must be >= 1"):
             self._make_uploader(mock_client, state_db, tmp_path, parallelism=0)
+
+
+class TestS3SessionPoolSizing:
+    """The shared S3 session's urllib3 pool must scale with parallelism.
+
+    Default ``HTTPAdapter`` pool size is 10. With ``upload_parallelism``
+    above that, urllib3 starts discarding connections after each PUT --
+    every excess request opens a fresh TLS connection, defeating the
+    whole point of keeping a long-lived session. The fix mounts an
+    explicit adapter sized to the configured parallelism.
+    """
+
+    def _make_uploader_for_session_check(
+        self,
+        mock_client: MagicMock,
+        state_db: StateDB,
+        watch_dir: Path,
+        *,
+        parallelism: int,
+    ) -> Uploader:
+        return Uploader(
+            client=mock_client,
+            state_db=state_db,
+            event_reporter=MagicMock(spec=EventReporter),
+            counters=WatcherCounters(),
+            instrument_id="test-instrument",
+            watcher_id="watcher-123",
+            watch_directory=watch_dir,
+            upload_parallelism=parallelism,
+        )
+
+    @pytest.mark.parametrize("parallelism", [1, 4, 16, 32])
+    def test_pool_maxsize_matches_parallelism(
+        self,
+        mock_client: MagicMock,
+        state_db: StateDB,
+        tmp_path: Path,
+        parallelism: int,
+    ) -> None:
+        uploader = self._make_uploader_for_session_check(
+            mock_client, state_db, tmp_path, parallelism=parallelism
+        )
+        # ``Session.get_adapter`` returns the abstract ``_BaseAdapter``
+        # supertype; we mounted concrete ``HTTPAdapter`` instances so
+        # casting is safe and unblocks the ``.poolmanager`` access.
+        # Probe both schemes so the test catches a regression that
+        # only mounts one.
+        for scheme in ("https://", "http://"):
+            adapter = cast(HTTPAdapter, uploader._s3_session.get_adapter(f"{scheme}example.com"))
+            # urllib3 stores the per-pool kwargs (including
+            # ``maxsize``) on ``connection_pool_kw``; ``HTTPAdapter``
+            # populates it from its constructor args.
+            pool_kwargs = adapter.poolmanager.connection_pool_kw
+            assert pool_kwargs.get("maxsize") == parallelism, (
+                f"{scheme}: expected pool maxsize={parallelism}, got {pool_kwargs.get('maxsize')}"
+            )
+
+    def test_default_session_adapter_is_replaced(
+        self,
+        mock_client: MagicMock,
+        state_db: StateDB,
+        tmp_path: Path,
+    ) -> None:
+        """A high-parallelism uploader must not be using requests' stock 10-conn adapter."""
+        uploader = self._make_uploader_for_session_check(
+            mock_client, state_db, tmp_path, parallelism=24
+        )
+        adapter = cast(HTTPAdapter, uploader._s3_session.get_adapter("https://s3.example.com"))
+        assert adapter.poolmanager.connection_pool_kw["maxsize"] == 24
+
+
+class TestPollUploadQueueCounterLocking:
+    """Manual-mode poll failures must increment the shared counter under the lock.
+
+    The optimisation introduced a parallel-upload worker pool that
+    races the heartbeat thread to read/write ``_counters``. Routing
+    ``poll_upload_queue``'s error bumps through ``_bump_errors``
+    keeps every mutation point under ``_counters_lock`` and avoids a
+    silent torn-write on the integer field.
+    """
+
+    def test_api_error_bumps_via_helper(
+        self,
+        uploader: Uploader,
+        mock_client: MagicMock,
+    ) -> None:
+        mock_client.get_upload_queue.side_effect = ApiError("ACL", status_code=403)
+
+        # Spy on the helper rather than the underlying integer so a
+        # future change that swaps the lock for atomics still passes
+        # without us re-writing the test.
+        with patch.object(uploader, "_bump_errors", wraps=uploader._bump_errors) as spy:
+            uploader.poll_upload_queue()
+
+        spy.assert_called_once()
+        assert uploader._counters.errors == 1
+
+    def test_missing_file_bumps_via_helper(
+        self,
+        uploader: Uploader,
+        mock_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        from data_hub_watcher.models import UploadQueueFile, UploadQueueResponse
+
+        # Queue references a file that no longer exists on disk -- the
+        # manual-mode "Queued file missing" branch must increment the
+        # counter via the helper, same as the auto-mode upload path.
+        mock_client.get_upload_queue.return_value = UploadQueueResponse(
+            files=[
+                UploadQueueFile(
+                    id=1,
+                    instrument_id="test-instrument",
+                    run_id="RUN-X",
+                    filename="ghost.csv",
+                    relative_path="ghost.csv",
+                )
+            ]
+        )
+
+        with patch.object(uploader, "_bump_errors", wraps=uploader._bump_errors) as spy:
+            uploader.poll_upload_queue()
+
+        spy.assert_called_once()
+        assert uploader._counters.errors == 1

--- a/watcher/tests/test_uploader.py
+++ b/watcher/tests/test_uploader.py
@@ -1,6 +1,8 @@
 """Unit tests for the presigned-URL upload flow in Uploader."""
 
 from __future__ import annotations
+import threading
+import time
 from collections.abc import Generator
 from pathlib import Path
 from typing import cast
@@ -234,14 +236,229 @@ class TestUploadQueuePollFailures:
 
 
 class TestPutToPresignedUrl:
-    def test_successful_put(self, tmp_file: Path) -> None:
-        with patch("data_hub_watcher.uploader.http_requests.put") as mock_put:
-            mock_put.return_value = MagicMock(status_code=200)
-            mock_put.return_value.raise_for_status = MagicMock()
+    def test_successful_put(self, uploader: Uploader, tmp_file: Path) -> None:
+        # ``_put_to_presigned_url`` is now an instance method so the
+        # shared ``self._s3_session`` (kept alive across batched
+        # parallel uploads) is reused on every PUT. We patch the
+        # session's ``put`` rather than ``http_requests.put`` to
+        # observe the real outgoing call.
+        mock_session_put = MagicMock(return_value=MagicMock(status_code=200))
+        mock_session_put.return_value.raise_for_status = MagicMock()
+        with patch.object(uploader._s3_session, "put", mock_session_put):
+            uploader._put_to_presigned_url("https://s3.example.com/presigned", tmp_file, "text/csv")
 
-            Uploader._put_to_presigned_url("https://s3.example.com/presigned", tmp_file, "text/csv")
-
-        mock_put.assert_called_once()
-        call_kwargs = mock_put.call_args
+        mock_session_put.assert_called_once()
+        call_kwargs = mock_session_put.call_args
         assert call_kwargs.kwargs["headers"]["Content-Type"] == "text/csv"
         assert call_kwargs.kwargs["timeout"] == 300
+
+
+class TestUploadFilesParallelism:
+    """Tests that ``upload_files`` actually parallelises per-file uploads.
+
+    The optimisation moves ``Uploader.upload_files`` from a serial
+    ``for info in files`` loop onto a small ``ThreadPoolExecutor``
+    sized by ``InstrumentConfig.upload_parallelism``. These tests
+    verify both correctness (every file still records as uploaded
+    and the run is marked uploaded only when all succeed) and that
+    work actually overlaps in time -- a regression to the serial
+    loop would still pass the correctness assertions but fail the
+    timing one.
+    """
+
+    def _make_uploader(
+        self,
+        mock_client: MagicMock,
+        state_db: StateDB,
+        watch_dir: Path,
+        *,
+        parallelism: int,
+    ) -> Uploader:
+        return Uploader(
+            client=mock_client,
+            state_db=state_db,
+            event_reporter=MagicMock(spec=EventReporter),
+            counters=WatcherCounters(),
+            instrument_id="test-instrument",
+            watcher_id="watcher-123",
+            watch_directory=watch_dir,
+            upload_parallelism=parallelism,
+        )
+
+    def test_serial_path_used_when_parallelism_is_one(
+        self,
+        mock_client: MagicMock,
+        state_db: StateDB,
+        tmp_path: Path,
+    ) -> None:
+        """parallelism=1 must take the no-pool fast path.
+
+        We can't directly observe pool creation, but we can confirm
+        the function still completes and records the run.
+        """
+        from data_hub_watcher.run_detector import FileInfo
+
+        files = []
+        for i in range(3):
+            f = tmp_path / f"file-{i}.csv"
+            f.write_text("a,b\n1,2\n")
+            files.append(FileInfo(path=f, filename=f.name, size_bytes=8))
+
+        mock_client.request_upload_url.side_effect = [
+            PresignedUploadResponse(
+                upload_url=f"https://s3.example.com/presigned/{i}",
+                s3_bucket="b",
+                s3_key=f"k/{i}",
+                file_id=i,
+                already_uploaded=False,
+            )
+            for i in range(3)
+        ]
+        mock_client.mark_file_uploaded.return_value = MagicMock()
+
+        uploader = self._make_uploader(mock_client, state_db, tmp_path, parallelism=1)
+
+        with patch.object(Uploader, "_put_to_presigned_url"):
+            succeeded = uploader.upload_files("RUN-001", files)
+
+        assert succeeded == 3
+
+    def test_parallel_path_runs_concurrently(
+        self,
+        mock_client: MagicMock,
+        state_db: StateDB,
+        tmp_path: Path,
+    ) -> None:
+        """A 6-file batch with parallelism=3 must overlap PUTs in time.
+
+        We use a ``threading.Barrier(3)`` inside the stubbed PUT to
+        prove three workers were inside ``_put_to_presigned_url`` at
+        the same instant. A serial implementation would deadlock the
+        barrier (and the test fails fast on its 5 s timeout), which is
+        the regression guard we want.
+        """
+        from data_hub_watcher.run_detector import FileInfo
+
+        files = []
+        for i in range(6):
+            f = tmp_path / f"file-{i}.csv"
+            f.write_text("a,b\n1,2\n")
+            files.append(FileInfo(path=f, filename=f.name, size_bytes=8))
+
+        mock_client.request_upload_url.side_effect = [
+            PresignedUploadResponse(
+                upload_url=f"https://s3.example.com/presigned/{i}",
+                s3_bucket="b",
+                s3_key=f"k/{i}",
+                file_id=i,
+                already_uploaded=False,
+            )
+            for i in range(6)
+        ]
+        mock_client.mark_file_uploaded.return_value = MagicMock()
+
+        # Three workers must reach the barrier together; if upload_files
+        # serialises them the barrier will time out and BrokenBarrierError
+        # is raised inside the worker, which we re-surface as the future's
+        # exception (and the test fails).
+        barrier = threading.Barrier(parties=3, timeout=5.0)
+        max_in_flight = 0
+        in_flight = 0
+        in_flight_lock = threading.Lock()
+
+        def fake_put(self_: Uploader, url: str, path: Path, content_type: str | None) -> None:
+            nonlocal max_in_flight, in_flight
+            with in_flight_lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+            try:
+                barrier.wait()
+            finally:
+                with in_flight_lock:
+                    in_flight -= 1
+            time.sleep(0.01)  # extend the overlap window for max_in_flight
+
+        uploader = self._make_uploader(mock_client, state_db, tmp_path, parallelism=3)
+
+        with patch.object(Uploader, "_put_to_presigned_url", new=fake_put):
+            succeeded = uploader.upload_files("RUN-001", files)
+
+        assert succeeded == 6
+        # If the pool actually runs three at a time the observed
+        # in-flight peak is exactly the parallelism setting.
+        assert max_in_flight == 3
+
+    def test_run_marked_uploaded_only_when_all_succeed(
+        self,
+        mock_client: MagicMock,
+        state_db: StateDB,
+        tmp_path: Path,
+    ) -> None:
+        from data_hub_watcher.run_detector import FileInfo
+
+        files = []
+        for i in range(3):
+            f = tmp_path / f"file-{i}.csv"
+            f.write_text("a,b\n1,2\n")
+            files.append(FileInfo(path=f, filename=f.name, size_bytes=8))
+
+        # The middle file fails its presign; the others succeed.
+        mock_client.request_upload_url.side_effect = [
+            PresignedUploadResponse(
+                upload_url="https://s3.example.com/presigned/0",
+                s3_bucket="b",
+                s3_key="k/0",
+                file_id=0,
+                already_uploaded=False,
+            ),
+            ApiError("transient", status_code=500),
+            PresignedUploadResponse(
+                upload_url="https://s3.example.com/presigned/2",
+                s3_bucket="b",
+                s3_key="k/2",
+                file_id=2,
+                already_uploaded=False,
+            ),
+        ]
+        mock_client.mark_file_uploaded.return_value = MagicMock()
+
+        uploader = self._make_uploader(mock_client, state_db, tmp_path, parallelism=2)
+
+        with patch.object(Uploader, "_put_to_presigned_url"):
+            succeeded = uploader.upload_files("RUN-002", files)
+
+        assert succeeded == 2
+        # A partial failure must NOT mark the run uploaded -- otherwise
+        # the next restart would skip a file we never finished.
+        run = state_db.get_run("RUN-002")
+        assert run is None or run.uploaded_at is None
+
+    def test_empty_file_list_marks_run_uploaded(
+        self,
+        mock_client: MagicMock,
+        state_db: StateDB,
+        tmp_path: Path,
+    ) -> None:
+        """Preserve the pre-parallelism behaviour for empty manifests."""
+        uploader = self._make_uploader(mock_client, state_db, tmp_path, parallelism=4)
+        # We have to seed the ``runs`` row first so the UPDATE inside
+        # ``record_run_uploaded`` actually flips a column we can read
+        # back. This mirrors how the run-detector orders calls in real
+        # life (POST run → record_run_reported → upload_files → empty).
+        state_db.record_run_reported("RUN-EMPTY")
+
+        succeeded = uploader.upload_files("RUN-EMPTY", [])
+
+        assert succeeded == 0
+        run = state_db.get_run("RUN-EMPTY")
+        assert run is not None
+        assert run.uploaded_at is not None
+
+    def test_invalid_parallelism_rejected(
+        self,
+        mock_client: MagicMock,
+        state_db: StateDB,
+        tmp_path: Path,
+    ) -> None:
+        with pytest.raises(ValueError, match="upload_parallelism must be >= 1"):
+            self._make_uploader(mock_client, state_db, tmp_path, parallelism=0)


### PR DESCRIPTION
## Summary

Four hot-path performance optimizations on the lab-PC watcher loop, scoped to `watcher/src/data_hub_watcher`. Targets the symptoms operators actually feel: minutes-long startup scans, sequential uploads bottlenecking large runs, and a process-wide SQLite lock that defeated WAL mode.

### Initial scan rewrite (`monitor.py`)
- Replaced `Path.rglob` + `is_file` + double `stat()` with an `os.scandir`-based walk against cached `DirEntry.stat(follow_symlinks=False)`.
- Pre-compiled fnmatch patterns into a single anchored regex shared between the scan loop and the watchdog `_EventHandler`.
- New `_load_dedup_index` builds an in-memory `dict[str, list[(size, mtime)]]` from one bulk `SELECT` per table, replacing two SQL round trips per scanned file with one Python dict lookup.

### StateDB thread-local connections (`state.py`)
- Per-thread `sqlite3.Connection` via `threading.local()` opened lazily through a `_conn` property (existing `state_db._conn` test access keeps working).
- Process-wide `_lock` replaced by a smaller `_write_lock` only around mutations; reads run unlocked under WAL.
- New `iter_uploaded_stat_keys` / `iter_detected_stat_keys` bulk loaders for the rewritten scan.
- Per-connection PRAGMAs added: `cache_size=-65536`, `temp_store=MEMORY`, `mmap_size=268435456`, `busy_timeout=5000`.
- `close()` now reaches every thread's connection.

### SHA-256 chunking + overlap (`util.py`, `uploader.py`)
- New `HASH_CHUNK_SIZE = 1 << 20` (1 MiB) constant replaces the 8 KiB streaming buffer (~128x fewer `read()` syscalls on multi-GiB instrument files).
- `Uploader._upload_single` runs `file_sha256` and `client.request_upload_url` on a 2-thread `ThreadPoolExecutor` so the hash and the presign network round trip overlap.

### Parallel uploads (`models.py`, `runtime.py`, `uploader.py`)
- New `InstrumentConfig.upload_parallelism: int = Field(default=4, ge=1, le=32)`. Defaulted, so existing config YAMLs need no migration.
- Plumbed through `runtime.build_runtime` into the `Uploader` constructor.
- `Uploader.upload_files` now uses a per-batch `ThreadPoolExecutor` sized by `min(parallelism, len(files))`, with a fast path when `parallelism == 1`.
- Single `requests.Session` shared across S3 PUTs for TLS keep-alive across parallel uploads.
- Counter mutations protected by a new `_counters_lock`.

## Test plan

- [x] `make check-all` clean (ruff format/lint, pyright, frontend formatter/lint/typecheck)
- [x] All 360 watcher unit tests pass
- [x] New `TestUploadFilesParallelism` (4 tests) — serial fast path, true concurrency proven via `threading.Barrier(3)`, partial-failure handling, empty-list behaviour, `parallelism=0` rejection
- [x] New `TestBulkLoadIterators`, `TestStatInDedupIndex`, `TestInitialScanBulkLoad` — last asserts exactly one `SELECT` per table and zero per-row `has_stat_match` calls in the scan
- [x] New `tests/test_state_db_concurrency.py` — 40-thread × 25-write contention, concurrent reads during writes, per-thread connection isolation, `close()` shutdown coverage
- [x] New `TestUploadParallelism` covers default/range/rejection cases for the new field
- [x] Updated `TestPutToPresignedUrl.test_successful_put` to use an `Uploader` instance and patch the shared session

## Out of scope (deferred)

The remaining items from the wider perf review (heartbeat thread split, `_persist_detected_files` delta-only writes, parallel `_pending` snapshot, `RunState.files` set membership, mimetype caching) are intentionally not in this PR. Easier to land + measure these four hot paths first.


Made with [Cursor](https://cursor.com)