### PR TITLE
Add read/write permission scopes to personal access tokens

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -25,7 +25,8 @@ Every personal access token carries an array of permission scopes. A request is 
 | `files:write` | Create/update/delete file records and reprocess files |
 | `watchers:read` | Read watcher state (list, heartbeats, events, config, upload queue, update-check) |
 | `watchers:write` | Register/deregister watchers, post heartbeats and events, push config |
-| `archive-jobs:write` | Update archive jobs (Lambda callback). Archive reads happen via `files:read`. |
+| `archive-jobs:read` | Read archive job state. No endpoints currently consume this scope — the existing run-archive download is gated on `files:read` because it returns file bytes — but it is reserved for future archive-job listing/status endpoints. |
+| `archive-jobs:write` | Update archive jobs (Lambda callback). |
 | `*` | Wildcard — matches every scope. Reserved for the migration backfill and the watcher/Lambda PATs until they are rotated to least-privilege scopes; `POST /api/v1/tokens` rejects `*` from API callers. |
 
 MCP tools enforce the same scopes their REST counterparts do: `search_runs` and `get_run` require `runs:read`, `reprocess_file` requires `files:write`, `claim_run`/`unclaim_run` require `runs:write`, and so on. There is no MCP-specific scope vocabulary — a token with `runs:read` over REST also covers the read-side run tools over MCP.

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,9 +26,9 @@ Every personal access token carries an array of permission scopes. A request is 
 | `watchers:read` | Read watcher state (list, heartbeats, events, config, upload queue, update-check) |
 | `watchers:write` | Register/deregister watchers, post heartbeats and events, push config |
 | `archive-jobs:write` | Update archive jobs (Lambda callback). Archive reads happen via `files:read`. |
-| `mcp:read` | Connect to the MCP endpoint and call read-only tools |
-| `mcp:write` | Call mutating MCP tools (`claim_run`, `unclaim_run`, `reprocess_file`) |
 | `*` | Wildcard — matches every scope. Reserved for the migration backfill and the watcher/Lambda PATs until they are rotated to least-privilege scopes; `POST /api/v1/tokens` rejects `*` from API callers. |
+
+MCP tools enforce the same scopes their REST counterparts do: `search_runs` and `get_run` require `runs:read`, `reprocess_file` requires `files:write`, `claim_run`/`unclaim_run` require `runs:write`, and so on. There is no MCP-specific scope vocabulary — a token with `runs:read` over REST also covers the read-side run tools over MCP.
 
 Migration `0022_pat_scopes` backfills every pre-existing token with `["*"]`, so deployed watchers and the Lambda continue to work after deploy until their tokens are rotated to explicit scopes.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,10 +6,42 @@ The Data Hub API is served by the Next.js web application at `/api/v1/`. It is u
 
 The API supports two authentication methods:
 
-- **Session cookies** — used by the web dashboard (Google OAuth via NextAuth).
+- **Session cookies** — used by the web dashboard (Google OAuth via NextAuth). Session-authenticated callers implicitly hold every scope; scope enforcement only applies to token-authenticated requests.
 - **Bearer tokens** — used by the watcher, Lambda, and MCP clients. Tokens are created in the web dashboard under personal access tokens and sent in the `Authorization: Bearer <token>` header.
 
 Tokens are hashed with SHA-256 before storage. The plaintext token is shown once at creation time.
+
+### Scopes
+
+Every personal access token carries an array of permission scopes. A request is rejected with `403 FORBIDDEN` when the token's scopes do not include the scope required by the route. The vocabulary is:
+
+| Scope | Grants |
+| --- | --- |
+| `instruments:read` | List/read instruments |
+| `instruments:write` | Create/update instruments |
+| `runs:read` | List/read runs (and their comments) |
+| `runs:write` | Create/update/delete runs, comments, attributions, and run-level upload/reprocess endpoints |
+| `files:read` | Read file metadata, download files, download run archives |
+| `files:write` | Create/update/delete file records and reprocess files |
+| `watchers:read` | Read watcher state (list, heartbeats, events, config, upload queue, update-check) |
+| `watchers:write` | Register/deregister watchers, post heartbeats and events, push config |
+| `archive-jobs:write` | Update archive jobs (Lambda callback). Archive reads happen via `files:read`. |
+| `mcp:read` | Connect to the MCP endpoint and call read-only tools |
+| `mcp:write` | Call mutating MCP tools (`claim_run`, `unclaim_run`, `reprocess_file`) |
+| `*` | Wildcard — matches every scope. Reserved for the migration backfill and the watcher/Lambda PATs until they are rotated to least-privilege scopes; `POST /api/v1/tokens` rejects `*` from API callers. |
+
+Migration `0022_pat_scopes` backfills every pre-existing token with `["*"]`, so deployed watchers and the Lambda continue to work after deploy until their tokens are rotated to explicit scopes.
+
+`403 FORBIDDEN` responses use the standard error shape:
+
+```json
+{
+  "error": {
+    "code": "FORBIDDEN",
+    "message": "Token is missing required scope: runs:write"
+  }
+}
+```
 
 ## Endpoints
 
@@ -85,8 +117,8 @@ The download-archive endpoint sits in front of a Lambda-driven builder pipeline 
 
 | Method | Path | Description |
 | --- | --- | --- |
-| `GET` | `/api/v1/tokens` | List personal access tokens |
-| `POST` | `/api/v1/tokens` | Create a new token |
+| `GET` | `/api/v1/tokens` | List personal access tokens. Response includes each token's `scopes`. |
+| `POST` | `/api/v1/tokens` | Create a new token. Requires a non-empty `scopes` array (see [Scopes](#scopes)); the wildcard `*` is rejected. |
 | `DELETE` | `/api/v1/tokens/:id` | Revoke a token |
 
 ### MCP (Model Context Protocol)

--- a/web-app/app/api/v1/archive-jobs/[id]/route.ts
+++ b/web-app/app/api/v1/archive-jobs/[id]/route.ts
@@ -5,6 +5,7 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
+import { requireScope } from "@/lib/api/scopes";
 import { isValidUUID } from "@/lib/api/validators";
 import { db } from "@/lib/db";
 import { archiveJobs } from "@/lib/db/schema";
@@ -49,6 +50,8 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "archive-jobs:write");
+  if (scopeError) return scopeError;
 
   const { id } = await params;
   if (!isValidUUID(id)) {

--- a/web-app/app/api/v1/files/[fileId]/download/route.ts
+++ b/web-app/app/api/v1/files/[fileId]/download/route.ts
@@ -5,6 +5,7 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
+import { requireScope } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { files, instrumentRuns } from "@/lib/db/schema";
 import { getPresignedDownloadUrl } from "@/lib/s3";
@@ -28,6 +29,8 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "files:read");
+  if (scopeError) return scopeError;
 
   const { fileId } = await params;
   const numericId = parseInt(fileId, 10);

--- a/web-app/app/api/v1/files/[fileId]/reprocess/route.ts
+++ b/web-app/app/api/v1/files/[fileId]/reprocess/route.ts
@@ -1,6 +1,7 @@
 import { authenticateRequest } from "@/lib/api/auth";
 import { apiError, UNAUTHORIZED, VALIDATION_ERROR } from "@/lib/api/errors";
 import { reprocessFile } from "@/lib/api/file-reprocessing";
+import { requireScope } from "@/lib/api/scopes";
 import type { NextRequest } from "next/server";
 
 type RouteContext = {
@@ -21,6 +22,8 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "files:write");
+  if (scopeError) return scopeError;
 
   const { fileId } = await params;
   const numericId = parseInt(fileId, 10);

--- a/web-app/app/api/v1/files/[fileId]/route.ts
+++ b/web-app/app/api/v1/files/[fileId]/route.ts
@@ -6,6 +6,7 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
+import { requireScope } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { files, instrumentRuns } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -44,6 +45,8 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "files:write");
+  if (scopeError) return scopeError;
 
   const { fileId } = await params;
   const numericId = parseInt(fileId, 10);
@@ -187,6 +190,8 @@ export async function DELETE(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "files:write");
+  if (scopeError) return scopeError;
 
   const { fileId } = await params;
   const numericId = parseInt(fileId, 10);

--- a/web-app/app/api/v1/instrument-runs/route.ts
+++ b/web-app/app/api/v1/instrument-runs/route.ts
@@ -1,6 +1,7 @@
 import { authenticateRequest } from "@/lib/api/auth";
 import { apiError, UNAUTHORIZED } from "@/lib/api/errors";
 import { buildRunListQuery } from "@/lib/api/instrument-runs";
+import { requireScope } from "@/lib/api/scopes";
 import { parseIntParam } from "@/lib/api/validators";
 import type { NextRequest } from "next/server";
 
@@ -17,6 +18,8 @@ export async function GET(request: NextRequest) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "runs:read");
+  if (scopeError) return scopeError;
 
   const { searchParams } = request.nextUrl;
 

--- a/web-app/app/api/v1/instruments/[instrumentId]/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/route.ts
@@ -5,6 +5,7 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
+import { requireScope } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import {
   instrumentRuns,
@@ -23,6 +24,8 @@ export async function GET(
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "instruments:read");
+  if (scopeError) return scopeError;
 
   const { instrumentId } = await params;
 
@@ -81,6 +84,8 @@ export async function PATCH(
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "instruments:write");
+  if (scopeError) return scopeError;
 
   const { instrumentId } = await params;
 

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/attributions/me/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/attributions/me/route.ts
@@ -4,6 +4,7 @@ import {
   getAttributionsByRunIds,
   lookupRunByNaturalKey,
 } from "@/lib/api/instrument-runs";
+import { requireScope } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { runAttributions } from "@/lib/db/schema";
 import { and, eq } from "drizzle-orm";
@@ -27,6 +28,8 @@ export async function PUT(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "runs:write");
+  if (scopeError) return scopeError;
 
   const { instrumentId, runId } = await params;
   const run = await lookupRunByNaturalKey(instrumentId, runId);
@@ -63,6 +66,8 @@ export async function DELETE(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "runs:write");
+  if (scopeError) return scopeError;
 
   const { instrumentId, runId } = await params;
   const run = await lookupRunByNaturalKey(instrumentId, runId);

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/comments/[commentId]/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/comments/[commentId]/route.ts
@@ -13,6 +13,7 @@ import {
   softDeleteComment,
   updateComment,
 } from "@/lib/api/run-comments";
+import { requireScope } from "@/lib/api/scopes";
 import type { NextRequest } from "next/server";
 
 type RouteContext = {
@@ -42,6 +43,13 @@ async function preflight(
       kind: "error",
       response: apiError(401, UNAUTHORIZED, "Authentication required"),
     };
+  }
+  // Both PATCH and DELETE on this route mutate comment state, so both
+  // require runs:write. Bake the check into the shared preflight so a
+  // future verb added here can't accidentally skip it.
+  const scopeError = requireScope(authResult, "runs:write");
+  if (scopeError) {
+    return { kind: "error", response: scopeError };
   }
 
   const { instrumentId, runId, commentId } = await params;

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/comments/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/comments/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/api/errors";
 import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
 import { createComment, listCommentsForRun } from "@/lib/api/run-comments";
+import { requireScope } from "@/lib/api/scopes";
 import type { NextRequest } from "next/server";
 
 type RouteContext = {
@@ -30,6 +31,8 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "runs:read");
+  if (scopeError) return scopeError;
 
   const { instrumentId, runId } = await params;
   const run = await lookupRunByNaturalKey(instrumentId, runId);
@@ -58,6 +61,8 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "runs:write");
+  if (scopeError) return scopeError;
 
   const { instrumentId, runId } = await params;
   const run = await lookupRunByNaturalKey(instrumentId, runId);

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/download-archive/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/download-archive/route.ts
@@ -15,6 +15,7 @@ import {
   UNAUTHORIZED,
 } from "@/lib/api/errors";
 import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
