### PR TITLE
Web: Show JPG preview above colony CSV table

### DIFF
--- a/web/components/runs/run-report-section.tsx
+++ b/web/components/runs/run-report-section.tsx
@@ -111,11 +111,11 @@ export function RunReportSection({ files }: { files: RunFile[] }) {
       </h2>
       <Card size="sm">
         <CardContent className="flex flex-col gap-6">
-          {processedCsvs.map((file) => (
-            <ColonyDataTable key={file.id} file={file} />
-          ))}
           {processedImages.map((file) => (
             <ProcessedImagePreview key={file.id} file={file} />
+          ))}
+          {processedCsvs.map((file) => (
+            <ColonyDataTable key={file.id} file={file} />
           ))}
           {pdfFiles.map((file) => (
             <PdfPreview key={file.id} file={file} />


### PR DESCRIPTION
## Summary

- Swaps the render order in `RunReportSection` so the processed image (JPG) preview appears **above** the colony data CSV table, matching a more natural image-first, data-second visual flow.
- Follow-up to #76.

## Test plan

- [x] Open an Epson V700 run with both a `*_colonies.csv` and JPG: JPG appears above the table.
- [x] Open a run with only a JPG (no CSV): renders as before.
- [x] `make check-all` passes.

Made with [Cursor](https://cursor.com)