### PR TITLE
Implement in-app notifications for runs and comments

### DIFF
--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/comments/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/comments/route.ts
@@ -9,6 +9,7 @@ import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
 import { notifyComment } from "@/lib/api/notifications";
 import { createComment, listCommentsForRun } from "@/lib/api/run-comments";
 import type { NextRequest } from "next/server";
+import { after } from "next/server";
 
 type RouteContext = {
   params: Promise<{ instrumentId: string; runId: string }>;
@@ -101,10 +102,12 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   // Fan out to attributees + prior commenters after the response is
   // sent. The helper itself decides who actually qualifies (and skips
   // the comment author) based on each user's notification preferences.
-  await notifyComment({
-    runInternalId: run.id,
-    commentId: comment.id,
-    authorUserId: authResult.userId,
+  after(async () => {
+    await notifyComment({
+      runInternalId: run.id,
+      commentId: comment.id,
+      authorUserId: authResult.userId,
+    });
   });
 
   return Response.json(comment, { status: 201 });

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/comments/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/comments/route.ts
@@ -9,7 +9,6 @@ import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
 import { notifyComment } from "@/lib/api/notifications";
 import { createComment, listCommentsForRun } from "@/lib/api/run-comments";
 import type { NextRequest } from "next/server";
-import { after } from "next/server";
 
 type RouteContext = {
   params: Promise<{ instrumentId: string; runId: string }>;
@@ -102,12 +101,10 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   // Fan out to attributees + prior commenters after the response is
   // sent. The helper itself decides who actually qualifies (and skips
   // the comment author) based on each user's notification preferences.
-  after(async () => {
-    await notifyComment({
-      runInternalId: run.id,
-      commentId: comment.id,
-      authorUserId: authResult.userId,
-    });
+  await notifyComment({
+    runInternalId: run.id,
+    commentId: comment.id,
+    authorUserId: authResult.userId,
   });
 
   return Response.json(comment, { status: 201 });

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/comments/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/comments/route.ts
@@ -6,8 +6,10 @@ import {
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
 import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
+import { notifyComment } from "@/lib/api/notifications";
 import { createComment, listCommentsForRun } from "@/lib/api/run-comments";
 import type { NextRequest } from "next/server";
+import { after } from "next/server";
 
 type RouteContext = {
   params: Promise<{ instrumentId: string; runId: string }>;
@@ -95,6 +97,17 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
     runInternalId: run.id,
     userId: authResult.userId,
     body: payload.body,
+  });
+
+  // Fan out to attributees + prior commenters after the response is
+  // sent. The helper itself decides who actually qualifies (and skips
+  // the comment author) based on each user's notification preferences.
+  after(async () => {
+    await notifyComment({
+      runInternalId: run.id,
+      commentId: comment.id,
+      authorUserId: authResult.userId,
+    });
   });
 
   return Response.json(comment, { status: 201 });

--- a/web/app/api/v1/instruments/[instrumentId]/runs/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/route.ts
@@ -7,7 +7,7 @@ import { db } from "@/lib/db";
 import { files, instrumentRuns, instruments, watchers } from "@/lib/db/schema";
 import { sendSlackMessage } from "@/lib/slack";
 import { and, eq, isNull, sql } from "drizzle-orm";
-import type { NextRequest } from "next/server";
+import { after, type NextRequest } from "next/server";
 
 type RouteContext = {
   params: Promise<{ instrumentId: string }>;
@@ -181,16 +181,18 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
 
   // Send Slack notification and notify app users of new run.
   if (isNew) {
-    const origin = new URL(request.url).origin;
-    await sendSlackMessage(
-      `*${instrument.displayName}*\n` +
-        `New instrument run reported: \`${runId}\`.\n` +
-        `<${origin}/instruments/${instrumentId}/runs/${encodeURIComponent(runId)}|View in Data Hub>`
-    );
+    after(async () => {
+      const origin = new URL(request.url).origin;
+      await sendSlackMessage(
+        `*${instrument.displayName}*\n` +
+          `New instrument run reported: \`${runId}\`.\n` +
+          `<${origin}/instruments/${instrumentId}/runs/${encodeURIComponent(runId)}|View in Data Hub>`
+      );
 
-    await notifyRunCreated({
-      runInternalId: run.id,
-      instrumentId,
+      await notifyRunCreated({
+        runInternalId: run.id,
+        instrumentId,
+      });
     });
   }
 

--- a/web/app/api/v1/instruments/[instrumentId]/runs/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/route.ts
@@ -1,12 +1,14 @@
 import { authorize } from "@/lib/api/auth";
 import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { buildRunListQuery, parseAcquiredAt } from "@/lib/api/instrument-runs";
+import { notifyRunCreated } from "@/lib/api/notifications";
 import { parseIntParam } from "@/lib/api/validators";
 import { db } from "@/lib/db";
 import { files, instrumentRuns, instruments, watchers } from "@/lib/db/schema";
 import { sendSlackMessage } from "@/lib/slack";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import type { NextRequest } from "next/server";
+import { after } from "next/server";
 
 type RouteContext = {
   params: Promise<{ instrumentId: string }>;
@@ -191,6 +193,17 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
         `New instrument run reported: \`${runId}\`.\n` +
         `<${origin}/instruments/${instrumentId}/runs/${encodeURIComponent(runId)}|View in Data Hub>`
     );
+
+    // In-app notification fan-out runs after the response is sent so a
+    // slow recipient query can't add latency to the writing route. The
+    // helper logs and swallows its own errors — a notifications outage
+    // must never fail run creation.
+    after(async () => {
+      await notifyRunCreated({
+        runInternalId: run.id,
+        instrumentId,
+      });
+    });
   }
 
   return Response.json(

--- a/web/app/api/v1/instruments/[instrumentId]/runs/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/route.ts
@@ -8,7 +8,6 @@ import { files, instrumentRuns, instruments, watchers } from "@/lib/db/schema";
 import { sendSlackMessage } from "@/lib/slack";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { after } from "next/server";
 
 type RouteContext = {
   params: Promise<{ instrumentId: string }>;
@@ -180,12 +179,7 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
     await db.insert(files).values(fileValues).onConflictDoNothing();
   }
 
-  // One Slack notification per newly-created run. The upsert above
-  // (`onConflictDoNothing`) gives us the "first time only" guarantee, so
-  // both the lambda-auto-create and watcher-report paths fire at most once
-  // per (instrument_id, run_id). Awaited so the message is delivered before
-  // the serverless function instance is recycled; `sendSlackMessage`
-  // swallows its own errors so a Slack outage cannot fail the API request.
+  // Send Slack notification and notify app users of new run.
   if (isNew) {
     const origin = new URL(request.url).origin;
     await sendSlackMessage(
@@ -194,15 +188,9 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
         `<${origin}/instruments/${instrumentId}/runs/${encodeURIComponent(runId)}|View in Data Hub>`
     );
 
-    // In-app notification fan-out runs after the response is sent so a
-    // slow recipient query can't add latency to the writing route. The
-    // helper logs and swallows its own errors — a notifications outage
-    // must never fail run creation.
-    after(async () => {
-      await notifyRunCreated({
-        runInternalId: run.id,
-        instrumentId,
-      });
+    await notifyRunCreated({
+      runInternalId: run.id,
+      instrumentId,
     });
   }
 

--- a/web/app/api/v1/notifications/route.ts
+++ b/web/app/api/v1/notifications/route.ts
@@ -1,0 +1,94 @@
+import { requireSession } from "@/lib/api/auth";
+import { apiError, UNAUTHORIZED, VALIDATION_ERROR } from "@/lib/api/errors";
+import {
+  countUnread,
+  listNotifications,
+  markRead,
+} from "@/lib/api/notifications";
+import type { NextRequest } from "next/server";
+import { z } from "zod";
+
+// Notification reads/writes are session-only — these are personal-UX
+// surfaces, never invoked by the watcher / Lambda PATs, so they don't
+// participate in the `Scope` vocabulary.
+
+const PostBodySchema = z.object({
+  ids: z.array(z.string().uuid()).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/notifications
+//
+// Returns `{ unreadCount, notifications }` for the bell popover. The
+// `?unread_only=true` query parameter narrows the list itself; the count
+// is always the unconditional unread total so the badge stays accurate.
+// ---------------------------------------------------------------------------
+
+export async function GET(request: NextRequest) {
+  const auth = await requireSession();
+  if (!auth) return apiError(401, UNAUTHORIZED, "Authentication required");
+
+  const unreadOnly = request.nextUrl.searchParams.get("unread_only") === "true";
+  const [items, unreadCount] = await Promise.all([
+    listNotifications(auth.userId, { unreadOnly }),
+    countUnread(auth.userId),
+  ]);
+
+  return Response.json({
+    unreadCount,
+    notifications: items.map((n) => ({
+      id: n.id,
+      type: n.type,
+      created_at: n.createdAt.toISOString(),
+      read_at: n.readAt?.toISOString() ?? null,
+      run_id: n.runId,
+      run_display_id: n.runDisplayId,
+      instrument_id: n.instrumentId,
+      instrument_display_name: n.instrumentDisplayName,
+      comment_id: n.commentId,
+      actor: n.actor,
+    })),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/notifications  { ids?: string[] }
+//
+// Marks notifications read. Empty body or omitted `ids` marks everything
+// unread for the user; an explicit array marks just those rows. The
+// `where` clause always scopes to `userId`, so a malicious id list can't
+// touch another user's rows.
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest) {
+  const auth = await requireSession();
+  if (!auth) return apiError(401, UNAUTHORIZED, "Authentication required");
+
+  let raw: unknown = {};
+  // Empty body is fine — it means "mark all". Only error on outright
+  // invalid JSON.
+  const text = await request.text();
+  if (text.length > 0) {
+    try {
+      raw = JSON.parse(text);
+    } catch {
+      return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
+    }
+  }
+
+  const parsed = PostBodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return apiError(400, VALIDATION_ERROR, "Invalid request body", {
+      issues: parsed.error.issues.map((issue) => ({
+        path: issue.path.join("."),
+        code: issue.code,
+        message: issue.message,
+      })),
+    });
+  }
+
+  await markRead(auth.userId, parsed.data.ids);
+
+  const unreadCount = await countUnread(auth.userId);
+  return Response.json({ unreadCount });
+}

--- a/web/app/api/v1/settings/notifications/instruments/[instrumentId]/route.ts
+++ b/web/app/api/v1/settings/notifications/instruments/[instrumentId]/route.ts
@@ -1,0 +1,74 @@
+import { requireSession } from "@/lib/api/auth";
+import {
+  apiError,
+  NOT_FOUND,
+  UNAUTHORIZED,
+  VALIDATION_ERROR,
+} from "@/lib/api/errors";
+import { setInstrumentSubscription } from "@/lib/api/notifications";
+import { db } from "@/lib/db";
+import { instruments } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+import { z } from "zod";
+
+const PutBodySchema = z.object({ enabled: z.boolean() }).strict();
+
+type RouteContext = {
+  params: Promise<{ instrumentId: string }>;
+};
+
+// ---------------------------------------------------------------------------
+// PUT /api/v1/settings/notifications/instruments/:instrumentId  { enabled }
+//
+// Upserts the per-(user, instrument) subscription row. We validate that
+// the instrument actually exists so a typo'd id doesn't silently insert
+// — the FK on `instrument_notification_subscriptions.instrument_id`
+// would also reject this, but a 404 is friendlier than a 500.
+// ---------------------------------------------------------------------------
+
+export async function PUT(request: NextRequest, { params }: RouteContext) {
+  const auth = await requireSession();
+  if (!auth) return apiError(401, UNAUTHORIZED, "Authentication required");
+
+  const { instrumentId } = await params;
+
+  const [instrument] = await db
+    .select({ id: instruments.id })
+    .from(instruments)
+    .where(eq(instruments.id, instrumentId))
+    .limit(1);
+
+  if (!instrument) {
+    return apiError(404, NOT_FOUND, `Instrument '${instrumentId}' not found`);
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
+  }
+
+  const parsed = PutBodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return apiError(400, VALIDATION_ERROR, "Invalid request body", {
+      issues: parsed.error.issues.map((issue) => ({
+        path: issue.path.join("."),
+        code: issue.code,
+        message: issue.message,
+      })),
+    });
+  }
+
+  await setInstrumentSubscription(
+    auth.userId,
+    instrumentId,
+    parsed.data.enabled
+  );
+
+  return Response.json({
+    instrument_id: instrumentId,
+    enabled: parsed.data.enabled,
+  });
+}

--- a/web/app/api/v1/settings/notifications/route.ts
+++ b/web/app/api/v1/settings/notifications/route.ts
@@ -1,0 +1,101 @@
+import { requireSession } from "@/lib/api/auth";
+import { apiError, UNAUTHORIZED, VALIDATION_ERROR } from "@/lib/api/errors";
+import {
+  getPreferences,
+  listInstrumentSubscriptions,
+  updatePreferences,
+} from "@/lib/api/notifications";
+import type { NextRequest } from "next/server";
+import { z } from "zod";
+
+// PUT body is a partial: every key is optional and only present fields
+// are written. Defaults live on the column, so a missing key on a fresh
+// preferences row picks up the schema-side default rather than `false`.
+const PutBodySchema = z
+  .object({
+    runs_all_muted: z.boolean().optional(),
+    comments_attributed_enabled: z.boolean().optional(),
+    comments_participated_enabled: z.boolean().optional(),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/settings/notifications
+//
+// Returns the current user's notification prefs + the full instrument
+// catalogue with each row's subscription state. Used by the settings page
+// to render the master toggles and the per-instrument switches in one
+// payload.
+// ---------------------------------------------------------------------------
+
+export async function GET() {
+  const auth = await requireSession();
+  if (!auth) return apiError(401, UNAUTHORIZED, "Authentication required");
+
+  const [prefs, subscriptions] = await Promise.all([
+    getPreferences(auth.userId),
+    listInstrumentSubscriptions(auth.userId),
+  ]);
+
+  return Response.json({
+    runs_all_muted: prefs.runsAllMuted,
+    comments_attributed_enabled: prefs.commentsAttributedEnabled,
+    comments_participated_enabled: prefs.commentsParticipatedEnabled,
+    instruments: subscriptions.map((s) => ({
+      instrument_id: s.instrumentId,
+      display_name: s.displayName,
+      enabled: s.enabled,
+    })),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// PUT /api/v1/settings/notifications
+//
+// Partial update of the three boolean prefs. Per-instrument subscriptions
+// have their own endpoint (`/instruments/:instrumentId`) so a single
+// switch toggle can be written without re-sending the whole bag.
+// ---------------------------------------------------------------------------
+
+export async function PUT(request: NextRequest) {
+  const auth = await requireSession();
+  if (!auth) return apiError(401, UNAUTHORIZED, "Authentication required");
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return apiError(400, VALIDATION_ERROR, "Invalid JSON body");
+  }
+
+  const parsed = PutBodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return apiError(400, VALIDATION_ERROR, "Invalid request body", {
+      issues: parsed.error.issues.map((issue) => ({
+        path: issue.path.join("."),
+        code: issue.code,
+        message: issue.message,
+      })),
+    });
+  }
+
+  const patch: Parameters<typeof updatePreferences>[1] = {};
+  if (parsed.data.runs_all_muted !== undefined) {
+    patch.runsAllMuted = parsed.data.runs_all_muted;
+  }
+  if (parsed.data.comments_attributed_enabled !== undefined) {
+    patch.commentsAttributedEnabled = parsed.data.comments_attributed_enabled;
+  }
+  if (parsed.data.comments_participated_enabled !== undefined) {
+    patch.commentsParticipatedEnabled =
+      parsed.data.comments_participated_enabled;
+  }
+
+  const updated = await updatePreferences(auth.userId, patch);
+
+  return Response.json({
+    runs_all_muted: updated.runsAllMuted,
+    comments_attributed_enabled: updated.commentsAttributedEnabled,
+    comments_participated_enabled: updated.commentsParticipatedEnabled,
+  });
+}

--- a/web/app/instruments/[instrumentId]/page.tsx
+++ b/web/app/instruments/[instrumentId]/page.tsx
@@ -26,6 +26,10 @@ import {
   type InstrumentFilterOptionsByType,
 } from "@/lib/api/instrument-runs";
 import { getInstrumentById } from "@/lib/api/instruments";
+import {
+  getPreferences,
+  listInstrumentSubscriptions,
+} from "@/lib/api/notifications";
 import { auth } from "@/lib/auth";
 import { instrumentDetailParamsCache } from "@/lib/search-params";
 import { notFound } from "next/navigation";
@@ -141,34 +145,38 @@ export default async function InstrumentDetailPage({
 
   const filters = instrumentDetailParamsCache.parse(await searchParams);
 
-  // Parallel fetch: instrument metadata (for header) and paginated runs
-  // (for table) are independent queries — neither depends on the other.
-  const [instrument, runResult] = await Promise.all([
-    getInstrumentById(instrumentId),
-    buildRunListQuery({
-      instrumentId,
-      search: filters.search || undefined,
-      dateFrom: filters.date_from ?? undefined,
-      dateTo: filters.date_to ?? undefined,
-      page: filters.page,
-      perPage: filters.per_page,
-      includeDeleted: filters.include_deleted,
-      wavelength: filters.wavelength ?? undefined,
-      measurementMode: filters.measurement_mode ?? undefined,
-      measurementType: filters.measurement_type ?? undefined,
-      captureType: filters.capture_type ?? undefined,
-      imagingMode: filters.imaging_mode ?? undefined,
-      gelWavelength: filters.gel_wavelength ?? undefined,
-      gelColor: filters.gel_color ?? undefined,
-      dyeChannel: filters.dye_channel ?? undefined,
-      hinaChannel: filters.hina_channel ?? undefined,
-      hinaDimension: filters.hina_dimension ?? undefined,
-      hinaSize: filters.hina_size ?? undefined,
-      dpi: filters.dpi ?? undefined,
-      colorMode: filters.color_mode ?? undefined,
-      ranBy: filters.ran_by ?? undefined,
-    }),
-  ]);
+  // Parallel fetch: instrument metadata (for header), paginated runs
+  // (for table), and the viewer's notification prefs + per-instrument
+  // subscription state are independent queries.
+  const [instrument, runResult, notificationPrefs, notificationSubscriptions] =
+    await Promise.all([
+      getInstrumentById(instrumentId),
+      buildRunListQuery({
+        instrumentId,
+        search: filters.search || undefined,
+        dateFrom: filters.date_from ?? undefined,
+        dateTo: filters.date_to ?? undefined,
+        page: filters.page,
+        perPage: filters.per_page,
+        includeDeleted: filters.include_deleted,
+        wavelength: filters.wavelength ?? undefined,
+        measurementMode: filters.measurement_mode ?? undefined,
+        measurementType: filters.measurement_type ?? undefined,
+        captureType: filters.capture_type ?? undefined,
+        imagingMode: filters.imaging_mode ?? undefined,
+        gelWavelength: filters.gel_wavelength ?? undefined,
+        gelColor: filters.gel_color ?? undefined,
+        dyeChannel: filters.dye_channel ?? undefined,
+        hinaChannel: filters.hina_channel ?? undefined,
+        hinaDimension: filters.hina_dimension ?? undefined,
+        hinaSize: filters.hina_size ?? undefined,
+        dpi: filters.dpi ?? undefined,
+        colorMode: filters.color_mode ?? undefined,
+        ranBy: filters.ran_by ?? undefined,
+      }),
+      getPreferences(session.user.id!),
+      listInstrumentSubscriptions(session.user.id!),
+    ]);
 
   if (!instrument) notFound();
 
@@ -226,9 +234,22 @@ export default async function InstrumentDetailPage({
     { value: "unattributed", label: "Unattributed" },
   ];
 
+  // The subscription list always contains every instrument (left-joined
+  // against `instruments`) so a missing entry would mean a stale read —
+  // fall back to `false` defensively.
+  const subscriptionForThisInstrument = notificationSubscriptions.find(
+    (s) => s.instrumentId === instrumentId
+  );
+
   return (
     <div className="mx-auto flex w-full max-w-7xl min-w-0 flex-col gap-6 p-6 2xl:w-7xl">
-      <InstrumentHeader instrument={instrument} />
+      <InstrumentHeader
+        instrument={instrument}
+        notifications={{
+          enabled: subscriptionForThisInstrument?.enabled ?? false,
+          masterMuted: notificationPrefs.runsAllMuted,
+        }}
+      />
       <RunSelectionProvider>
         <TablePendingProvider>
           <InstrumentRunsToolbar />

--- a/web/app/instruments/page.tsx
+++ b/web/app/instruments/page.tsx
@@ -4,6 +4,10 @@ import {
   InstrumentsTable,
 } from "@/components/instruments/instruments-table";
 import { getInstrumentListWithCounts } from "@/lib/api/instruments";
+import {
+  getPreferences,
+  listInstrumentSubscriptions,
+} from "@/lib/api/notifications";
 import { auth } from "@/lib/auth";
 import type { Metadata } from "next/types";
 
@@ -26,7 +30,16 @@ export default async function InstrumentsPage() {
     );
   }
 
-  const instruments = await getInstrumentListWithCounts();
+  // All four queries are independent; running them together avoids the
+  // ladder of waterfalls a serial fetch would incur. The subscription
+  // helper returns the full instrument catalogue with each row's
+  // current `enabled` state, which we collapse into a Map for O(1)
+  // lookup inside the table.
+  const [instruments, subscriptions, prefs] = await Promise.all([
+    getInstrumentListWithCounts(),
+    listInstrumentSubscriptions(session.user.id!),
+    getPreferences(session.user.id!),
+  ]);
 
   // Composition: the management actions cell (Edit dialog + Confirm
   // pending button) is rendered only for admins. Regular members see the
@@ -34,6 +47,10 @@ export default async function InstrumentsPage() {
   // already supports `renderRowActions` being omitted entirely, so no
   // table-level prop changes are needed.
   const isAdmin = session.user.isAdmin === true;
+
+  const subscriptionMap = new Map(
+    subscriptions.map((s) => [s.instrumentId, s.enabled])
+  );
 
   return (
     <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-6 2xl:w-7xl">
@@ -43,6 +60,10 @@ export default async function InstrumentsPage() {
       <InstrumentsTable
         data={instruments}
         renderRowActions={isAdmin ? InstrumentRowManagementActions : undefined}
+        notifications={{
+          subscriptions: subscriptionMap,
+          masterMuted: prefs.runsAllMuted,
+        }}
       />
     </div>
   );

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -2,6 +2,8 @@ import { Geist, Geist_Mono } from "next/font/google";
 
 import "@/app/globals.css";
 import { AppSidebar } from "@/components/app-sidebar";
+import { NotificationBell } from "@/components/notifications/notification-bell";
+import { NotificationsProvider } from "@/components/notifications/notifications-provider";
 import { ArchiveDownloadProvider } from "@/components/runs/archive-download-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import {
@@ -12,6 +14,7 @@ import {
 } from "@/components/ui/sidebar";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { countUnread } from "@/lib/api/notifications";
 import { getSidebarInstruments, getSidebarWatchers } from "@/lib/api/sidebar";
 import { auth, signOut } from "@/lib/auth";
 import { cn } from "@/lib/utils";
@@ -88,9 +91,18 @@ export default async function RootLayout({
   // doesn't introduce an additional round-trip. Skipped entirely when the
   // user isn't signed in — the unauthenticated routes don't render the
   // sidebar.
-  const [instruments, watchers] = session
-    ? await Promise.all([getSidebarInstruments(), getSidebarWatchers()])
-    : [[], []];
+  //
+  // The unread-count query rides alongside the sidebar fetches so the
+  // notification bell renders with an accurate badge on first paint —
+  // the partial `idx_notifications_user_id_unread` index keeps the
+  // count cheap regardless of total notification volume.
+  const [instruments, watchers, initialUnreadCount] = session
+    ? await Promise.all([
+        getSidebarInstruments(),
+        getSidebarWatchers(),
+        countUnread(session.user.id!),
+      ])
+    : [[], [], 0];
 
   // Hydrate the sidebar's open/collapsed state from the cookie that
   // `SidebarProvider` writes on toggle. Defaulting to `true` keeps the
@@ -115,25 +127,30 @@ export default async function RootLayout({
             <NuqsAdapter>
               <TooltipProvider>
                 {session ? (
-                  <ArchiveDownloadProvider>
-                    <SidebarProvider defaultOpen={sidebarDefaultOpen}>
-                      <AppSidebar
-                        session={session}
-                        instruments={instruments}
-                        watchers={watchers}
-                        signOutAction={async () => {
-                          "use server";
-                          await signOut({ redirectTo: "/login" });
-                        }}
-                      />
-                      <SidebarInset className="pb-12">
-                        <header className="flex h-12 shrink-0 items-center gap-2 px-4">
-                          <SidebarTrigger />
-                        </header>
-                        {children}
-                      </SidebarInset>
-                    </SidebarProvider>
-                  </ArchiveDownloadProvider>
+                  <NotificationsProvider
+                    initialUnreadCount={initialUnreadCount}
+                  >
+                    <ArchiveDownloadProvider>
+                      <SidebarProvider defaultOpen={sidebarDefaultOpen}>
+                        <AppSidebar
+                          session={session}
+                          instruments={instruments}
+                          watchers={watchers}
+                          signOutAction={async () => {
+                            "use server";
+                            await signOut({ redirectTo: "/login" });
+                          }}
+                        />
+                        <SidebarInset className="pb-12">
+                          <header className="flex h-12 shrink-0 items-center justify-between gap-2 px-4">
+                            <SidebarTrigger />
+                            <NotificationBell />
+                          </header>
+                          {children}
+                        </SidebarInset>
+                      </SidebarProvider>
+                    </ArchiveDownloadProvider>
+                  </NotificationsProvider>
                 ) : (
                   children
                 )}

--- a/web/app/settings/notifications/page.tsx
+++ b/web/app/settings/notifications/page.tsx
@@ -1,0 +1,66 @@
+import { SignInRequired } from "@/components/auth/sign-in-required";
+import { NotificationsSettingsForm } from "@/components/notifications/notifications-settings-form";
+import {
+  getPreferences,
+  listInstrumentSubscriptions,
+} from "@/lib/api/notifications";
+import { auth } from "@/lib/auth";
+import type { Metadata } from "next/types";
+
+const description = "Choose which Data Hub events to be notified about.";
+
+export const metadata: Metadata = {
+  title: "Notifications",
+  description,
+  openGraph: { title: "Notifications", description },
+  twitter: { title: "Notifications", description },
+};
+
+export default async function NotificationsSettingsPage() {
+  const session = await auth();
+  if (!session?.user) {
+    return (
+      <SignInRequired callbackUrl="/settings/notifications">
+        Sign in to manage notification settings.
+      </SignInRequired>
+    );
+  }
+
+  // Parallel fetch: the prefs row and the per-instrument subscription
+  // list are independent queries. `getPreferences` lazily upserts a
+  // defaults row on first read, so the form always renders with
+  // concrete values — no need for nullable form state.
+  const [prefs, subscriptions] = await Promise.all([
+    getPreferences(session.user.id!),
+    listInstrumentSubscriptions(session.user.id!),
+  ]);
+
+  return (
+    <div>
+      <div>
+        <h2 className="text-lg font-semibold tracking-tight">Notifications</h2>
+        <p className="text-sm text-muted-foreground">
+          Choose which Data Hub events should produce an in-app notification.
+          Per-instrument subscriptions opt you in to <em>new run</em>{" "}
+          notifications; comment notifications fire when someone replies on a
+          run you&apos;re attributed to or have commented on.
+        </p>
+      </div>
+
+      <div className="mt-6">
+        <NotificationsSettingsForm
+          initialPreferences={{
+            runsAllMuted: prefs.runsAllMuted,
+            commentsAttributedEnabled: prefs.commentsAttributedEnabled,
+            commentsParticipatedEnabled: prefs.commentsParticipatedEnabled,
+          }}
+          initialInstruments={subscriptions.map((s) => ({
+            instrumentId: s.instrumentId,
+            displayName: s.displayName,
+            enabled: s.enabled,
+          }))}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/app/settings/notifications/page.tsx
+++ b/web/app/settings/notifications/page.tsx
@@ -27,9 +27,9 @@ export default async function NotificationsSettingsPage() {
   }
 
   // Parallel fetch: the prefs row and the per-instrument subscription
-  // list are independent queries. `getPreferences` lazily upserts a
-  // defaults row on first read, so the form always renders with
-  // concrete values — no need for nullable form state.
+  // list are independent queries. `getPreferences` falls back to
+  // schema-side defaults when no row exists yet, so the form always
+  // renders with concrete values — no need for nullable form state.
   const [prefs, subscriptions] = await Promise.all([
     getPreferences(session.user.id!),
     listInstrumentSubscriptions(session.user.id!),

--- a/web/components/app-sidebar/settings-nav.tsx
+++ b/web/components/app-sidebar/settings-nav.tsx
@@ -21,6 +21,7 @@ type SettingsSection = {
 };
 
 const SETTINGS_SECTIONS: SettingsSection[] = [
+  { href: "/settings/notifications", label: "Notifications" },
   { href: "/settings/tokens", label: "Access Tokens" },
   { href: "/settings/watchers", label: "Watchers", adminOnly: true },
   { href: "/settings/members", label: "Members", adminOnly: true },

--- a/web/components/instruments/instrument-header.tsx
+++ b/web/components/instruments/instrument-header.tsx
@@ -1,3 +1,4 @@
+import { InstrumentNotificationSwitch } from "@/components/notifications/instrument-notification-switch";
 import { Badge } from "@/components/ui/badge";
 import {
   Breadcrumb,
@@ -14,8 +15,19 @@ import Link from "next/link";
 
 export function InstrumentHeader({
   instrument,
+  notifications,
 }: {
   instrument: InstrumentDetail;
+  /**
+   * Per-viewer notification state for this instrument. When omitted
+   * (e.g. unauthenticated callers, or contexts that don't want to
+   * surface the switch), the action row falls back to the original
+   * watcher-status + run-count layout.
+   */
+  notifications?: {
+    enabled: boolean;
+    masterMuted: boolean;
+  };
 }) {
   const watcherStatus = getWatcherOnlineStatus(instrument);
 
@@ -49,6 +61,13 @@ export function InstrumentHeader({
         </div>
 
         <div className="flex items-center gap-2">
+          {notifications ? (
+            <InstrumentNotificationSwitch
+              instrumentId={instrument.id}
+              initialEnabled={notifications.enabled}
+              masterMuted={notifications.masterMuted}
+            />
+          ) : null}
           {instrument.activeWatcherId ? (
             <Link href={`/watchers/${instrument.activeWatcherId}`}>
               <WatcherStatusBadge

--- a/web/components/instruments/instruments-table.tsx
+++ b/web/components/instruments/instruments-table.tsx
@@ -3,6 +3,7 @@ import { EditInstrumentDialog } from "@/components/instruments/edit-instrument-d
 import { RowActionsCell } from "@/components/instruments/row-actions-cell";
 import { ClickableRow } from "@/components/instruments/runs-table/clickable-row";
 import { StatusActions } from "@/components/instruments/status-actions";
+import { InstrumentNotificationsCell } from "@/components/notifications/instrument-notifications-cell";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -42,6 +43,7 @@ export function InstrumentsTable({
   data,
   footer,
   renderRowActions,
+  notifications,
 }: {
   data: InstrumentListItem[];
   /**
@@ -54,6 +56,17 @@ export function InstrumentsTable({
    * is hidden entirely — useful for read-only contexts like the dashboard.
    */
   renderRowActions?: (row: InstrumentListItem) => ReactNode;
+  /**
+   * Per-instrument notification subscription state for the viewer, plus
+   * the viewer's master-mute flag. Threaded in from the page so the
+   * notifications column can render without a per-row client fetch.
+   * Pass `null`/omit to hide the column entirely (used by the
+   * dashboard's truncated table where the column would be noise).
+   */
+  notifications?: {
+    subscriptions: Map<string, boolean>;
+    masterMuted: boolean;
+  };
 }) {
   if (data.length === 0) {
     return (
@@ -76,6 +89,9 @@ export function InstrumentsTable({
             <TableHead>File Patterns</TableHead>
             <TableHead>Runs This Week</TableHead>
             <TableHead>Last Run</TableHead>
+            {notifications ? (
+              <TableHead className="w-[80px]">Notify</TableHead>
+            ) : null}
             {renderRowActions ? <TableHead className="w-[100px]" /> : null}
           </TableRow>
         </TableHeader>
@@ -125,6 +141,15 @@ export function InstrumentsTable({
                     <span className="text-muted-foreground">—</span>
                   )}
                 </TableCell>
+                {notifications ? (
+                  <InstrumentNotificationsCell
+                    instrumentId={row.id}
+                    initialEnabled={
+                      notifications.subscriptions.get(row.id) ?? false
+                    }
+                    masterMuted={notifications.masterMuted}
+                  />
+                ) : null}
                 {renderRowActions ? (
                   <RowActionsCell>{renderRowActions(row)}</RowActionsCell>
                 ) : null}

--- a/web/components/notifications/instrument-notification-switch.tsx
+++ b/web/components/notifications/instrument-notification-switch.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+// Composition over a `tooltip` boolean prop: the Tooltip is wrapped here
+// so callers don't have to know about the active vs muted copy. Three
+// places mount this component — the per-instrument cell in the
+// instruments table, the row in the InstrumentHeader's action area, and
+// the per-instrument list inside the Notifications settings form — and
+// they all want identical behaviour.
+
+export function InstrumentNotificationSwitch({
+  instrumentId,
+  initialEnabled,
+  masterMuted,
+  size = "default",
+  ariaLabel = "Notify me about new runs on this instrument",
+}: {
+  instrumentId: string;
+  initialEnabled: boolean;
+  masterMuted: boolean;
+  size?: "sm" | "default";
+  ariaLabel?: string;
+}) {
+  // Optimistic local state mirrors the row's `enabled` column. We flip
+  // it immediately for visual feedback and roll back if the server says
+  // no — the alternative ("await the round-trip then update") makes the
+  // switch feel laggy on every toggle.
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [isPending, startTransition] = useTransition();
+
+  const handleChange = (next: boolean) => {
+    const previous = enabled;
+    setEnabled(next);
+
+    // Wrapping the network call in `startTransition` keeps callback
+    // identity stable across renders and lets the Switch report its
+    // pending state via `disabled`.
+    startTransition(async () => {
+      try {
+        const res = await fetch(
+          `/api/v1/settings/notifications/instruments/${encodeURIComponent(
+            instrumentId
+          )}`,
+          {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ enabled: next }),
+          }
+        );
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      } catch (err) {
+        setEnabled(previous);
+        toast.error("Couldn't update instrument notifications", {
+          description:
+            err instanceof Error
+              ? err.message
+              : "An unexpected error occurred.",
+        });
+      }
+    });
+  };
+
+  // Visual logic mirrors the WatcherReleaseForm "Mandatory update"
+  // pattern: we never overwrite the underlying value when masterMuted
+  // is true — the user's per-instrument intent is preserved through a
+  // master toggle round-trip — but the switch reads as off until the
+  // master mute is cleared.
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {/* The wrapper span keeps the tooltip target hoverable even when
+            the switch is disabled — a disabled Radix Switch swallows
+            pointer events otherwise. */}
+        <span className="inline-flex">
+          <Switch
+            size={size}
+            checked={enabled && !masterMuted}
+            onCheckedChange={handleChange}
+            disabled={masterMuted || isPending}
+            aria-label={ariaLabel}
+          />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        {masterMuted
+          ? "All instrument notifications muted in Settings"
+          : enabled
+            ? "Notifying you about new runs on this instrument"
+            : "Click to be notified about new runs on this instrument"}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/web/components/notifications/instrument-notifications-cell.tsx
+++ b/web/components/notifications/instrument-notifications-cell.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { InstrumentNotificationSwitch } from "@/components/notifications/instrument-notification-switch";
+import { TableCell } from "@/components/ui/table";
+
+/**
+ * Thin client wrapper around `<InstrumentNotificationSwitch>` for the
+ * `<InstrumentsTable>` row. Lives in its own component because the table
+ * is a Server Component and can't directly attach `onClick` handlers
+ * across the boundary — the wrapping `<TableCell>` stops click bubbling
+ * so toggling the switch doesn't navigate the parent `<ClickableRow>`.
+ */
+export function InstrumentNotificationsCell({
+  instrumentId,
+  initialEnabled,
+  masterMuted,
+}: {
+  instrumentId: string;
+  initialEnabled: boolean;
+  masterMuted: boolean;
+}) {
+  return (
+    <TableCell onClick={(e) => e.stopPropagation()}>
+      <InstrumentNotificationSwitch
+        instrumentId={instrumentId}
+        initialEnabled={initialEnabled}
+        masterMuted={masterMuted}
+        size="sm"
+      />
+    </TableCell>
+  );
+}

--- a/web/components/notifications/notification-bell-content.tsx
+++ b/web/components/notifications/notification-bell-content.tsx
@@ -43,16 +43,16 @@ export function NotificationBellContent({
 }: {
   onNavigate?: () => void;
 }) {
-  const { recent, markAllRead, unreadCount } = useNotifications();
+  const { recent, markAllRead, markOneRead, unreadCount } = useNotifications();
 
   return (
     <div className="flex flex-col">
-      <div className="flex items-center justify-between gap-2 border-b pb-3">
+      <div className="flex items-center justify-between gap-2 border-b pb-2">
         <p className="text-sm font-medium">Notifications</p>
         <Button
           type="button"
           variant="ghost"
-          size="xs"
+          size="sm"
           onClick={() => {
             void markAllRead();
           }}
@@ -81,7 +81,14 @@ export function NotificationBellContent({
               <li key={n.id}>
                 <Link
                   href={notificationHref(n)}
-                  onClick={onNavigate}
+                  onClick={() => {
+                    // Mark this row read as the user navigates into it —
+                    // gated on `isUnread` so re-clicking a read row
+                    // doesn't fire a pointless POST. The provider
+                    // handles its own optimistic update + error toast.
+                    if (isUnread) void markOneRead(n.id);
+                    onNavigate?.();
+                  }}
                   className={cn(
                     "flex items-start gap-3 rounded-md px-3 py-2 hover:bg-muted",
                     isUnread && "bg-primary/5"

--- a/web/components/notifications/notification-bell-content.tsx
+++ b/web/components/notifications/notification-bell-content.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import {
+  useNotifications,
+  type NotificationItem,
+} from "@/components/notifications/notifications-provider";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { avatarColor } from "@/lib/avatar-color";
+import { cn, formatRelativeTime } from "@/lib/utils";
+import { BellOff } from "lucide-react";
+import Link from "next/link";
+
+// Mapping a notification row to a human-readable summary line. Kept here
+// (rather than at the API boundary) so the trigger taxonomy in the DB
+// stays separate from the presentational copy.
+function renderSummary(n: NotificationItem): string {
+  switch (n.type) {
+    case "run_created":
+      return `New run on ${n.instrumentDisplayName}`;
+    case "comment_attributed":
+      return n.actor
+        ? `${n.actor.displayName} commented on a run you ran`
+        : "New comment on a run you ran";
+    case "comment_participated":
+      return n.actor
+        ? `${n.actor.displayName} replied on a run you commented on`
+        : "New reply on a run you commented on";
+  }
+}
+
+function notificationHref(n: NotificationItem): string {
+  // Anchor to the comment id when present so the destination page can
+  // scroll the comment into view.
+  const base = `/instruments/${encodeURIComponent(
+    n.instrumentId
+  )}/runs/${encodeURIComponent(n.runDisplayId)}`;
+  return n.commentId ? `${base}#comment-${n.commentId}` : base;
+}
+
+export function NotificationBellContent({
+  onNavigate,
+}: {
+  onNavigate?: () => void;
+}) {
+  const { recent, markAllRead, unreadCount } = useNotifications();
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center justify-between gap-2 border-b pb-3">
+        <p className="text-sm font-medium">Notifications</p>
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          onClick={() => {
+            void markAllRead();
+          }}
+          disabled={unreadCount === 0}
+        >
+          Mark all as read
+        </Button>
+      </div>
+
+      {recent.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-2 py-8 text-center">
+          <BellOff className="size-6 text-muted-foreground/60" />
+          <p className="text-sm text-muted-foreground">
+            You&apos;re all caught up.
+          </p>
+          <p className="text-xs text-muted-foreground/70">
+            New runs and replies will show up here when you have something
+            subscribed.
+          </p>
+        </div>
+      ) : (
+        <ul className="-mx-1 max-h-[60vh] overflow-y-auto py-1">
+          {recent.map((n) => {
+            const isUnread = n.readAt === null;
+            return (
+              <li key={n.id}>
+                <Link
+                  href={notificationHref(n)}
+                  onClick={onNavigate}
+                  className={cn(
+                    "flex items-start gap-3 rounded-md px-3 py-2 hover:bg-muted",
+                    isUnread && "bg-primary/5"
+                  )}
+                >
+                  {n.actor ? (
+                    <Avatar size="sm">
+                      {n.actor.avatarUrl ? (
+                        <AvatarImage
+                          src={n.actor.avatarUrl}
+                          alt={n.actor.displayName}
+                        />
+                      ) : null}
+                      <AvatarFallback className={avatarColor(n.actor.id)}>
+                        {n.actor.initials}
+                      </AvatarFallback>
+                    </Avatar>
+                  ) : (
+                    <span
+                      aria-hidden
+                      className="mt-1.5 inline-block size-2 shrink-0 rounded-full bg-primary"
+                    />
+                  )}
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="text-sm leading-snug">
+                      {renderSummary(n)}
+                    </span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      <span className="font-mono">{n.runDisplayId}</span>
+                      {" · "}
+                      <span suppressHydrationWarning>
+                        {formatRelativeTime(n.createdAt)}
+                      </span>
+                    </span>
+                  </span>
+                  {isUnread ? (
+                    <span
+                      aria-label="Unread"
+                      className="mt-1.5 inline-block size-2 shrink-0 rounded-full bg-primary"
+                    />
+                  ) : null}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/components/notifications/notification-bell.tsx
+++ b/web/components/notifications/notification-bell.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { NotificationBellContent } from "@/components/notifications/notification-bell-content";
+import { useNotifications } from "@/components/notifications/notifications-provider";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Bell } from "lucide-react";
+import { useState } from "react";
+
+// Bell + Popover wrapper. Kept separate from the popover content so the
+// content component can subscribe to `recent` without re-rendering the
+// trigger button on every poll.
+export function NotificationBell() {
+  const { unreadCount, refresh } = useNotifications();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        // Pull fresh data when the popover opens so the user sees the
+        // latest list even between polling ticks. Failures are silent —
+        // the polling loop will retry.
+        if (next) void refresh();
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label={
+            unreadCount > 0
+              ? `Notifications, ${unreadCount} unread`
+              : "Notifications"
+          }
+          className="relative"
+        >
+          <Bell />
+          {/* Badge renders only when count > 0 (per
+              `rendering-conditional-render`); the trailing two-digit cap
+              keeps the badge from breaking the icon-button bounds. */}
+          {unreadCount > 0 ? (
+            <span
+              aria-hidden
+              className="absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] leading-none font-semibold text-primary-foreground tabular-nums"
+            >
+              {unreadCount > 99 ? "99+" : unreadCount}
+            </span>
+          ) : null}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" sideOffset={8} className="w-96 p-2">
+        <NotificationBellContent onNavigate={() => setOpen(false)} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/components/notifications/notification-bell.tsx
+++ b/web/components/notifications/notification-bell.tsx
@@ -54,7 +54,7 @@ export function NotificationBell() {
           ) : null}
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="end" sideOffset={8} className="w-96 p-2">
+      <PopoverContent align="end" sideOffset={8} className="w-96 p-4">
         <NotificationBellContent onNavigate={() => setOpen(false)} />
       </PopoverContent>
     </Popover>

--- a/web/components/notifications/notifications-provider.tsx
+++ b/web/components/notifications/notifications-provider.tsx
@@ -44,12 +44,16 @@ type NotificationsValue = {
   recent: NotificationItem[];
   refresh: () => Promise<void>;
   markAllRead: () => Promise<void>;
+  markOneRead: (id: string) => Promise<void>;
 };
 
 const NotificationsContext = createContext<NotificationsValue | null>(null);
 
-// Re-poll cadence for the bell badge + popover list. Plenty fresh for an
-// internal-tool surface; bumping is a one-line change.
+// Re-poll cadence for the bell badge + popover list while the tab is
+// visible. Hidden tabs don't poll at all — the visibilitychange listener
+// in the effect below kicks an immediate refresh when the tab comes
+// back, so freshness on focus is preserved without burning RTTs on
+// background tabs.
 const POLL_INTERVAL_MS = 60_000;
 
 // ---------------------------------------------------------------------------
@@ -141,16 +145,81 @@ export function NotificationsProvider({
     }
   }, [refresh]);
 
-  // Pull initial data on mount and re-poll every minute. Effect runs once
-  // because `refresh` identity is stable (functional setState above).
+  // Mark a single notification read — used when the popover row is
+  // clicked through to its target. Callers are expected to gate this on
+  // `readAt === null` (the optimistic update + server filter make a
+  // redundant call harmless, but skipping it avoids a pointless RTT).
+  const markOneRead = useCallback(
+    async (id: string) => {
+      const stampedAt = new Date().toISOString();
+      setRecent((prev) =>
+        prev.map((n) =>
+          n.id === id && !n.readAt ? { ...n, readAt: stampedAt } : n
+        )
+      );
+      // Clamp at zero so any drift between the cached `recent` list and
+      // the server-side unread count can't push the badge negative.
+      setUnreadCount((count) => Math.max(0, count - 1));
+      try {
+        const res = await fetch("/api/v1/notifications", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: [id] }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      } catch (err) {
+        toast.error("Couldn't mark notification as read", {
+          description:
+            err instanceof Error
+              ? err.message
+              : "An unexpected error occurred.",
+        });
+        await refresh();
+      }
+    },
+    [refresh]
+  );
+
+  // Initial fetch on mount, then poll every minute *only* while the tab
+  // is visible. `visibilitychange` resumes the loop (and does an
+  // immediate refresh) when the user comes back to the tab so the badge
+  // catches up without waiting for the next tick. `refresh` identity is
+  // stable so the effect runs once.
   useEffect(() => {
-    refresh();
-    const id = setInterval(refresh, POLL_INTERVAL_MS);
-    return () => clearInterval(id);
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    const start = () => {
+      if (intervalId != null) return;
+      intervalId = setInterval(refresh, POLL_INTERVAL_MS);
+    };
+    const stop = () => {
+      if (intervalId == null) return;
+      clearInterval(intervalId);
+      intervalId = null;
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void refresh();
+        start();
+      } else {
+        stop();
+      }
+    };
+
+    void refresh();
+    if (document.visibilityState === "visible") start();
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      stop();
+    };
   }, [refresh]);
 
   return (
-    <NotificationsContext value={{ unreadCount, recent, refresh, markAllRead }}>
+    <NotificationsContext
+      value={{ unreadCount, recent, refresh, markAllRead, markOneRead }}
+    >
       {children}
     </NotificationsContext>
   );

--- a/web/components/notifications/notifications-provider.tsx
+++ b/web/components/notifications/notifications-provider.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import {
+  createContext,
+  use,
+  useCallback,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { toast } from "sonner";
+
+// ---------------------------------------------------------------------------
+// Notifications provider — single source of truth for the bell badge and
+// popover content. Decouples the rest of the UI from the API shape: the
+// only surface consumers see is `{ unreadCount, recent, markAllRead,
+// refresh }`. Subcomponents that don't need `recent` (the bell badge)
+// re-render only when other state slices change because the popover
+// content is mounted lazily.
+// ---------------------------------------------------------------------------
+
+export type NotificationActor = {
+  id: string;
+  displayName: string;
+  initials: string;
+  avatarUrl: string | null;
+};
+
+export type NotificationItem = {
+  id: string;
+  type: "run_created" | "comment_attributed" | "comment_participated";
+  createdAt: string;
+  readAt: string | null;
+  runId: string;
+  runDisplayId: string;
+  instrumentId: string;
+  instrumentDisplayName: string;
+  commentId: string | null;
+  actor: NotificationActor | null;
+};
+
+type NotificationsValue = {
+  unreadCount: number;
+  recent: NotificationItem[];
+  refresh: () => Promise<void>;
+  markAllRead: () => Promise<void>;
+};
+
+const NotificationsContext = createContext<NotificationsValue | null>(null);
+
+// Re-poll cadence for the bell badge + popover list. Plenty fresh for an
+// internal-tool surface; bumping is a one-line change.
+const POLL_INTERVAL_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Wire shape returned by `GET /api/v1/notifications`. Maps snake_case
+// → camelCase at the boundary so the rest of the client tree never
+// sees the API's casing.
+// ---------------------------------------------------------------------------
+
+type ApiNotification = {
+  id: string;
+  type: NotificationItem["type"];
+  created_at: string;
+  read_at: string | null;
+  run_id: string;
+  run_display_id: string;
+  instrument_id: string;
+  instrument_display_name: string;
+  comment_id: string | null;
+  actor: NotificationActor | null;
+};
+
+function fromApi(n: ApiNotification): NotificationItem {
+  return {
+    id: n.id,
+    type: n.type,
+    createdAt: n.created_at,
+    readAt: n.read_at,
+    runId: n.run_id,
+    runDisplayId: n.run_display_id,
+    instrumentId: n.instrument_id,
+    instrumentDisplayName: n.instrument_display_name,
+    commentId: n.comment_id,
+    actor: n.actor,
+  };
+}
+
+export function NotificationsProvider({
+  initialUnreadCount,
+  children,
+}: {
+  initialUnreadCount: number;
+  children: ReactNode;
+}) {
+  const [unreadCount, setUnreadCount] = useState(initialUnreadCount);
+  const [recent, setRecent] = useState<NotificationItem[]>([]);
+
+  // Functional setState in the fetcher means `refresh` doesn't depend on
+  // the latest `unreadCount` / `recent` — its identity stays stable across
+  // renders, which keeps the polling effect from tearing down its
+  // setInterval on every state update.
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch("/api/v1/notifications", { cache: "no-store" });
+      if (!res.ok) return;
+      const body = (await res.json()) as {
+        unreadCount: number;
+        notifications: ApiNotification[];
+      };
+      setUnreadCount(body.unreadCount);
+      setRecent(body.notifications.map(fromApi));
+    } catch {
+      // Network blips during polling are silently ignored — the next tick
+      // will retry. Failures on user-initiated refresh (popover open) are
+      // visible via the empty-state copy when nothing has loaded yet.
+    }
+  }, []);
+
+  const markAllRead = useCallback(async () => {
+    // Optimistically clear the badge + flag every recent row read.
+    // Failure recovers truth via a follow-up refresh.
+    const stampedAt = new Date().toISOString();
+    setUnreadCount(() => 0);
+    setRecent((prev) =>
+      prev.map((n) => (n.readAt ? n : { ...n, readAt: stampedAt }))
+    );
+    try {
+      const res = await fetch("/api/v1/notifications", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    } catch (err) {
+      toast.error("Couldn't mark notifications as read", {
+        description:
+          err instanceof Error ? err.message : "An unexpected error occurred.",
+      });
+      await refresh();
+    }
+  }, [refresh]);
+
+  // Pull initial data on mount and re-poll every minute. Effect runs once
+  // because `refresh` identity is stable (functional setState above).
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [refresh]);
+
+  return (
+    <NotificationsContext value={{ unreadCount, recent, refresh, markAllRead }}>
+      {children}
+    </NotificationsContext>
+  );
+}
+
+export function useNotifications(): NotificationsValue {
+  const ctx = use(NotificationsContext);
+  if (!ctx) {
+    throw new Error(
+      "useNotifications must be used within a <NotificationsProvider>"
+    );
+  }
+  return ctx;
+}

--- a/web/components/notifications/notifications-settings-form.tsx
+++ b/web/components/notifications/notifications-settings-form.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter } from "@/components/ui/card";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldSeparator,
+} from "@/components/ui/field";
+import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useForm } from "@tanstack/react-form";
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { z } from "zod";
+
+// Mirror of the server's PUT body shape, in form-friendly camelCase. The
+// schema is reused for `onSubmit` validation so the client surfaces the
+// same validity rule the server enforces.
+const preferencesSchema = z.object({
+  runsAllMuted: z.boolean(),
+  commentsAttributedEnabled: z.boolean(),
+  commentsParticipatedEnabled: z.boolean(),
+});
+
+type FormPreferences = z.infer<typeof preferencesSchema>;
+
+type InstrumentRow = {
+  instrumentId: string;
+  displayName: string;
+  enabled: boolean;
+};
+
+// The form's `perInstrument` field is a Record<string, boolean> keyed by
+// instrument id. Storing it as a plain map (rather than parallel arrays)
+// keeps the per-row Field paths predictable: `perInstrument.${id}`.
+type FormValues = FormPreferences & {
+  perInstrument: Record<string, boolean>;
+};
+
+type Props = {
+  initialPreferences: FormPreferences;
+  initialInstruments: InstrumentRow[];
+};
+
+export function NotificationsSettingsForm({
+  initialPreferences,
+  initialInstruments,
+}: Props) {
+  const router = useRouter();
+
+  const initialPerInstrument = Object.fromEntries(
+    initialInstruments.map((row) => [row.instrumentId, row.enabled])
+  );
+
+  const form = useForm({
+    defaultValues: {
+      ...initialPreferences,
+      perInstrument: initialPerInstrument,
+    } satisfies FormValues,
+    validators: {
+      // Only the prefs object has Zod-level validation (booleans only —
+      // the per-instrument map is structural). The schema's onSubmit
+      // pass acts as a final guard against malformed values.
+      onSubmit: ({ value }) => {
+        const result = preferencesSchema.safeParse(value);
+        return result.success ? undefined : result.error;
+      },
+    },
+    onSubmit: async ({ value }) => {
+      // Save in parallel: the prefs payload and any per-instrument PUTs
+      // that diverge from their initial state. Tracking the diff (rather
+      // than blindly PUTting every row) keeps the request count bounded
+      // by what the user actually changed.
+      const prefsBody = {
+        runs_all_muted: value.runsAllMuted,
+        comments_attributed_enabled: value.commentsAttributedEnabled,
+        comments_participated_enabled: value.commentsParticipatedEnabled,
+      };
+
+      const changedInstruments = initialInstruments.filter(
+        (row) => value.perInstrument[row.instrumentId] !== row.enabled
+      );
+
+      const requests: Promise<Response>[] = [
+        fetch("/api/v1/settings/notifications", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(prefsBody),
+        }),
+        ...changedInstruments.map((row) =>
+          fetch(
+            `/api/v1/settings/notifications/instruments/${encodeURIComponent(
+              row.instrumentId
+            )}`,
+            {
+              method: "PUT",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                enabled: value.perInstrument[row.instrumentId],
+              }),
+            }
+          )
+        ),
+      ];
+
+      const results = await Promise.all(requests);
+      const failed = results.find((res) => !res.ok);
+      if (failed) {
+        const body = await failed.json().catch(() => null);
+        toast.error(
+          body?.error?.message ?? "Couldn't save notification settings"
+        );
+        return;
+      }
+
+      toast.success("Notification settings saved");
+      // router.refresh() re-runs the page server component so the
+      // form's defaults get re-seeded from the just-saved state.
+      router.refresh();
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        form.handleSubmit();
+      }}
+    >
+      <Card>
+        <CardContent className="max-w-2xl">
+          <FieldGroup>
+            <form.Field name="runsAllMuted">
+              {(field) => (
+                <Field orientation="horizontal">
+                  <FieldContent>
+                    <FieldLabel htmlFor={field.name}>
+                      Mute all instrument notifications
+                    </FieldLabel>
+                    <FieldDescription>
+                      When on, you won&apos;t be notified about new runs on any
+                      instrument — useful for quiet periods. Per-instrument
+                      preferences below are preserved and resume when you
+                      unmute.
+                    </FieldDescription>
+                  </FieldContent>
+                  <Switch
+                    id={field.name}
+                    name={field.name}
+                    checked={field.state.value}
+                    onCheckedChange={field.handleChange}
+                    aria-label="Mute all instrument notifications"
+                  />
+                </Field>
+              )}
+            </form.Field>
+
+            <FieldSeparator />
+
+            <form.Field name="commentsAttributedEnabled">
+              {(field) => (
+                <Field orientation="horizontal">
+                  <FieldContent>
+                    <FieldLabel htmlFor={field.name}>
+                      Comments on runs you ran
+                    </FieldLabel>
+                    <FieldDescription>
+                      Notify me when someone comments on a run I&apos;m
+                      attributed to.
+                    </FieldDescription>
+                  </FieldContent>
+                  <Switch
+                    id={field.name}
+                    name={field.name}
+                    checked={field.state.value}
+                    onCheckedChange={field.handleChange}
+                    aria-label="Notify me when someone comments on a run I'm attributed to"
+                  />
+                </Field>
+              )}
+            </form.Field>
+
+            <form.Field name="commentsParticipatedEnabled">
+              {(field) => (
+                <Field orientation="horizontal">
+                  <FieldContent>
+                    <FieldLabel htmlFor={field.name}>
+                      Replies to your comments
+                    </FieldLabel>
+                    <FieldDescription>
+                      Notify me when someone comments on a run I&apos;ve
+                      previously commented on.
+                    </FieldDescription>
+                  </FieldContent>
+                  <Switch
+                    id={field.name}
+                    name={field.name}
+                    checked={field.state.value}
+                    onCheckedChange={field.handleChange}
+                    aria-label="Notify me when someone replies on a run I've commented on"
+                  />
+                </Field>
+              )}
+            </form.Field>
+          </FieldGroup>
+        </CardContent>
+
+        {initialInstruments.length > 0 ? (
+          <>
+            <FieldSeparator />
+            <CardContent className="max-w-2xl">
+              <div className="mb-4">
+                <h3 className="text-sm font-medium">Per-instrument</h3>
+                <p className="text-sm text-muted-foreground">
+                  Pick the instruments you want to be notified about whenever a
+                  new run is reported.
+                </p>
+              </div>
+              {/* The per-instrument list subscribes only to the master-mute
+                  boolean (a single primitive), so toggling the master doesn't
+                  re-render every row's local Field — instead, each row's
+                  Switch is `disabled` when muted. This keeps the per-row
+                  subscriptions on their own form.Field renderers. */}
+              <form.Subscribe selector={(state) => state.values.runsAllMuted}>
+                {(masterMuted) => (
+                  <FieldGroup>
+                    {initialInstruments.map((row) => (
+                      <form.Field
+                        key={row.instrumentId}
+                        name={`perInstrument.${row.instrumentId}`}
+                      >
+                        {(field) => {
+                          const enabled = field.state.value as boolean;
+                          return (
+                            <Field orientation="horizontal">
+                              <FieldContent>
+                                <FieldLabel htmlFor={field.name}>
+                                  {row.displayName}
+                                </FieldLabel>
+                                <FieldDescription className="font-mono text-xs">
+                                  {row.instrumentId}
+                                </FieldDescription>
+                              </FieldContent>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span className="inline-flex">
+                                    <Switch
+                                      id={field.name}
+                                      name={field.name}
+                                      checked={enabled && !masterMuted}
+                                      onCheckedChange={(v) =>
+                                        field.handleChange(v)
+                                      }
+                                      disabled={masterMuted}
+                                      aria-label={`Notify me about new runs on ${row.displayName}`}
+                                    />
+                                  </span>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  {masterMuted
+                                    ? "All instrument notifications muted"
+                                    : enabled
+                                      ? "Notifying you about new runs"
+                                      : "Click to be notified about new runs"}
+                                </TooltipContent>
+                              </Tooltip>
+                            </Field>
+                          );
+                        }}
+                      </form.Field>
+                    ))}
+                  </FieldGroup>
+                )}
+              </form.Subscribe>
+            </CardContent>
+          </>
+        ) : null}
+
+        <CardFooter className="border-t">
+          <div className="flex w-full items-center justify-end gap-4">
+            <form.Subscribe
+              selector={(state) => ({
+                canSubmit: state.canSubmit,
+                isSubmitting: state.isSubmitting,
+              })}
+            >
+              {({ canSubmit, isSubmitting }) => (
+                <Button type="submit" disabled={!canSubmit || isSubmitting}>
+                  {isSubmitting ? (
+                    <Loader2
+                      data-icon="inline-start"
+                      className="animate-spin"
+                    />
+                  ) : null}
+                  Save
+                </Button>
+              )}
+            </form.Subscribe>
+          </div>
+        </CardFooter>
+      </Card>
+    </form>
+  );
+}

--- a/web/drizzle/0025_add_notifications.sql
+++ b/web/drizzle/0025_add_notifications.sql
@@ -1,0 +1,39 @@
+CREATE TYPE "public"."notification_type" AS ENUM('run_created', 'comment_attributed', 'comment_participated');--> statement-breakpoint
+CREATE TABLE "instrument_notification_subscriptions" (
+	"user_id" text NOT NULL,
+	"instrument_id" text NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "instrument_notification_subscriptions_user_id_instrument_id_pk" PRIMARY KEY("user_id","instrument_id")
+);
+--> statement-breakpoint
+CREATE TABLE "notification_preferences" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"runs_all_muted" boolean DEFAULT false NOT NULL,
+	"comments_attributed_enabled" boolean DEFAULT true NOT NULL,
+	"comments_participated_enabled" boolean DEFAULT true NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "notifications" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"type" "notification_type" NOT NULL,
+	"run_id" uuid NOT NULL,
+	"comment_id" uuid,
+	"actor_user_id" text,
+	"read_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "instrument_notification_subscriptions" ADD CONSTRAINT "instrument_notification_subscriptions_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "instrument_notification_subscriptions" ADD CONSTRAINT "instrument_notification_subscriptions_instrument_id_instruments_id_fk" FOREIGN KEY ("instrument_id") REFERENCES "public"."instruments"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notification_preferences" ADD CONSTRAINT "notification_preferences_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_run_id_instrument_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."instrument_runs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_comment_id_run_comments_id_fk" FOREIGN KEY ("comment_id") REFERENCES "public"."run_comments"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_actor_user_id_user_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_instrument_notification_subscriptions_user_id" ON "instrument_notification_subscriptions" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_notifications_user_id_created_at" ON "notifications" USING btree ("user_id","created_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "idx_notifications_user_id_unread" ON "notifications" USING btree ("user_id","created_at" DESC NULLS LAST) WHERE "notifications"."read_at" is null;

--- a/web/drizzle/meta/0025_snapshot.json
+++ b/web/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,2125 @@
+{
+  "id": "cc84fe60-df57-4af4-8ee6-bc44ce620e25",
+  "prevId": "898e4cab-6b8f-40d9-9521-08574b076d5e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archive_jobs": {
+      "name": "archive_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archive_bucket": {
+          "name": "archive_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_key": {
+          "name": "archive_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "archive_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_archive_jobs_inflight": {
+          "name": "uq_archive_jobs_inflight",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"archive_jobs\".\"status\" in ('pending', 'building')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_archive_jobs_run_fingerprint_status": {
+          "name": "idx_archive_jobs_run_fingerprint_status",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "archive_jobs_instrument_run_id_instrument_runs_id_fk": {
+          "name": "archive_jobs_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "archive_jobs_created_by_user_id_fk": {
+          "name": "archive_jobs_created_by_user_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "file_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raw'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_requested_at": {
+          "name": "upload_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_files_instrument_run_id_relative_path": {
+          "name": "uq_files_instrument_run_id_relative_path",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"relative_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_active_instrument_run_id_filename": {
+          "name": "uq_files_active_instrument_run_id_filename",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_s3_key": {
+          "name": "uq_files_s3_key",
+          "columns": [
+            {
+              "expression": "s3_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"s3_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_instrument_run_id": {
+          "name": "idx_files_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_status_instrument_run_id": {
+          "name": "idx_files_status_instrument_run_id",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_upload_queue": {
+          "name": "idx_files_upload_queue",
+          "columns": [
+            {
+              "expression": "upload_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"upload_requested_at\" is not null and \"files\".\"uploaded_at\" is null and \"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_metadata_gin": {
+          "name": "idx_files_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_instrument_run_id_instrument_runs_id_fk": {
+          "name": "files_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "instrument_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_notification_subscriptions": {
+      "name": "instrument_notification_subscriptions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_instrument_notification_subscriptions_user_id": {
+          "name": "idx_instrument_notification_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_notification_subscriptions_user_id_user_id_fk": {
+          "name": "instrument_notification_subscriptions_user_id_user_id_fk",
+          "tableFrom": "instrument_notification_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "instrument_notification_subscriptions_instrument_id_instruments_id_fk": {
+          "name": "instrument_notification_subscriptions_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_notification_subscriptions",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "instrument_notification_subscriptions_user_id_instrument_id_pk": {
+          "name": "instrument_notification_subscriptions_user_id_instrument_id_pk",
+          "columns": [
+            "user_id",
+            "instrument_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_runs": {
+      "name": "instrument_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "instrument_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lambda'"
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instrument_runs_instrument_id_created_at": {
+          "name": "idx_instrument_runs_instrument_id_created_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active": {
+          "name": "idx_instrument_runs_active",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active_acquired_at": {
+          "name": "idx_instrument_runs_active_acquired_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"acquired_at\", \"created_at\") desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_metadata_gin": {
+          "name": "idx_instrument_runs_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_runs_instrument_id_instruments_id_fk": {
+          "name": "instrument_runs_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_watcher_id_watchers_id_fk": {
+          "name": "instrument_runs_watcher_id_watchers_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_instrument_runs_instrument_id_run_id": {
+          "name": "uq_instrument_runs_instrument_id_run_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instrument_id",
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instruments": {
+      "name": "instruments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instrument_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instrument_type": {
+          "name": "instrument_type",
+          "type": "instrument_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runs_all_muted": {
+          "name": "runs_all_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "comments_attributed_enabled": {
+          "name": "comments_attributed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "comments_participated_enabled": {
+          "name": "comments_participated_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_user_id_fk": {
+          "name": "notification_preferences_user_id_user_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id_created_at": {
+          "name": "idx_notifications_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_id_unread": {
+          "name": "idx_notifications_user_id_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_run_id_instrument_runs_id_fk": {
+          "name": "notifications_run_id_instrument_runs_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_comment_id_run_comments_id_fk": {
+          "name": "notifications_comment_id_run_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "run_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_user_id_user_id_fk": {
+          "name": "notifications_actor_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['*']::text[]"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_personal_access_tokens_user_id": {
+          "name": "idx_personal_access_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_user_id_fk": {
+          "name": "personal_access_tokens_user_id_user_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_attributions": {
+      "name": "run_attributions",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_attributions_run_id": {
+          "name": "idx_run_attributions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_attributions_user_id": {
+          "name": "idx_run_attributions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_attributions_run_id_instrument_runs_id_fk": {
+          "name": "run_attributions_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_attributions_user_id_user_id_fk": {
+          "name": "run_attributions_user_id_user_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_attributions_run_id_user_id_pk": {
+          "name": "run_attributions_run_id_user_id_pk",
+          "columns": [
+            "run_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_comments": {
+      "name": "run_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_run_comments_run_id_created_at": {
+          "name": "idx_run_comments_run_id_created_at",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_comments_user_id": {
+          "name": "idx_run_comments_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_comments_run_id_instrument_runs_id_fk": {
+          "name": "run_comments_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "instrument_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_comments_user_id_user_id_fk": {
+          "name": "run_comments_user_id_user_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_events": {
+      "name": "watcher_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "watcher_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_events_watcher_id_timestamp": {
+          "name": "idx_watcher_events_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_watcher_events_watcher_id_event_type": {
+          "name": "idx_watcher_events_watcher_id_event_type",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_events_watcher_id_watchers_id_fk": {
+          "name": "watcher_events_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_events",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_heartbeats": {
+      "name": "watcher_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_mode": {
+          "name": "upload_mode",
+          "type": "upload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_uploaded_since_last": {
+          "name": "files_uploaded_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "runs_reported_since_last": {
+          "name": "runs_reported_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_since_last": {
+          "name": "errors_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_heartbeats_watcher_id_timestamp": {
+          "name": "idx_watcher_heartbeats_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_heartbeats_watcher_id_watchers_id_fk": {
+          "name": "watcher_heartbeats_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_heartbeats",
+          "tableTo": "watchers",
+          "columnsFrom": [
+            "watcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_release_config": {
+      "name": "watcher_release_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_supported_version": {
+          "name": "min_supported_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stable'"
+        },
+        "mandatory": {
+          "name": "mandatory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watcher_release_config_updated_by_user_id_fk": {
+          "name": "watcher_release_config_updated_by_user_id_fk",
+          "tableFrom": "watcher_release_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "watcher_release_config_singleton": {
+          "name": "watcher_release_config_singleton",
+          "value": "\"watcher_release_config\".\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.watchers": {
+      "name": "watchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_info": {
+          "name": "os_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watcher_version": {
+          "name": "watcher_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_checksum": {
+          "name": "config_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_yaml": {
+          "name": "config_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "watcher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_watchers_active_instrument_id": {
+          "name": "uq_watchers_active_instrument_id",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"watchers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchers_instrument_id_instruments_id_fk": {
+          "name": "watchers_instrument_id_instruments_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.archive_job_status": {
+      "name": "archive_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "building",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.file_category": {
+      "name": "file_category",
+      "schema": "public",
+      "values": [
+        "raw",
+        "processed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "detected",
+        "upload_requested",
+        "uploaded",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.instrument_run_source": {
+      "name": "instrument_run_source",
+      "schema": "public",
+      "values": [
+        "lambda",
+        "watcher"
+      ]
+    },
+    "public.instrument_status": {
+      "name": "instrument_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "inactive"
+      ]
+    },
+    "public.instrument_type": {
+      "name": "instrument_type",
+      "schema": "public",
+      "values": [
+        "generic",
+        "plate_reader",
+        "gel_doc",
+        "qpcr",
+        "tape_station",
+        "hina_microscope",
+        "epson_v700_scanner",
+        "instant_raman"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "run_created",
+        "comment_attributed",
+        "comment_participated"
+      ]
+    },
+    "public.upload_mode": {
+      "name": "upload_mode",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual"
+      ]
+    },
+    "public.watcher_event_type": {
+      "name": "watcher_event_type",
+      "schema": "public",
+      "values": [
+        "watcher_started",
+        "watcher_stopped",
+        "file_uploaded",
+        "upload_failed",
+        "run_reported",
+        "config_synced",
+        "error",
+        "update_started",
+        "update_succeeded",
+        "update_failed"
+      ]
+    },
+    "public.watcher_status": {
+      "name": "watcher_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "watching",
+        "stopped"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1778958471151,
       "tag": "0024_add_watcher_release_config",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1779301905199,
+      "tag": "0025_add_notifications",
+      "breakpoints": true
     }
   ]
 }

--- a/web/lib/api/notifications.ts
+++ b/web/lib/api/notifications.ts
@@ -51,33 +51,15 @@ const DEFAULT_PREFERENCES: NotificationPreferencesDto = {
 };
 
 // ---------------------------------------------------------------------------
-// Preferences: lazy upsert on first read so the settings form always has
-// concrete values, and idempotent partial update on write.
+// Preferences: SELECT-only on the read path with a `DEFAULT_PREFERENCES`
+// fallback for users who haven't materialized a row yet. `updatePreferences`
+// does its own upsert on write, so we never need to insert from the read
+// side just to make the form render — keeping the read at one RTT.
 // ---------------------------------------------------------------------------
 
 export async function getPreferences(
   userId: string
 ): Promise<NotificationPreferencesDto> {
-  // Lazy upsert with `ON CONFLICT DO NOTHING` keeps repeat reads cheap
-  // without a separate select. Returning is best-effort — when the row
-  // already existed, drizzle returns no rows so we fall through to a
-  // follow-up select.
-  const inserted = await db
-    .insert(notificationPreferences)
-    .values({ userId })
-    .onConflictDoNothing({ target: notificationPreferences.userId })
-    .returning({
-      runsAllMuted: notificationPreferences.runsAllMuted,
-      commentsAttributedEnabled:
-        notificationPreferences.commentsAttributedEnabled,
-      commentsParticipatedEnabled:
-        notificationPreferences.commentsParticipatedEnabled,
-    });
-
-  if (inserted.length > 0) {
-    return inserted[0];
-  }
-
   const [row] = await db
     .select({
       runsAllMuted: notificationPreferences.runsAllMuted,

--- a/web/lib/api/notifications.ts
+++ b/web/lib/api/notifications.ts
@@ -1,0 +1,411 @@
+import { db } from "@/lib/db";
+import {
+  instrumentNotificationSubscriptions,
+  instrumentRuns,
+  instruments,
+  notificationPreferences,
+  notifications,
+  runAttributions,
+  runComments,
+  users,
+} from "@/lib/db/schema";
+import { toInitials } from "@/lib/utils";
+import {
+  aliasedTable,
+  and,
+  asc,
+  desc,
+  eq,
+  inArray,
+  isNull,
+  sql,
+} from "drizzle-orm";
+
+// ---------------------------------------------------------------------------
+// Notifications — in-app event delivery for instrument runs and run comments.
+//
+// Three trigger types live in `notification_type`:
+//   - `run_created`           : a new run was created on a subscribed
+//                                instrument; emitted to every user with a
+//                                `instrument_notification_subscriptions`
+//                                row that has `enabled = true` AND whose
+//                                `notification_preferences.runsAllMuted`
+//                                is false.
+//   - `comment_attributed`    : a run-attributee received a new comment.
+//   - `comment_participated`  : a prior commenter received a new comment.
+//
+// All preference-mutating routes are session-only — these endpoints are
+// personal-UX, never invoked by PATs, so we don't add a scope.
+// ---------------------------------------------------------------------------
+
+export type NotificationPreferencesDto = {
+  runsAllMuted: boolean;
+  commentsAttributedEnabled: boolean;
+  commentsParticipatedEnabled: boolean;
+};
+
+const DEFAULT_PREFERENCES: NotificationPreferencesDto = {
+  runsAllMuted: false,
+  commentsAttributedEnabled: true,
+  commentsParticipatedEnabled: true,
+};
+
+// ---------------------------------------------------------------------------
+// Preferences: lazy upsert on first read so the settings form always has
+// concrete values, and idempotent partial update on write.
+// ---------------------------------------------------------------------------
+
+export async function getPreferences(
+  userId: string
+): Promise<NotificationPreferencesDto> {
+  // Lazy upsert with `ON CONFLICT DO NOTHING` keeps repeat reads cheap
+  // without a separate select. Returning is best-effort — when the row
+  // already existed, drizzle returns no rows so we fall through to a
+  // follow-up select.
+  const inserted = await db
+    .insert(notificationPreferences)
+    .values({ userId })
+    .onConflictDoNothing({ target: notificationPreferences.userId })
+    .returning({
+      runsAllMuted: notificationPreferences.runsAllMuted,
+      commentsAttributedEnabled:
+        notificationPreferences.commentsAttributedEnabled,
+      commentsParticipatedEnabled:
+        notificationPreferences.commentsParticipatedEnabled,
+    });
+
+  if (inserted.length > 0) {
+    return inserted[0];
+  }
+
+  const [row] = await db
+    .select({
+      runsAllMuted: notificationPreferences.runsAllMuted,
+      commentsAttributedEnabled:
+        notificationPreferences.commentsAttributedEnabled,
+      commentsParticipatedEnabled:
+        notificationPreferences.commentsParticipatedEnabled,
+    })
+    .from(notificationPreferences)
+    .where(eq(notificationPreferences.userId, userId))
+    .limit(1);
+
+  return row ?? DEFAULT_PREFERENCES;
+}
+
+export async function updatePreferences(
+  userId: string,
+  patch: Partial<NotificationPreferencesDto>
+): Promise<NotificationPreferencesDto> {
+  // Make sure the row exists so the subsequent UPDATE has something to
+  // touch — keeps the function valid as a first-write entry point.
+  await db
+    .insert(notificationPreferences)
+    .values({ userId, ...patch })
+    .onConflictDoUpdate({
+      target: notificationPreferences.userId,
+      set: { ...patch, updatedAt: new Date() },
+    });
+
+  return getPreferences(userId);
+}
+
+// ---------------------------------------------------------------------------
+// Per-instrument subscriptions: left-joined against `instruments` so the
+// settings page sees the full instrument catalogue with each row's current
+// `enabled` state (missing row → disabled).
+// ---------------------------------------------------------------------------
+
+export type InstrumentSubscriptionRow = {
+  instrumentId: string;
+  displayName: string;
+  enabled: boolean;
+};
+
+export async function listInstrumentSubscriptions(
+  userId: string
+): Promise<InstrumentSubscriptionRow[]> {
+  const rows = await db
+    .select({
+      instrumentId: instruments.id,
+      displayName: instruments.displayName,
+      enabled: instrumentNotificationSubscriptions.enabled,
+    })
+    .from(instruments)
+    .leftJoin(
+      instrumentNotificationSubscriptions,
+      and(
+        eq(instrumentNotificationSubscriptions.instrumentId, instruments.id),
+        eq(instrumentNotificationSubscriptions.userId, userId)
+      )
+    )
+    .orderBy(asc(instruments.displayName));
+
+  return rows.map((r) => ({
+    instrumentId: r.instrumentId,
+    displayName: r.displayName,
+    enabled: r.enabled ?? false,
+  }));
+}
+
+export async function setInstrumentSubscription(
+  userId: string,
+  instrumentId: string,
+  enabled: boolean
+): Promise<void> {
+  await db
+    .insert(instrumentNotificationSubscriptions)
+    .values({ userId, instrumentId, enabled })
+    .onConflictDoUpdate({
+      target: [
+        instrumentNotificationSubscriptions.userId,
+        instrumentNotificationSubscriptions.instrumentId,
+      ],
+      set: { enabled, updatedAt: new Date() },
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Listing notifications for the bell popover. Joins the run + instrument +
+// actor user once so the wire shape is render-ready and the popover doesn't
+// need follow-up requests.
+// ---------------------------------------------------------------------------
+
+export type NotificationDto = {
+  id: string;
+  type: "run_created" | "comment_attributed" | "comment_participated";
+  createdAt: Date;
+  readAt: Date | null;
+  runId: string;
+  // Natural keys for linking — `/instruments/:instrumentId/runs/:runId` is
+  // what the row navigates to.
+  instrumentId: string;
+  runDisplayId: string;
+  instrumentDisplayName: string;
+  commentId: string | null;
+  actor: {
+    id: string;
+    displayName: string;
+    initials: string;
+    avatarUrl: string | null;
+  } | null;
+};
+
+export async function listNotifications(
+  userId: string,
+  opts: { limit?: number; unreadOnly?: boolean } = {}
+): Promise<NotificationDto[]> {
+  const limit = opts.limit ?? 20;
+  const actor = aliasedTable(users, "actor");
+
+  const rows = await db
+    .select({
+      id: notifications.id,
+      type: notifications.type,
+      createdAt: notifications.createdAt,
+      readAt: notifications.readAt,
+      runId: instrumentRuns.id,
+      runDisplayId: instrumentRuns.runId,
+      instrumentId: instrumentRuns.instrumentId,
+      instrumentDisplayName: instruments.displayName,
+      commentId: notifications.commentId,
+      actorId: actor.id,
+      actorName: actor.name,
+      actorEmail: actor.email,
+      actorImage: actor.image,
+    })
+    .from(notifications)
+    .innerJoin(instrumentRuns, eq(instrumentRuns.id, notifications.runId))
+    .innerJoin(instruments, eq(instruments.id, instrumentRuns.instrumentId))
+    .leftJoin(actor, eq(actor.id, notifications.actorUserId))
+    .where(
+      opts.unreadOnly
+        ? and(eq(notifications.userId, userId), isNull(notifications.readAt))
+        : eq(notifications.userId, userId)
+    )
+    .orderBy(desc(notifications.createdAt))
+    .limit(limit);
+
+  return rows.map((row) => {
+    const actorDisplayName = row.actorId
+      ? (row.actorName ?? row.actorEmail ?? "Unknown")
+      : null;
+    return {
+      id: row.id,
+      type: row.type,
+      createdAt: row.createdAt,
+      readAt: row.readAt,
+      runId: row.runId,
+      runDisplayId: row.runDisplayId,
+      instrumentId: row.instrumentId,
+      instrumentDisplayName: row.instrumentDisplayName,
+      commentId: row.commentId,
+      actor:
+        row.actorId && actorDisplayName
+          ? {
+              id: row.actorId,
+              displayName: actorDisplayName,
+              initials: toInitials(actorDisplayName),
+              avatarUrl: row.actorImage,
+            }
+          : null,
+    };
+  });
+}
+
+export async function countUnread(userId: string): Promise<number> {
+  // Hits the partial `idx_notifications_user_id_unread` index; the count
+  // never has to scan read rows.
+  const [row] = await db
+    .select({ count: sql<number>`cast(count(*) as int)` })
+    .from(notifications)
+    .where(and(eq(notifications.userId, userId), isNull(notifications.readAt)));
+  return row?.count ?? 0;
+}
+
+export async function markRead(userId: string, ids?: string[]): Promise<void> {
+  if (ids && ids.length === 0) return;
+  const now = new Date();
+  await db
+    .update(notifications)
+    .set({ readAt: now })
+    .where(
+      ids
+        ? and(
+            eq(notifications.userId, userId),
+            inArray(notifications.id, ids),
+            isNull(notifications.readAt)
+          )
+        : and(eq(notifications.userId, userId), isNull(notifications.readAt))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fan-out helpers — invoked from inside `after(...)` hooks on the run-create
+// and comment-create routes so the writing route can return immediately.
+// Each helper performs a single targeted SELECT to compute recipients, then
+// a single bulk INSERT. Failures are swallowed and logged: a notification
+// outage must never fail the underlying mutation.
+// ---------------------------------------------------------------------------
+
+export async function notifyRunCreated(input: {
+  runInternalId: string;
+  instrumentId: string;
+}): Promise<void> {
+  try {
+    // Recipients: every user whose subscription for this instrument is
+    // enabled AND whose master `runs_all_muted` is false (or absent —
+    // missing row implies defaults i.e. master not muted).
+    const recipients = await db
+      .select({
+        userId: instrumentNotificationSubscriptions.userId,
+      })
+      .from(instrumentNotificationSubscriptions)
+      .leftJoin(
+        notificationPreferences,
+        eq(
+          notificationPreferences.userId,
+          instrumentNotificationSubscriptions.userId
+        )
+      )
+      .where(
+        and(
+          eq(
+            instrumentNotificationSubscriptions.instrumentId,
+            input.instrumentId
+          ),
+          eq(instrumentNotificationSubscriptions.enabled, true),
+          // `coalesce(..., false)` so the master flag missing entirely
+          // (no preferences row yet) is treated as not-muted.
+          sql`coalesce(${notificationPreferences.runsAllMuted}, false) = false`
+        )
+      );
+
+    if (recipients.length === 0) return;
+
+    await db.insert(notifications).values(
+      recipients.map((r) => ({
+        userId: r.userId,
+        type: "run_created" as const,
+        runId: input.runInternalId,
+      }))
+    );
+  } catch (err) {
+    console.error("notifyRunCreated failed", err);
+  }
+}
+
+export async function notifyComment(input: {
+  runInternalId: string;
+  commentId: string;
+  authorUserId: string;
+}): Promise<void> {
+  try {
+    // Build the recipient set in two SELECTs that we union in JS so the
+    // attributed→participated precedence is enforced cleanly without a
+    // PostgreSQL-only DISTINCT ON. Each branch is independently gated on
+    // the user's own `comments_*_enabled` toggle and skips the comment
+    // author themselves.
+    const [attributedRows, participatedRows] = await Promise.all([
+      db
+        .select({ userId: runAttributions.userId })
+        .from(runAttributions)
+        .leftJoin(
+          notificationPreferences,
+          eq(notificationPreferences.userId, runAttributions.userId)
+        )
+        .where(
+          and(
+            eq(runAttributions.runId, input.runInternalId),
+            sql`${runAttributions.userId} <> ${input.authorUserId}`,
+            sql`coalesce(${notificationPreferences.commentsAttributedEnabled}, true) = true`
+          )
+        ),
+      db
+        .selectDistinct({ userId: runComments.userId })
+        .from(runComments)
+        .leftJoin(
+          notificationPreferences,
+          eq(notificationPreferences.userId, runComments.userId)
+        )
+        .where(
+          and(
+            eq(runComments.runId, input.runInternalId),
+            sql`${runComments.userId} <> ${input.authorUserId}`,
+            isNull(runComments.deletedAt),
+            sql`coalesce(${notificationPreferences.commentsParticipatedEnabled}, true) = true`
+          )
+        ),
+    ]);
+
+    // Attributed wins on overlap so the user only sees one row per
+    // (recipient, comment) and the type carries the strongest signal.
+    const attributedSet = new Set(attributedRows.map((r) => r.userId));
+    const participatedOnly = participatedRows
+      .map((r) => r.userId)
+      .filter((id) => !attributedSet.has(id));
+
+    const rows = [
+      ...attributedRows.map((r) => ({
+        userId: r.userId,
+        type: "comment_attributed" as const,
+        runId: input.runInternalId,
+        commentId: input.commentId,
+        actorUserId: input.authorUserId,
+      })),
+      ...participatedOnly.map((userId) => ({
+        userId,
+        type: "comment_participated" as const,
+        runId: input.runInternalId,
+        commentId: input.commentId,
+        actorUserId: input.authorUserId,
+      })),
+    ];
+
+    if (rows.length === 0) return;
+
+    await db.insert(notifications).values(rows);
+  } catch (err) {
+    console.error("notifyComment failed", err);
+  }
+}

--- a/web/lib/db/schema.ts
+++ b/web/lib/db/schema.ts
@@ -713,9 +713,11 @@ export const notificationTypeEnum = pgEnum("notification_type", [
   "comment_participated",
 ]);
 
-// One row per user holding the global notification toggles. Created lazily
-// on first read in `notifications.getPreferences` so the settings form can
-// always show concrete values; absence here is treated as "all defaults".
+// One row per user holding the global notification toggles. Created on
+// first *write* (via the upsert in `notifications.updatePreferences`);
+// readers fall back to `DEFAULT_PREFERENCES` when no row exists so the
+// settings form can always render concrete values without a write-path
+// query.
 export const notificationPreferences = pgTable("notification_preferences", {
   userId: text("user_id")
     .primaryKey()

--- a/web/lib/db/schema.ts
+++ b/web/lib/db/schema.ts
@@ -701,6 +701,143 @@ export const archiveJobs = pgTable(
   ]
 );
 
+// Notification trigger taxonomy. `run_created` fires once per newly-created
+// run for every user who has an enabled per-instrument subscription;
+// `comment_attributed` and `comment_participated` fire on a new comment for
+// run attributees and prior commenters respectively. The `attributed`
+// variant takes precedence when a single recipient qualifies under both
+// rules so the popover doesn't show the same comment twice.
+export const notificationTypeEnum = pgEnum("notification_type", [
+  "run_created",
+  "comment_attributed",
+  "comment_participated",
+]);
+
+// One row per user holding the global notification toggles. Created lazily
+// on first read in `notifications.getPreferences` so the settings form can
+// always show concrete values; absence here is treated as "all defaults".
+export const notificationPreferences = pgTable("notification_preferences", {
+  userId: text("user_id")
+    .primaryKey()
+    .references(() => users.id, { onDelete: "cascade" }),
+  // Master mute: when true, suppresses every per-instrument run notification
+  // regardless of the user's `instrument_notification_subscriptions` rows.
+  // Comment notifications are governed independently by the two booleans
+  // below so a muted user can still receive replies on runs they care
+  // about.
+  runsAllMuted: boolean("runs_all_muted").notNull().default(false),
+  // Receive a notification when someone comments on a run the user is
+  // attributed to (via `run_attributions`).
+  commentsAttributedEnabled: boolean("comments_attributed_enabled")
+    .notNull()
+    .default(true),
+  // Receive a notification when someone comments on a run the user has
+  // previously commented on (excluding the user's own follow-ups).
+  commentsParticipatedEnabled: boolean("comments_participated_enabled")
+    .notNull()
+    .default(true),
+  updatedAt: timestamp("updated_at", {
+    withTimezone: true,
+    mode: "date",
+  })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+});
+
+// Per-(user, instrument) opt-in for `run_created` notifications. Absence of
+// a row is treated as "unsubscribed"; the row is kept around even when
+// disabled so toggling off doesn't lose the user's prior interest history.
+export const instrumentNotificationSubscriptions = pgTable(
+  "instrument_notification_subscriptions",
+  {
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    instrumentId: text("instrument_id")
+      .notNull()
+      .references(() => instruments.id, { onDelete: "cascade" }),
+    enabled: boolean("enabled").notNull().default(true),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "date",
+    })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", {
+      withTimezone: true,
+      mode: "date",
+    })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (sub) => [
+    primaryKey({ columns: [sub.userId, sub.instrumentId] }),
+    // Settings page lists every subscription for the current user; this
+    // index keeps that lookup index-only.
+    index("idx_instrument_notification_subscriptions_user_id").on(sub.userId),
+  ]
+);
+
+// Delivered in-app notifications, one row per (recipient, event). Read
+// state lives on the row via `readAt` so unread counts are a single
+// indexed query — the `idx_notifications_user_id_unread` partial index
+// drops the `read_at is null` filter into the index itself for the hot
+// bell-badge path.
+export const notifications = pgTable(
+  "notifications",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    // Recipient. The actor (who caused the notification) is stored
+    // separately as `actorUserId` and may be NULL for system-originated
+    // events like `run_created`.
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    type: notificationTypeEnum("type").notNull(),
+    // The run the notification refers to; cascade on delete so soft- or
+    // hard-deleted runs don't leave orphan rows in the popover. (Runs are
+    // soft-deleted in practice, but the FK protects against accidental
+    // hard delete in tests / future cleanups.)
+    runId: uuid("run_id")
+      .notNull()
+      .references(() => instrumentRuns.id, { onDelete: "cascade" }),
+    // NULL for `run_created`. Set for both comment trigger types.
+    commentId: uuid("comment_id").references(() => runComments.id, {
+      onDelete: "cascade",
+    }),
+    // The user whose action produced the notification. `set null` so a
+    // deleted user doesn't take the recipient's history with them.
+    actorUserId: text("actor_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    readAt: timestamp("read_at", {
+      withTimezone: true,
+      mode: "date",
+    }),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "date",
+    })
+      .notNull()
+      .defaultNow(),
+  },
+  (notification) => [
+    index("idx_notifications_user_id_created_at").on(
+      notification.userId,
+      notification.createdAt.desc()
+    ),
+    // Partial index that backs the unread-count query (`select count(*)
+    // from notifications where user_id = ? and read_at is null`) used on
+    // every bell render. Indexing only unread rows keeps the index small
+    // even after long retention.
+    index("idx_notifications_user_id_unread")
+      .on(notification.userId, notification.createdAt.desc())
+      .where(sql`${notification.readAt} is null`),
+  ]
+);
+
 // Many-to-many link between users and runs: a user "claims" a run they
 // personally performed. Attribution is self-service — users create and remove
 // only their own row. Composite PK enforces one row per (run, user).

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6932,9 +6932,9 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -7392,9 +7392,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/tests/integration/global-setup.ts
+++ b/web/tests/integration/global-setup.ts
@@ -210,6 +210,13 @@ export async function setup() {
   process.env.__TEST_BASE_URL = baseUrl;
   process.env.__TEST_DATABASE_URL = databaseUrl;
   process.env.__TEST_SLACK_CAPTURE_URL = slackCaptureBaseUrl;
+  // Point the `@/lib/db` singleton at the test DB so library helpers
+  // imported directly into test files (e.g. `notifyRunCreated` from
+  // `@/lib/api/notifications`) hit the same database as `getTestDb()`.
+  // Without this they'd silently read the developer's local
+  // `DATABASE_URL`, where the relations under test don't exist. The
+  // spawned Next.js server already gets the test DB via `serverEnv`.
+  process.env.DATABASE_URL = databaseUrl;
 
   return async () => {
     if (serverProcess) {

--- a/web/tests/integration/helpers.ts
+++ b/web/tests/integration/helpers.ts
@@ -35,6 +35,9 @@ export async function closeTestDb() {
 // CASCADE handles any ordering gaps, but explicit order avoids relying on it.
 // Quoted names match Drizzle-generated tables that use camelCase identifiers.
 const TRUNCATE_ORDER = [
+  "notifications",
+  "instrument_notification_subscriptions",
+  "notification_preferences",
   "files",
   "run_attributions",
   "run_comments",

--- a/web/tests/integration/notifications.test.ts
+++ b/web/tests/integration/notifications.test.ts
@@ -1,0 +1,964 @@
+import {
+  countUnread,
+  getPreferences,
+  listInstrumentSubscriptions,
+  listNotifications,
+  markRead,
+  notifyComment,
+  notifyRunCreated,
+  setInstrumentSubscription,
+  updatePreferences,
+} from "@/lib/api/notifications";
+import {
+  instrumentNotificationSubscriptions,
+  instrumentRuns,
+  instruments,
+  notifications,
+  runAttributions,
+  runComments,
+} from "@/lib/db/schema";
+import {
+  api,
+  closeTestDb,
+  getTestDb,
+  resetDb,
+  seedTestUser,
+} from "@/tests/integration/helpers";
+import { and, eq } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+// End-to-end + library-level coverage for the in-app notifications system.
+// The library matrix exercises the recipient-selection logic directly
+// against the test DB so it stays deterministic; one HTTP smoke per route
+// proves the `after(...)` wiring in the runs / comments handlers is in place.
+//
+// Session-only HTTP routes (the read/settings surfaces) are only checked
+// for their 401 gate — the harness has no session-cookie synthesis (see
+// users.test.ts for the same gap), and the underlying call sites are
+// covered transitively by the library suites.
+
+describe("Notifications", () => {
+  beforeAll(async () => {
+    await resetDb();
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test helpers — small wrappers that keep individual cases focused.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Seed a run on a given instrument and return its surrogate UUID. Tests
+   * that don't need a specific run id (most of the library matrix) use this
+   * to get a fresh, isolated row.
+   */
+  async function seedRun(instrumentId: string, runId: string): Promise<string> {
+    const db = getTestDb();
+    const [row] = await db
+      .insert(instrumentRuns)
+      .values({ instrumentId, runId, source: "lambda" })
+      .returning({ id: instrumentRuns.id });
+    return row.id;
+  }
+
+  async function seedInstrument(id: string, displayName: string) {
+    const db = getTestDb();
+    await db.insert(instruments).values({ id, displayName, status: "active" });
+  }
+
+  /**
+   * Polls until `predicate` resolves true or the deadline lapses. Used by
+   * the HTTP smoke tests to wait out the `after(...)` deferral on the
+   * runs / comments routes.
+   */
+  async function waitForNotification(
+    predicate: () => Promise<boolean>,
+    { timeoutMs = 3000, intervalMs = 50 } = {}
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (await predicate()) return;
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    throw new Error("Timed out waiting for after()-deferred notification");
+  }
+
+  // =========================================================================
+  // Preferences — library suite
+  // =========================================================================
+
+  describe("Notification preferences", () => {
+    beforeEach(async () => {
+      await resetDb();
+    });
+
+    it("getPreferences returns concrete defaults for a brand-new user", async () => {
+      const { userId } = await seedTestUser();
+
+      const prefs = await getPreferences(userId);
+
+      expect(prefs).toEqual({
+        runsAllMuted: false,
+        commentsAttributedEnabled: true,
+        commentsParticipatedEnabled: true,
+      });
+
+      // Defaults are lazy-upserted so subsequent reads hit the row, not
+      // the insert path — both should return the same shape.
+      const second = await getPreferences(userId);
+      expect(second).toEqual(prefs);
+    });
+
+    it("updatePreferences patches only the fields specified", async () => {
+      const { userId } = await seedTestUser();
+
+      await updatePreferences(userId, { runsAllMuted: true });
+      let prefs = await getPreferences(userId);
+      expect(prefs).toEqual({
+        runsAllMuted: true,
+        commentsAttributedEnabled: true,
+        commentsParticipatedEnabled: true,
+      });
+
+      // A partial patch on the other axis leaves the first one intact.
+      await updatePreferences(userId, { commentsParticipatedEnabled: false });
+      prefs = await getPreferences(userId);
+      expect(prefs).toEqual({
+        runsAllMuted: true,
+        commentsAttributedEnabled: true,
+        commentsParticipatedEnabled: false,
+      });
+    });
+
+    it("updatePreferences creates the row when none exists yet", async () => {
+      const { userId } = await seedTestUser();
+
+      await updatePreferences(userId, { commentsAttributedEnabled: false });
+
+      const prefs = await getPreferences(userId);
+      expect(prefs.commentsAttributedEnabled).toBe(false);
+      // Schema defaults survive the partial create.
+      expect(prefs.runsAllMuted).toBe(false);
+      expect(prefs.commentsParticipatedEnabled).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // Instrument subscriptions — library suite
+  // =========================================================================
+
+  describe("Instrument subscriptions", () => {
+    beforeEach(async () => {
+      await resetDb();
+    });
+
+    it("listInstrumentSubscriptions returns the full catalogue with enabled=false defaults", async () => {
+      const { userId } = await seedTestUser();
+      await seedInstrument("alpha", "Alpha");
+      await seedInstrument("beta", "Beta");
+
+      const rows = await listInstrumentSubscriptions(userId);
+
+      expect(rows).toHaveLength(2);
+      expect(rows.every((r) => r.enabled === false)).toBe(true);
+    });
+
+    it("orders rows by display name ascending", async () => {
+      const { userId } = await seedTestUser();
+      await seedInstrument("z-id", "Zebra");
+      await seedInstrument("a-id", "Aardvark");
+      await seedInstrument("m-id", "Mongoose");
+
+      const rows = await listInstrumentSubscriptions(userId);
+
+      expect(rows.map((r) => r.displayName)).toEqual([
+        "Aardvark",
+        "Mongoose",
+        "Zebra",
+      ]);
+    });
+
+    it("setInstrumentSubscription flips only the targeted row", async () => {
+      const { userId } = await seedTestUser();
+      await seedInstrument("alpha", "Alpha");
+      await seedInstrument("beta", "Beta");
+
+      await setInstrumentSubscription(userId, "alpha", true);
+
+      const rows = await listInstrumentSubscriptions(userId);
+      const byId = new Map(rows.map((r) => [r.instrumentId, r.enabled]));
+      expect(byId.get("alpha")).toBe(true);
+      expect(byId.get("beta")).toBe(false);
+    });
+
+    it("toggling off then on preserves the underlying row (no delete-on-disable)", async () => {
+      const { userId } = await seedTestUser();
+      await seedInstrument("alpha", "Alpha");
+
+      await setInstrumentSubscription(userId, "alpha", true);
+
+      const db = getTestDb();
+      const [created] = await db
+        .select()
+        .from(instrumentNotificationSubscriptions)
+        .where(
+          and(
+            eq(instrumentNotificationSubscriptions.userId, userId),
+            eq(instrumentNotificationSubscriptions.instrumentId, "alpha")
+          )
+        );
+      const originalCreatedAt = created.createdAt;
+
+      // Tiny gap so updated_at can strictly advance under SQL's now().
+      await new Promise((r) => setTimeout(r, 10));
+      await setInstrumentSubscription(userId, "alpha", false);
+      await new Promise((r) => setTimeout(r, 10));
+      await setInstrumentSubscription(userId, "alpha", true);
+
+      const [final] = await db
+        .select()
+        .from(instrumentNotificationSubscriptions)
+        .where(
+          and(
+            eq(instrumentNotificationSubscriptions.userId, userId),
+            eq(instrumentNotificationSubscriptions.instrumentId, "alpha")
+          )
+        );
+      expect(final.enabled).toBe(true);
+      expect(final.createdAt.getTime()).toBe(originalCreatedAt.getTime());
+      expect(final.updatedAt.getTime()).toBeGreaterThan(
+        originalCreatedAt.getTime()
+      );
+    });
+  });
+
+  // =========================================================================
+  // notifyRunCreated — library matrix + HTTP smoke
+  // =========================================================================
+
+  describe("notifyRunCreated", () => {
+    const instrumentId = "fanout-runs-instrument";
+
+    beforeEach(async () => {
+      await resetDb();
+      await seedInstrument(instrumentId, "Fanout Runs Instrument");
+    });
+
+    it("inserts one run_created row per subscribed user", async () => {
+      const { userId } = await seedTestUser();
+      await setInstrumentSubscription(userId, instrumentId, true);
+
+      const runInternalId = await seedRun(instrumentId, "run-subscribed");
+      await notifyRunCreated({ runInternalId, instrumentId });
+
+      const db = getTestDb();
+      const rows = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, runInternalId));
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].userId).toBe(userId);
+      expect(rows[0].type).toBe("run_created");
+      expect(rows[0].actorUserId).toBeNull();
+      expect(rows[0].commentId).toBeNull();
+      expect(rows[0].readAt).toBeNull();
+    });
+
+    it("skips users whose subscription is disabled", async () => {
+      const { userId: subscribed } = await seedTestUser();
+      const { userId: disabled } = await seedTestUser();
+
+      await setInstrumentSubscription(subscribed, instrumentId, true);
+      await setInstrumentSubscription(disabled, instrumentId, false);
+
+      const runInternalId = await seedRun(instrumentId, "run-mixed");
+      await notifyRunCreated({ runInternalId, instrumentId });
+
+      const db = getTestDb();
+      const rows = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, runInternalId));
+
+      expect(rows.map((r) => r.userId)).toEqual([subscribed]);
+    });
+
+    it("skips subscribed users whose master mute is set", async () => {
+      const { userId } = await seedTestUser();
+      await setInstrumentSubscription(userId, instrumentId, true);
+      await updatePreferences(userId, { runsAllMuted: true });
+
+      const runInternalId = await seedRun(instrumentId, "run-muted");
+      await notifyRunCreated({ runInternalId, instrumentId });
+
+      const db = getTestDb();
+      const rows = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, runInternalId));
+
+      expect(rows).toHaveLength(0);
+    });
+
+    it("notifies subscribed users with no preferences row (coalesce branch)", async () => {
+      const { userId } = await seedTestUser();
+      await setInstrumentSubscription(userId, instrumentId, true);
+      // Explicitly do NOT call updatePreferences — exercises the
+      // `coalesce(runs_all_muted, false) = false` SQL branch.
+
+      const runInternalId = await seedRun(instrumentId, "run-no-prefs");
+      await notifyRunCreated({ runInternalId, instrumentId });
+
+      const db = getTestDb();
+      const rows = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, runInternalId));
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].userId).toBe(userId);
+    });
+
+    it("is not idempotent on repeat calls (route-level isNew owns dedup)", async () => {
+      const { userId } = await seedTestUser();
+      await setInstrumentSubscription(userId, instrumentId, true);
+
+      const runInternalId = await seedRun(instrumentId, "run-repeat");
+
+      await notifyRunCreated({ runInternalId, instrumentId });
+      await notifyRunCreated({ runInternalId, instrumentId });
+
+      const db = getTestDb();
+      const rows = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, runInternalId));
+
+      // Two invocations → two rows. The "only fire once per run"
+      // guarantee lives in the route, not the helper; pinned by the
+      // HTTP smoke below.
+      expect(rows).toHaveLength(2);
+    });
+
+    it("does not exclude the run author (distinct from comment fan-out)", async () => {
+      // notifyRunCreated has no concept of an "author" — anyone with a
+      // matching subscription receives the notification, including the
+      // PAT owner that POSTed the run.
+      const { userId } = await seedTestUser();
+      await setInstrumentSubscription(userId, instrumentId, true);
+
+      const runInternalId = await seedRun(instrumentId, "run-author");
+      await notifyRunCreated({ runInternalId, instrumentId });
+
+      const db = getTestDb();
+      const rows = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, runInternalId));
+
+      expect(rows.map((r) => r.userId)).toEqual([userId]);
+    });
+
+    it("HTTP: POSTing a new run fans out, duplicate POST does not refire", async () => {
+      const { userId, token } = await seedTestUser();
+      await setInstrumentSubscription(userId, instrumentId, true);
+
+      const runId = "run-http-smoke";
+      const first = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+        method: "POST",
+        token,
+        body: { run_id: runId, source: "lambda" },
+      });
+      expect(first.status).toBe(201);
+
+      const db = getTestDb();
+      await waitForNotification(async () => {
+        const rows = await db
+          .select()
+          .from(notifications)
+          .where(eq(notifications.userId, userId));
+        return rows.length >= 1;
+      });
+
+      // Sanity check the row shape after the after() callback flushed.
+      const [run] = await db
+        .select({ id: instrumentRuns.id })
+        .from(instrumentRuns)
+        .where(
+          and(
+            eq(instrumentRuns.instrumentId, instrumentId),
+            eq(instrumentRuns.runId, runId)
+          )
+        );
+      const afterFirst = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, run.id));
+      expect(afterFirst).toHaveLength(1);
+      expect(afterFirst[0].type).toBe("run_created");
+
+      // Duplicate POST: same (instrument_id, run_id). isNew=false in the
+      // route handler → no `notifyRunCreated` call → no new rows.
+      const dup = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+        method: "POST",
+        token,
+        body: { run_id: runId, source: "lambda" },
+      });
+      expect(dup.status).toBe(200);
+
+      // Wait long enough for any hypothetical after() to flush, then
+      // assert the count is unchanged.
+      await new Promise((r) => setTimeout(r, 300));
+      const afterDup = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, run.id));
+      expect(afterDup).toHaveLength(1);
+    });
+  });
+
+  // =========================================================================
+  // notifyComment — library matrix + HTTP smoke
+  // =========================================================================
+
+  describe("notifyComment", () => {
+    const instrumentId = "fanout-comments-instrument";
+
+    beforeEach(async () => {
+      await resetDb();
+      await seedInstrument(instrumentId, "Fanout Comments Instrument");
+    });
+
+    // Seed a prior comment from `userId` on `runInternalId` so they
+    // qualify as a "participated" recipient on subsequent comments. The
+    // returned id is used by the soft-delete test to flip deleted_at.
+    async function seedPriorComment(
+      runInternalId: string,
+      userId: string,
+      body = "earlier message"
+    ): Promise<string> {
+      const db = getTestDb();
+      const [row] = await db
+        .insert(runComments)
+        .values({ runId: runInternalId, userId, body })
+        .returning({ id: runComments.id });
+      return row.id;
+    }
+
+    async function seedAttribution(runInternalId: string, userId: string) {
+      const db = getTestDb();
+      await db.insert(runAttributions).values({ runId: runInternalId, userId });
+    }
+
+    async function seedAuthorComment(
+      runInternalId: string,
+      authorId: string
+    ): Promise<string> {
+      // The "new" comment that notifyComment is fanning out for. Seeded
+      // directly so the matrix tests don't have to go through HTTP.
+      const db = getTestDb();
+      const [row] = await db
+        .insert(runComments)
+        .values({
+          runId: runInternalId,
+          userId: authorId,
+          body: "new comment",
+        })
+        .returning({ id: runComments.id });
+      return row.id;
+    }
+
+    it("notifies attributees with comment_attributed", async () => {
+      const { userId: author } = await seedTestUser();
+      const { userId: attributee } = await seedTestUser();
+
+      const runInternalId = await seedRun(instrumentId, "run-attributed");
+      await seedAttribution(runInternalId, attributee);
+      const commentId = await seedAuthorComment(runInternalId, author);
+
+      await notifyComment({
+        runInternalId,
+        commentId,
+        authorUserId: author,
+      });
+
+      const db = getTestDb();
+      const rows = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, runInternalId));
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].userId).toBe(attributee);
+      expect(rows[0].type).toBe("comment_attributed");
+      expect(rows[0].actorUserId).toBe(author);
+      expect(rows[0].commentId).toBe(commentId);
+    });
+
+    it("notifies prior commenters with comment_participated", async () => {
+      const { userId: author } = await seedTestUser();
+      const { userId: participant } = await seedTestUser();
+
+      const runInternalId = await seedRun(instrumentId, "run-participated");
+      await seedPriorComment(runInternalId, participant);
+      const commentId = await seedAuthorComment(runInternalId, author);
+
+      await notifyComment({
+        runInternalId,
+        commentId,
+        authorUserId: author,
+      });
+
+      const db = getTestDb();
+      const rows = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, runInternalId));
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].userId).toBe(participant);
+      expect(rows[0].type).toBe("comment_participated");
+      expect(rows[0].actorUserId).toBe(author);
+    });
+
+    it("attributed wins over participated when a recipient qualifies for both", async () => {
+      const { userId: author } = await seedTestUser();
+      const { userId: both } = await seedTestUser();
+
+      const runInternalId = await seedRun(instrumentId, "run-overlap");
+      await seedAttribution(runInternalId, both);
+      await seedPriorComment(runInternalId, both);
+      const commentId = await seedAuthorComment(runInternalId, author);
+
+      await notifyComment({
+        runInternalId,
+        commentId,
+        authorUserId: author,
+      });
+
+      const db = getTestDb();
+      const rows = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, runInternalId));
+
+      // Exactly one row, and the stronger signal (`attributed`) wins.
+      expect(rows).toHaveLength(1);
+      expect(rows[0].userId).toBe(both);
+      expect(rows[0].type).toBe("comment_attributed");
+    });
+
+    it("never notifies the comment author, even when self-attributed or self-participating", async () => {
+      const { userId: author } = await seedTestUser();
+
+      const runInternalId = await seedRun(instrumentId, "run-author-skip");
+      await seedAttribution(runInternalId, author);
+      await seedPriorComment(runInternalId, author);
+      const commentId = await seedAuthorComment(runInternalId, author);
+
+      await notifyComment({
+        runInternalId,
+        commentId,
+        authorUserId: author,
+      });
+
+      const db = getTestDb();
+      const rows = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, runInternalId));
+
+      expect(rows).toHaveLength(0);
+    });
+
+    it("excludes prior commenters whose own comment is soft-deleted", async () => {
+      const { userId: author } = await seedTestUser();
+      const { userId: ghost } = await seedTestUser();
+
+      const runInternalId = await seedRun(instrumentId, "run-ghost");
+      const ghostCommentId = await seedPriorComment(runInternalId, ghost);
+
+      const db = getTestDb();
+      await db
+        .update(runComments)
+        .set({ deletedAt: new Date() })
+        .where(eq(runComments.id, ghostCommentId));
+
+      const commentId = await seedAuthorComment(runInternalId, author);
+      await notifyComment({
+        runInternalId,
+        commentId,
+        authorUserId: author,
+      });
+
+      const rows = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, runInternalId));
+
+      expect(rows).toHaveLength(0);
+    });
+
+    it("respects per-user comment toggles", async () => {
+      const { userId: author } = await seedTestUser();
+      const { userId: mutedAttributee } = await seedTestUser();
+      const { userId: mutedParticipant } = await seedTestUser();
+      const { userId: enabledAttributee } = await seedTestUser();
+
+      await updatePreferences(mutedAttributee, {
+        commentsAttributedEnabled: false,
+      });
+      await updatePreferences(mutedParticipant, {
+        commentsParticipatedEnabled: false,
+      });
+
+      const runInternalId = await seedRun(instrumentId, "run-toggles");
+      await seedAttribution(runInternalId, mutedAttributee);
+      await seedAttribution(runInternalId, enabledAttributee);
+      await seedPriorComment(runInternalId, mutedParticipant);
+
+      const commentId = await seedAuthorComment(runInternalId, author);
+      await notifyComment({
+        runInternalId,
+        commentId,
+        authorUserId: author,
+      });
+
+      const db = getTestDb();
+      const rows = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, runInternalId));
+
+      // Only the enabled attributee should be notified — both muted
+      // users are skipped, and the per-user gates don't shut down
+      // delivery to unaffected recipients.
+      expect(rows).toHaveLength(1);
+      expect(rows[0].userId).toBe(enabledAttributee);
+      expect(rows[0].type).toBe("comment_attributed");
+    });
+
+    it("short-circuits cleanly when there are no recipients", async () => {
+      const { userId: author } = await seedTestUser();
+
+      const runInternalId = await seedRun(instrumentId, "run-empty");
+      const commentId = await seedAuthorComment(runInternalId, author);
+
+      await expect(
+        notifyComment({
+          runInternalId,
+          commentId,
+          authorUserId: author,
+        })
+      ).resolves.toBeUndefined();
+
+      const db = getTestDb();
+      const rows = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, runInternalId));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("HTTP: POSTing a comment fans out attributees + participants", async () => {
+      const { userId: author, token: authorToken } = await seedTestUser();
+      const { userId: attributee } = await seedTestUser();
+      const { userId: participant } = await seedTestUser();
+
+      const runId = "run-http-comment-smoke";
+      const runInternalId = await seedRun(instrumentId, runId);
+      await seedAttribution(runInternalId, attributee);
+      await seedPriorComment(runInternalId, participant);
+
+      const res = await api(
+        `/api/v1/instruments/${instrumentId}/runs/${runId}/comments`,
+        {
+          method: "POST",
+          token: authorToken,
+          body: { body: "new comment" },
+        }
+      );
+      expect(res.status).toBe(201);
+
+      const db = getTestDb();
+      await waitForNotification(async () => {
+        const rows = await db
+          .select()
+          .from(notifications)
+          .where(eq(notifications.runId, runInternalId));
+        return rows.length >= 2;
+      });
+
+      const rows = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.runId, runInternalId));
+
+      const byUser = new Map(rows.map((r) => [r.userId, r.type]));
+      expect(byUser.get(attributee)).toBe("comment_attributed");
+      expect(byUser.get(participant)).toBe("comment_participated");
+      expect(byUser.has(author)).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // Reading notifications — listNotifications, countUnread, markRead
+  // =========================================================================
+
+  describe("Reading notifications", () => {
+    const instrumentId = "read-tests-instrument";
+    const instrumentDisplayName = "Read Tests Instrument";
+
+    let userA: string;
+    let userB: string;
+    let actor: string;
+
+    beforeEach(async () => {
+      await resetDb();
+      await seedInstrument(instrumentId, instrumentDisplayName);
+      ({ userId: userA } = await seedTestUser());
+      ({ userId: userB } = await seedTestUser());
+      ({ userId: actor } = await seedTestUser());
+    });
+
+    /**
+     * Drive `notifyRunCreated` + `notifyComment` to put rows in the DB
+     * across two recipients. Returns the run + comment ids so individual
+     * tests can assert against them.
+     */
+    async function seedNotificationFixture(runId: string) {
+      const runInternalId = await seedRun(instrumentId, runId);
+
+      // Both recipients subscribed → both receive a `run_created` row.
+      await setInstrumentSubscription(userA, instrumentId, true);
+      await setInstrumentSubscription(userB, instrumentId, true);
+      await notifyRunCreated({ runInternalId, instrumentId });
+
+      // Comment fan-out: userA attributed → comment_attributed; userB
+      // has a prior comment → comment_participated.
+      const db = getTestDb();
+      await db.insert(runAttributions).values({
+        runId: runInternalId,
+        userId: userA,
+      });
+      await db
+        .insert(runComments)
+        .values({ runId: runInternalId, userId: userB, body: "earlier" });
+      const [comment] = await db
+        .insert(runComments)
+        .values({ runId: runInternalId, userId: actor, body: "from actor" })
+        .returning({ id: runComments.id });
+      await notifyComment({
+        runInternalId,
+        commentId: comment.id,
+        authorUserId: actor,
+      });
+
+      return { runInternalId, commentId: comment.id };
+    }
+
+    it("listNotifications orders by createdAt desc and joins run/instrument/actor", async () => {
+      await seedNotificationFixture("run-list-shape");
+
+      const rows = await listNotifications(userA);
+
+      expect(rows.length).toBeGreaterThanOrEqual(2);
+      // Newest first — the comment notification was inserted after the
+      // run notification, so it should appear before it.
+      const types = rows.map((r) => r.type);
+      expect(types.indexOf("comment_attributed")).toBeLessThan(
+        types.indexOf("run_created")
+      );
+
+      const runRow = rows.find((r) => r.type === "run_created")!;
+      expect(runRow.instrumentDisplayName).toBe(instrumentDisplayName);
+      expect(runRow.runDisplayId).toBe("run-list-shape");
+      expect(runRow.actor).toBeNull();
+      expect(runRow.commentId).toBeNull();
+
+      const commentRow = rows.find((r) => r.type === "comment_attributed")!;
+      expect(commentRow.actor).not.toBeNull();
+      expect(commentRow.actor!.id).toBe(actor);
+      expect(commentRow.actor!.initials).toBeTruthy();
+      expect(commentRow.commentId).toBeTruthy();
+    });
+
+    it("listNotifications respects the limit option", async () => {
+      // Three separate runs → three run_created + per-attribution rows
+      // for userA. Asserting limit=1 returns exactly one row.
+      await seedNotificationFixture("run-limit-1");
+      await seedNotificationFixture("run-limit-2");
+      await seedNotificationFixture("run-limit-3");
+
+      const rows = await listNotifications(userA, { limit: 1 });
+      expect(rows).toHaveLength(1);
+    });
+
+    it("listNotifications with unreadOnly filters out already-read rows", async () => {
+      await seedNotificationFixture("run-unread-only");
+
+      const all = await listNotifications(userA);
+      expect(all.length).toBeGreaterThan(0);
+
+      // Mark the first row read and assert it disappears from
+      // unread-only without affecting the unfiltered list.
+      await markRead(userA, [all[0].id]);
+
+      const unread = await listNotifications(userA, { unreadOnly: true });
+      expect(unread.find((r) => r.id === all[0].id)).toBeUndefined();
+      expect(unread.length).toBe(all.length - 1);
+
+      const stillAll = await listNotifications(userA);
+      expect(stillAll.length).toBe(all.length);
+    });
+
+    it("countUnread tracks the unread row count exactly", async () => {
+      await seedNotificationFixture("run-count");
+
+      const initial = await countUnread(userA);
+      expect(initial).toBeGreaterThan(0);
+
+      const rows = await listNotifications(userA);
+      const idsToRead = rows.slice(0, 2).map((r) => r.id);
+      await markRead(userA, idsToRead);
+
+      const after = await countUnread(userA);
+      expect(after).toBe(initial - idsToRead.length);
+    });
+
+    it("markRead with explicit ids marks only those rows", async () => {
+      await seedNotificationFixture("run-mark-targeted");
+
+      const rows = await listNotifications(userA);
+      const target = rows[0];
+
+      await markRead(userA, [target.id]);
+
+      const fresh = await listNotifications(userA);
+      const updated = fresh.find((r) => r.id === target.id)!;
+      expect(updated.readAt).not.toBeNull();
+
+      // Other rows remain unread.
+      const others = fresh.filter((r) => r.id !== target.id);
+      expect(others.every((r) => r.readAt === null)).toBe(true);
+    });
+
+    it("markRead with no ids marks every remaining unread row for the user", async () => {
+      await seedNotificationFixture("run-mark-all");
+
+      expect(await countUnread(userA)).toBeGreaterThan(0);
+      await markRead(userA);
+      expect(await countUnread(userA)).toBe(0);
+    });
+
+    it("markRead cannot touch another user's rows even when their ids are passed", async () => {
+      await seedNotificationFixture("run-cross-user");
+
+      const bRows = await listNotifications(userB);
+      const targetForB = bRows.find((r) => r.readAt === null);
+      expect(targetForB).toBeDefined();
+
+      const bUnreadBefore = await countUnread(userB);
+
+      // Caller is userA, but the id belongs to userB — the user-scoped
+      // `where` in markRead must reject the cross-user attempt.
+      await markRead(userA, [targetForB!.id]);
+
+      const bUnreadAfter = await countUnread(userB);
+      expect(bUnreadAfter).toBe(bUnreadBefore);
+
+      const stillUnread = (await listNotifications(userB)).find(
+        (r) => r.id === targetForB!.id
+      );
+      expect(stillUnread).toBeDefined();
+      expect(stillUnread!.readAt).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // HTTP session gate — every notifications/settings route is session-only
+  // =========================================================================
+
+  describe("Notifications HTTP session gate", () => {
+    let token: string;
+
+    beforeAll(async () => {
+      await resetDb();
+      ({ token } = await seedTestUser({ scopes: ["*"] }));
+    });
+
+    const routes: Array<{
+      label: string;
+      method: "GET" | "POST" | "PUT";
+      path: string;
+      body?: unknown;
+    }> = [
+      {
+        label: "GET /api/v1/notifications",
+        method: "GET",
+        path: "/api/v1/notifications",
+      },
+      {
+        label: "POST /api/v1/notifications",
+        method: "POST",
+        path: "/api/v1/notifications",
+        body: { ids: [] },
+      },
+      {
+        label: "GET /api/v1/settings/notifications",
+        method: "GET",
+        path: "/api/v1/settings/notifications",
+      },
+      {
+        label: "PUT /api/v1/settings/notifications",
+        method: "PUT",
+        path: "/api/v1/settings/notifications",
+        body: { runs_all_muted: true },
+      },
+      {
+        label: "PUT /api/v1/settings/notifications/instruments/:id",
+        method: "PUT",
+        path: "/api/v1/settings/notifications/instruments/anything",
+        body: { enabled: true },
+      },
+    ];
+
+    for (const route of routes) {
+      it(`${route.label} rejects PAT auth with 401`, async () => {
+        const res = await api(route.path, {
+          method: route.method,
+          token,
+          body: route.body,
+        });
+        expect(res.status).toBe(401);
+      });
+
+      it(`${route.label} rejects unauthenticated requests with 401`, async () => {
+        const res = await api(route.path, {
+          method: route.method,
+          body: route.body,
+        });
+        expect(res.status).toBe(401);
+      });
+    }
+
+    it("PUT /settings/notifications/instruments/:id short-circuits at the session gate (not the 404 instrument lookup)", async () => {
+      // The session gate is the first thing the route checks. A PAT
+      // caller targeting a definitely-nonexistent instrument should
+      // still get 401, not 404 — pins ordering between the two checks.
+      const res = await api(
+        "/api/v1/settings/notifications/instruments/definitely-does-not-exist",
+        {
+          method: "PUT",
+          token,
+          body: { enabled: true },
+        }
+      );
+      expect(res.status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an in-app notifications system: a top-right bell + popover, per-instrument subscription switches, and a `/settings/notifications` page for configuring delivery.

- **Schema** — new `notification_type` enum and three tables: `notification_preferences` (per-user master mute + comment triggers), `instrument_notification_subscriptions` (opt-in per (user, instrument)), and `notifications` (one row per delivered event, with a partial index for the unread count). Migration `web/drizzle/0025_add_notifications.sql`.
- **Fan-out** — `notifyRunCreated` fires for new runs (gated by per-user subscription + master mute) and `notifyComment` fires for new comments (attributed and prior-commenter users, with attributed-over-participated precedence, never to the author). Both invoked via `after(...)` from the existing run-create and comment-create routes so the writing path returns immediately.
- **APIs** — session-authed `GET/POST /api/v1/notifications`, `GET/PUT /api/v1/settings/notifications`, and `PUT /api/v1/settings/notifications/instruments/[instrumentId]`.
- **UI** — bell with badge and popover (initial unread count is server-rendered; provider polls every 60 s and supports optimistic mark-all-read); shared `InstrumentNotificationSwitch` reused in the instruments table (new Notify column), in the instrument detail header, and on the settings page; `/settings/notifications` page built with TanStack Form, saving prefs and only the diffed per-instrument PUTs in parallel.

## Test plan

- [x] Apply migration `0025_add_notifications` and verify the new tables/enum exist.
- [x] Visit `/settings/notifications` — confirm the master mute, comment toggles, and per-instrument switches render with current state, can be edited, and persist after refresh.
- [x] On `/instruments` and `/instruments/[id]`, toggle the per-instrument switch and confirm it persists (and the tooltip text reflects the master-muted state).
- [ ] Report a new run (via watcher or `POST /api/v1/instruments/:id/runs`) and verify subscribed users receive a `run_created` notification; muted/unsubscribed users do not.
- [ ] Add a comment to a run — confirm attributed users get a `comment_attributed` notification and prior commenters get `comment_participated`, the comment author never notifies themselves, and the same user only gets one row (attributed precedence).
- [ ] Open the bell popover and verify badge count, item rendering, links to the run/comment, and that "Mark all as read" clears the badge.
- [x] Run `make check-all` (already clean locally).

Made with [Cursor](https://cursor.com)