### PR TITLE
Web: Add workspace admin role for instrument edits, token management, and members

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,16 @@ Tokens are hashed with SHA-256 before storage. The plaintext token is shown once
 
 Web page routes use a different gating model from the `/api/v1/*` surface: they're publicly reachable so link previews work, and the page body itself short-circuits to a sign-in CTA when there's no session. The API always requires either a session cookie or a bearer token (see [architecture](architecture.md)).
 
+### Admin role
+
+A subset of mutations is gated on the workspace admin role in addition to (or instead of) the scope check:
+
+- `PATCH /api/v1/instruments/:instrumentId` — session callers must be admin; bearer-token callers continue to authenticate solely via the `instruments:write` scope, so existing watcher/Lambda automation is unaffected.
+- `POST /api/v1/tokens` and `DELETE /api/v1/tokens/:id` — admin-only, session-only. Bearer tokens cannot manage other tokens.
+- `GET /api/v1/users`, `PATCH /api/v1/users/:userId` — admin-only, session-only. Used by the **Settings > Members** page to toggle other users' admin flag.
+
+The first admin is bootstrapped from the `ADMIN_EMAILS` env var (comma-separated, case-insensitive); listed users are promoted to admin on every sign-in. Subsequent admins can be promoted in the UI by any existing admin. Admins cannot demote themselves — `PATCH /api/v1/users/:userId` with `{ is_admin: false }` on the caller's own user id returns `400 VALIDATION_ERROR`.
+
 ### Scopes
 
 Every personal access token carries an array of permission scopes. A request is rejected with `403 FORBIDDEN` when the token's scopes do not include the scope required by the route. The vocabulary is:
@@ -121,8 +131,15 @@ The download-archive endpoint sits in front of a Lambda-driven builder pipeline 
 | Method | Path | Description |
 | --- | --- | --- |
 | `GET` | `/api/v1/tokens` | List personal access tokens. Response includes each token's `scopes`. |