+import { requireScope } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { archiveJobs, files } from "@/lib/db/schema";
 import {
@@ -95,6 +96,8 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "files:read");
+  if (scopeError) return scopeError;
 
   const { instrumentId, runId } = await params;
   const run = await lookupRunByNaturalKey(instrumentId, runId);

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/files/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/files/route.ts
@@ -7,6 +7,7 @@ import {
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
 import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
+import { requireScope } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { files } from "@/lib/db/schema";
 import { and, eq, isNull } from "drizzle-orm";
@@ -37,6 +38,8 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "files:write");
+  if (scopeError) return scopeError;
 
   const { instrumentId, runId } = await params;
   const run = await lookupRunByNaturalKey(instrumentId, runId);

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/reprocess/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/reprocess/route.ts
@@ -2,6 +2,7 @@ import { authenticateRequest } from "@/lib/api/auth";
 import { apiError, CONFLICT, NOT_FOUND, UNAUTHORIZED } from "@/lib/api/errors";
 import { reprocessFile } from "@/lib/api/file-reprocessing";
 import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
+import { requireScope } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { files } from "@/lib/db/schema";
 import { and, eq, inArray, isNull } from "drizzle-orm";
@@ -28,6 +29,8 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "runs:write");
+  if (scopeError) return scopeError;
 
   const { instrumentId, runId } = await params;
   const run = await lookupRunByNaturalKey(instrumentId, runId);

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload-all/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload-all/route.ts
@@ -1,6 +1,7 @@
 import { authenticateRequest } from "@/lib/api/auth";
 import { apiError, CONFLICT, NOT_FOUND, UNAUTHORIZED } from "@/lib/api/errors";
 import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
+import { requireScope } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { files, instrumentRuns } from "@/lib/db/schema";
 import { and, eq, isNull } from "drizzle-orm";
@@ -24,6 +25,8 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "runs:write");
+  if (scopeError) return scopeError;
 
   const { instrumentId, runId } = await params;
   const run = await lookupRunByNaturalKey(instrumentId, runId);

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload-url/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload-url/route.ts
@@ -8,6 +8,7 @@ import {
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
 import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
+import { requireScope } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { files } from "@/lib/db/schema";
 import { getPresignedUploadUrl, getS3RawDataBucket } from "@/lib/s3";
@@ -41,6 +42,8 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "runs:write");
+  if (scopeError) return scopeError;
 
   const { instrumentId, runId } = await params;
   const run = await lookupRunByNaturalKey(instrumentId, runId);

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload/route.ts
@@ -7,6 +7,7 @@ import {
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
 import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
+import { requireScope } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { files, instrumentRuns } from "@/lib/db/schema";
 import { eq, inArray } from "drizzle-orm";
@@ -31,6 +32,8 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "runs:write");
+  if (scopeError) return scopeError;
 
   const { instrumentId, runId } = await params;
   const run = await lookupRunByNaturalKey(instrumentId, runId);

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/restore/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/restore/route.ts
@@ -1,6 +1,7 @@
 import { authenticateRequest } from "@/lib/api/auth";
 import { apiError, CONFLICT, NOT_FOUND, UNAUTHORIZED } from "@/lib/api/errors";
 import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
+import { requireScope } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { instrumentRuns } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -23,6 +24,8 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "runs:write");
+  if (scopeError) return scopeError;
 
   const { instrumentId, runId } = await params;
   const run = await lookupRunByNaturalKey(instrumentId, runId);

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/[runId]/route.ts
@@ -10,6 +10,7 @@ import {
   lookupRunByNaturalKey,
   parseAcquiredAt,
 } from "@/lib/api/instrument-runs";
+import { requireScope } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { files, instrumentRuns } from "@/lib/db/schema";
 import { getPresignedDownloadUrl } from "@/lib/s3";
@@ -32,6 +33,8 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "runs:read");
+  if (scopeError) return scopeError;
 
   const { instrumentId, runId } = await params;
   const run = await lookupRunByNaturalKey(instrumentId, runId);
@@ -108,6 +111,8 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "runs:write");
+  if (scopeError) return scopeError;
 
   const { instrumentId, runId } = await params;
   const run = await lookupRunByNaturalKey(instrumentId, runId);
@@ -231,6 +236,8 @@ export async function DELETE(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "runs:write");
+  if (scopeError) return scopeError;
 
   const { instrumentId, runId } = await params;
   const run = await lookupRunByNaturalKey(instrumentId, runId);

--- a/web-app/app/api/v1/instruments/[instrumentId]/runs/route.ts
+++ b/web-app/app/api/v1/instruments/[instrumentId]/runs/route.ts
@@ -6,6 +6,7 @@ import {
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
 import { buildRunListQuery, parseAcquiredAt } from "@/lib/api/instrument-runs";
+import { requireScope } from "@/lib/api/scopes";
 import { parseIntParam } from "@/lib/api/validators";
 import { db } from "@/lib/db";
 import { files, instrumentRuns, instruments, watchers } from "@/lib/db/schema";
@@ -33,6 +34,8 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "runs:write");
+  if (scopeError) return scopeError;
 
   const { instrumentId } = await params;
 
@@ -223,6 +226,8 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "runs:read");
+  if (scopeError) return scopeError;
 
   const { instrumentId } = await params;
 

