### PR TITLE
Enforce minimum support watcher version on heartbeats

### DIFF
--- a/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
@@ -1,9 +1,19 @@
 import { authorize } from "@/lib/api/auth";
-import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
+import {
+  apiError,
+  NOT_FOUND,
+  UPGRADE_REQUIRED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
 import { isValidUUID } from "@/lib/api/validators";
+import { isBelowFloor } from "@/lib/api/watcher-versions";
 import { findActiveWatcher } from "@/lib/api/watchers";
 import { db } from "@/lib/db";
-import { watcherHeartbeats, watchers } from "@/lib/db/schema";
+import {
+  watcherHeartbeats,
+  watcherReleaseConfig,
+  watchers,
+} from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 
@@ -53,6 +63,43 @@ export async function POST(
     : new Date();
   if (isNaN(timestamp.getTime())) {
     return apiError(400, VALIDATION_ERROR, "Invalid timestamp");
+  }
+
+  // Enforce the configured min-supported-version floor before recording
+  // anything. Below-floor watchers are sent away with a 426 so they
+  // can't keep heartbeating (and silently look "alive") while skipping
+  // a mandatory upgrade. We compare against `body.watcher_version`
+  // rather than the stored `watchers.watcher_version` so the very first
+  // heartbeat after a manual upgrade is judged on the new version, not
+  // the stale stored one. The singleton constraint on
+  // `watcher_release_config` keeps this a constant-cost select.
+  const reportedVersion =
+    typeof body.watcher_version === "string" && body.watcher_version
+      ? body.watcher_version
+      : null;
+  const [releaseRow] = await db
+    .select({
+      minSupportedVersion: watcherReleaseConfig.minSupportedVersion,
+      latestVersion: watcherReleaseConfig.latestVersion,
+      channel: watcherReleaseConfig.channel,
+    })
+    .from(watcherReleaseConfig);
+
+  if (
+    releaseRow &&
+    isBelowFloor(reportedVersion, releaseRow.minSupportedVersion)
+  ) {
+    return apiError(
+      426,
+      UPGRADE_REQUIRED,
+      `Watcher version ${reportedVersion} is below the minimum supported version ${releaseRow.minSupportedVersion}. Self-update before continuing.`,
+      {
+        current_version: reportedVersion,
+        min_supported_version: releaseRow.minSupportedVersion,
+        latest_version: releaseRow.latestVersion,
+        channel: releaseRow.channel,
+      }
+    );
   }
 
   // Two parallel writes: (1) append to the heartbeat history log, and

--- a/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
@@ -130,9 +130,7 @@ export async function POST(
         // Older watchers (pre-version-reporting) won't include this field —
         // fall back to the existing value rather than nulling it out so the
         // dashboard keeps the last-known version visible.
-        ...(typeof body.watcher_version === "string" && body.watcher_version
-          ? { watcherVersion: body.watcher_version }
-          : {}),
+        ...(reportedVersion ? { watcherVersion: reportedVersion } : {}),
       })
       .where(eq(watchers.id, watcherId)),
   ]);