-| `POST` | `/api/v1/tokens` | Create a new token. Requires a non-empty `scopes` array (see [Scopes](#scopes)); the wildcard `*` is rejected. |
-| `DELETE` | `/api/v1/tokens/:id` | Revoke a token |
+| `POST` | `/api/v1/tokens` | Create a new token. Admin-only; requires a non-empty `scopes` array (see [Scopes](#scopes)); the wildcard `*` is rejected. |
+| `DELETE` | `/api/v1/tokens/:id` | Revoke a token. Admin-only; admins can revoke any user's PAT. |
+
+### Users
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/v1/users` | List workspace users with their admin flag. Admin-only, session-only. |
+| `PATCH` | `/api/v1/users/:userId` | Toggle the workspace `is_admin` flag for a user. Admin-only, session-only; admins cannot demote themselves. |
 
 ### MCP (Model Context Protocol)
 

--- a/docs/guides/managing-tokens.md
+++ b/docs/guides/managing-tokens.md
@@ -2,11 +2,13 @@
 
 Personal access tokens authenticate the watcher and other API clients with the Data Hub API. This guide covers creating, using, and revoking tokens.
 
+> **Admin-only.** Creating and revoking tokens requires the workspace admin role. Regular members can view the workspace token audit list at **Settings > Access Tokens** but cannot mint or delete tokens. Ask an existing admin (or someone with their email listed in `ADMIN_EMAILS`) if you need a token issued.
+
 ## Creating a token
 
 ### In the web app
 
-1. Sign in to the Data Hub web app.
+1. Sign in to the Data Hub web app as an admin.
 2. Go to **Settings > Access Tokens**.
 3. Click **Create Token**.
 4. Enter a descriptive name (e.g., "FPLC watcher - Lab 201").
@@ -118,8 +120,7 @@ curl -X DELETE https://data-hub.arcadiascience.com/api/v1/tokens/<token-id> \
 ## Security notes
 
 - Tokens are hashed with SHA-256 before storage. The plaintext is never persisted.
-- Each token is scoped to the user who created it.
-- You can only delete your own tokens.
+- Token create and delete are admin-only operations. Admins can revoke any user's token to support off-boarding and incident response.
 - Use descriptive names so you can identify which watcher or client each token belongs to.
 - Set expiration dates for tokens used in temporary setups.
 - Revoke tokens immediately when a watcher is decommissioned or a token may have been exposed.

--- a/web/README.md
+++ b/web/README.md
@@ -82,6 +82,7 @@ See the table below for a summary of environment variables configured for this a
 | `AUTH_GOOGLE_ID`            | Yes      | Google OAuth client ID                                 |
 | `AUTH_GOOGLE_SECRET`        | Yes      | Google OAuth client secret                             |
 | `AUTH_SECRET`               | Yes      | NextAuth session encryption key                        |
+| `ADMIN_EMAILS`              | No       | Comma-separated email allowlist for the workspace admin role. Listed users are auto-promoted to admin on every sign-in (one-way). Once at least one admin exists, additional admins can be promoted via **Settings > Members**. |
 
 ## CI
 

--- a/web/app/api/v1/instruments/[instrumentId]/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/route.ts
@@ -1,4 +1,4 @@
-import { authorize } from "@/lib/api/auth";
+import { authorize, requireAdminForSession } from "@/lib/api/auth";
 import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { db } from "@/lib/db";
 import {
@@ -72,6 +72,13 @@ export async function PATCH(
 ) {
   const authResult = await authorize(request, "instruments:write");
   if (authResult instanceof Response) return authResult;
+
+  // Browser callers (the Edit dialog and the "Confirm pending" button on
+  // `/instruments`) must additionally be admins. PAT callers — the watcher
+  // CLI and Lambda — pass through purely on the `instruments:write` scope
+  // so existing automation continues to work without rotation.
+  const adminGate = await requireAdminForSession(authResult);
+  if (adminGate) return adminGate;
 
   const { instrumentId } = await params;
 

--- a/web/app/api/v1/tokens/[id]/route.ts
+++ b/web/app/api/v1/tokens/[id]/route.ts
@@ -1,16 +1,18 @@
-import { requireSession } from "@/lib/api/auth";
+import { requireAdmin } from "@/lib/api/auth";
 import { db } from "@/lib/db";
 import { personalAccessTokens } from "@/lib/db/schema";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 export async function DELETE(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const authResult = await requireSession();
-  if (!authResult) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  // Token deletion is admin-only. Admins can revoke any user's PAT —
+  // useful for off-boarding, compromised credentials, and pruning unused
+  // tokens during an audit. The previous owner-scoped delete made
+  // multi-user revocation impossible from the UI.
+  const authResult = await requireAdmin();
+  if (authResult instanceof Response) return authResult;
 
   const { id } = await params;
 
@@ -20,16 +22,9 @@ export async function DELETE(
     return Response.json({ error: "Invalid token ID" }, { status: 400 });
   }
 
-  // Scope the delete to the authenticated user so one user can never
-  // delete another user's token — a non-match returns 0 rows → 404.
   const deleted = await db
     .delete(personalAccessTokens)
-    .where(
-      and(
-        eq(personalAccessTokens.id, id),
-        eq(personalAccessTokens.userId, authResult.userId)
-      )
-    )
+    .where(eq(personalAccessTokens.id, id))
     .returning({ id: personalAccessTokens.id });
 
   if (deleted.length === 0) {

--- a/web/app/api/v1/tokens/[id]/route.ts
+++ b/web/app/api/v1/tokens/[id]/route.ts
@@ -1,4 +1,5 @@
 import { requireAdmin } from "@/lib/api/auth";
+import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { db } from "@/lib/db";
 import { personalAccessTokens } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -19,7 +20,7 @@ export async function DELETE(
   const UUID_RE =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   if (!UUID_RE.test(id)) {
-    return Response.json({ error: "Invalid token ID" }, { status: 400 });
+    return apiError(400, VALIDATION_ERROR, "Invalid token ID");
   }
 
   const deleted = await db
@@ -28,7 +29,7 @@ export async function DELETE(
     .returning({ id: personalAccessTokens.id });
 
   if (deleted.length === 0) {
-    return Response.json({ error: "Token not found" }, { status: 404 });
+    return apiError(404, NOT_FOUND, "Token not found");
   }
 
   return new Response(null, { status: 204 });

--- a/web/app/api/v1/tokens/route.ts
+++ b/web/app/api/v1/tokens/route.ts
@@ -1,4 +1,5 @@
 import { requireAdmin, requireSession } from "@/lib/api/auth";
+import { apiError, UNAUTHORIZED, VALIDATION_ERROR } from "@/lib/api/errors";
 import { validateRequestedScopes } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { personalAccessTokens } from "@/lib/db/schema";
@@ -14,7 +15,7 @@ export async function GET() {
   // typical PAT-management UIs.
   const authResult = await requireSession();
   if (!authResult) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError(401, UNAUTHORIZED, "Authentication required");
   }
 
   const tokens = await db
@@ -45,20 +46,21 @@ export async function POST(request: NextRequest) {
   try {
     body = await request.json();
   } catch {
-    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+    return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
   }
 
   const name = typeof body.name === "string" ? body.name.trim() : "";
   if (!name || name.length > 100) {
-    return Response.json(
-      { error: "name is required and must be at most 100 characters" },
-      { status: 400 }
+    return apiError(
+      400,
+      VALIDATION_ERROR,
+      "name is required and must be at most 100 characters"
     );
   }
 
   const validation = validateRequestedScopes(body.scopes);
   if (!validation.ok) {
-    return Response.json({ error: validation.error }, { status: 400 });
+    return apiError(400, VALIDATION_ERROR, validation.error);
   }
   const scopes = validation.scopes;
 
@@ -66,15 +68,17 @@ export async function POST(request: NextRequest) {
   if (body.expires_at) {
     expiresAt = new Date(body.expires_at);
     if (isNaN(expiresAt.getTime())) {
-      return Response.json(
-        { error: "expires_at must be a valid ISO 8601 date" },
-        { status: 400 }
+      return apiError(
+        400,
+        VALIDATION_ERROR,
+        "expires_at must be a valid ISO 8601 date"
       );
     }
     if (expiresAt <= new Date()) {
-      return Response.json(
-        { error: "expires_at must be in the future" },
-        { status: 400 }
+      return apiError(
+        400,
+        VALIDATION_ERROR,
+        "expires_at must be in the future"
       );
     }
   }

--- a/web/app/api/v1/tokens/route.ts
+++ b/web/app/api/v1/tokens/route.ts
@@ -1,4 +1,4 @@
-import { requireSession } from "@/lib/api/auth";
+import { requireAdmin, requireSession } from "@/lib/api/auth";
 import { validateRequestedScopes } from "@/lib/api/scopes";
 import { db } from "@/lib/db";
 import { personalAccessTokens } from "@/lib/db/schema";
@@ -7,6 +7,11 @@ import { desc, eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 
 export async function GET() {
+  // Listing is open to any signed-in user — regular members see their own
+  // tokens here. The workspace-wide audit list shown on `/settings/tokens`
+  // bypasses this endpoint entirely (it queries the DB directly in the
+  // server component), so this remains a per-user view consistent with
+  // typical PAT-management UIs.
   const authResult = await requireSession();
   if (!authResult) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
@@ -30,10 +35,11 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
-  const authResult = await requireSession();
-  if (!authResult) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  // Token creation is admin-only. Non-admins can still view the workspace
+  // PAT list on `/settings/tokens` and call `GET` above, but only admins
+  // can mint new credentials.
+  const authResult = await requireAdmin();
+  if (authResult instanceof Response) return authResult;
 
   let body: { name?: string; expires_at?: string; scopes?: unknown };
   try {

--- a/web/app/api/v1/users/[userId]/route.ts
+++ b/web/app/api/v1/users/[userId]/route.ts
@@ -1,0 +1,83 @@
+import { requireAdmin } from "@/lib/api/auth";
+import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+const ALLOWED_PATCH_FIELDS = new Set(["is_admin"]);
+
+// Admin-only role toggle invoked by `/settings/members`. Only the
+// `is_admin` boolean is mutable here; user identity fields (name, email,
+// image) come from Google and are owned by the NextAuth adapter.
+//
+// Self-demotion is rejected to keep the "no admins left" failure mode out
+// of the API. The members UI mirrors this by disabling the toggle on the
+// current user's row, but the server-side check is what actually keeps
+// the workspace from becoming admin-less.
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const authResult = await requireAdmin();
+  if (authResult instanceof Response) return authResult;
+
+  const { userId } = await params;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
+  }
+
+  const unknownKeys = Object.keys(body).filter(
+    (k) => !ALLOWED_PATCH_FIELDS.has(k)
+  );
+  if (unknownKeys.length > 0) {
+    return apiError(400, VALIDATION_ERROR, "Unknown fields", {
+      unknown_fields: unknownKeys,
+      allowed_fields: [...ALLOWED_PATCH_FIELDS],
+    });
+  }
+
+  if (!("is_admin" in body) || typeof body.is_admin !== "boolean") {
+    return apiError(400, VALIDATION_ERROR, "is_admin must be a boolean");
+  }
+
+  const isAdmin = body.is_admin;
+
+  // Self-demotion guard. Promotion-of-self is harmless (it's a no-op for
+  // the caller, who is already admin) so we only reject the false case.
+  if (authResult.userId === userId && isAdmin === false) {
+    return apiError(
+      400,
+      VALIDATION_ERROR,
+      "Admins cannot demote themselves. Ask another admin to do it."
+    );
+  }
+
+  const [existing] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!existing) {
+    return apiError(404, NOT_FOUND, `User '${userId}' not found`);
+  }
+
+  const [updated] = await db
+    .update(users)
+    .set({ isAdmin })
+    .where(eq(users.id, userId))
+    .returning({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      image: users.image,
+      is_admin: users.isAdmin,
+    });
+
+  return Response.json(updated);
+}

--- a/web/app/api/v1/users/route.ts
+++ b/web/app/api/v1/users/route.ts
@@ -1,0 +1,28 @@
+import { requireAdmin } from "@/lib/api/auth";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+import { asc } from "drizzle-orm";
+
+// Admin-only roster used by `/settings/members`. Returns every signed-in
+// user along with their workspace admin flag so the members page can
+// render the toggle. We intentionally do not paginate — the Data Hub
+// workspace is small enough (single-digit-to-low-tens of teammates) that
+// a single round-trip is faster than building list UI on top of cursor
+// state.
+export async function GET() {
+  const authResult = await requireAdmin();
+  if (authResult instanceof Response) return authResult;
+
+  const rows = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      image: users.image,
+      is_admin: users.isAdmin,
+    })
+    .from(users)
+    .orderBy(asc(users.email));
+
+  return Response.json(rows);
+}

--- a/web/app/instruments/[instrumentId]/page.tsx
+++ b/web/app/instruments/[instrumentId]/page.tsx
@@ -227,7 +227,7 @@ export default async function InstrumentDetailPage({
   ];
 
   return (
-    <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-6 2xl:w-7xl">
+    <div className="mx-auto flex w-full max-w-7xl min-w-0 flex-col gap-6 p-6 2xl:w-7xl">
       <InstrumentHeader instrument={instrument} />
       <RunSelectionProvider>
         <TablePendingProvider>

--- a/web/app/instruments/page.tsx
+++ b/web/app/instruments/page.tsx
@@ -28,6 +28,13 @@ export default async function InstrumentsPage() {
 
   const instruments = await getInstrumentListWithCounts();
 
+  // Composition: the management actions cell (Edit dialog + Confirm
+  // pending button) is rendered only for admins. Regular members see the
+  // same listing without the trailing actions column. InstrumentsTable
+  // already supports `renderRowActions` being omitted entirely, so no
+  // table-level prop changes are needed.
+  const isAdmin = session.user.isAdmin === true;
+
   return (
     <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-6 2xl:w-7xl">
       <div className="flex items-center justify-between">
@@ -35,7 +42,7 @@ export default async function InstrumentsPage() {
       </div>
       <InstrumentsTable
         data={instruments}
-        renderRowActions={InstrumentRowManagementActions}
+        renderRowActions={isAdmin ? InstrumentRowManagementActions : undefined}
       />
     </div>
   );

--- a/web/app/settings/members/page.tsx
+++ b/web/app/settings/members/page.tsx
@@ -1,0 +1,75 @@
+import { SignInRequired } from "@/components/auth/sign-in-required";
+import { MembersTable } from "@/components/members/members-table";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+import { asc } from "drizzle-orm";
+import { ShieldOff } from "lucide-react";
+import type { Metadata } from "next/types";
+
+const description = "Manage workspace members and admin access.";
+
+export const metadata: Metadata = {
+  title: "Members",
+  description,
+  openGraph: { title: "Members", description },
+  twitter: { title: "Members", description },
+};
+
+export default async function MembersPage() {
+  const session = await auth();
+  if (!session?.user) {
+    return (
+      <SignInRequired callbackUrl="/settings/members">
+        Sign in to manage members.
+      </SignInRequired>
+    );
+  }
+
+  // Page-level admin gate. Non-admins reach this URL via a stale link,
+  // bookmark, or by typing it in — render an explicit explanation rather
+  // than redirecting silently so the missing-permission failure mode is
+  // visible. The settings sidebar already hides this entry for non-admins.
+  if (!session.user.isAdmin) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-lg border border-dashed bg-background py-16 dark:bg-muted">
+        <ShieldOff className="size-10 text-muted-foreground/50" />
+        <p className="mt-3 text-sm font-medium text-muted-foreground">
+          Admins only
+        </p>
+        <p className="mt-1 max-w-sm text-center text-sm text-muted-foreground/70">
+          You need workspace admin access to view or change member roles. Ask an
+          existing admin if you need to be promoted.
+        </p>
+      </div>
+    );
+  }
+
+  const members = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      image: users.image,
+      isAdmin: users.isAdmin,
+    })
+    .from(users)
+    .orderBy(asc(users.email));
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold tracking-tight">Members</h2>
+          <p className="text-sm text-muted-foreground">
+            Grant or revoke admin access for teammates signed in to Data Hub.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <MembersTable data={members} currentUserId={session.user.id} />
+      </div>
+    </div>
+  );
+}

--- a/web/app/settings/tokens/page.tsx
+++ b/web/app/settings/tokens/page.tsx
@@ -17,6 +17,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { auth } from "@/lib/auth";
+import { avatarColor, toInitials } from "@/lib/avatar-color";
 import { db } from "@/lib/db";
 import { personalAccessTokens, users } from "@/lib/db/schema";
 import { formatRelativeTime } from "@/lib/utils";
@@ -32,34 +33,6 @@ export const metadata: Metadata = {
   openGraph: { title: "Access Tokens", description },
   twitter: { title: "Access Tokens", description },
 };
-
-// Mirrors the deterministic palette used by RanByCell so the same user gets
-// the same avatar bubble color across the run tables and this page.
-const AVATAR_PALETTE = [
-  "bg-blue-200 text-blue-900 dark:bg-blue-800 dark:text-blue-100",
-  "bg-emerald-200 text-emerald-900 dark:bg-emerald-800 dark:text-emerald-100",
-  "bg-violet-200 text-violet-900 dark:bg-violet-800 dark:text-violet-100",
-  "bg-amber-200 text-amber-900 dark:bg-amber-800 dark:text-amber-100",
-  "bg-rose-200 text-rose-900 dark:bg-rose-800 dark:text-rose-100",
-  "bg-teal-200 text-teal-900 dark:bg-teal-800 dark:text-teal-100",
-  "bg-fuchsia-200 text-fuchsia-900 dark:bg-fuchsia-800 dark:text-fuchsia-100",
-  "bg-orange-200 text-orange-900 dark:bg-orange-800 dark:text-orange-100",
-];
-
-function avatarColor(userId: string): string {
-  let hash = 0;
-  for (let i = 0; i < userId.length; i++) {
-    hash = (hash * 31 + userId.charCodeAt(i)) | 0;
-  }
-  return AVATAR_PALETTE[Math.abs(hash) % AVATAR_PALETTE.length];
-}
-
-function toInitials(displayName: string): string {
-  const parts = displayName.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return "?";
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-}
 
 // Render a token's scopes as a compact column. Four branches:
 //
@@ -150,6 +123,11 @@ export default async function TokensPage() {
     );
   }
 
+  // Composition over boolean props: the Create/Delete dialogs are mounted
+  // only for admins. Regular members see the same audit list but without
+  // the mutating affordances.
+  const isAdmin = session.user.isAdmin === true;
+
   // This is an internal-tool settings page; we intentionally show every PAT
   // across the workspace so admins can audit them.
   const tokens = await db
@@ -183,10 +161,12 @@ export default async function TokensPage() {
             Access Tokens
           </h2>
           <p className="text-sm text-muted-foreground">
-            Manage personal access tokens for API authentication.
+            {isAdmin
+              ? "Manage personal access tokens for API authentication."
+              : "View personal access tokens for API authentication."}
           </p>
         </div>
-        <CreateTokenDialog />
+        {isAdmin ? <CreateTokenDialog /> : null}
       </div>
 
       <div className="mt-6">
@@ -197,7 +177,9 @@ export default async function TokensPage() {
               No access tokens yet
             </p>
             <p className="mt-1 text-sm text-muted-foreground/70">
-              Create a token to authenticate with the API.
+              {isAdmin
+                ? "Create a token to authenticate with the API."
+                : "Ask an admin to create a token for you."}
             </p>
           </div>
         ) : (
@@ -212,7 +194,7 @@ export default async function TokensPage() {
                   <TableHead>Last used</TableHead>
                   <TableHead>Expires</TableHead>
                   <TableHead>Created</TableHead>
-                  <TableHead className="w-12" />
+                  {isAdmin ? <TableHead className="w-12" /> : null}
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -286,12 +268,14 @@ export default async function TokensPage() {
                       >
                         {formatRelativeTime(token.createdAt)}
                       </TableCell>
-                      <TableCell>
-                        <DeleteTokenDialog
-                          tokenId={token.id}
-                          tokenName={token.name}
-                        />
-                      </TableCell>
+                      {isAdmin ? (
+                        <TableCell>
+                          <DeleteTokenDialog
+                            tokenId={token.id}
+                            tokenName={token.name}
+                          />
+                        </TableCell>
+                      ) : null}
                     </TableRow>
                   );
                 })}

--- a/web/components/app-sidebar/app-sidebar-content.tsx
+++ b/web/components/app-sidebar/app-sidebar-content.tsx
@@ -9,6 +9,7 @@ import { usePathname } from "next/navigation";
 type AppSidebarContentProps = {
   instruments: SidebarInstrument[];
   watchers: SidebarWatcher[];
+  isAdmin: boolean;
 };
 
 // Centralizes the "main vs. settings" mode toggle so the rest of the sidebar
@@ -18,6 +19,7 @@ type AppSidebarContentProps = {
 export function AppSidebarContent({
   instruments,
   watchers,
+  isAdmin,
 }: AppSidebarContentProps) {
   const pathname = usePathname();
   const isSettings = pathname.startsWith("/settings");
@@ -25,7 +27,7 @@ export function AppSidebarContent({
   return (
     <SidebarContent>
       {isSettings ? (
-        <SettingsNav />
+        <SettingsNav isAdmin={isAdmin} />
       ) : (
         <MainNav instruments={instruments} watchers={watchers} />
       )}

--- a/web/components/app-sidebar/index.tsx
+++ b/web/components/app-sidebar/index.tsx
@@ -52,7 +52,11 @@ export function AppSidebar({
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarHeader>
-      <AppSidebarContent instruments={instruments} watchers={watchers} />
+      <AppSidebarContent
+        instruments={instruments}
+        watchers={watchers}
+        isAdmin={session.user.isAdmin === true}
+      />
       <SidebarFooter>
         <UserMenuFooter user={session.user} signOutAction={signOutAction} />
       </SidebarFooter>

--- a/web/components/app-sidebar/settings-nav.tsx
+++ b/web/components/app-sidebar/settings-nav.tsx
@@ -14,10 +14,15 @@ import { usePathname } from "next/navigation";
 type SettingsSection = {
   href: string;
   label: string;
+  // Admin-only entries are mounted into the nav only when the viewer is
+  // an admin. Using composition here (filter by predicate, then render)
+  // keeps the SettingsNav body free of per-item `isAdmin && …` branches.
+  adminOnly?: boolean;
 };
 
 const SETTINGS_SECTIONS: SettingsSection[] = [
   { href: "/settings/tokens", label: "Access Tokens" },
+  { href: "/settings/members", label: "Members", adminOnly: true },
 ];
 
 // Single, predictable destination for the "leave settings" affordance. A
@@ -27,8 +32,11 @@ const SETTINGS_SECTIONS: SettingsSection[] = [
 // dashboard so middle-click / cmd-click / "Copy link" all behave too.
 const EXIT_SETTINGS_HREF = "/";
 
-export function SettingsNav() {
+export function SettingsNav({ isAdmin }: { isAdmin: boolean }) {
   const pathname = usePathname();
+  const sections = SETTINGS_SECTIONS.filter(
+    (section) => !section.adminOnly || isAdmin
+  );
 
   return (
     <>
@@ -57,7 +65,7 @@ export function SettingsNav() {
       <SidebarGroup className="pt-1">
         <SidebarGroupContent>
           <SidebarMenu>
-            {SETTINGS_SECTIONS.map((section) => (
+            {sections.map((section) => (
               <SidebarMenuItem key={section.href}>
                 <SidebarMenuButton
                   asChild

--- a/web/components/dashboard/runs-table.tsx
+++ b/web/components/dashboard/runs-table.tsx
@@ -76,7 +76,7 @@ export function RunsTable({
             <TableHead className="text-right">
               <AcquiredColumnHeader />
             </TableHead>
-            <TableHead className="w-[132px]">
+            <TableHead className="w-[108px]">
               <span className="sr-only">Actions</span>
             </TableHead>
           </TableRow>
@@ -183,7 +183,7 @@ export function RunsTableSkeleton() {
             <TableHead className="text-right">
               <AcquiredColumnHeader />
             </TableHead>
-            <TableHead className="w-[132px]" />
+            <TableHead className="w-[108px]" />
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/web/components/instruments/runs-table/default-runs-table.tsx
+++ b/web/components/instruments/runs-table/default-runs-table.tsx
@@ -53,7 +53,7 @@ export function DefaultRunsTable({
           <TableHead className="text-right">
             <AcquiredColumnHeader />
           </TableHead>
-          <TableHead className="w-[132px]">
+          <TableHead className="w-[108px]">
             <span className="sr-only">Actions</span>
           </TableHead>
         </TableRow>

--- a/web/components/instruments/runs-table/epson-scanner-runs-table.tsx
+++ b/web/components/instruments/runs-table/epson-scanner-runs-table.tsx
@@ -92,7 +92,7 @@ export function EpsonScannerRunsTable({
           <TableHead className="text-right">
             <AcquiredColumnHeader />
           </TableHead>
-          <TableHead className="w-[132px]">
+          <TableHead className="w-[108px]">
             <span className="sr-only">Actions</span>
           </TableHead>
         </TableRow>

--- a/web/components/instruments/runs-table/gel-doc-runs-table.tsx
+++ b/web/components/instruments/runs-table/gel-doc-runs-table.tsx
@@ -106,7 +106,7 @@ export function GelDocRunsTable({
           <TableHead className="text-right">
             <AcquiredColumnHeader />
           </TableHead>
-          <TableHead className="w-[132px]">
+          <TableHead className="w-[108px]">
             <span className="sr-only">Actions</span>
           </TableHead>
         </TableRow>
@@ -187,7 +187,7 @@ export function GelDocRunsTable({
                 <TruncatedBadges
                   values={wavelengthColorLabels}
                   colorMap={CHANNEL_COLOR_STYLES}
-                  maxVisible={2}
+                  maxVisible={1}
                 />
               </TableCell>
               <TableCell>

--- a/web/components/instruments/runs-table/hina-runs-table.tsx
+++ b/web/components/instruments/runs-table/hina-runs-table.tsx
@@ -91,7 +91,7 @@ export function HinaRunsTable({
           <TableHead className="text-right">
             <AcquiredColumnHeader />
           </TableHead>
-          <TableHead className="w-[132px]">
+          <TableHead className="w-[108px]">
             <span className="sr-only">Actions</span>
           </TableHead>
         </TableRow>

--- a/web/components/instruments/runs-table/plate-reader-runs-table.tsx
+++ b/web/components/instruments/runs-table/plate-reader-runs-table.tsx
@@ -95,7 +95,7 @@ export function PlateReaderRunsTable({
           <TableHead className="text-right">
             <AcquiredColumnHeader />
           </TableHead>
-          <TableHead className="w-[132px]">
+          <TableHead className="w-[108px]">
             <span className="sr-only">Actions</span>
           </TableHead>
         </TableRow>

--- a/web/components/instruments/runs-table/qpcr-runs-table.tsx
+++ b/web/components/instruments/runs-table/qpcr-runs-table.tsx
@@ -69,7 +69,7 @@ export function QpcrRunsTable({
           <TableHead className="text-right">
             <AcquiredColumnHeader />
           </TableHead>
-          <TableHead className="w-[132px]">
+          <TableHead className="w-[108px]">
             <span className="sr-only">Actions</span>
           </TableHead>
         </TableRow>

--- a/web/components/instruments/runs-table/run-bulk-action-bar.tsx
+++ b/web/components/instruments/runs-table/run-bulk-action-bar.tsx
@@ -181,9 +181,9 @@ export function RunBulkActionBar() {
   }));
 
   // On desktop the expanded sidebar reserves space on the left, so anchor the
-  // bar to the center of the main panel (not the viewport) by shifting `left`
-  // by half the sidebar width. On mobile the sidebar is an overlay sheet, so
-  // the main panel already spans the full viewport.
+  // bar's left edge to the sidebar's right edge so it spans the full main
+  // panel width. On mobile the sidebar is an overlay sheet, so the main panel
+  // already spans the full viewport.
   const offsetForSidebar = !isMobile && sidebarState === "expanded";
 
   return (
@@ -192,10 +192,8 @@ export function RunBulkActionBar() {
         role="region"
         aria-label="Bulk actions for selected runs"
         className={cn(
-          "fixed bottom-6 z-50 flex -translate-x-1/2 animate-in items-center gap-8 rounded-lg border bg-popover px-8 py-2.5 text-popover-foreground shadow-xl transition-[left] duration-200 ease-linear fade-in slide-in-from-bottom-4",
-          offsetForSidebar
-            ? "left-[calc(50%+var(--sidebar-width)/2)]"
-            : "left-1/2"
+          "fixed right-0 bottom-6 z-50 mx-auto flex max-w-6xl animate-in items-center justify-between gap-4 rounded-lg border bg-popover px-8 py-2.5 text-popover-foreground shadow-2xl transition-[left] duration-200 ease-linear fade-in slide-in-from-bottom-4",
+          offsetForSidebar ? "left-[var(--sidebar-width)]" : "left-0"
         )}
       >
         <div className="text-sm">

--- a/web/components/instruments/runs-table/run-id-label.tsx
+++ b/web/components/instruments/runs-table/run-id-label.tsx
@@ -8,7 +8,7 @@ import {
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 
-const MAX_RUN_ID_LENGTH = 48;
+const MAX_RUN_ID_LENGTH = 32;
 
 export function RunIdLabel({
   runId,

--- a/web/components/members/admin-toggle.tsx
+++ b/web/components/members/admin-toggle.tsx
@@ -52,11 +52,7 @@ export function AdminToggle({
 
       if (!res.ok) {
         const body = await res.json().catch(() => null);
-        toast.error(
-          body?.error?.message ??
-            body?.error ??
-            "Failed to update member's role"
-        );
+        toast.error(body?.error?.message ?? "Failed to update member's role");
         return;
       }
 

--- a/web/components/members/admin-toggle.tsx
+++ b/web/components/members/admin-toggle.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import { toast } from "sonner";
+
+type AdminToggleProps = {
+  userId: string;
+  /**
+   * Current admin state, taken from the latest server render. The switch
+   * is uncontrolled with respect to local UI state — the optimistic flip
+   * happens via `router.refresh()` after the API call succeeds.
+   */
+  isAdmin: boolean;
+  /**
+   * True when this row represents the signed-in user themselves. The
+   * server-side PATCH rejects self-demotion with a 400; we disable the
+   * switch here so the user never sees that failure path.
+   */
+  isSelf: boolean;
+  /**
+   * Pre-resolved display label used in the success / error toasts so the
+   * caller doesn't have to thread the user-row data into the toast
+   * messages from the parent table cell.
+   */
+  displayName: string;
+};
+
+export function AdminToggle({
+  userId,
+  isAdmin,
+  isSelf,
+  displayName,
+}: AdminToggleProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const handleChange = (next: boolean) => {
+    startTransition(async () => {
+      const res = await fetch(`/api/v1/users/${userId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ is_admin: next }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        toast.error(
+          body?.error?.message ??
+            body?.error ??
+            "Failed to update member's role"
+        );
+        return;
+      }
+
+      toast.success(
+        next
+          ? `${displayName} is now an admin`
+          : `${displayName} is no longer an admin`
+      );
+      router.refresh();
+    });
+  };
+
+  const control = (
+    <div className="flex items-center gap-2">
+      {isPending ? (
+        <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+      ) : null}
+      <Switch
+        checked={isAdmin}
+        disabled={isSelf || isPending}
+        onCheckedChange={handleChange}
+        aria-label={isAdmin ? "Revoke admin" : "Grant admin"}
+      />
+    </div>
+  );
+
+  if (!isSelf) return control;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex">{control}</span>
+      </TooltipTrigger>
+      <TooltipContent>
+        Admins can&apos;t demote themselves. Ask another admin.
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/web/components/members/members-table.tsx
+++ b/web/components/members/members-table.tsx
@@ -1,0 +1,100 @@
+import { AdminToggle } from "@/components/members/admin-toggle";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { avatarColor, toInitials } from "@/lib/avatar-color";
+
+export type MemberRow = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  isAdmin: boolean;
+};
+
+type MembersTableProps = {
+  data: MemberRow[];
+  /**
+   * The signed-in admin viewing the table. Used to flag the self row so
+   * the toggle is disabled (server also rejects self-demotion).
+   */
+  currentUserId: string;
+};
+
+export function MembersTable({ data, currentUserId }: MembersTableProps) {
+  return (
+    <div className="rounded-lg border bg-background dark:bg-muted">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Member</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Role</TableHead>
+            <TableHead className="w-28 text-right">Admin</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.map((member) => {
+            const displayName = member.name ?? member.email ?? "Unknown member";
+            const isSelf = member.id === currentUserId;
+            return (
+              <TableRow key={member.id}>
+                <TableCell>
+                  <div className="flex items-center gap-3">
+                    <Avatar size="sm">
+                      {member.image ? (
+                        <AvatarImage src={member.image} alt={displayName} />
+                      ) : null}
+                      <AvatarFallback className={avatarColor(member.id)}>
+                        {toInitials(displayName)}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="flex flex-col">
+                      <span className="font-medium">
+                        {displayName}
+                        {isSelf ? (
+                          <span className="ml-1.5 text-xs text-muted-foreground">
+                            (you)
+                          </span>
+                        ) : null}
+                      </span>
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {member.email ?? "—"}
+                </TableCell>
+                <TableCell>
+                  {member.isAdmin ? (
+                    <Badge variant="secondary">Admin</Badge>
+                  ) : (
+                    <Badge variant="outline" className="text-muted-foreground">
+                      Member
+                    </Badge>
+                  )}
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="flex justify-end">
+                    <AdminToggle
+                      userId={member.id}
+                      isAdmin={member.isAdmin}
+                      isSelf={isSelf}
+                      displayName={displayName}
+                    />
+                  </div>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/web/components/tokens/create-token-dialog.tsx
+++ b/web/components/tokens/create-token-dialog.tsx
@@ -167,7 +167,7 @@ function CreateTokenForm({
 
       if (!res.ok) {
         const body = await res.json().catch(() => null);
-        toast.error(body?.error ?? "Failed to create token");
+        toast.error(body?.error?.message ?? "Failed to create token");
         return;
       }
 

--- a/web/components/ui/table.tsx
+++ b/web/components/ui/table.tsx
@@ -70,7 +70,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        "h-10 px-1.5 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
         className
       )}
       {...props}
@@ -83,7 +83,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        "px-1.5 py-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
         className
       )}
       {...props}

--- a/web/drizzle/0023_add_user_is_admin.sql
+++ b/web/drizzle/0023_add_user_is_admin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "is_admin" boolean DEFAULT false NOT NULL;

--- a/web/drizzle/meta/0023_snapshot.json
+++ b/web/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,1719 @@
+{
+  "id": "224f790c-1d23-4d44-b581-99a8e9976228",
+  "prevId": "79bcfbae-e4ba-405e-8dde-fe328e4a1f5e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archive_jobs": {
+      "name": "archive_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archive_bucket": {
+          "name": "archive_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_key": {
+          "name": "archive_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "archive_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_archive_jobs_inflight": {
+          "name": "uq_archive_jobs_inflight",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"archive_jobs\".\"status\" in ('pending', 'building')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_archive_jobs_run_fingerprint_status": {
+          "name": "idx_archive_jobs_run_fingerprint_status",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "archive_jobs_instrument_run_id_instrument_runs_id_fk": {
+          "name": "archive_jobs_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "archive_jobs_created_by_user_id_fk": {
+          "name": "archive_jobs_created_by_user_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "file_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raw'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_requested_at": {
+          "name": "upload_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_files_instrument_run_id_relative_path": {
+          "name": "uq_files_instrument_run_id_relative_path",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"relative_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_active_instrument_run_id_filename": {
+          "name": "uq_files_active_instrument_run_id_filename",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_s3_key": {
+          "name": "uq_files_s3_key",
+          "columns": [
+            {
+              "expression": "s3_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"s3_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_instrument_run_id": {
+          "name": "idx_files_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_status_instrument_run_id": {
+          "name": "idx_files_status_instrument_run_id",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_upload_queue": {
+          "name": "idx_files_upload_queue",
+          "columns": [
+            {
+              "expression": "upload_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"upload_requested_at\" is not null and \"files\".\"uploaded_at\" is null and \"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_metadata_gin": {
+          "name": "idx_files_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_instrument_run_id_instrument_runs_id_fk": {
+          "name": "files_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_runs": {
+      "name": "instrument_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "instrument_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lambda'"
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instrument_runs_instrument_id_created_at": {
+          "name": "idx_instrument_runs_instrument_id_created_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active": {
+          "name": "idx_instrument_runs_active",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active_acquired_at": {
+          "name": "idx_instrument_runs_active_acquired_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"acquired_at\", \"created_at\") desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_metadata_gin": {
+          "name": "idx_instrument_runs_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_runs_instrument_id_instruments_id_fk": {
+          "name": "instrument_runs_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_watcher_id_watchers_id_fk": {
+          "name": "instrument_runs_watcher_id_watchers_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_instrument_runs_instrument_id_run_id": {
+          "name": "uq_instrument_runs_instrument_id_run_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instrument_id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instruments": {
+      "name": "instruments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instrument_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instrument_type": {
+          "name": "instrument_type",
+          "type": "instrument_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['*']::text[]"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_personal_access_tokens_user_id": {
+          "name": "idx_personal_access_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_user_id_fk": {
+          "name": "personal_access_tokens_user_id_user_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_attributions": {
+      "name": "run_attributions",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_attributions_run_id": {
+          "name": "idx_run_attributions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_attributions_user_id": {
+          "name": "idx_run_attributions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_attributions_run_id_instrument_runs_id_fk": {
+          "name": "run_attributions_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_attributions_user_id_user_id_fk": {
+          "name": "run_attributions_user_id_user_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_attributions_run_id_user_id_pk": {
+          "name": "run_attributions_run_id_user_id_pk",
+          "columns": [
+            "run_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_comments": {
+      "name": "run_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_run_comments_run_id_created_at": {
+          "name": "idx_run_comments_run_id_created_at",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_comments_user_id": {
+          "name": "idx_run_comments_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_comments_run_id_instrument_runs_id_fk": {
+          "name": "run_comments_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_comments_user_id_user_id_fk": {
+          "name": "run_comments_user_id_user_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_events": {
+      "name": "watcher_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "watcher_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_events_watcher_id_timestamp": {
+          "name": "idx_watcher_events_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_watcher_events_watcher_id_event_type": {
+          "name": "idx_watcher_events_watcher_id_event_type",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_events_watcher_id_watchers_id_fk": {
+          "name": "watcher_events_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_events",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_heartbeats": {
+      "name": "watcher_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_mode": {
+          "name": "upload_mode",
+          "type": "upload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_uploaded_since_last": {
+          "name": "files_uploaded_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "runs_reported_since_last": {
+          "name": "runs_reported_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_since_last": {
+          "name": "errors_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_heartbeats_watcher_id_timestamp": {
+          "name": "idx_watcher_heartbeats_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_heartbeats_watcher_id_watchers_id_fk": {
+          "name": "watcher_heartbeats_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_heartbeats",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watchers": {
+      "name": "watchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_info": {
+          "name": "os_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watcher_version": {
+          "name": "watcher_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_checksum": {
+          "name": "config_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_yaml": {
+          "name": "config_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "watcher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_watchers_active_instrument_id": {
+          "name": "uq_watchers_active_instrument_id",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"watchers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchers_instrument_id_instruments_id_fk": {
+          "name": "watchers_instrument_id_instruments_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.archive_job_status": {
+      "name": "archive_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "building",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.file_category": {
+      "name": "file_category",
+      "schema": "public",
+      "values": [
+        "raw",
+        "processed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "detected",
+        "upload_requested",
+        "uploaded",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.instrument_run_source": {
+      "name": "instrument_run_source",
+      "schema": "public",
+      "values": [
+        "lambda",
+        "watcher"
+      ]
+    },
+    "public.instrument_status": {
+      "name": "instrument_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "inactive"
+      ]
+    },
+    "public.instrument_type": {
+      "name": "instrument_type",
+      "schema": "public",
+      "values": [
+        "generic",
+        "plate_reader",
+        "gel_doc",
+        "qpcr",
+        "tape_station",
+        "hina_microscope",
+        "epson_v700_scanner",
+        "instant_raman"
+      ]
+    },
+    "public.upload_mode": {
+      "name": "upload_mode",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual"
+      ]
+    },
+    "public.watcher_event_type": {
+      "name": "watcher_event_type",
+      "schema": "public",
+      "values": [
+        "watcher_started",
+        "watcher_stopped",
+        "file_uploaded",
+        "upload_failed",
+        "run_reported",
+        "config_synced",
+        "error",
+        "update_started",
+        "update_succeeded",
+        "update_failed"
+      ]
+    },
+    "public.watcher_status": {
+      "name": "watcher_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "watching",
+        "stopped"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1778799469455,
       "tag": "0022_pat_scopes",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1778882678139,
+      "tag": "0023_add_user_is_admin",
+      "breakpoints": true
     }
   ]
 }

--- a/web/lib/admin-emails.ts
+++ b/web/lib/admin-emails.ts
@@ -1,0 +1,35 @@
+// Bootstrap allowlist for the workspace admin role. Read from the
+// `ADMIN_EMAILS` env var as a comma-separated list (whitespace tolerated).
+// Emails listed here are auto-promoted to `is_admin = true` on every
+// sign-in, which means:
+//
+//   - The first admin can be established without touching the DB.
+//   - The list also works as a "permanent admins" floor — if the DB row is
+//     ever demoted manually, the next sign-in re-promotes. This is
+//     intentional; the `/settings/members` toggle is meant for ad-hoc
+//     promotions of teammates not in the env, while the env list captures
+//     the small set of operators who should always retain access.
+//
+// Comparison is case-insensitive and trimmed. Empty / unset env var means
+// no env-bootstrapped admins; the only path to admin is then the members
+// page (which itself requires an admin, so a totally-empty deployment has
+// no admins until `ADMIN_EMAILS` is set and someone signs in).
+
+let cached: Set<string> | null = null;
+
+export function getAdminEmails(): Set<string> {
+  if (cached) return cached;
+  const raw = process.env.ADMIN_EMAILS ?? "";
+  const set = new Set<string>();
+  for (const entry of raw.split(",")) {
+    const normalized = entry.trim().toLowerCase();
+    if (normalized) set.add(normalized);
+  }
+  cached = set;
+  return set;
+}
+
+export function isAdminEmail(email: string | null | undefined): boolean {
+  if (!email) return false;
+  return getAdminEmails().has(email.trim().toLowerCase());
+}

--- a/web/lib/api/auth.ts
+++ b/web/lib/api/auth.ts
@@ -118,9 +118,7 @@ export async function requireSession(): Promise<AuthResult | null> {
  * `/settings/members` takes effect on the next request — the JWT's cached
  * `session.user.isAdmin` is used only for cheap UI affordance gating.
  */
-export async function requireAdmin(): Promise<
-  { userId: string; isAdmin: true } | Response
-> {
+export async function requireAdmin(): Promise<{ userId: string } | Response> {
   const session = await auth();
   if (!session?.user?.id) {
     return apiError(401, UNAUTHORIZED, "Authentication required");
@@ -136,7 +134,7 @@ export async function requireAdmin(): Promise<
     return apiError(403, FORBIDDEN, "Admin role required");
   }
 
-  return { userId: session.user.id, isAdmin: true };
+  return { userId: session.user.id };
 }
 
 /**

--- a/web/lib/api/auth.ts
+++ b/web/lib/api/auth.ts
@@ -2,7 +2,7 @@ import { apiError, FORBIDDEN, UNAUTHORIZED } from "@/lib/api/errors";
 import { hasScope, type Scope } from "@/lib/api/scopes";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { personalAccessTokens } from "@/lib/db/schema";
+import { personalAccessTokens, users } from "@/lib/db/schema";
 import { hashToken } from "@/lib/tokens";
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
@@ -105,6 +105,67 @@ export async function requireSession(): Promise<AuthResult | null> {
   if (session?.user?.id) {
     return { userId: session.user.id, authMethod: "session", scopes: ["*"] };
   }
+  return null;
+}
+
+/**
+ * Session-only admin gate. Use for routes that have no PAT analogue
+ * (PAT create/delete, member toggle). Returns the authenticated user's id
+ * on success, or a `Response` (401 if not signed in, 403 if signed in but
+ * not admin) that the handler should return.
+ *
+ * The admin check always reads `users.is_admin` directly so a demotion via
+ * `/settings/members` takes effect on the next request — the JWT's cached
+ * `session.user.isAdmin` is used only for cheap UI affordance gating.
+ */
+export async function requireAdmin(): Promise<
+  { userId: string; isAdmin: true } | Response
+> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+
+  const [row] = await db
+    .select({ isAdmin: users.isAdmin })
+    .from(users)
+    .where(eq(users.id, session.user.id))
+    .limit(1);
+
+  if (!row?.isAdmin) {
+    return apiError(403, FORBIDDEN, "Admin role required");
+  }
+
+  return { userId: session.user.id, isAdmin: true };
+}
+
+/**
+ * Layered admin gate for routes that accept either a session or a PAT.
+ * Given an already-resolved `AuthResult` from {@link authorize}, enforce
+ * the admin role on session-authenticated callers but leave PAT callers
+ * alone — the watcher and Lambda PATs continue to authenticate purely via
+ * their stored `scopes` array. Returns `null` to indicate "all good", or a
+ * 403 `Response` the caller should return immediately.
+ *
+ * Splitting this from {@link requireAdmin} keeps the admin DB lookup off
+ * the hot PAT path (every watcher heartbeat / Lambda callback) — only
+ * session-authenticated mutations pay for it.
+ */
+export async function requireAdminForSession(
+  authResult: AuthResult
+): Promise<Response | null> {
+  if (authResult.authMethod !== "session") return null;
+
+  const [row] = await db
+    .select({ isAdmin: users.isAdmin })
+    .from(users)
+    .where(eq(users.id, authResult.userId))
+    .limit(1);
+
+  if (!row?.isAdmin) {
+    return apiError(403, FORBIDDEN, "Admin role required");
+  }
+
   return null;
 }
 

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -1,6 +1,8 @@
+import { isAdminEmail } from "@/lib/admin-emails";
 import { db } from "@/lib/db";
 import { accounts, sessions, users } from "@/lib/db/schema";
 import { DrizzleAdapter } from "@auth/drizzle-adapter";
+import { eq } from "drizzle-orm";
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 import { cache } from "react";
@@ -12,8 +14,45 @@ declare module "next-auth" {
       name?: string | null;
       email?: string | null;
       image?: string | null;
+      // Workspace admin flag. Source of truth lives in `user.is_admin`;
+      // this is the JWT-cached projection used for cheap UI affordance
+      // gating (Edit dialog, Create token button, Members nav entry, etc).
+      // Route handlers that authorize mutations re-read from the DB via
+      // `requireAdmin()` so a demotion takes effect on the next request,
+      // not the next sign-in.
+      isAdmin: boolean;
     };
   }
+}
+
+declare module "@auth/core/jwt" {
+  interface JWT {
+    id?: string;
+    isAdmin?: boolean;
+  }
+}
+
+// Resolve the canonical `is_admin` value for a user, applying the env
+// allowlist as a one-way upgrade. Returns the value to expose on the JWT.
+// Safe to call on every JWT issue — one indexed SELECT plus, at most, one
+// UPDATE the first time an allowlisted user signs in (or after their row
+// gets reset). Falls back to `false` if the user row has disappeared, so a
+// stale JWT can never claim admin against a deleted account.
+async function resolveIsAdmin(userId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ email: users.email, isAdmin: users.isAdmin })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!row) return false;
+
+  if (!row.isAdmin && isAdminEmail(row.email)) {
+    await db.update(users).set({ isAdmin: true }).where(eq(users.id, userId));
+    return true;
+  }
+
+  return row.isAdmin;
 }
 
 const {
@@ -35,14 +74,32 @@ const {
     strategy: "jwt",
   },
   callbacks: {
-    jwt({ token, user }) {
+    async jwt({ token, user, trigger }) {
+      // `user` is only present on the first JWT issue (immediately after
+      // sign-in) and on session updates. Capture the id then so we have a
+      // stable key for the admin lookup on subsequent token refreshes.
       if (user) {
         token.id = user.id;
+      }
+      // Re-resolve `isAdmin` from the DB on sign-in and on explicit
+      // `session.update()` calls. Existing tokens keep their cached flag
+      // for the lifetime of the JWT — route handlers do their own DB
+      // check via `requireAdmin()` for any mutation, so a stale-true
+      // flag in the UI never lets a non-admin actually mutate anything.
+      //
+      // `token.id` is cast because `JWT` extends `Record<string, unknown>`
+      // in @auth/core — the module-augmentation `id?: string` narrows the
+      // property but the index signature still widens it to `unknown` at
+      // the call site.
+      const id = token.id as string | undefined;
+      if (id && (trigger === "signIn" || trigger === "update")) {
+        token.isAdmin = await resolveIsAdmin(id);
       }
       return token;
     },
     session({ session, token }) {
       session.user.id = token.id as string;
+      session.user.isAdmin = token.isAdmin === true;
       return session;
     },
   },

--- a/web/lib/avatar-color.ts
+++ b/web/lib/avatar-color.ts
@@ -1,0 +1,30 @@
+// Deterministic per-user avatar styling shared by the access-tokens table,
+// the members table, and the run-attribution chips. Keeping the palette
+// and hashing function here means the same user gets the same bubble
+// color everywhere they show up in the UI.
+
+export const AVATAR_PALETTE = [
+  "bg-blue-200 text-blue-900 dark:bg-blue-800 dark:text-blue-100",
+  "bg-emerald-200 text-emerald-900 dark:bg-emerald-800 dark:text-emerald-100",
+  "bg-violet-200 text-violet-900 dark:bg-violet-800 dark:text-violet-100",
+  "bg-amber-200 text-amber-900 dark:bg-amber-800 dark:text-amber-100",
+  "bg-rose-200 text-rose-900 dark:bg-rose-800 dark:text-rose-100",
+  "bg-teal-200 text-teal-900 dark:bg-teal-800 dark:text-teal-100",
+  "bg-fuchsia-200 text-fuchsia-900 dark:bg-fuchsia-800 dark:text-fuchsia-100",
+  "bg-orange-200 text-orange-900 dark:bg-orange-800 dark:text-orange-100",
+];
+
+export function avatarColor(userId: string): string {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) | 0;
+  }
+  return AVATAR_PALETTE[Math.abs(hash) % AVATAR_PALETTE.length];
+}
+
+export function toInitials(displayName: string): string {
+  const parts = displayName.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}

--- a/web/lib/db/schema.ts
+++ b/web/lib/db/schema.ts
@@ -3,6 +3,7 @@ import { sql } from "drizzle-orm";
 import {
   bigint,
   bigserial,
+  boolean,
   index,
   integer,
   jsonb,
@@ -95,6 +96,13 @@ export const users = pgTable("user", {
   emailVerified: timestamp("emailVerified", { mode: "date" }),
   // Profile image URL from Google.
   image: text("image"),
+  // Workspace-wide admin flag. Bootstrapped from the `ADMIN_EMAILS` env var
+  // at sign-in (see `web/lib/auth.ts`); subsequent toggles happen via the
+  // admin-only `/settings/members` page. Used to gate session-authenticated
+  // mutations (PAT create/delete, instrument edits, member toggles). PAT-
+  // authenticated requests are unaffected — they're still authorized by
+  // `personal_access_tokens.scopes`.
+  isAdmin: boolean("is_admin").notNull().default(false),
 });
 
 export const accounts = pgTable(

--- a/web/tests/integration/helpers.ts
+++ b/web/tests/integration/helpers.ts
@@ -88,9 +88,14 @@ function getTokenPrefix(plaintext: string): string {
 // Pass `expiresAt` to test expired-token rejection. Defaults to no expiry.
 // Pass `scopes` to test scope enforcement; defaults to `["*"]` so every
 // existing test (which expects full access) keeps passing.
+// Pass `isAdmin` to seed a workspace admin row. The role only matters for
+// session-authenticated routes (PAT requests never consult `user.is_admin`),
+// but exposing the option here keeps the seeding helper future-proof for
+// any cookie-based session test harness layered on later.
 export async function seedTestUser(options?: {
   expiresAt?: Date | null;
   scopes?: string[];
+  isAdmin?: boolean;
 }) {
   const db = getTestDb();
 
@@ -99,6 +104,7 @@ export async function seedTestUser(options?: {
     id: userId,
     name: "Test User",
     email: `test-${userId.slice(0, 8)}@example.com`,
+    isAdmin: options?.isAdmin ?? false,
   });
 
   const plaintext = generateToken();

--- a/web/tests/integration/users.test.ts
+++ b/web/tests/integration/users.test.ts
@@ -1,0 +1,64 @@
+import {
+  api,
+  closeTestDb,
+  resetDb,
+  seedTestUser,
+} from "@/tests/integration/helpers";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// The `/api/v1/users` surface is admin-only and session-only — PATs never
+// pass the gate. The full happy-path (admin promoting a teammate) needs a
+// session cookie, which the current harness doesn't synthesise. We
+// instead lock down the negative cases so the gate is verifiably wired
+// up; the session-auth round-trip is covered by manual QA per the PR
+// description.
+
+describe("Users API admin gate", () => {
+  let token: string;
+
+  beforeAll(async () => {
+    await resetDb();
+    // Even seeding a user as admin doesn't help here — PATs don't carry a
+    // session, and `requireAdmin()` only consults the NextAuth session.
+    // This intentionally makes "PAT tries to manage members" a 401, not a
+    // 403, so the failure mode is clearly "session required".
+    ({ token } = await seedTestUser({ isAdmin: true }));
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  it("GET /api/v1/users rejects PAT auth (session required)", async () => {
+    const res = await api("/api/v1/users", { token });
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/v1/users rejects unauthenticated requests", async () => {
+    const res = await api("/api/v1/users");
+    expect(res.status).toBe(401);
+  });
+
+  it("PATCH /api/v1/users/:userId rejects PAT auth", async () => {
+    const res = await api(
+      "/api/v1/users/00000000-0000-0000-0000-000000000000",
+      {
+        method: "PATCH",
+        token,
+        body: { is_admin: true },
+      }
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("PATCH /api/v1/users/:userId rejects unauthenticated requests", async () => {
+    const res = await api(
+      "/api/v1/users/00000000-0000-0000-0000-000000000000",
+      {
+        method: "PATCH",
+        body: { is_admin: true },
+      }
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/web/tests/unit/admin-emails.test.ts
+++ b/web/tests/unit/admin-emails.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The helper memoizes `ADMIN_EMAILS` on first read for the lifetime of the
+// process. Each test resets module state via `vi.resetModules()` and then
+// imports the module fresh, exercising a different env value in isolation.
+async function loadHelper(value: string | undefined) {
+  if (value === undefined) {
+    delete process.env.ADMIN_EMAILS;
+  } else {
+    process.env.ADMIN_EMAILS = value;
+  }
+  vi.resetModules();
+  return await import("@/lib/admin-emails");
+}
+
+describe("admin-emails helper", () => {
+  const originalEnv = process.env.ADMIN_EMAILS;
+
+  beforeEach(() => {
+    delete process.env.ADMIN_EMAILS;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.ADMIN_EMAILS;
+    } else {
+      process.env.ADMIN_EMAILS = originalEnv;
+    }
+  });
+
+  it("returns an empty set when ADMIN_EMAILS is unset", async () => {
+    const { getAdminEmails, isAdminEmail } = await loadHelper(undefined);
+    expect(getAdminEmails().size).toBe(0);
+    expect(isAdminEmail("anyone@example.com")).toBe(false);
+  });
+
+  it("parses a single email", async () => {
+    const { isAdminEmail } = await loadHelper("alice@arcadia.com");
+    expect(isAdminEmail("alice@arcadia.com")).toBe(true);
+    expect(isAdminEmail("bob@arcadia.com")).toBe(false);
+  });
+
+  it("parses a comma-separated list", async () => {
+    const { getAdminEmails, isAdminEmail } = await loadHelper(
+      "alice@arcadia.com,bob@arcadia.com,carol@arcadia.com"
+    );
+    expect(getAdminEmails().size).toBe(3);
+    expect(isAdminEmail("alice@arcadia.com")).toBe(true);
+    expect(isAdminEmail("bob@arcadia.com")).toBe(true);
+    expect(isAdminEmail("carol@arcadia.com")).toBe(true);
+  });
+
+  it("treats comparisons as case-insensitive and trims whitespace", async () => {
+    const { isAdminEmail } = await loadHelper(
+      "  Alice@arcadia.com , bob@arcadia.com  "
+    );
+    expect(isAdminEmail("ALICE@arcadia.com")).toBe(true);
+    expect(isAdminEmail("bob@ARCADIA.com")).toBe(true);
+    expect(isAdminEmail("  bob@arcadia.com  ")).toBe(true);
+    expect(isAdminEmail("carol@arcadia.com")).toBe(false);
+  });
+
+  it("rejects null / undefined / empty inputs", async () => {
+    const { isAdminEmail } = await loadHelper("alice@arcadia.com");
+    expect(isAdminEmail(null)).toBe(false);
+    expect(isAdminEmail(undefined)).toBe(false);
+    expect(isAdminEmail("")).toBe(false);
+  });
+
+  it("ignores empty entries from leading/trailing/double commas", async () => {
+    const { getAdminEmails } = await loadHelper(",,alice@arcadia.com,,");
+    expect(getAdminEmails().size).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Introduces an explicit workspace **admin role** on `user.is_admin`, bootstrapped from a new `ADMIN_EMAILS` env-var allowlist on every Google sign-in. Admins (and only admins) can:

- Edit instrument names/types and confirm pending instruments on `/instruments`.
- Create and delete personal access tokens (delete now works on any user's token so admins can off-board / revoke compromised credentials).
- Toggle other users' admin flag on a new `/settings/members` page.

Non-admins keep the existing read access: instrument browsing, the workspace-wide token audit list at `/settings/tokens`, and the per-user `GET /api/v1/tokens` list.

The API admin gate applies to **session callers only**. PAT-authenticated requests (watcher, Lambda, MCP) still authenticate purely on their stored `scopes`, so existing automation continues to work — no token rotation required.

### Layout

- **Schema** (`web/drizzle/0023_add_user_is_admin.sql`): adds `is_admin boolean NOT NULL DEFAULT false` on `user`.
- **Auth** (`web/lib/auth.ts` + `web/lib/admin-emails.ts`): JWT/session callbacks resolve `isAdmin` against the allowlist and DB on sign-in / `session.update()`; `session.user.isAdmin` is the JWT-cached projection used for UI affordance gating.
- **API helpers** (`web/lib/api/auth.ts`):
  - `requireAdmin()` — session-only gate that re-reads `user.is_admin` from the DB on every request, so a demotion takes effect immediately (not on next sign-in).
  - `requireAdminForSession(authResult)` — layered gate that only enforces admin for session callers; PAT callers pass through unchanged. Used on `PATCH /api/v1/instruments/:id` after the existing `instruments:write` scope check.
- **Routes**: `POST /api/v1/tokens`, `DELETE /api/v1/tokens/:id`, `GET /api/v1/users`, `PATCH /api/v1/users/:userId` are admin-only & session-only. Self-demotion is rejected with `400 VALIDATION_ERROR` so the workspace can't end up admin-less.
- **UI** (composition, per the React composition guidelines): admin-only dialogs are mounted only for admins rather than threaded through boolean props. `/instruments` omits `renderRowActions` for non-admins; `/settings/tokens` skips the Create / Delete dialogs; the Members sidebar entry is filtered out for non-admins.
- **Members page** (`/settings/members`): admin-only roster with a per-row `<Switch>` that PATCHes the users API. The switch is disabled on the caller's own row with an explanatory tooltip; the server-side guard mirrors that.
- **Docs**: `docs/api.md` gets a new "Admin role" section and a Users endpoint table; `docs/guides/managing-tokens.md` notes the admin-only requirement; `web/README.md` documents the `ADMIN_EMAILS` env var.

## Test plan

- [x] `make check-all` passes locally (Ruff, Pyright, Prettier, ESLint, tsc).
- [x] `npm run test:mcp` — 55 passed (includes new `admin-emails` unit tests).
- [x] `npm run test:integration` — 173 passed (includes new `users.test.ts` confirming admin-only routes reject PAT auth with 401).
- [x] Set `ADMIN_EMAILS` on a preview deployment, sign in with a listed email, and verify:
  - [x] Members nav entry visible; `/settings/members` lists users; toggling another user's admin shows a toast and refreshes the row.
  - [x] Self-row toggle is disabled with the explanatory tooltip; attempting it server-side returns 400.
  - [x] On `/instruments`, Edit / Confirm buttons appear; for non-admin sessions they're hidden.
  - [x] On `/settings/tokens`, Create / Delete dialogs render for admins only; the workspace-wide list still shows for everyone.
- [ ] **Manual:** confirm the watcher's `PATCH /api/v1/instruments/:id` paths (if any) continue to work — scope check is unchanged, but worth a smoke test post-merge.

Made with [Cursor](https://cursor.com)