--- a/web-app/app/api/v1/instruments/route.ts
+++ b/web-app/app/api/v1/instruments/route.ts
@@ -5,6 +5,7 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
+import { requireScope } from "@/lib/api/scopes";
 import { isValidKebabCase } from "@/lib/api/validators";
 import { db } from "@/lib/db";
 import {
@@ -20,6 +21,8 @@ export async function GET(request: NextRequest) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "instruments:read");
+  if (scopeError) return scopeError;
 
   const rows = await db
     .select({
@@ -38,6 +41,8 @@ export async function POST(request: NextRequest) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "instruments:write");
+  if (scopeError) return scopeError;
 
   let body: { id?: string; display_name?: string; instrument_type?: string };
   try {

--- a/web-app/app/api/v1/mcp/route.ts
+++ b/web-app/app/api/v1/mcp/route.ts
@@ -1,5 +1,4 @@
 import { authenticateWithToken } from "@/lib/api/auth";
-import { hasScope } from "@/lib/api/scopes";
 import { registerPrompts } from "@/lib/mcp/prompts";
 import { registerResources } from "@/lib/mcp/resources";
 import { registerTools } from "@/lib/mcp/tools";
@@ -25,11 +24,12 @@ const handler = createMcpHandler(
   }
 );
 
-// Translate the PAT's internal scope vocabulary to the MCP-facing
-// `["read", "write"]` shape the SDK exposes to clients. The MCP surface
-// is gated as a whole on `mcp:read` (any caller without it is rejected
-// here); finer-grained `mcp:write` then controls the mutating tools via
-// `requireMcpScope` inside the tool implementations.
+// Pass the PAT's resource scopes through to the MCP layer unchanged. Each
+// tool checks the same `<resource>:<action>` scope its REST counterpart
+// does (see `requireMcpScope` in `lib/mcp/tools.ts`), so there's no
+// MCP-specific scope vocabulary and no connect-time gate beyond a valid
+// token. The `*` wildcard from legacy/backfilled tokens is honored by
+// `hasScope`, so deployed watchers and the Lambda keep working.
 const verifyToken = async (
   req: Request,
   bearerToken?: string
@@ -37,17 +37,10 @@ const verifyToken = async (
   const result = await authenticateWithToken(req);
   if (!result) return undefined;
 
-  if (!hasScope(result, "mcp:read")) return undefined;
-
-  const mcpScopes: string[] = ["read"];
-  if (hasScope(result, "mcp:write")) {
-    mcpScopes.push("write");
-  }
-
   return {
     token: bearerToken ?? "",
     clientId: result.userId,
-    scopes: mcpScopes,
+    scopes: result.scopes,
     extra: { userId: result.userId, authMethod: result.authMethod },
   };
 };

--- a/web-app/app/api/v1/mcp/route.ts
+++ b/web-app/app/api/v1/mcp/route.ts
@@ -1,4 +1,5 @@
 import { authenticateWithToken } from "@/lib/api/auth";
+import { hasScope } from "@/lib/api/scopes";
 import { registerPrompts } from "@/lib/mcp/prompts";
 import { registerResources } from "@/lib/mcp/resources";
 import { registerTools } from "@/lib/mcp/tools";
@@ -24,16 +25,29 @@ const handler = createMcpHandler(
   }
 );
 
+// Translate the PAT's internal scope vocabulary to the MCP-facing
+// `["read", "write"]` shape the SDK exposes to clients. The MCP surface
+// is gated as a whole on `mcp:read` (any caller without it is rejected
+// here); finer-grained `mcp:write` then controls the mutating tools via
+// `requireMcpScope` inside the tool implementations.
 const verifyToken = async (
   req: Request,
   bearerToken?: string
 ): Promise<AuthInfo | undefined> => {
   const result = await authenticateWithToken(req);
   if (!result) return undefined;
+
+  if (!hasScope(result, "mcp:read")) return undefined;
+
+  const mcpScopes: string[] = ["read"];
+  if (hasScope(result, "mcp:write")) {
+    mcpScopes.push("write");
+  }
+
   return {
     token: bearerToken ?? "",
     clientId: result.userId,
-    scopes: ["read", "write"],
+    scopes: mcpScopes,
     extra: { userId: result.userId, authMethod: result.authMethod },
   };
 };

--- a/web-app/app/api/v1/tokens/route.ts
+++ b/web-app/app/api/v1/tokens/route.ts
@@ -1,5 +1,5 @@
 import { requireSession } from "@/lib/api/auth";
-import { ALL_SCOPES, SCOPE_SET, type Scope } from "@/lib/api/scopes";
+import { validateRequestedScopes } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { personalAccessTokens } from "@/lib/db/schema";
 import { generateToken, getTokenPrefix, hashToken } from "@/lib/tokens";
@@ -50,37 +50,11 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Scope validation. The wildcard `*` is reserved for the migration
-  // backfill and the watcher/Lambda PATs; API callers must request an
-  // explicit, non-empty scope list. Membership is checked against the
-  // pre-built SCOPE_SET (O(1)) rather than scanning ALL_SCOPES per entry.
-  if (!Array.isArray(body.scopes) || body.scopes.length === 0) {
-    return Response.json(
-      { error: "scopes must be a non-empty array" },
-      { status: 400 }
-    );
+  const validation = validateRequestedScopes(body.scopes);
+  if (!validation.ok) {
+    return Response.json({ error: validation.error }, { status: 400 });
   }
-  if (body.scopes.some((s) => s === "*")) {
-    return Response.json(
-      {
-        error:
-          "scopes must not include the wildcard '*' — list explicit scopes",
-      },
-      { status: 400 }
-    );
-  }
-  const invalid = body.scopes.filter(
-    (s): s is string => typeof s !== "string" || !SCOPE_SET.has(s as Scope)
-  );
-  if (invalid.length > 0) {
-    return Response.json(
-      {
-        error: `Invalid scopes: ${invalid.join(", ")}. Valid scopes: ${ALL_SCOPES.join(", ")}`,
-      },
-      { status: 400 }
-    );
-  }
-  const scopes: Scope[] = body.scopes as Scope[];
+  const scopes = validation.scopes;
 
   let expiresAt: Date | null = null;
   if (body.expires_at) {

--- a/web-app/app/api/v1/tokens/route.ts
+++ b/web-app/app/api/v1/tokens/route.ts
@@ -1,4 +1,5 @@
 import { requireSession } from "@/lib/api/auth";
+import { ALL_SCOPES, SCOPE_SET, type Scope } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { personalAccessTokens } from "@/lib/db/schema";
 import { generateToken, getTokenPrefix, hashToken } from "@/lib/tokens";
@@ -16,6 +17,7 @@ export async function GET() {
       id: personalAccessTokens.id,
       name: personalAccessTokens.name,
       token_prefix: personalAccessTokens.tokenPrefix,
+      scopes: personalAccessTokens.scopes,
       last_used_at: personalAccessTokens.lastUsedAt,
       expires_at: personalAccessTokens.expiresAt,
       created_at: personalAccessTokens.createdAt,
@@ -33,7 +35,7 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  let body: { name?: string; expires_at?: string };
+  let body: { name?: string; expires_at?: string; scopes?: unknown };
   try {
     body = await request.json();
   } catch {
@@ -47,6 +49,38 @@ export async function POST(request: NextRequest) {
       { status: 400 }
     );
   }
+
+  // Scope validation. The wildcard `*` is reserved for the migration
+  // backfill and the watcher/Lambda PATs; API callers must request an
+  // explicit, non-empty scope list. Membership is checked against the
+  // pre-built SCOPE_SET (O(1)) rather than scanning ALL_SCOPES per entry.
+  if (!Array.isArray(body.scopes) || body.scopes.length === 0) {
+    return Response.json(
+      { error: "scopes must be a non-empty array" },
+      { status: 400 }
+    );
+  }
+  if (body.scopes.some((s) => s === "*")) {
+    return Response.json(
+      {
+        error:
+          "scopes must not include the wildcard '*' — list explicit scopes",
+      },
+      { status: 400 }
+    );
+  }
+  const invalid = body.scopes.filter(
+    (s): s is string => typeof s !== "string" || !SCOPE_SET.has(s as Scope)
+  );
+  if (invalid.length > 0) {
+    return Response.json(
+      {
+        error: `Invalid scopes: ${invalid.join(", ")}. Valid scopes: ${ALL_SCOPES.join(", ")}`,
+      },
+      { status: 400 }
+    );
+  }
+  const scopes: Scope[] = body.scopes as Scope[];
 
   let expiresAt: Date | null = null;
   if (body.expires_at) {
@@ -78,12 +112,14 @@ export async function POST(request: NextRequest) {
       name,
       tokenHash,
       tokenPrefix,
+      scopes,
       expiresAt,
     })
     .returning({
       id: personalAccessTokens.id,
       name: personalAccessTokens.name,
       token_prefix: personalAccessTokens.tokenPrefix,
+      scopes: personalAccessTokens.scopes,
       expires_at: personalAccessTokens.expiresAt,
       created_at: personalAccessTokens.createdAt,
     });

--- a/web-app/app/api/v1/watchers/[watcherId]/config-checksum/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/config-checksum/route.ts
@@ -5,6 +5,7 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
+import { requireScope } from "@/lib/api/scopes";
 import { isValidUUID } from "@/lib/api/validators";
 import { findActiveWatcher } from "@/lib/api/watchers";
 import type { NextRequest } from "next/server";
@@ -17,6 +18,8 @@ export async function GET(
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "watchers:read");
+  if (scopeError) return scopeError;
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {

--- a/web-app/app/api/v1/watchers/[watcherId]/config/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/config/route.ts
@@ -5,6 +5,7 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
+import { requireScope } from "@/lib/api/scopes";
 import { isValidUUID } from "@/lib/api/validators";
 import { findActiveWatcher } from "@/lib/api/watchers";
 import { db } from "@/lib/db";
@@ -20,6 +21,8 @@ export async function PUT(
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "watchers:write");
+  if (scopeError) return scopeError;
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {

--- a/web-app/app/api/v1/watchers/[watcherId]/events/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/events/route.ts
@@ -5,6 +5,7 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
+import { requireScope } from "@/lib/api/scopes";
 import {
   isValidUUID,
   parseDateParam,
@@ -30,6 +31,8 @@ export async function POST(
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "watchers:write");
+  if (scopeError) return scopeError;
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {
@@ -110,6 +113,8 @@ export async function GET(
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "watchers:read");
+  if (scopeError) return scopeError;
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {

--- a/web-app/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
@@ -5,6 +5,7 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
+import { requireScope } from "@/lib/api/scopes";
 import { isValidUUID } from "@/lib/api/validators";
 import { findActiveWatcher } from "@/lib/api/watchers";
 import { db } from "@/lib/db";
@@ -20,6 +21,8 @@ export async function POST(
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "watchers:write");
+  if (scopeError) return scopeError;
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {

--- a/web-app/app/api/v1/watchers/[watcherId]/heartbeats/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/heartbeats/route.ts
@@ -5,6 +5,7 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
+import { requireScope } from "@/lib/api/scopes";
 import {
   isValidUUID,
   parseDateParam,
@@ -24,6 +25,8 @@ export async function GET(
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "watchers:read");
+  if (scopeError) return scopeError;
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {

--- a/web-app/app/api/v1/watchers/[watcherId]/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/route.ts
@@ -6,6 +6,7 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
+import { requireScope } from "@/lib/api/scopes";
 import { isValidUUID } from "@/lib/api/validators";
 import { computeEffectiveStatus, findActiveWatcher } from "@/lib/api/watchers";
 import { db } from "@/lib/db";
@@ -21,6 +22,8 @@ export async function GET(
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "watchers:read");
+  if (scopeError) return scopeError;
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {
@@ -61,6 +64,8 @@ export async function DELETE(
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "watchers:write");
+  if (scopeError) return scopeError;
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {

--- a/web-app/app/api/v1/watchers/[watcherId]/update-check/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/update-check/route.ts
@@ -5,6 +5,7 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
+import { requireScope } from "@/lib/api/scopes";
 import { isValidUUID } from "@/lib/api/validators";
 import { findActiveWatcher } from "@/lib/api/watchers";
 import type { NextRequest } from "next/server";
@@ -57,6 +58,8 @@ export async function GET(
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "watchers:read");
+  if (scopeError) return scopeError;
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {

--- a/web-app/app/api/v1/watchers/[watcherId]/upload-queue/route.ts
+++ b/web-app/app/api/v1/watchers/[watcherId]/upload-queue/route.ts
@@ -5,6 +5,7 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
+import { requireScope } from "@/lib/api/scopes";
 import { isValidUUID } from "@/lib/api/validators";
 import { findActiveWatcher } from "@/lib/api/watchers";
 import { db } from "@/lib/db";
@@ -20,6 +21,8 @@ export async function GET(
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "watchers:read");
+  if (scopeError) return scopeError;
 
   const { watcherId } = await params;
   if (!isValidUUID(watcherId)) {

--- a/web-app/app/api/v1/watchers/register/route.ts
+++ b/web-app/app/api/v1/watchers/register/route.ts
@@ -6,6 +6,7 @@ import {
   UNAUTHORIZED,
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
+import { requireScope } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { instruments, watchers } from "@/lib/db/schema";
 import { and, eq, isNull } from "drizzle-orm";
@@ -16,6 +17,8 @@ export async function POST(request: NextRequest) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "watchers:write");
+  if (scopeError) return scopeError;
 
   let body: {
     instrument_id?: string;

--- a/web-app/app/api/v1/watchers/route.ts
+++ b/web-app/app/api/v1/watchers/route.ts
@@ -1,5 +1,6 @@
 import { authenticateRequest } from "@/lib/api/auth";
 import { apiError, UNAUTHORIZED } from "@/lib/api/errors";
+import { requireScope } from "@/lib/api/scopes";
 import { computeEffectiveStatus, STALE_THRESHOLD_MS } from "@/lib/api/watchers";
 import { db } from "@/lib/db";
 import { instruments, watchers } from "@/lib/db/schema";
@@ -11,6 +12,8 @@ export async function GET(request: NextRequest) {
   if (!authResult) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
   }
+  const scopeError = requireScope(authResult, "watchers:read");
+  if (scopeError) return scopeError;
 
   const { searchParams } = request.nextUrl;
   const instrumentIdFilter = searchParams.get("instrument_id");

--- a/web-app/app/settings/tokens/page.tsx
+++ b/web-app/app/settings/tokens/page.tsx
@@ -54,6 +54,34 @@ function toInitials(displayName: string): string {
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
+// Render a token's scopes as a compact column. `["*"]` is the backfill
+// wildcard — render it as a single "Full access" pill so legacy tokens
+// stand out at a glance, since they will eventually be rotated to
+// least-privilege scopes. Anything else is rendered one badge per scope,
+// grouped by resource so reads and writes for the same noun sit next to
+// each other.
+function TokenScopeBadges({ scopes }: { scopes: string[] }) {
+  if (scopes.length === 1 && scopes[0] === "*") {
+    return (
+      <Badge variant="secondary" className="text-xs">
+        Full access
+      </Badge>
+    );
+  }
+  // Stable sort grouped by resource: scopes within the same resource share
+  // a prefix, so a plain lexicographic sort already groups them.
+  const sorted = [...scopes].sort();
+  return (
+    <div className="flex flex-wrap gap-1">
+      {sorted.map((scope) => (
+        <Badge key={scope} variant="secondary" className="font-mono text-xs">
+          {scope}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
 export default async function TokensPage() {
   // This is an internal-tool settings page; we intentionally show every PAT
   // across the workspace so admins can audit them. Auth is enforced by the
@@ -63,6 +91,7 @@ export default async function TokensPage() {
       id: personalAccessTokens.id,
       name: personalAccessTokens.name,
       tokenPrefix: personalAccessTokens.tokenPrefix,
+      scopes: personalAccessTokens.scopes,
       lastUsedAt: personalAccessTokens.lastUsedAt,
       expiresAt: personalAccessTokens.expiresAt,
       createdAt: personalAccessTokens.createdAt,
@@ -113,6 +142,7 @@ export default async function TokensPage() {
                   <TableHead>Name</TableHead>
                   <TableHead>User</TableHead>
                   <TableHead>Token</TableHead>
+                  <TableHead>Scopes</TableHead>
                   <TableHead>Last used</TableHead>
                   <TableHead>Expires</TableHead>
                   <TableHead>Created</TableHead>
@@ -155,6 +185,9 @@ export default async function TokensPage() {
                         >
                           {token.tokenPrefix}...
                         </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <TokenScopeBadges scopes={token.scopes} />
                       </TableCell>
                       <TableCell
                         className="text-muted-foreground"

--- a/web-app/app/settings/tokens/page.tsx
+++ b/web-app/app/settings/tokens/page.tsx
@@ -54,12 +54,15 @@ function toInitials(displayName: string): string {
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
-// Render a token's scopes as a compact column. `["*"]` is the backfill
-// wildcard — render it as a single "Full access" pill so legacy tokens
-// stand out at a glance, since they will eventually be rotated to
-// least-privilege scopes. Anything else is rendered one badge per scope,
-// grouped by resource so reads and writes for the same noun sit next to
-// each other.
+// Render a token's scopes as a compact column. Three branches:
+//
+//   1. `["*"]` (backfill wildcard) → single "Full access" pill so legacy
+//      tokens stand out at a glance.
+//   2. Single explicit scope → that scope as a badge, no tooltip needed
+//      because everything is already visible.
+//   3. Multiple explicit scopes → first scope (sorted) plus a "+N"
+//      counter badge. Hovering the cell reveals the full list in a
+//      tooltip so the table stays scannable on tokens with many scopes.
 function TokenScopeBadges({ scopes }: { scopes: string[] }) {
   if (scopes.length === 1 && scopes[0] === "*") {
     return (
@@ -68,17 +71,45 @@ function TokenScopeBadges({ scopes }: { scopes: string[] }) {
       </Badge>
     );
   }
+
   // Stable sort grouped by resource: scopes within the same resource share
-  // a prefix, so a plain lexicographic sort already groups them.
+  // a prefix, so a plain lexicographic sort already groups them. The first
+  // entry in the sorted list is the one shown in the collapsed cell.
   const sorted = [...scopes].sort();
+
+  if (sorted.length <= 1) {
+    return (
+      <div className="flex flex-wrap gap-1">
+        {sorted.map((scope) => (
+          <Badge key={scope} variant="secondary" className="font-mono text-xs">
+            {scope}
+          </Badge>
+        ))}
+      </div>
+    );
+  }
+
+  const [first, ...rest] = sorted;
   return (
-    <div className="flex flex-wrap gap-1">
-      {sorted.map((scope) => (
-        <Badge key={scope} variant="secondary" className="font-mono text-xs">
-          {scope}
-        </Badge>
-      ))}
-    </div>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="flex w-fit flex-wrap items-center gap-1">
+          <Badge variant="secondary" className="font-mono text-xs">
+            {first}
+          </Badge>
+          <Badge variant="secondary" className="text-xs">
+            +{rest.length}
+          </Badge>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="flex flex-col gap-0.5 font-mono text-xs">
+          {sorted.map((scope) => (
+            <span key={scope}>{scope}</span>
+          ))}
+        </div>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -183,7 +214,7 @@ export default async function TokensPage() {
                           variant="secondary"
                           className="font-mono text-xs"
                         >
-                          {token.tokenPrefix}...
+                          {token.tokenPrefix}…
                         </Badge>
                       </TableCell>
                       <TableCell>

--- a/web-app/components/tokens/create-token-dialog.tsx
+++ b/web-app/components/tokens/create-token-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { CopyButton } from "@/components/copy-button";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -20,12 +21,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { ALL_SCOPES, type Scope } from "@/lib/api/scopes";
 import { Loader2, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useState, useTransition } from "react";
+import { useCallback, useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
 
-type Step = "form" | "display";
+// Lifted dialog state: the form and success bodies are sibling components
+// that never share state across the boundary, so the parent only tracks the
+// modal's view via a discriminated union. The plaintext token lives only
+// inside the success branch — it's structurally absent during the form
+// phase, which makes "show plaintext while filling out the form" a type
+// error rather than a runtime bug.
+type View = { kind: "form" } | { kind: "success"; plaintext: string };
 
 const EXPIRY_PRESETS = [
   { label: "30 days", value: "30" },
@@ -41,60 +49,43 @@ function computeExpiresAt(days: string): string | undefined {
   return d.toISOString();
 }
 
+// Resource → [read, write] grid order. Derived from ALL_SCOPES so adding a
+// new scope automatically surfaces in the picker. Tokens API rejects "*"
+// from callers, so it's intentionally absent here.
+type ResourceRow = {
+  resource: string;
+  read?: Scope;
+  write?: Scope;
+};
+
+function buildResourceRows(): ResourceRow[] {
+  const byResource = new Map<string, ResourceRow>();
+  for (const scope of ALL_SCOPES) {
+    const [resource, action] = scope.split(":") as [string, "read" | "write"];
+    const row = byResource.get(resource) ?? { resource };
+    row[action] = scope;
+    byResource.set(resource, row);
+  }
+  return Array.from(byResource.values());
+}
+
 export function CreateTokenDialog() {
-  const router = useRouter();
   const [open, setOpen] = useState(false);
-  const [step, setStep] = useState<Step>("form");
-  const [name, setName] = useState("");
-  const [expiry, setExpiry] = useState("90");
-  const [isPending, startTransition] = useTransition();
-  const [plaintext, setPlaintext] = useState("");
-  const reset = useCallback(() => {
-    setStep("form");
-    setName("");
-    setExpiry("90");
-    setPlaintext("");
-  }, []);
+  const [view, setView] = useState<View>({ kind: "form" });
 
-  const handleCreate = () => {
-    startTransition(async () => {
-      const expiresAt = computeExpiresAt(expiry);
-      const res = await fetch("/api/v1/tokens", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: name.trim(),
-          expires_at: expiresAt,
-        }),
-      });
-
-      if (!res.ok) {
-        const body = await res.json().catch(() => null);
-        toast.error(body?.error ?? "Failed to create token");
-        return;
-      }
-
-      const data = await res.json();
-      setPlaintext(data.token);
-      setStep("display");
-    });
-  };
-
-  const handleDone = () => {
-    setOpen(false);
-    reset();
-    router.refresh();
-  };
-
+  // Discriminated `view` controls the body: `"form"` while creating, then
+  // flipping to `{ kind: "success", plaintext }` once the API responds.
+  // No `step` boolean, no shared plaintext state — `plaintext` exists only
+  // in the success branch.
   return (
     <Dialog
       open={open}
       onOpenChange={(value) => {
         // Block dismissal while the plaintext is shown — the token can never
         // be retrieved again, so the user must explicitly click "Done".
-        if (!value && step === "display") return;
+        if (!value && view.kind === "success") return;
         setOpen(value);
-        if (!value) reset();
+        if (!value) setView({ kind: "form" });
       }}
     >
       <DialogTrigger asChild>
@@ -105,84 +96,233 @@ export function CreateTokenDialog() {
       </DialogTrigger>
       <DialogContent
         onPointerDownOutside={(e) => {
-          if (step === "display") e.preventDefault();
+          if (view.kind === "success") e.preventDefault();
         }}
         onEscapeKeyDown={(e) => {
-          if (step === "display") e.preventDefault();
+          if (view.kind === "success") e.preventDefault();
         }}
       >
-        {step === "form" ? (
-          <>
-            <DialogHeader>
-              <DialogTitle>Create access token</DialogTitle>
-              <DialogDescription>
-                Tokens are used to authenticate API requests from external
-                tools.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="grid gap-4 py-2">
-              <div className="grid gap-2">
-                <Label htmlFor="token-name">Name</Label>
-                <Input
-                  id="token-name"
-                  placeholder="e.g. Plate Reader PC"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  maxLength={100}
-                  autoFocus
-                />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="token-expiry">Expiration</Label>
-                <Select value={expiry} onValueChange={setExpiry}>
-                  <SelectTrigger id="token-expiry">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {EXPIRY_PRESETS.map((preset) => (
-                      <SelectItem key={preset.value} value={preset.value}>
-                        {preset.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-            <DialogFooter>
-              <Button
-                onClick={handleCreate}
-                disabled={!name.trim() || isPending}
-              >
-                {isPending ? (
-                  <Loader2 className="animate-spin" data-icon="inline-start" />
-                ) : null}
-                Create token
-              </Button>
-            </DialogFooter>
-          </>
+        {view.kind === "form" ? (
+          <CreateTokenForm
+            onCreated={(plaintext) => setView({ kind: "success", plaintext })}
+          />
         ) : (
-          <>
-            <DialogHeader>
-              <DialogTitle>Token created</DialogTitle>
-              <DialogDescription>
-                Make sure to copy your token now. You won&apos;t be able to see
-                it again.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="min-w-0 py-2">
-              <div className="flex items-center gap-2">
-                <code className="min-w-0 flex-1 overflow-x-hidden rounded-md border bg-muted px-3 py-2 font-mono text-sm">
-                  {plaintext}
-                </code>
-                <CopyButton value={plaintext} />
-              </div>
-            </div>
-            <DialogFooter>
-              <Button onClick={handleDone}>Done</Button>
-            </DialogFooter>
-          </>
+          <CreateTokenSuccess
+            plaintext={view.plaintext}
+            onDone={() => {
+              setOpen(false);
+              setView({ kind: "form" });
+            }}
+          />
         )}
       </DialogContent>
     </Dialog>
+  );
+}
+
+function CreateTokenForm({
+  onCreated,
+}: {
+  onCreated: (plaintext: string) => void;
+}) {
+  const [name, setName] = useState("");
+  const [expiry, setExpiry] = useState("90");
+  const [selected, setSelected] = useState<Set<Scope>>(() => new Set());
+  const [isPending, startTransition] = useTransition();
+
+  // ALL_SCOPES is module-level constant, so the grid is stable across
+  // renders — memoising the build avoids re-grouping on every keystroke.
+  const resourceRows = useMemo(() => buildResourceRows(), []);
+
+  // Functional setState so the handler identity stays stable across
+  // renders; the Checkbox subtree can rely on Object.is to skip re-render.
+  const toggle = useCallback((s: Scope) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(s)) {
+        next.delete(s);
+      } else {
+        next.add(s);
+      }
+      return next;
+    });
+  }, []);
+
+  // Disabled state is derived inline from the inputs — no extra `useState`
+  // mirror, no effect to keep them in sync.
+  const canSubmit = Boolean(name.trim()) && selected.size > 0 && !isPending;
+
+  const handleCreate = () => {
+    startTransition(async () => {
+      const expiresAt = computeExpiresAt(expiry);
+      const res = await fetch("/api/v1/tokens", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          expires_at: expiresAt,
+          scopes: Array.from(selected),
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        toast.error(body?.error ?? "Failed to create token");
+        return;
+      }
+
+      const data = await res.json();
+      onCreated(data.token);
+    });
+  };
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Create access token</DialogTitle>
+        <DialogDescription>
+          Tokens are used to authenticate API requests from external tools.
+        </DialogDescription>
+      </DialogHeader>
+      <div className="grid gap-4 py-2">
+        <div className="grid gap-2">
+          <Label htmlFor="token-name">Name</Label>
+          <Input
+            id="token-name"
+            placeholder="e.g. Plate Reader PC"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            maxLength={100}
+            autoFocus
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="token-expiry">Expiration</Label>
+          <Select value={expiry} onValueChange={setExpiry}>
+            <SelectTrigger id="token-expiry">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {EXPIRY_PRESETS.map((preset) => (
+                <SelectItem key={preset.value} value={preset.value}>
+                  {preset.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="grid gap-2">
+          <Label>Scopes</Label>
+          <div className="grid grid-cols-[1fr_auto_auto] items-center gap-x-4 gap-y-2 rounded-md border bg-background px-3 py-2 dark:bg-muted">
+            <div className="text-xs font-medium text-muted-foreground">
+              Resource
+            </div>
+            <div className="w-14 text-center text-xs font-medium text-muted-foreground">
+              Read
+            </div>
+            <div className="w-14 text-center text-xs font-medium text-muted-foreground">
+              Write
+            </div>
+            {resourceRows.map((row) => (
+              <ScopeRow
+                key={row.resource}
+                row={row}
+                selected={selected}
+                onToggle={toggle}
+              />
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Pick the minimum scopes this token needs. You can&apos;t change them
+            after creation — revoke and re-issue instead.
+          </p>
+        </div>
+      </div>
+      <DialogFooter>
+        <Button onClick={handleCreate} disabled={!canSubmit}>
+          {isPending ? (
+            <Loader2 className="animate-spin" data-icon="inline-start" />
+          ) : null}
+          Create token
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function ScopeRow({
+  row,
+  selected,
+  onToggle,
+}: {
+  row: ResourceRow;
+  selected: Set<Scope>;
+  onToggle: (s: Scope) => void;
+}) {
+  return (
+    <>
+      <div className="text-sm">{row.resource}</div>
+      <div className="flex w-14 justify-center">
+        {row.read ? (
+          <Checkbox
+            id={`scope-${row.read}`}
+            checked={selected.has(row.read)}
+            onCheckedChange={() => onToggle(row.read as Scope)}
+            aria-label={row.read}
+          />
+        ) : (
+          <span className="text-xs text-muted-foreground/40">—</span>
+        )}
+      </div>
+      <div className="flex w-14 justify-center">
+        {row.write ? (
+          <Checkbox
+            id={`scope-${row.write}`}
+            checked={selected.has(row.write)}
+            onCheckedChange={() => onToggle(row.write as Scope)}
+            aria-label={row.write}
+          />
+        ) : (
+          <span className="text-xs text-muted-foreground/40">—</span>
+        )}
+      </div>
+    </>
+  );
+}
+
+function CreateTokenSuccess({
+  plaintext,
+  onDone,
+}: {
+  plaintext: string;
+  onDone: () => void;
+}) {
+  const router = useRouter();
+  const handleDone = () => {
+    onDone();
+    router.refresh();
+  };
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Token created</DialogTitle>
+        <DialogDescription>
+          Make sure to copy your token now. You won&apos;t be able to see it
+          again.
+        </DialogDescription>
+      </DialogHeader>
+      <div className="min-w-0 py-2">
+        <div className="flex items-center gap-2">
+          <code className="min-w-0 flex-1 overflow-x-hidden rounded-md border bg-muted px-3 py-2 font-mono text-sm">
+            {plaintext}
+          </code>
+          <CopyButton value={plaintext} />
+        </div>
+      </div>
+      <DialogFooter>
+        <Button onClick={handleDone}>Done</Button>
+      </DialogFooter>
+    </>
   );
 }

--- a/web-app/drizzle/0022_pat_scopes.sql
+++ b/web-app/drizzle/0022_pat_scopes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "personal_access_tokens" ADD COLUMN "scopes" text[] DEFAULT ARRAY['*']::text[] NOT NULL;

--- a/web-app/drizzle/meta/0022_snapshot.json
+++ b/web-app/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,1712 @@
+{
+  "id": "79bcfbae-e4ba-405e-8dde-fe328e4a1f5e",
+  "prevId": "f2cb32f9-dd57-4afd-9ab4-88f97c9eb0d2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archive_jobs": {
+      "name": "archive_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archive_bucket": {
+          "name": "archive_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_key": {
+          "name": "archive_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "archive_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_archive_jobs_inflight": {
+          "name": "uq_archive_jobs_inflight",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"archive_jobs\".\"status\" in ('pending', 'building')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_archive_jobs_run_fingerprint_status": {
+          "name": "idx_archive_jobs_run_fingerprint_status",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "archive_jobs_instrument_run_id_instrument_runs_id_fk": {
+          "name": "archive_jobs_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "archive_jobs_created_by_user_id_fk": {
+          "name": "archive_jobs_created_by_user_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "file_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raw'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_requested_at": {
+          "name": "upload_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_files_instrument_run_id_relative_path": {
+          "name": "uq_files_instrument_run_id_relative_path",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"relative_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_active_instrument_run_id_filename": {
+          "name": "uq_files_active_instrument_run_id_filename",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_s3_key": {
+          "name": "uq_files_s3_key",
+          "columns": [
+            {
+              "expression": "s3_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"s3_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_instrument_run_id": {
+          "name": "idx_files_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_status_instrument_run_id": {
+          "name": "idx_files_status_instrument_run_id",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_upload_queue": {
+          "name": "idx_files_upload_queue",
+          "columns": [
+            {
+              "expression": "upload_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"upload_requested_at\" is not null and \"files\".\"uploaded_at\" is null and \"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_metadata_gin": {
+          "name": "idx_files_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_instrument_run_id_instrument_runs_id_fk": {
+          "name": "files_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_runs": {
+      "name": "instrument_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "instrument_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lambda'"
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instrument_runs_instrument_id_created_at": {
+          "name": "idx_instrument_runs_instrument_id_created_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active": {
+          "name": "idx_instrument_runs_active",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active_acquired_at": {
+          "name": "idx_instrument_runs_active_acquired_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"acquired_at\", \"created_at\") desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_metadata_gin": {
+          "name": "idx_instrument_runs_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_runs_instrument_id_instruments_id_fk": {
+          "name": "instrument_runs_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_watcher_id_watchers_id_fk": {
+          "name": "instrument_runs_watcher_id_watchers_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_instrument_runs_instrument_id_run_id": {
+          "name": "uq_instrument_runs_instrument_id_run_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instrument_id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instruments": {
+      "name": "instruments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instrument_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instrument_type": {
+          "name": "instrument_type",
+          "type": "instrument_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['*']::text[]"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_personal_access_tokens_user_id": {
+          "name": "idx_personal_access_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_user_id_fk": {
+          "name": "personal_access_tokens_user_id_user_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_attributions": {
+      "name": "run_attributions",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_attributions_run_id": {
+          "name": "idx_run_attributions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_attributions_user_id": {
+          "name": "idx_run_attributions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_attributions_run_id_instrument_runs_id_fk": {
+          "name": "run_attributions_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_attributions_user_id_user_id_fk": {
+          "name": "run_attributions_user_id_user_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_attributions_run_id_user_id_pk": {
+          "name": "run_attributions_run_id_user_id_pk",
+          "columns": [
+            "run_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_comments": {
+      "name": "run_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_run_comments_run_id_created_at": {
+          "name": "idx_run_comments_run_id_created_at",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_comments_user_id": {
+          "name": "idx_run_comments_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_comments_run_id_instrument_runs_id_fk": {
+          "name": "run_comments_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_comments_user_id_user_id_fk": {
+          "name": "run_comments_user_id_user_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_events": {
+      "name": "watcher_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "watcher_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_events_watcher_id_timestamp": {
+          "name": "idx_watcher_events_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_watcher_events_watcher_id_event_type": {
+          "name": "idx_watcher_events_watcher_id_event_type",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_events_watcher_id_watchers_id_fk": {
+          "name": "watcher_events_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_events",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_heartbeats": {
+      "name": "watcher_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_mode": {
+          "name": "upload_mode",
+          "type": "upload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_uploaded_since_last": {
+          "name": "files_uploaded_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "runs_reported_since_last": {
+          "name": "runs_reported_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_since_last": {
+          "name": "errors_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_heartbeats_watcher_id_timestamp": {
+          "name": "idx_watcher_heartbeats_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_heartbeats_watcher_id_watchers_id_fk": {
+          "name": "watcher_heartbeats_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_heartbeats",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watchers": {
+      "name": "watchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_info": {
+          "name": "os_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watcher_version": {
+          "name": "watcher_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_checksum": {
+          "name": "config_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_yaml": {
+          "name": "config_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "watcher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_watchers_active_instrument_id": {
+          "name": "uq_watchers_active_instrument_id",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"watchers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchers_instrument_id_instruments_id_fk": {
+          "name": "watchers_instrument_id_instruments_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.archive_job_status": {
+      "name": "archive_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "building",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.file_category": {
+      "name": "file_category",
+      "schema": "public",
+      "values": [
+        "raw",
+        "processed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "detected",
+        "upload_requested",
+        "uploaded",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.instrument_run_source": {
+      "name": "instrument_run_source",
+      "schema": "public",
+      "values": [
+        "lambda",
+        "watcher"
+      ]
+    },
+    "public.instrument_status": {
+      "name": "instrument_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "inactive"
+      ]
+    },
+    "public.instrument_type": {
+      "name": "instrument_type",
+      "schema": "public",
+      "values": [
+        "generic",
+        "plate_reader",
+        "gel_doc",
+        "qpcr",
+        "tape_station",
+        "hina_microscope",
+        "epson_v700_scanner",
+        "instant_raman"
+      ]
+    },
+    "public.upload_mode": {
+      "name": "upload_mode",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual"
+      ]
+    },
+    "public.watcher_event_type": {
+      "name": "watcher_event_type",
+      "schema": "public",
+      "values": [
+        "watcher_started",
+        "watcher_stopped",
+        "file_uploaded",
+        "upload_failed",
+        "run_reported",
+        "config_synced",
+        "error",
+        "update_started",
+        "update_succeeded",
+        "update_failed"
+      ]
+    },
+    "public.watcher_status": {
+      "name": "watcher_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "watching",
+        "stopped"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web-app/drizzle/meta/_journal.json
+++ b/web-app/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1778878800000,
       "tag": "0021_instant_raman_type",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1778799469455,
+      "tag": "0022_pat_scopes",
+      "breakpoints": true
     }
   ]
 }

--- a/web-app/lib/api/auth.ts
+++ b/web-app/lib/api/auth.ts
@@ -6,9 +6,14 @@ import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 import { after } from "next/server";
 
-type AuthResult = {
+export type AuthResult = {
   userId: string;
   authMethod: "session" | "token";
+  // Permission scopes carried by this request. Token-authenticated requests
+  // carry the scopes column from `personal_access_tokens`. Session
+  // (NextAuth) authentication is treated as fully privileged and always
+  // returns `["*"]`, so `requireScope` is a no-op for browser sessions.
+  scopes: string[];
 };
 
 /**
@@ -36,6 +41,7 @@ async function validatePat(
       id: personalAccessTokens.id,
       userId: personalAccessTokens.userId,
       expiresAt: personalAccessTokens.expiresAt,
+      scopes: personalAccessTokens.scopes,
     })
     .from(personalAccessTokens)
     .where(eq(personalAccessTokens.tokenHash, hash))
@@ -58,7 +64,7 @@ async function validatePat(
       .where(eq(personalAccessTokens.id, pat.id));
   });
 
-  return { userId: pat.userId, authMethod: "token" };
+  return { userId: pat.userId, authMethod: "token", scopes: pat.scopes };
 }
 
 export async function authenticateRequest(
@@ -66,7 +72,7 @@ export async function authenticateRequest(
 ): Promise<AuthResult | null> {
   const session = await auth();
   if (session?.user?.id) {
-    return { userId: session.user.id, authMethod: "session" };
+    return { userId: session.user.id, authMethod: "session", scopes: ["*"] };
   }
 
   return validatePat(_request.headers.get("authorization"));
@@ -86,7 +92,7 @@ export async function authenticateWithToken(
 export async function requireSession(): Promise<AuthResult | null> {
   const session = await auth();
   if (session?.user?.id) {
-    return { userId: session.user.id, authMethod: "session" };
+    return { userId: session.user.id, authMethod: "session", scopes: ["*"] };
   }
   return null;
 }

--- a/web-app/lib/api/scopes.ts
+++ b/web-app/lib/api/scopes.ts
@@ -15,8 +15,6 @@ export const ALL_SCOPES = [
   "watchers:read",
   "watchers:write",
   "archive-jobs:write",
-  "mcp:read",
-  "mcp:write",
 ] as const;
 
 export type Scope = (typeof ALL_SCOPES)[number];

--- a/web-app/lib/api/scopes.ts
+++ b/web-app/lib/api/scopes.ts
@@ -14,6 +14,7 @@ export const ALL_SCOPES = [
   "files:write",
   "watchers:read",
   "watchers:write",
+  "archive-jobs:read",
   "archive-jobs:write",
 ] as const;
 
@@ -43,4 +44,43 @@ export function requireScope(auth: AuthLike, required: Scope): Response | null {
     FORBIDDEN,
     `Token is missing required scope: ${required}`
   );
+}
+
+// Validates the `scopes` field on a `POST /api/v1/tokens` request body.
+// Returns the typed scope array on success, or an error message ready for
+// the 400 response. Extracted from the route handler so the rules
+// ("non-empty", "no wildcard", "valid vocabulary") can be unit-tested
+// without spinning up the Next.js server, NextAuth, or the database.
+//
+// Rules enforced here:
+//   - `scopes` must be an array with at least one entry.
+//   - The wildcard `*` is rejected — it's reserved for the migration
+//     backfill and the watcher/Lambda PATs; API callers must enumerate.
+//   - Every entry must be a string in `SCOPE_SET`. Unknown / non-string
+//     entries are reported in the error message verbatim so callers can
+//     spot typos quickly.
+export type ScopeValidationResult =
+  | { ok: true; scopes: Scope[] }
+  | { ok: false; error: string };
+
+export function validateRequestedScopes(input: unknown): ScopeValidationResult {
+  if (!Array.isArray(input) || input.length === 0) {
+    return { ok: false, error: "scopes must be a non-empty array" };
+  }
+  if (input.some((s) => s === "*")) {
+    return {
+      ok: false,
+      error: "scopes must not include the wildcard '*' — list explicit scopes",
+    };
+  }
+  const invalid = input.filter(
+    (s): s is string => typeof s !== "string" || !SCOPE_SET.has(s as Scope)
+  );
+  if (invalid.length > 0) {
+    return {
+      ok: false,
+      error: `Invalid scopes: ${invalid.join(", ")}. Valid scopes: ${ALL_SCOPES.join(", ")}`,
+    };
+  }
+  return { ok: true, scopes: input as Scope[] };
 }

--- a/web-app/lib/api/scopes.ts
+++ b/web-app/lib/api/scopes.ts
@@ -1,0 +1,48 @@
+import { apiError, FORBIDDEN } from "@/lib/api/errors";
+
+// Canonical scope vocabulary. Each entry is `resource:action` and is added
+// or revoked atomically — there are no implicit hierarchies (e.g. `:write`
+// does not imply `:read`). The `*` wildcard is reserved for the migration
+// backfill and for the watcher/Lambda PATs until they are rotated to
+// least-privilege; `POST /api/v1/tokens` rejects it from API callers.
+export const ALL_SCOPES = [
+  "instruments:read",
+  "instruments:write",
+  "runs:read",
+  "runs:write",
+  "files:read",
+  "files:write",
+  "watchers:read",
+  "watchers:write",
+  "archive-jobs:write",
+  "mcp:read",
+  "mcp:write",
+] as const;
+
+export type Scope = (typeof ALL_SCOPES)[number];
+
+// Pre-built set for O(1) membership checks in hot validation paths
+// (`POST /api/v1/tokens`). Avoids re-scanning ALL_SCOPES on every request.
+export const SCOPE_SET: Set<Scope> = new Set<Scope>(ALL_SCOPES);
+
+// Shape required by `hasScope` / `requireScope`. We intentionally avoid
+// importing the full `AuthResult` from `@/lib/api/auth` to break a circular
+// dependency — scopes.ts is imported by auth.ts callers.
+type AuthLike = { scopes: string[] };
+
+export function hasScope(auth: AuthLike, required: Scope): boolean {
+  return auth.scopes.includes("*") || auth.scopes.includes(required);
+}
+
+// Returns a `Response` to short-circuit the handler when the scope is
+// missing, or `null` when the caller is authorized. Route handlers should
+// use the pattern: `const scopeError = requireScope(auth, "runs:write");
+// if (scopeError) return scopeError;`
+export function requireScope(auth: AuthLike, required: Scope): Response | null {
+  if (hasScope(auth, required)) return null;
+  return apiError(
+    403,
+    FORBIDDEN,
+    `Token is missing required scope: ${required}`
+  );
+}

--- a/web-app/lib/db/schema.ts
+++ b/web-app/lib/db/schema.ts
@@ -158,6 +158,15 @@ export const personalAccessTokens = pgTable(
     // First 8 characters of the token, stored for display purposes
     // (e.g., `dhub_a1b2...`).
     tokenPrefix: text("token_prefix").notNull(),
+    // Permission scopes granted to this token (e.g., `runs:read`,
+    // `files:write`). The wildcard `*` matches everything and is used as
+    // the backfill value for pre-scope tokens. New tokens created via the
+    // API always carry an explicit, non-wildcard scope list. Enforcement
+    // happens in the auth middleware via `requireScope`.
+    scopes: text("scopes")
+      .array()
+      .notNull()
+      .default(sql`ARRAY['*']::text[]`),
     // Updated on each API call authenticated with this token.
     lastUsedAt: timestamp("last_used_at", {
       withTimezone: true,

--- a/web-app/lib/mcp/tools.ts
+++ b/web-app/lib/mcp/tools.ts
@@ -48,12 +48,19 @@ function errorResult(message: string) {
 // short-circuits with a clear error result when the caller's PAT lacks
 // `mcp:write`. Tools that mutate state (claim_run, unclaim_run,
 // reprocess_file) call this before doing any DB work.
+//
+// When `authInfo` is undefined we skip the check: production traffic always
+// has it (enforced by `withMcpAuth({ required: true })` in the route), and
+// the in-memory test transport intentionally omits it. Letting unauthenticated
+// callers through here keeps scope enforcement aligned with the HTTP
+// boundary; downstream user-identity checks (e.g. `resolveAttributionTarget`)
+// still reject the call when a user id is required.
 function requireMcpScope(
   authInfo: AuthInfo | undefined,
   required: "read" | "write"
 ) {
-  const scopes = authInfo?.scopes ?? [];
-  if (scopes.includes(required)) return null;
+  if (!authInfo) return null;
+  if (authInfo.scopes?.includes(required)) return null;
   return errorResult(`Token is missing required MCP scope: ${required}`);
 }
 

--- a/web-app/lib/mcp/tools.ts
+++ b/web-app/lib/mcp/tools.ts
@@ -16,6 +16,7 @@ import {
   getInstrumentById,
   getInstrumentListWithCounts,
 } from "@/lib/api/instruments";
+import { hasScope, type Scope } from "@/lib/api/scopes";
 import { getWatcherHeartbeats, getWatcherList } from "@/lib/api/watchers";
 import { db } from "@/lib/db";
 import { runAttributions } from "@/lib/db/schema";
@@ -43,11 +44,10 @@ function errorResult(message: string) {
   };
 }
 
-// Guard for mutating MCP tools. The MCP route's verifyToken translates PAT
-// scopes into the SDK-facing `["read", "write"]` vocabulary; this helper
-// short-circuits with a clear error result when the caller's PAT lacks
-// `mcp:write`. Tools that mutate state (claim_run, unclaim_run,
-// reprocess_file) call this before doing any DB work.
+// Per-tool scope guard. Every MCP tool checks the same `<resource>:<action>`
+// scope its REST counterpart enforces — there is no MCP-specific scope
+// vocabulary, so a token with `runs:read` over REST also covers `search_runs`
+// over MCP, and so on.
 //
 // When `authInfo` is undefined we skip the check: production traffic always
 // has it (enforced by `withMcpAuth({ required: true })` in the route), and
@@ -57,11 +57,11 @@ function errorResult(message: string) {
 // still reject the call when a user id is required.
 function requireMcpScope(
   authInfo: AuthInfo | undefined,
-  required: "read" | "write"
-) {
+  required: Scope
+): ReturnType<typeof errorResult> | null {
   if (!authInfo) return null;
-  if (authInfo.scopes?.includes(required)) return null;
-  return errorResult(`Token is missing required MCP scope: ${required}`);
+  if (hasScope({ scopes: authInfo.scopes ?? [] }, required)) return null;
+  return errorResult(`Token is missing required scope: ${required}`);
 }
 
 type AttributionResolution =
@@ -111,7 +111,9 @@ export function registerTools(server: McpServer) {
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ status }) => {
+    async ({ status }, { authInfo }) => {
+      const scopeError = requireMcpScope(authInfo, "instruments:read");
+      if (scopeError) return scopeError;
       const instruments = await getInstrumentListWithCounts();
       const filtered = status
         ? instruments.filter((i) => i.status === status)
@@ -135,7 +137,9 @@ export function registerTools(server: McpServer) {
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ instrumentId }) => {
+    async ({ instrumentId }, { authInfo }) => {
+      const scopeError = requireMcpScope(authInfo, "instruments:read");
+      if (scopeError) return scopeError;
       const instrument = await getInstrumentById(instrumentId);
       if (!instrument) {
         return errorResult(`Instrument '${instrumentId}' not found.`);
@@ -219,7 +223,9 @@ export function registerTools(server: McpServer) {
       },
       annotations: { readOnlyHint: true },
     },
-    async (args) => {
+    async (args, { authInfo }) => {
+      const scopeError = requireMcpScope(authInfo, "runs:read");
+      if (scopeError) return scopeError;
       const result = await buildRunListQuery({
         instrumentId: args.instrumentId,
         source: args.source,
@@ -252,7 +258,9 @@ export function registerTools(server: McpServer) {
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ instrumentId, runId }) => {
+    async ({ instrumentId, runId }, { authInfo }) => {
+      const scopeError = requireMcpScope(authInfo, "runs:read");
+      if (scopeError) return scopeError;
       const run = await lookupRunByNaturalKey(instrumentId, runId);
       if (!run) {
         return errorResult(
@@ -275,7 +283,13 @@ export function registerTools(server: McpServer) {
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ instrumentId, runId }) => {
+    async ({ instrumentId, runId }, { authInfo }) => {
+      // The tool is keyed by run and the result is "what files belong to
+      // this run", which lives under the runs domain in the REST API too
+      // (`GET /instruments/:id/runs/:runId` returns files alongside the
+      // run). One scope (`runs:read`) covers both.
+      const scopeError = requireMcpScope(authInfo, "runs:read");
+      if (scopeError) return scopeError;
       const run = await lookupRunByNaturalKey(instrumentId, runId);
       if (!run) {
         return errorResult(
@@ -295,7 +309,14 @@ export function registerTools(server: McpServer) {
         "Get a dashboard-level overview: per-instrument run counts, watcher health (online/offline/no_watcher), and pending upload counts.",
       annotations: { readOnlyHint: true },
     },
-    async () => {
+    // No inputSchema → the SDK passes the request `extra` as a single
+    // argument; pull `authInfo` directly off it.
+    async ({ authInfo }) => {
+      // Dashboard summary keyed per-instrument; gated on `instruments:read`
+      // for parity with the dashboard data source. Watcher health is
+      // included for context but isn't the primary axis.
+      const scopeError = requireMcpScope(authInfo, "instruments:read");
+      if (scopeError) return scopeError;
       const summaries = await getInstrumentSummaries();
       return textResult(summaries);
     }
@@ -315,7 +336,9 @@ export function registerTools(server: McpServer) {
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ instrumentId }) => {
+    async ({ instrumentId }, { authInfo }) => {
+      const scopeError = requireMcpScope(authInfo, "watchers:read");
+      if (scopeError) return scopeError;
       const allWatchers = await getWatcherList({ includeDeleted: false });
       const filtered = instrumentId
         ? allWatchers.filter((w) => w.instrumentId === instrumentId)
@@ -335,7 +358,9 @@ export function registerTools(server: McpServer) {
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ fileId }) => {
+    async ({ fileId }, { authInfo }) => {
+      const scopeError = requireMcpScope(authInfo, "files:read");
+      if (scopeError) return scopeError;
       const file = await getActiveFileById(fileId);
       if (!file) {
         return errorResult(`File '${fileId}' not found.`);
@@ -355,7 +380,9 @@ export function registerTools(server: McpServer) {
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ fileId }) => {
+    async ({ fileId }, { authInfo }) => {
+      const scopeError = requireMcpScope(authInfo, "files:read");
+      if (scopeError) return scopeError;
       const lookup = await lookupFileForDownload(fileId);
       if (!lookup.ok) {
         if (lookup.reason === "not_uploaded") {
@@ -393,7 +420,10 @@ export function registerTools(server: McpServer) {
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ instrumentId, runId }) => {
+    async ({ instrumentId, runId }, { authInfo }) => {
+      // Mirror the REST archive route which is gated on `files:read`.
+      const scopeError = requireMcpScope(authInfo, "files:read");
+      if (scopeError) return scopeError;
       const run = await lookupRunByNaturalKey(instrumentId, runId);
       if (!run) {
         return errorResult(
@@ -439,7 +469,7 @@ export function registerTools(server: McpServer) {
       annotations: { readOnlyHint: false, destructiveHint: true },
     },
     async ({ fileId }, { authInfo }) => {
-      const scopeError = requireMcpScope(authInfo, "write");
+      const scopeError = requireMcpScope(authInfo, "files:write");
       if (scopeError) return scopeError;
       const result = await reprocessFile(fileId);
       if (!result.ok) {
@@ -467,7 +497,9 @@ export function registerTools(server: McpServer) {
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ watcherId, hours }) => {
+    async ({ watcherId, hours }, { authInfo }) => {
+      const scopeError = requireMcpScope(authInfo, "watchers:read");
+      if (scopeError) return scopeError;
       const lookbackHours = hours ?? 24;
       const since = new Date(Date.now() - lookbackHours * 60 * 60 * 1000);
       const { rows, total } = await getWatcherHeartbeats(watcherId, {
@@ -502,7 +534,7 @@ export function registerTools(server: McpServer) {
       },
     },
     async ({ instrumentId, runId }, { authInfo }) => {
-      const scopeError = requireMcpScope(authInfo, "write");
+      const scopeError = requireMcpScope(authInfo, "runs:write");
       if (scopeError) return scopeError;
       const resolved = await resolveAttributionTarget(
         authInfo,
@@ -544,7 +576,7 @@ export function registerTools(server: McpServer) {
       },
     },
     async ({ instrumentId, runId }, { authInfo }) => {
-      const scopeError = requireMcpScope(authInfo, "write");
+      const scopeError = requireMcpScope(authInfo, "runs:write");
       if (scopeError) return scopeError;
       const resolved = await resolveAttributionTarget(
         authInfo,
@@ -582,7 +614,9 @@ export function registerTools(server: McpServer) {
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ instrumentId }) => {
+    async ({ instrumentId }, { authInfo }) => {
+      const scopeError = requireMcpScope(authInfo, "runs:read");
+      if (scopeError) return scopeError;
       const attributors = await getRanByFilterOptions(instrumentId);
       return textResult(attributors);
     }

--- a/web-app/lib/mcp/tools.ts
+++ b/web-app/lib/mcp/tools.ts
@@ -43,6 +43,20 @@ function errorResult(message: string) {
   };
 }
 
+// Guard for mutating MCP tools. The MCP route's verifyToken translates PAT
+// scopes into the SDK-facing `["read", "write"]` vocabulary; this helper
+// short-circuits with a clear error result when the caller's PAT lacks
+// `mcp:write`. Tools that mutate state (claim_run, unclaim_run,
+// reprocess_file) call this before doing any DB work.
+function requireMcpScope(
+  authInfo: AuthInfo | undefined,
+  required: "read" | "write"
+) {
+  const scopes = authInfo?.scopes ?? [];
+  if (scopes.includes(required)) return null;
+  return errorResult(`Token is missing required MCP scope: ${required}`);
+}
+
 type AttributionResolution =
   | { ok: true; userId: string; runUuid: string }
   | { ok: false; error: ReturnType<typeof errorResult> };
@@ -417,7 +431,9 @@ export function registerTools(server: McpServer) {
       // irreversible from the tool's perspective and clients should confirm.
       annotations: { readOnlyHint: false, destructiveHint: true },
     },
-    async ({ fileId }) => {
+    async ({ fileId }, { authInfo }) => {
+      const scopeError = requireMcpScope(authInfo, "write");
+      if (scopeError) return scopeError;
       const result = await reprocessFile(fileId);
       if (!result.ok) {
         return errorResult(`[${result.code}] ${result.message}`);
@@ -479,6 +495,8 @@ export function registerTools(server: McpServer) {
       },
     },
     async ({ instrumentId, runId }, { authInfo }) => {
+      const scopeError = requireMcpScope(authInfo, "write");
+      if (scopeError) return scopeError;
       const resolved = await resolveAttributionTarget(
         authInfo,
         instrumentId,
@@ -519,6 +537,8 @@ export function registerTools(server: McpServer) {
       },
     },
     async ({ instrumentId, runId }, { authInfo }) => {
+      const scopeError = requireMcpScope(authInfo, "write");
+      if (scopeError) return scopeError;
       const resolved = await resolveAttributionTarget(
         authInfo,
         instrumentId,

--- a/web-app/tests/integration/helpers.ts
+++ b/web-app/tests/integration/helpers.ts
@@ -86,7 +86,12 @@ function getTokenPrefix(plaintext: string): string {
 // token here and pass it to both the DB (hashed) and the test (plaintext).
 //
 // Pass `expiresAt` to test expired-token rejection. Defaults to no expiry.
-export async function seedTestUser(options?: { expiresAt?: Date | null }) {
+// Pass `scopes` to test scope enforcement; defaults to `["*"]` so every
+// existing test (which expects full access) keeps passing.
+export async function seedTestUser(options?: {
+  expiresAt?: Date | null;
+  scopes?: string[];
+}) {
   const db = getTestDb();
 
   const userId = crypto.randomUUID();
@@ -102,6 +107,7 @@ export async function seedTestUser(options?: { expiresAt?: Date | null }) {
     name: "integration-test-token",
     tokenHash: hashToken(plaintext),
     tokenPrefix: getTokenPrefix(plaintext),
+    scopes: options?.scopes ?? ["*"],
     expiresAt: options?.expiresAt !== undefined ? options.expiresAt : null,
   });
 

--- a/web-app/tests/integration/mcp.test.ts
+++ b/web-app/tests/integration/mcp.test.ts
@@ -295,4 +295,96 @@ describe("MCP Server (HTTP)", () => {
     expect(parsed.attributions).toHaveLength(1);
     expect(parsed.attributions[0].userId).toBe(userId);
   });
+
+  // ---- PAT scope enforcement -----------------------------------------------
+  //
+  // Each MCP tool calls `requireMcpScope(authInfo, "<resource>:<action>")`
+  // matching its REST counterpart (see `lib/mcp/tools.ts`). These tests seed
+  // a PAT with a narrow scope set and confirm that:
+  //   - tools whose required scope is granted execute normally;
+  //   - tools whose required scope is missing return `isError: true` with
+  //     a "missing required scope: <scope>" message.
+  //
+  // The scope guard runs before any DB lookup, so we don't need to seed
+  // the file/run referenced by the call — a non-existent id is fine since
+  // the call should be rejected at the guard, not at the lookup.
+
+  it("['runs:read'] can call search_runs but not claim_run", async () => {
+    const { token: scopedToken } = await seedTestUser({
+      scopes: ["runs:read"],
+    });
+
+    const search = await callTool("search_runs", { instrumentId }, scopedToken);
+    expect(search.isError).toBeFalsy();
+
+    const claim = await callTool(
+      "claim_run",
+      { instrumentId, runId },
+      scopedToken
+    );
+    expect(claim.isError).toBe(true);
+    expect(claim.content[0].text).toMatch(/missing required scope: runs:write/);
+  });
+
+  it("['files:read'] can call get_file but not reprocess_file", async () => {
+    const { token: scopedToken } = await seedTestUser({
+      scopes: ["files:read"],
+    });
+
+    // get_file with a nonexistent id still passes the scope guard; it
+    // surfaces a "not found" error instead of a missing-scope error.
+    const getFile = await callTool("get_file", { fileId: 99_999 }, scopedToken);
+    expect(getFile.isError).toBe(true);
+    expect(getFile.content[0].text).toMatch(/not found/);
+    expect(getFile.content[0].text).not.toMatch(/missing required scope/);
+
+    const reprocess = await callTool(
+      "reprocess_file",
+      { fileId: 99_999 },
+      scopedToken
+    );
+    expect(reprocess.isError).toBe(true);
+    expect(reprocess.content[0].text).toMatch(
+      /missing required scope: files:write/
+    );
+  });
+
+  it("['watchers:read'] can call list_watchers but not list_instruments", async () => {
+    const { token: scopedToken } = await seedTestUser({
+      scopes: ["watchers:read"],
+    });
+
+    const watchers = await callTool("list_watchers", {}, scopedToken);
+    expect(watchers.isError).toBeFalsy();
+
+    const instruments = await callTool("list_instruments", {}, scopedToken);
+    expect(instruments.isError).toBe(true);
+    expect(instruments.content[0].text).toMatch(
+      /missing required scope: instruments:read/
+    );
+  });
+
+  it("[] is denied on every protected tool", async () => {
+    const { token: scopedToken } = await seedTestUser({ scopes: [] });
+
+    for (const toolName of [
+      "list_instruments",
+      "search_runs",
+      "list_watchers",
+      "claim_run",
+      "reprocess_file",
+    ]) {
+      const result = await callTool(
+        toolName,
+        toolName === "claim_run"
+          ? { instrumentId, runId }
+          : toolName === "reprocess_file"
+            ? { fileId: 99_999 }
+            : {},
+        scopedToken
+      );
+      expect(result.isError, `expected ${toolName} to be denied`).toBe(true);
+      expect(result.content[0].text).toMatch(/missing required scope/);
+    }
+  });
 });

--- a/web-app/tests/integration/scopes.test.ts
+++ b/web-app/tests/integration/scopes.test.ts
@@ -131,4 +131,104 @@ describe("PAT scopes", () => {
     });
     expect(runsPost.status).toBe(403);
   });
+
+  // -------------------------------------------------------------------------
+  // Cross-resource coverage. The route handler pattern is mechanical (28
+  // routes all call `requireScope(authResult, "...")`) but a typo in any
+  // single route — say `runs:read` pasted into a watchers handler — would
+  // be invisible if every assertion only hit the runs surface. These cases
+  // touch each remaining resource family with a representative read + write
+  // route so the wrong-scope-string class of bug is detectable.
+  //
+  // Endpoints that need the requested scope return their normal 2xx /
+  // missing-fixture status; ones that don't return 403. We assert the
+  // status code rather than the response body when scope-passes route into
+  // a "not found" branch so the test doesn't depend on fixture details.
+  // -------------------------------------------------------------------------
+
+  it("['instruments:read'] can GET instruments but is 403 on POST", async () => {
+    const { token } = await seedTestUser({ scopes: ["instruments:read"] });
+
+    const getRes = await api("/api/v1/instruments", { token });
+    expect(getRes.status).toBe(200);
+
+    const postRes = await api("/api/v1/instruments", {
+      method: "POST",
+      token,
+      body: { id: "scopes-test-write-only", display_name: "Should be denied" },
+    });
+    expect(postRes.status).toBe(403);
+    const body = await postRes.json();
+    expect(body.error.message).toMatch(
+      /missing required scope: instruments:write/
+    );
+  });
+
+  it("['watchers:read'] can GET watchers but is 403 on POST register", async () => {
+    const { token } = await seedTestUser({ scopes: ["watchers:read"] });
+
+    const getRes = await api("/api/v1/watchers", { token });
+    expect(getRes.status).toBe(200);
+
+    // POST /watchers/register requires `watchers:write`. We send a
+    // well-formed body referencing a non-existent instrument; the scope
+    // guard runs before the lookup, so 403 = scope-fail and any other
+    // 4xx = scope-pass.
+    const postRes = await api("/api/v1/watchers/register", {
+      method: "POST",
+      token,
+      body: { instrument_id: "does-not-exist", hostname: "host.example.com" },
+    });
+    expect(postRes.status).toBe(403);
+    const body = await postRes.json();
+    expect(body.error.message).toMatch(
+      /missing required scope: watchers:write/
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Mixed scopes. Confirms that scopes are independent — `:write` does not
+  // imply `:read` and vice versa, and granting one resource doesn't grant
+  // another. Catches the class of bug where someone "helpfully" adds an
+  // implicit hierarchy to `hasScope`.
+  // -------------------------------------------------------------------------
+
+  it("['runs:read', 'files:write'] grants exactly those scopes and nothing else", async () => {
+    const { token } = await seedTestUser({
+      scopes: ["runs:read", "files:write"],
+    });
+
+    // runs:read → GET succeeds
+    const runsGet = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      token,
+    });
+    expect(runsGet.status).toBe(200);
+
+    // runs:write → POST denied (no implicit `:write` from `:read`)
+    const runsPost = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: { run_id: "mixed-scope-run", source: "lambda" },
+    });
+    expect(runsPost.status).toBe(403);
+    expect((await runsPost.json()).error.message).toMatch(
+      /missing required scope: runs:write/
+    );
+
+    // files:write → PATCH passes the scope guard. The file doesn't exist
+    // so we get a 404 from the not-found branch, not 403 from the guard.
+    const filesPatch = await api("/api/v1/files/99999", {
+      method: "PATCH",
+      token,
+      body: { status: "completed" },
+    });
+    expect(filesPatch.status).toBe(404);
+
+    // files:read → GET denied (no implicit `:read` from `:write`)
+    const filesGet = await api("/api/v1/files/99999/download", { token });
+    expect(filesGet.status).toBe(403);
+    expect((await filesGet.json()).error.message).toMatch(
+      /missing required scope: files:read/
+    );
+  });
 });

--- a/web-app/tests/integration/scopes.test.ts
+++ b/web-app/tests/integration/scopes.test.ts
@@ -1,0 +1,134 @@
+import { instruments } from "@/lib/db/schema";
+import {
+  api,
+  closeTestDb,
+  getTestDb,
+  resetDb,
+  seedTestUser,
+} from "@/tests/integration/helpers";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// Exercises the scope guard inserted by requireScope() in the v1 route
+// handlers. Each test seeds a fresh PAT with a specific scopes array and
+// then hits a read + write endpoint to confirm that:
+//
+//   - present scope → 200/201/... (the route's normal success path)
+//   - missing scope → 403 FORBIDDEN with the standard `{ error: { code,
+//     message } }` body
+//
+// The full allow/deny matrix is exercised against the runs surface because
+// it has both a `:read` and a `:write` route handler that are cheap to
+// invoke and don't require fixture files in S3.
+describe("PAT scopes", () => {
+  const instrumentId = "scopes-test-instrument";
+
+  beforeAll(async () => {
+    await resetDb();
+    const db = getTestDb();
+    await db.insert(instruments).values({
+      id: instrumentId,
+      displayName: "Scopes Test Instrument",
+      status: "active",
+    });
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  // -------------------------------------------------------------------------
+  // runs:read — allowed to GET, blocked on POST
+  // -------------------------------------------------------------------------
+
+  it("['runs:read'] can GET runs but is 403 on POST", async () => {
+    const { token } = await seedTestUser({ scopes: ["runs:read"] });
+
+    const getRes = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      token,
+    });
+    expect(getRes.status).toBe(200);
+
+    const postRes = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: { run_id: "scoped-read-run", source: "lambda" },
+    });
+    expect(postRes.status).toBe(403);
+    const body = await postRes.json();
+    expect(body.error.code).toBe("FORBIDDEN");
+    expect(body.error.message).toMatch(/missing required scope: runs:write/);
+  });
+
+  // -------------------------------------------------------------------------
+  // runs:write — allowed to POST. (We don't assert GET-denied here because
+  // some callers grant both `:read` and `:write` for the same noun, and the
+  // route enforcement is the same one tested in the read-only case above.)
+  // -------------------------------------------------------------------------
+
+  it("['runs:write'] can POST runs", async () => {
+    const { token } = await seedTestUser({ scopes: ["runs:write"] });
+
+    const postRes = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: { run_id: "scoped-write-run", source: "lambda" },
+    });
+    expect(postRes.status).toBe(201);
+  });
+
+  // -------------------------------------------------------------------------
+  // ['*'] — wildcard matches every scope (used for the backfill / watcher
+  // PATs). Same fixture as the seedTestUser default, asserted explicitly so
+  // a future change to the default value can't silently weaken this test.
+  // -------------------------------------------------------------------------
+
+  it("['*'] grants every scope", async () => {
+    const { token } = await seedTestUser({ scopes: ["*"] });
+
+    const instrumentsRes = await api("/api/v1/instruments", { token });
+    expect(instrumentsRes.status).toBe(200);
+
+    const runsGet = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      token,
+    });
+    expect(runsGet.status).toBe(200);
+
+    const runsPost = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: { run_id: "wildcard-run", source: "lambda" },
+    });
+    // 200 if a previous test (or the dedup race below) already inserted
+    // this run, 201 on a fresh insert. Either status proves the scope
+    // check let the request through.
+    expect([200, 201]).toContain(runsPost.status);
+  });
+
+  // -------------------------------------------------------------------------
+  // [] — empty scopes list, every authenticated request is 403.
+  // -------------------------------------------------------------------------
+
+  it("[] is 403 on every protected route", async () => {
+    const { token } = await seedTestUser({ scopes: [] });
+
+    const instrumentsRes = await api("/api/v1/instruments", { token });
+    expect(instrumentsRes.status).toBe(403);
+    const body = await instrumentsRes.json();
+    expect(body.error.code).toBe("FORBIDDEN");
+    expect(body.error.message).toMatch(
+      /missing required scope: instruments:read/
+    );
+
+    const runsGet = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      token,
+    });
+    expect(runsGet.status).toBe(403);
+
+    const runsPost = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: { run_id: "no-scope-run", source: "lambda" },
+    });
+    expect(runsPost.status).toBe(403);
+  });
+});

--- a/web-app/tests/integration/scopes.test.ts
+++ b/web-app/tests/integration/scopes.test.ts
@@ -187,6 +187,35 @@ describe("PAT scopes", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Token management is session-only — pins the security invariant that a
+  // PAT cannot mint, list, or revoke other PATs even when it carries the
+  // wildcard scope. Regression guard for the token routes drifting from
+  // `requireSession()` to `authenticateRequest()`.
+  // -------------------------------------------------------------------------
+
+  it("PATs cannot manage tokens even with ['*']", async () => {
+    const { token } = await seedTestUser({ scopes: ["*"] });
+
+    const listRes = await api("/api/v1/tokens", { token });
+    expect(listRes.status).toBe(401);
+
+    const createRes = await api("/api/v1/tokens", {
+      method: "POST",
+      token,
+      body: { name: "should-fail", scopes: ["runs:read"] },
+    });
+    expect(createRes.status).toBe(401);
+
+    // Random UUID — the auth check runs before the lookup, so 401 means
+    // session was required and the PAT was rejected, not "token not found".
+    const deleteRes = await api(
+      "/api/v1/tokens/00000000-0000-0000-0000-000000000000",
+      { method: "DELETE", token }
+    );
+    expect(deleteRes.status).toBe(401);
+  });
+
+  // -------------------------------------------------------------------------
   // Mixed scopes. Confirms that scopes are independent — `:write` does not
   // imply `:read` and vice versa, and granting one resource doesn't grant
   // another. Catches the class of bug where someone "helpfully" adds an

--- a/web-app/tests/unit/scope-validation.test.ts
+++ b/web-app/tests/unit/scope-validation.test.ts
@@ -1,0 +1,76 @@
+import { ALL_SCOPES, validateRequestedScopes } from "@/lib/api/scopes";
+import { describe, expect, it } from "vitest";
+
+// Validates the scope-list parsing rules used by `POST /api/v1/tokens`.
+// These tests run with no DB / no Next.js server — `validateRequestedScopes`
+// is a pure function. The HTTP wiring around it (auth check, DB insert) is
+// trivial and exercised indirectly by the integration suite via the
+// `seedTestUser` helper, which writes scopes through the same column.
+
+describe("validateRequestedScopes", () => {
+  it("rejects a missing scopes field", () => {
+    const result = validateRequestedScopes(undefined);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/non-empty array/);
+  });
+
+  it("rejects a non-array scopes field", () => {
+    const result = validateRequestedScopes("runs:read");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/non-empty array/);
+  });
+
+  it("rejects an empty array", () => {
+    const result = validateRequestedScopes([]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/non-empty array/);
+  });
+
+  it("rejects the wildcard '*' (reserved for backfill / watcher PATs)", () => {
+    const result = validateRequestedScopes(["*"]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/wildcard/);
+  });
+
+  it("rejects '*' even when mixed with valid scopes", () => {
+    const result = validateRequestedScopes(["runs:read", "*"]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/wildcard/);
+  });
+
+  it("rejects unknown scope names and reports them in the error", () => {
+    const result = validateRequestedScopes(["runs:read", "bogus:read"]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/Invalid scopes: bogus:read/);
+      // The full vocabulary is enumerated so callers can spot typos.
+      expect(result.error).toContain("runs:read");
+      expect(result.error).toContain("files:write");
+    }
+  });
+
+  it("rejects non-string entries", () => {
+    const result = validateRequestedScopes(["runs:read", 42]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/Invalid scopes/);
+  });
+
+  it("accepts a single valid scope", () => {
+    const result = validateRequestedScopes(["runs:read"]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.scopes).toEqual(["runs:read"]);
+  });
+
+  it("accepts a mix of read and write scopes across resources", () => {
+    const requested = ["runs:read", "files:write", "watchers:read"];
+    const result = validateRequestedScopes(requested);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.scopes).toEqual(requested);
+  });
+
+  it("accepts every documented scope from ALL_SCOPES", () => {
+    const result = validateRequestedScopes([...ALL_SCOPES]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.scopes).toHaveLength(ALL_SCOPES.length);
+  });
+});

--- a/web-app/vitest.config.ts
+++ b/web-app/vitest.config.ts
@@ -1,9 +1,12 @@
 import path from "path";
 import { defineConfig } from "vitest/config";
 
+// Fast unit-style suite — pure functions and in-memory MCP transport tests.
+// No Postgres, no Next.js dev server, no global setup. The integration suite
+// (vitest.integration.config.ts) covers the HTTP boundary.
 export default defineConfig({
   test: {
-    include: ["tests/mcp/**/*.test.ts"],
+    include: ["tests/mcp/**/*.test.ts", "tests/unit/**/*.test.ts"],
     testTimeout: 10_000,
   },
   resolve: {


### PR DESCRIPTION
## Summary

Adds explicit permission scopes to personal access tokens. Every authenticated `v1` route and the MCP handler now require a specific scope; misses return `403 FORBIDDEN`. Existing tokens are backfilled to `{"*"}` so deployed watchers and the Lambda keep working until they're rotated to least-privilege PATs.

- **Scope vocabulary** (`web-app/lib/api/scopes.ts`): `instruments`, `runs`, `files`, `watchers`, `archive-jobs` each `:read`/`:write`, plus a `*` wildcard reserved for backfill.
- **Schema**: new `scopes text[]` column on `personal_access_tokens` via migration `0022_pat_scopes.sql`, defaulting to `ARRAY['*']`.
- **Auth middleware**: `AuthResult.scopes` plumbed through `validatePat`; session callers implicitly hold `["*"]`. New `requireScope` guard returns the 403 response.
- **Routes**: `requireScope` inserted into every authenticated handler under `web-app/app/api/v1/` (~30 files).
- **Tokens API**: `POST /api/v1/tokens` validates the supplied scopes against the canonical set and rejects `*` from API callers. `GET` and `POST` responses now include `scopes`.
- **UI**: `CreateTokenDialog` refactored into `CreateTokenForm` + `CreateTokenSuccess` variants with a 6×(read/write) scope checkbox grid. Settings page gains a Scopes column with badges (collapsed to a "Full access" pill for wildcard tokens).
- **Tests**: `seedTestUser` accepts an optional `scopes` argument; new `tests/integration/scopes.test.ts` covers the allow/deny matrix and the 403 response shape.
- **Docs**: `docs/api.md` Authentication section documents the scope list, backfill rule, and 403 shape.

## Test plan

- [x] `make check-all` (passes locally: format + lint + typecheck)
- [x] Run `web-app/tests/integration/scopes.test.ts` against the integration DB
- [ ] Manually create a token in the UI with a subset of scopes and verify allowed/denied API calls
- [ ] Post-merge: rotate watcher PATs to `runs:write,files:read,files:write,watchers:read,watchers:write` and the Lambda `DATA_HUB_API_KEY` to `archive-jobs:write,files:read`


Made with [Cursor](https://cursor.com)