--- a/web/app/settings/layout.tsx
+++ b/web/app/settings/layout.tsx
@@ -38,7 +38,7 @@ export default async function SettingsLayout({
   // labels this section, so rendering an H1 here was duplicative chrome
   // on every settings page. Pages render their own H2 instead.
   return (
-    <div className="mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 lg:px-8 2xl:w-7xl">
+    <div className="mx-auto w-full max-w-7xl px-4 pt-4 pb-10 sm:px-6 lg:px-8 2xl:w-7xl">
       {children}
     </div>
   );

--- a/web/app/settings/watchers/page.tsx
+++ b/web/app/settings/watchers/page.tsx
@@ -61,29 +61,54 @@ export default async function WatchersSettingsPage() {
     .from(watcherReleaseConfig)
     .leftJoin(users, eq(users.id, watcherReleaseConfig.updatedBy));
 
-  // The form owns its own Card chrome (heading, description, fields,
-  // footer) so it renders as a self-contained settings panel. The page
-  // just wires server-fetched state into it.
+  // Page-level heading + description match the layout used by
+  // `/settings/tokens` and `/settings/members` so the h2 aligns
+  // vertically with the "Settings" label in the sidebar. The form below
+  // is content-only (Card body + footer) — same pattern as the table
+  // components those sibling pages render.
   return (
-    <WatcherReleaseForm
-      initial={{
-        latestVersion: row?.latestVersion ?? "",
-        minSupportedVersion: row?.minSupportedVersion ?? "",
-        channel: row?.channel ?? "stable",
-        mandatory: row?.mandatory ?? false,
-      }}
-      // Only the primitive form values + the small "last updated"
-      // metadata cross the server/client boundary — keep the
-      // server/client payload minimal per `server-serialization`.
-      lastUpdated={
-        row
-          ? {
-              at: row.updatedAt.toISOString(),
-              byName: row.updatedByName,
-              byEmail: row.updatedByEmail,
-            }
-          : null
-      }
-    />
+    <div>
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold tracking-tight">
+            Watcher Version
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Configure the release advertised by{" "}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs dark:bg-background/40">
+              GET /api/v1/watchers/:id/update-check
+            </code>
+            . Watchers compare their installed version against{" "}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs dark:bg-background/40">
+              latest_version
+            </code>{" "}
+            and self-upgrade when a newer release is offered.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <WatcherReleaseForm
+          initial={{
+            latestVersion: row?.latestVersion ?? "",
+            minSupportedVersion: row?.minSupportedVersion ?? "",
+            channel: row?.channel ?? "stable",
+            mandatory: row?.mandatory ?? false,
+          }}
+          // Only the primitive form values + the small "last updated"
+          // metadata cross the server/client boundary — keep the
+          // server/client payload minimal per `server-serialization`.
+          lastUpdated={
+            row
+              ? {
+                  at: row.updatedAt.toISOString(),
+                  byName: row.updatedByName,
+                  byEmail: row.updatedByEmail,
+                }
+              : null
+          }
+        />
+      </div>
+    </div>
   );
 }

--- a/web/components/watcher-release/watcher-release-form.tsx
+++ b/web/components/watcher-release/watcher-release-form.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import {
   Field,
   FieldContent,
@@ -116,12 +109,13 @@ export function WatcherReleaseForm({
   });
 
   return (
-    // The Card wrapper mirrors Vercel's project-settings panel pattern:
-    // heading + description, form fields, then a CardFooter holding the
-    // meta + Save action separated by a single border. The Card spans
-    // the full width of the page area; CardHeader/CardContent and the
-    // inner footer row are capped at `max-w-2xl` so input rows and body
-    // copy stay at a readable measure regardless of viewport.
+    // The form renders as a content-only Card (body + footer separated
+    // by a single border). The page-level heading + description live in
+    // the route's `page.tsx` so they align with the sibling settings
+    // pages and the sidebar "Settings" label. The Card spans the full
+    // width of the page area; CardContent and the inner footer row are
+    // capped at `max-w-2xl` so input rows and body copy stay at a
+    // readable measure regardless of viewport.
     //
     // The fields stay in a single Card (rather than one-card-per-field)
     // because they all configure the same logical resource — the
@@ -134,23 +128,6 @@ export function WatcherReleaseForm({
       }}
     >
       <Card>
-        <CardHeader>
-          <CardTitle className="text-lg font-semibold tracking-tight">
-            Watcher Version
-          </CardTitle>
-          <CardDescription>
-            Configure the release advertised by{" "}
-            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs dark:bg-background/40">
-              GET /api/v1/watchers/:id/update-check
-            </code>
-            .<br /> Watchers compare their installed version against{" "}
-            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs dark:bg-background/40">
-              latest_version
-            </code>{" "}
-            and self-upgrade when a newer release is offered.
-          </CardDescription>
-        </CardHeader>
-
         <CardContent className="max-w-2xl">
           <FieldGroup>
             <form.Field name="latestVersion">

--- a/web/components/watcher-release/watcher-release-form.tsx
+++ b/web/components/watcher-release/watcher-release-form.tsx
@@ -208,8 +208,11 @@ export function WatcherReleaseForm({
                       className="font-mono"
                     />
                     <FieldDescription>
-                      Optional floor surfaced in the response for future use.
-                      Not yet enforced server-side.
+                      Optional floor. Watchers reporting an installed version
+                      below this have their heartbeats rejected with{" "}
+                      <code className="font-mono">426 Upgrade Required</code>,
+                      forcing them to self-update before they can check in
+                      again. Leave blank to disable the floor.
                     </FieldDescription>
                     {isInvalid && (
                       <FieldError errors={field.state.meta.errors} />

--- a/web/lib/api/errors.ts
+++ b/web/lib/api/errors.ts
@@ -4,6 +4,10 @@ export const CONFLICT = "CONFLICT";
 export const UNAUTHORIZED = "UNAUTHORIZED";
 export const FORBIDDEN = "FORBIDDEN";
 export const INTERNAL_ERROR = "INTERNAL_ERROR";
+// Paired with HTTP 426. Returned by the heartbeat route when the
+// watcher's reported version is below the configured
+// `watcher_release_config.min_supported_version` floor.
+export const UPGRADE_REQUIRED = "UPGRADE_REQUIRED";
 
 export function apiError(
   status: number,

--- a/web/lib/api/watcher-versions.ts
+++ b/web/lib/api/watcher-versions.ts
@@ -1,0 +1,57 @@
+// Loose PEP 440-ish ordering. Mirrors the VERSION_REGEX used by
+// `app/api/v1/settings/watcher-release/route.ts` and the form in
+// `components/watcher-release/watcher-release-form.tsx` — together they're
+// the single source of truth for which version shapes the platform
+// understands. Doing real PEP 440 ordering here would mean either a
+// dependency or ~200 lines of spec code; the shapes we actually advertise
+// (X.Y.Z, X.Y.Z.postN, X.Y.ZrcN, X.Y.Z-dev0) all fit cleanly under this
+// simpler model so we keep the implementation small.
+
+type ParsedVersion = {
+  core: [number, number, number];
+  // Anything after the X.Y.Z prefix, including the leading "." / "-".
+  // Empty string ⇒ release; non-empty ⇒ pre-release / post-release suffix.
+  suffix: string;
+};
+
+function parseLoose(v: string): ParsedVersion | null {
+  const m = /^(\d+)\.(\d+)\.(\d+)([.-].+)?$/.exec(v.trim());
+  if (!m) return null;
+  return {
+    core: [Number(m[1]), Number(m[2]), Number(m[3])],
+    suffix: m[4] ?? "",
+  };
+}
+
+/**
+ * Returns `true` only when both `current` and `floor` are present, parse
+ * cleanly, and `current < floor`. Any other input — null/undefined,
+ * unparseable strings, or current ≥ floor — returns `false`.
+ *
+ * The fail-safe default is deliberate: enforcement on the heartbeat path
+ * blocks watchers from checking in, so we'd rather miss an enforcement
+ * (the next admin save can tighten it) than spuriously orphan a lab PC.
+ * Mirrors the philosophy in `evaluate_update` on the watcher side, which
+ * also refuses to act on un-parseable version strings.
+ *
+ * On equal X.Y.Z, an empty suffix (release) is treated as the highest
+ * sort key — so `1.2.3` ≥ `1.2.3rc1`, matching PEP 440's release > pre
+ * ordering. For two suffixed values we fall back to string compare,
+ * which is conservative but enough for the rare pre-release floor case.
+ */
+export function isBelowFloor(
+  current: string | null | undefined,
+  floor: string | null | undefined
+): boolean {
+  if (!current || !floor) return false;
+  const a = parseLoose(current);
+  const b = parseLoose(floor);
+  if (!a || !b) return false;
+  for (let i = 0; i < 3; i++) {
+    if (a.core[i] !== b.core[i]) return a.core[i] < b.core[i];
+  }
+  if (a.suffix === b.suffix) return false;
+  if (a.suffix === "") return false;
+  if (b.suffix === "") return true;
+  return a.suffix < b.suffix;
+}

--- a/web/lib/db/schema.ts
+++ b/web/lib/db/schema.ts
@@ -172,8 +172,10 @@ export const watcherReleaseConfig = pgTable(
     // Required to advertise a release. NULL → watchers skip the upgrade
     // attempt.
     latestVersion: text("latest_version"),
-    // Optional floor; surfaced in the response for future use, not yet
-    // enforced server-side.
+    // Optional floor enforced on the heartbeat path: watchers reporting an
+    // installed version below this are rejected with 426 Upgrade Required
+    // (see `app/api/v1/watchers/[watcherId]/heartbeat/route.ts`) so they
+    // can't continue checking in without self-updating first.
     minSupportedVersion: text("min_supported_version"),
     // Defaults to "stable"; surfaced in the response and shown in
     // `self-update` output.

--- a/web/tests/integration/watcher-release.test.ts
+++ b/web/tests/integration/watcher-release.test.ts
@@ -1,4 +1,4 @@
-import { instruments, watcherReleaseConfig } from "@/lib/db/schema";
+import { instruments, watcherReleaseConfig, watchers } from "@/lib/db/schema";
 import {
   api,
   closeTestDb,
@@ -244,5 +244,200 @@ describe("Watcher Release singleton flows through update-check", () => {
         sql`INSERT INTO watcher_release_config (id, channel) VALUES (false, 'stable')`
       )
     ).rejects.toThrow();
+  });
+});
+
+// Enforcement of `min_supported_version` on the heartbeat path. The route
+// reads the singleton release row on every heartbeat and refuses to
+// record anything when the reported version is below the floor — the
+// "block_heartbeat" enforcement mode chosen for this rollout. We vary the
+// row directly via Drizzle to isolate the schema → heartbeat-route chain
+// from the (separately-tested) admin write surface.
+describe("Heartbeat enforces watcher_release_config.min_supported_version", () => {
+  let token: string;
+  let watcherId: string;
+  const instrumentId = "watcher-floor-test-instrument";
+
+  // Set the singleton's `min_supported_version` for the current test.
+  // Wrapped in a helper so each test reads as "set floor → heartbeat →
+  // assert", without the upsert boilerplate drowning the intent.
+  async function setFloor(floor: string | null) {
+    const db = getTestDb();
+    await db
+      .insert(watcherReleaseConfig)
+      .values({
+        id: true,
+        latestVersion: "9.9.9",
+        minSupportedVersion: floor,
+        channel: "stable",
+        mandatory: false,
+      })
+      .onConflictDoUpdate({
+        target: watcherReleaseConfig.id,
+        set: {
+          latestVersion: "9.9.9",
+          minSupportedVersion: floor,
+          channel: "stable",
+          mandatory: false,
+        },
+      });
+  }
+
+  async function heartbeat(body: Record<string, unknown>): Promise<Response> {
+    return api(`/api/v1/watchers/${watcherId}/heartbeat`, {
+      method: "POST",
+      token,
+      body,
+    });
+  }
+
+  beforeAll(async () => {
+    await resetDb();
+    ({ token } = await seedTestUser());
+
+    const db = getTestDb();
+    await db.insert(instruments).values({
+      id: instrumentId,
+      displayName: "Watcher Floor Test Instrument",
+      status: "active",
+    });
+
+    const res = await api("/api/v1/watchers/register", {
+      method: "POST",
+      token,
+      body: {
+        instrument_id: instrumentId,
+        hostname: "floor-test-lab-pc",
+        os_info: "Linux integration-test",
+      },
+    });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    watcherId = data.watcher_id;
+  });
+
+  afterEach(async () => {
+    // Restore the global-setup baseline so this file's earlier
+    // `update-check` assertions (and any later tests) stay deterministic.
+    await setFloor("0.1.0");
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  it("rejects below-floor watcher_version with 426 UPGRADE_REQUIRED", async () => {
+    await setFloor("1.0.0");
+    const res = await heartbeat({
+      status: "watching",
+      watcher_version: "0.5.0",
+    });
+    expect(res.status).toBe(426);
+    const body = await res.json();
+    expect(body).toEqual({
+      error: {
+        code: "UPGRADE_REQUIRED",
+        message: expect.stringContaining("0.5.0"),
+        details: {
+          current_version: "0.5.0",
+          min_supported_version: "1.0.0",
+          latest_version: "9.9.9",
+          channel: "stable",
+        },
+      },
+    });
+  });
+
+  it("does not touch the watcher row when rejecting below-floor heartbeats", async () => {
+    // Set a known baseline via an at-floor heartbeat first, then verify
+    // the subsequent below-floor rejection leaves both the stored
+    // version and lastHeartbeatAt exactly where they were. This guards
+    // the "rejection is fully side-effect-free" invariant the dashboard
+    // staleness rule depends on to surface below-floor watchers as
+    // stale rather than as having silently kept checking in.
+    await setFloor("1.0.0");
+    const okRes = await heartbeat({
+      status: "watching",
+      watcher_version: "1.0.0",
+    });
+    expect(okRes.status).toBe(200);
+
+    const db = getTestDb();
+    const [before] = await db
+      .select({
+        watcherVersion: watchers.watcherVersion,
+        lastHeartbeatAt: watchers.lastHeartbeatAt,
+      })
+      .from(watchers)
+      .where(eq(watchers.id, watcherId));
+    expect(before.watcherVersion).toBe("1.0.0");
+
+    const rejectRes = await heartbeat({
+      status: "watching",
+      watcher_version: "0.5.0",
+    });
+    expect(rejectRes.status).toBe(426);
+
+    const [after] = await db
+      .select({
+        watcherVersion: watchers.watcherVersion,
+        lastHeartbeatAt: watchers.lastHeartbeatAt,
+      })
+      .from(watchers)
+      .where(eq(watchers.id, watcherId));
+    expect(after.watcherVersion).toBe(before.watcherVersion);
+    expect(after.lastHeartbeatAt?.toISOString()).toBe(
+      before.lastHeartbeatAt?.toISOString()
+    );
+  });
+
+  it("accepts a watcher_version equal to the floor", async () => {
+    await setFloor("1.0.0");
+    const res = await heartbeat({
+      status: "watching",
+      watcher_version: "1.0.0",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts a watcher_version above the floor", async () => {
+    await setFloor("1.0.0");
+    const res = await heartbeat({
+      status: "watching",
+      watcher_version: "2.0.0",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts heartbeats missing watcher_version (old-watcher back-compat)", async () => {
+    // Pre-0.3.0 watchers don't report a version. Blocking them would
+    // orphan still-supported lab PCs whose only crime is not yet
+    // self-updating to a version that ships the version field, so the
+    // comparator's fail-safe default lets them through.
+    await setFloor("1.0.0");
+    const res = await heartbeat({ status: "watching" });
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts heartbeats with an unparseable watcher_version", async () => {
+    // Mirrors the fail-safe philosophy in `evaluate_update` on the
+    // watcher side: if either side of the comparison can't be parsed
+    // we refuse to act on it, so a malformed string never spuriously
+    // orphans an otherwise-healthy watcher.
+    await setFloor("1.0.0");
+    const res = await heartbeat({
+      status: "watching",
+      watcher_version: "not-a-version",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts any version when the floor is null", async () => {
+    await setFloor(null);
+    const res = await heartbeat({
+      status: "watching",
+      watcher_version: "0.0.1",
+    });
+    expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary

`watcher_release_config.min_supported_version` was already persisted and surfaced by both the admin write route and the public `/update-check` route, but nothing acted on it — the form field even admitted "Optional floor surfaced in the response for future use. Not yet enforced server-side."

This PR makes the floor real on the heartbeat path: when a watcher reports a `watcher_version` below the configured floor, the heartbeat is rejected with `426 Upgrade Required` and **no** DB writes happen (no heartbeat row, no `lastHeartbeatAt` bump, no `watcherVersion` update). Below-floor watchers therefore surface naturally as stale via the existing 5-minute staleness rule.

- New `isBelowFloor` comparator (loose PEP 440-ish, mirrors the existing `VERSION_REGEX`). Fail-safe: returns `false` for null/undefined/unparseable inputs so old or malformed watchers are never spuriously orphaned.
- New `UPGRADE_REQUIRED` error code; the 426 response body includes `current_version`, `min_supported_version`, `latest_version`, and `channel` under `error.details` so operators can debug in one round trip.
- Form copy and schema comment updated to describe the real behavior.
- The reported `body.watcher_version` is the source of truth (not the stored `watchers.watcher_version`), so the first heartbeat after a manual upgrade is judged on the new version, not a stale stored one.

Out of scope (kept intentionally narrow):

- No watcher client changes — the existing `ApiError` path in `api_client.py` already surfaces 4xx rejections; a friendlier "below floor" log line can land in a future watcher release.
- No change to `/update-check` — `mandatory` stays driven by the admin toggle.
- No dashboard "below floor" badge — staleness via the existing rule is enough signal for v1.

## Test plan

- [x] `make check-all` (py + fe format / lint / typecheck) green locally.
- [x] New integration tests in `web/tests/integration/watcher-release.test.ts` cover:
  - below-floor → 426 with correct `error.code` / `error.details`
  - at-floor and above-floor → 200
  - missing `watcher_version` → 200 (old-watcher back-compat)
  - unparseable `watcher_version` → 200 (fail-safe)
  - `min_supported_version=null` → 200
  - after a 426, `watchers.watcherVersion` and `watchers.lastHeartbeatAt` are byte-for-byte unchanged
- [ ] Manual QA: set a floor via `/settings/watchers`, point a watcher below it, confirm the heartbeat loop logs `ApiError` 426 and the dashboard transitions the watcher to stale after the staleness window.

Made with [Cursor](https://cursor.com)