### PR TITLE
Add zero-credential local dev workflow for Next.js app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,14 @@ fe-test:
 dev:
 	cd web && npm run dev
 
+# Reset the local Postgres database, re-push the Drizzle schema, and load
+# a deterministic seed (dev user + PAT, one instrument per type, watchers,
+# runs, files, comments, attributions, archive jobs). See
+# docs/local-development.md for the full local-only dev workflow.
+.PHONY: db-reseed
+db-reseed:
+	cd web && npm run db:reseed
+
 .PHONY: fe-build
 fe-build:
 	cd web && npm run build

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ See the full [Getting Started guide](docs/getting-started.md) for prerequisites 
 
 ### Guides
 
+- [Local development](docs/local-development.md) — zero-credential dev workflow for the web app + API + database (no watcher / Lambda needed)
 - [Adding an instrument](docs/guides/adding-an-instrument.md) — end-to-end: watcher setup, activation, optional Lambda preprocessing
 - [Installing a watcher](docs/guides/installing-a-watcher.md) — lab operator focused: init, watch, troubleshooting
 - [Managing tokens](docs/guides/managing-tokens.md) — creating, using, and revoking API tokens

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,6 +90,10 @@ Other database commands:
 | `npm run db:push` | Push schema directly (no migration files) |
 | `npm run db:studio` | Open Drizzle Studio GUI |
 | `npm run db:reset` | Drop and re-create the public schema |
+| `npm run db:seed` | Load a deterministic seed (see [Local development](local-development.md)) |
+| `npm run db:reseed` | `db:reset` + `db:push` + `db:seed` in one shot |
+
+> **Web + API + database only?** If you don't need the watcher or Lambda, see [Local development](local-development.md) for a zero-credential setup using `make db-reseed` and a dev-only sign-in.
 
 ## Running locally
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -103,14 +103,16 @@ You can also run `npm run db:seed` on its own — it calls the schema-driven `cl
 | `watchers` | 7 (for active instruments) | Rotates through `watching` / `registered` / `stopped` |
 | `watcher_heartbeats` | ~10 per watching watcher | Spread over the last hour |
 | `watcher_events` | 3 per watching watcher | `watcher_started`, `config_synced`, `file_uploaded` |
-| `instrument_runs` | 5 per active instrument | Last 14 days, alternating `lambda` / `watcher` source |
+| `instrument_runs` | 5 per active instrument | Spread across the last ~2 weeks (3, 6, 9, 12, 15 days back), alternating `lambda` / `watcher` source |
 | `files` | 3 per run | Mix of `uploaded` / `completed` / `failed`, `raw` / `processed` |
 | `run_comments` | 1 per run | Authored by the dev user |
 | `run_attributions` | 1 per run | Dev user attributed |
 | `archive_jobs` | 3 | One each of `ready` / `building` / `failed` |
 | `watcher_release_config` | 1 (singleton) | `9.9.9 / 0.1.0 / stable / false` |
 
-Identifiers are deterministic (`seed-<type>`, `seed-run-1`, …) so screenshots, bug reports, and `curl` examples stay stable across reseeds. The seed does not use Faker or randomness beyond UUIDs and PAT bytes.
+Externally-visible identifiers used in URLs and API paths — instrument IDs (`seed-<type>`) and run IDs (`seed-run-1`, …) — are deterministic across reseeds, so screenshots, bug reports, and `curl` examples against `/api/v1/instruments/seed-plate-reader/runs/seed-run-1` stay stable.
+
+Surrogate UUIDs (watcher IDs, archive job IDs, the per-row primary keys on `instrument_runs` and `files`) and the PAT plaintext are regenerated on every reseed — the seed does not use Faker but it does call `crypto.randomUUID()` and `crypto.randomBytes()` where the schema needs server-side IDs.
 
 ## What's deliberately missing
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,141 @@
+# Local development
+
+A zero-credential workflow for iterating on the **web app + API + database** without standing up the watcher, Lambda, S3, Slack, or Google OAuth. Useful when you're working on UI, REST endpoints, MCP tools, or schema changes and don't care about the full ingestion pipeline.
+
+For the full setup (Google OAuth, real AWS credentials, deployable artifacts) see [Getting started](getting-started.md).
+
+## TL;DR
+
+```sh
+# 1. One-time: install dependencies and create the local Postgres database.
+cd web && npm install && cd ..
+createdb data-hub-local
+
+# 2. Drop a minimal .env into web/ (see below).
+
+# 3. Reset, push schema, seed.
+make db-reseed
+
+# 4. Start the dev server and open http://localhost:3000.
+make dev
+```
+
+Sign in at `/login` using the "Sign in (dev)" button with the seeded `dev@local` email — no password, no Google Workspace.
+
+## Prerequisites
+
+- **PostgreSQL >= 15** running locally on `127.0.0.1:5432` and reachable as the OS user.
+- **Node.js >= 22**.
+
+Python, AWS CLI, Docker, and SAM are not required for this workflow.
+
+## Minimal `.env`
+
+Create `web/.env` with the following. The first two are mandatory; the rest are dummy values that let signed-URL generation and IAM-flagged code paths run without hitting AWS.
+
+```sh
+DATABASE_URL=postgres://localhost:5432/data-hub-local
+
+# Any 32+ character string. NextAuth uses it to sign session JWTs.
+AUTH_SECRET=local-dev-secret-at-least-32-characters!!
+
+# Dummy AWS credentials. The AWS SDK signs presigned URLs locally
+# (HMAC-only — no network call), so any non-empty values work. Actual
+# uploads/downloads against `test-raw-data-bucket` will fail at the
+# browser, which is fine for local dev (see "What's deliberately
+# missing" below).
+AWS_ACCESS_KEY_ID=test-key
+AWS_SECRET_ACCESS_KEY=test-secret
+AWS_REGION=us-east-1
+S3_RAW_DATA_BUCKET=test-raw-data-bucket
+```
+
+Explicitly **do not** set the following — leaving them unset is what makes the relevant features short-circuit cleanly:
+
+- `LAMBDA_FUNCTION_URL` — file reprocessing and "Download all" buttons surface a 503 / "Lambda not configured" message instead of trying to invoke a Function URL.
+- `SLACK_WEBHOOK_URL` — `sendSlackMessage()` in `web/lib/slack.ts` becomes a no-op with a single warn line.
+- `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` — Google sign-in is unused locally; the dev Credentials provider handles auth.
+- `AWS_ROLE_ARN` — Vercel OIDC federation is for production. The local AWS SDK falls back to the static credentials above.
+
+## Sign in (dev only)
+
+`web/lib/auth.ts` registers a `Credentials` provider with id `"dev"` when `process.env.NODE_ENV !== "production"`. The `/login` page renders a matching "Sign in (dev)" form under the Google button. The form accepts any email present in the `user` table and mints a session via the existing JWT strategy — `users.is_admin` is read on sign-in just like for Google sign-ins, so the seeded `dev@local` lands as a workspace admin.
+
+The dev provider is **not** instantiated in production builds. The form is also conditionally rendered server-side, so a production `npm run build` never ships the affordance.
+
+To sign in as a non-admin user instead, seed an extra row manually (or edit `web/scripts/seed-database.ts`) and enter their email in the form.
+
+## Using the seeded PAT
+
+The seed script prints a personal access token after it finishes:
+
+```
+Or call the API with the seeded PAT:
+  curl -H 'Authorization: Bearer dhub_<long-hex>' \
+    http://localhost:3000/api/v1/instruments
+```
+
+The token carries the `*` (wildcard) scope so every v1 endpoint accepts it. Useful for poking at the REST API, the MCP server (`/api/v1/mcp`), or wiring up an external tool while you iterate.
+
+## Resetting
+
+```sh
+make db-reseed
+```
+
+This is `npm run db:reset && npm run db:push && npm run db:seed` under the hood:
+
+| Command | What it does |
+| --- | --- |
+| `npm run db:reset` | `DROP SCHEMA public CASCADE; CREATE SCHEMA public` |
+| `npm run db:push` | Re-apply the Drizzle schema in `web/lib/db/schema.ts` |
+| `npm run db:seed` | Run `web/scripts/seed-database.ts` |
+
+You can also run `npm run db:seed` on its own — it calls the schema-driven `clearAll()` first, so it's safe against an already-populated database.
+
+## What the seed builds
+
+| Entity | Count | Notes |
+| --- | --- | --- |
+| `user` | 1 | `dev@local`, `is_admin = true` |
+| `personal_access_tokens` | 1 | Wildcard scope, no expiry |
+| `instruments` | 8 (one per `instrument_type`) | First row is `pending`; rest `active` |
+| `watchers` | 7 (for active instruments) | Rotates through `watching` / `registered` / `stopped` |
+| `watcher_heartbeats` | ~10 per watching watcher | Spread over the last hour |
+| `watcher_events` | 3 per watching watcher | `watcher_started`, `config_synced`, `file_uploaded` |
+| `instrument_runs` | 5 per active instrument | Last 14 days, alternating `lambda` / `watcher` source |
+| `files` | 3 per run | Mix of `uploaded` / `completed` / `failed`, `raw` / `processed` |
+| `run_comments` | 1 per run | Authored by the dev user |
+| `run_attributions` | 1 per run | Dev user attributed |
+| `archive_jobs` | 3 | One each of `ready` / `building` / `failed` |
+| `watcher_release_config` | 1 (singleton) | `9.9.9 / 0.1.0 / stable / false` |
+
+Identifiers are deterministic (`seed-<type>`, `seed-run-1`, …) so screenshots, bug reports, and `curl` examples stay stable across reseeds. The seed does not use Faker or randomness beyond UUIDs and PAT bytes.
+
+## What's deliberately missing
+
+Some features depend on services that aren't running in this workflow. Each one degrades cleanly rather than crashing the dashboard:
+
+| Feature | Behavior locally | How to enable |
+| --- | --- | --- |
+| File download | Presigned URL renders but GET fails — no real S3 object | Point S3 env vars at a real bucket or LocalStack/MinIO |
+| File upload (from watcher) | `request-upload-url` returns a usable signed URL, but actually PUTting fails | Same |
+| Run archive ("Download all") | 503 "Archive builder is not configured" | Set `LAMBDA_FUNCTION_URL` + `S3_ARCHIVES_BUCKET` and grant `lambda:InvokeFunctionUrl` |
+| File reprocessing | The reprocess endpoint returns null and no Lambda is invoked | Same |
+| Slack notifications on new runs | `console.warn` only, no HTTP call | Set `SLACK_WEBHOOK_URL` |
+| Watcher uploads → Lambda → API loop | Not exercised; the seed inserts the resulting rows directly | Run the watcher (`docs/watcher.md`) and the Lambda (`docs/lambda.md`) end-to-end |
+| Sign in with Google | The button still renders but OAuth callback will 4xx without `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` | `vercel env pull` per `docs/getting-started.md` |
+
+## Where the seed lives
+
+- [web/lib/db/seed.ts](../web/lib/db/seed.ts) — shared builder functions (`seedDevUser`, `seedInstruments`, `seedRuns`, etc.) plus a schema-driven `clearAll()`.
+- [web/scripts/seed-database.ts](../web/scripts/seed-database.ts) — the entry point that `npm run db:seed` runs.
+
+The same builders back the integration test harness in [web/tests/integration/helpers.ts](../web/tests/integration/helpers.ts), so any new table added to `web/lib/db/schema.ts` is automatically included in `clearAll()` and only needs a new builder function if you want it populated by the dev seed.
+
+## Cross-links
+
+- [Getting started](getting-started.md) — full setup with real Google OAuth and AWS credentials.
+- [Architecture](architecture.md) — system overview and data flow.
+- [REST API](api.md) — endpoint reference for the seeded PAT.
+- [MCP server](mcp.md) — Model Context Protocol tools at `/api/v1/mcp`.

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,5 +1,7 @@
 import { Button } from "@/components/ui/button";
-import { signIn } from "@/lib/auth";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { isDevAuthEnabled, signIn } from "@/lib/auth";
 import { Metadata } from "next/types";
 
 export const metadata: Metadata = {
@@ -29,7 +31,54 @@ export default function LoginPage() {
             Sign in with Google
           </Button>
         </form>
+        {isDevAuthEnabled && <DevSignInForm />}
       </div>
+    </div>
+  );
+}
+
+// Dev-only password-less sign-in. Looks up the supplied email in the
+// `user` table (typically a row seeded by `npm run db:seed`) and mints a
+// session via the `dev` Credentials provider in `lib/auth.ts`. The whole
+// component is rendered only when `isDevAuthEnabled` is true — which is
+// derived from `process.env.NODE_ENV !== "production"` server-side — so
+// production builds never ship the affordance.
+function DevSignInForm() {
+  return (
+    <div className="w-full border-t border-border pt-6">
+      <p className="mb-3 text-center text-xs tracking-wider text-muted-foreground uppercase">
+        Local development
+      </p>
+      <form
+        action={async (formData: FormData) => {
+          "use server";
+          const email = formData.get("email");
+          await signIn("dev", {
+            email: typeof email === "string" ? email : "",
+            redirectTo: "/",
+          });
+        }}
+        className="flex w-full flex-col gap-3"
+      >
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="dev-email">Email</Label>
+          <Input
+            id="dev-email"
+            name="email"
+            type="email"
+            placeholder="dev@local"
+            defaultValue="dev@local"
+            required
+          />
+        </div>
+        <Button
+          type="submit"
+          variant="outline"
+          className="w-full cursor-pointer"
+        >
+          Sign in (dev)
+        </Button>
+      </form>
     </div>
   );
 }

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,6 +1,5 @@
+import { DevSignInForm } from "@/components/auth/dev-sign-in-form";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { isDevAuthEnabled, signIn } from "@/lib/auth";
 import { Metadata } from "next/types";
 
@@ -31,54 +30,10 @@ export default function LoginPage() {
             Sign in with Google
           </Button>
         </form>
-        {isDevAuthEnabled && <DevSignInForm />}
+        {isDevAuthEnabled && (
+          <DevSignInForm callbackUrl="/" inputId="login-dev-email" />
+        )}
       </div>
-    </div>
-  );
-}
-
-// Dev-only password-less sign-in. Looks up the supplied email in the
-// `user` table (typically a row seeded by `npm run db:seed`) and mints a
-// session via the `dev` Credentials provider in `lib/auth.ts`. The whole
-// component is rendered only when `isDevAuthEnabled` is true — which is
-// derived from `process.env.NODE_ENV !== "production"` server-side — so
-// production builds never ship the affordance.
-function DevSignInForm() {
-  return (
-    <div className="w-full border-t border-border pt-6">
-      <p className="mb-3 text-center text-xs tracking-wider text-muted-foreground uppercase">
-        Local development
-      </p>
-      <form
-        action={async (formData: FormData) => {
-          "use server";
-          const email = formData.get("email");
-          await signIn("dev", {
-            email: typeof email === "string" ? email : "",
-            redirectTo: "/",
-          });
-        }}
-        className="flex w-full flex-col gap-3"
-      >
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="dev-email">Email</Label>
-          <Input
-            id="dev-email"
-            name="email"
-            type="email"
-            placeholder="dev@local"
-            defaultValue="dev@local"
-            required
-          />
-        </div>
-        <Button
-          type="submit"
-          variant="outline"
-          className="w-full cursor-pointer"
-        >
-          Sign in (dev)
-        </Button>
-      </form>
     </div>
   );
 }

--- a/web/components/auth/dev-sign-in-form.tsx
+++ b/web/components/auth/dev-sign-in-form.tsx
@@ -1,0 +1,60 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { signIn } from "@/lib/auth";
+
+// Dev-only password-less sign-in. Shared between `/login` (the dedicated
+// sign-in route) and the in-page `SignInRequired` gate so both surfaces
+// render the same affordance and never drift. The component itself does
+// not check `isDevAuthEnabled` — call sites are expected to do that —
+// because rendering this form is meaningless unless the matching
+// Credentials provider is registered in `lib/auth.ts`.
+//
+// `inputId` is parameterized to keep the `<label htmlFor>` association
+// unique if both gates ever render in the same React tree (e.g. while
+// debugging).
+export function DevSignInForm({
+  callbackUrl,
+  inputId = "dev-sign-in-email",
+}: {
+  callbackUrl: string;
+  inputId?: string;
+}) {
+  return (
+    <div className="w-full border-t border-border pt-6">
+      <p className="mb-3 text-center text-xs tracking-wider text-muted-foreground uppercase">
+        Local development
+      </p>
+      <form
+        action={async (formData: FormData) => {
+          "use server";
+          const email = formData.get("email");
+          await signIn("dev", {
+            email: typeof email === "string" ? email : "",
+            redirectTo: callbackUrl,
+          });
+        }}
+        className="flex w-full flex-col gap-3"
+      >
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={inputId}>Email</Label>
+          <Input
+            id={inputId}
+            name="email"
+            type="email"
+            placeholder="dev@local"
+            defaultValue="dev@local"
+            required
+          />
+        </div>
+        <Button
+          type="submit"
+          variant="outline"
+          className="w-full cursor-pointer"
+        >
+          Sign in (dev)
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/web/components/auth/dev-sign-in-form.tsx
+++ b/web/components/auth/dev-sign-in-form.tsx
@@ -28,6 +28,9 @@ export function DevSignInForm({
       <form
         action={async (formData: FormData) => {
           "use server";
+          if (process.env.NODE_ENV === "production") {
+            throw new Error("Dev sign-in is disabled in production");
+          }
           const email = formData.get("email");
           await signIn("dev", {
             email: typeof email === "string" ? email : "",

--- a/web/components/auth/sign-in-required.tsx
+++ b/web/components/auth/sign-in-required.tsx
@@ -1,5 +1,6 @@
+import { DevSignInForm } from "@/components/auth/dev-sign-in-form";
 import { Button } from "@/components/ui/button";
-import { signIn } from "@/lib/auth";
+import { isDevAuthEnabled, signIn } from "@/lib/auth";
 
 type SignInRequiredProps = {
   /**
@@ -24,8 +25,10 @@ type SignInRequiredProps = {
  * `og:title` / `og:description` for the route. Real users land on a clean
  * sign-in CTA that returns them to the original URL afterwards.
  *
- * Mirrors the visual shell of `app/login/page.tsx` so the experience is
- * indistinguishable from hitting `/login` directly.
+ * Mirrors the visual shell of `app/login/page.tsx` (including the
+ * non-production dev sign-in affordance) so the experience is
+ * indistinguishable from hitting `/login` directly. Both gates pull from
+ * the same `isDevAuthEnabled` flag in `lib/auth.ts`.
  */
 export function SignInRequired({ callbackUrl, children }: SignInRequiredProps) {
   return (
@@ -50,6 +53,12 @@ export function SignInRequired({ callbackUrl, children }: SignInRequiredProps) {
             Sign in with Google
           </Button>
         </form>
+        {isDevAuthEnabled && (
+          <DevSignInForm
+            callbackUrl={callbackUrl}
+            inputId="sign-in-required-dev-email"
+          />
+        )}
       </div>
     </div>
   );

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -4,6 +4,7 @@ import { accounts, sessions, users } from "@/lib/db/schema";
 import { DrizzleAdapter } from "@auth/drizzle-adapter";
 import { eq } from "drizzle-orm";
 import NextAuth from "next-auth";
+import Credentials from "next-auth/providers/credentials";
 import Google from "next-auth/providers/google";
 import { cache } from "react";
 
@@ -55,6 +56,49 @@ async function resolveIsAdmin(userId: string): Promise<boolean> {
   return row.isAdmin;
 }
 
+// Dev-only credentials provider: lets a local developer sign in as any
+// user already present in the `user` table (typically seeded by
+// `npm run db:seed`) by entering only their email — no Google OAuth, no
+// password. Gated to non-production so a production build can never
+// instantiate it; the `/login` page hides the affordance under the same
+// guard. Combined with `session.strategy: "jwt"` below, the credentials
+// provider mints a JWT directly (the DrizzleAdapter is bypassed for this
+// provider — NextAuth's documented behavior for credentials + JWT).
+const isDevAuthEnabled = process.env.NODE_ENV !== "production";
+
+const providers = [
+  Google,
+  ...(isDevAuthEnabled
+    ? [
+        Credentials({
+          id: "dev",
+          name: "Dev account",
+          credentials: {
+            email: { label: "Email", type: "text" },
+          },
+          async authorize(credentials) {
+            const email =
+              typeof credentials?.email === "string"
+                ? credentials.email.trim().toLowerCase()
+                : null;
+            if (!email) return null;
+            const [row] = await db
+              .select({
+                id: users.id,
+                name: users.name,
+                email: users.email,
+                image: users.image,
+              })
+              .from(users)
+              .where(eq(users.email, email))
+              .limit(1);
+            return row ?? null;
+          },
+        }),
+      ]
+    : []),
+];
+
 const {
   handlers,
   signIn,
@@ -66,7 +110,7 @@ const {
     accountsTable: accounts,
     sessionsTable: sessions,
   }),
-  providers: [Google],
+  providers,
   pages: {
     signIn: "/login",
   },
@@ -105,6 +149,6 @@ const {
   },
 });
 
-export { handlers, signIn, signOut };
+export { handlers, isDevAuthEnabled, signIn, signOut };
 
 export const auth = cache(uncachedAuth);

--- a/web/lib/db/seed.ts
+++ b/web/lib/db/seed.ts
@@ -1,0 +1,383 @@
+// Shared seed builders used by both the local dev seed script
+// (`scripts/seed-database.ts` → `npm run db:seed`) and the integration test
+// helpers (`tests/integration/helpers.ts`). Centralizing them in `lib/`
+// keeps the token-generation logic, instrument-type coverage, and TRUNCATE
+// list in sync between the two consumers — adding a new table to the
+// schema only requires updating this file.
+//
+// The functions are intentionally minimal and deterministic: no Faker, no
+// randomness beyond UUIDs / token bytes. Bug reports against a seeded
+// database should be reproducible from the same seed call sequence.
+
+import { generateToken, getTokenPrefix, hashToken } from "@/lib/tokens";
+import { getTableName, isTable, sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import * as schema from "./schema";
+
+export type Db = PostgresJsDatabase<typeof schema>;
+
+// ---------------------------------------------------------------------------
+// clearAll — schema-driven TRUNCATE of every `pgTable` declared in
+// `lib/db/schema.ts`. Uses CASCADE so FK ordering doesn't matter; the
+// previous static `TRUNCATE_ORDER` list was a maintenance hazard (every
+// new table required a manual edit) and is replaced by this.
+// ---------------------------------------------------------------------------
+
+export async function clearAll(db: Db): Promise<void> {
+  // Cast through `unknown[]` so the `isTable` type predicate can narrow
+  // away the `PgEnum`s and other non-table exports in the schema module
+  // without TS complaining about cross-module generic identity on the
+  // `PgTable<…>` types (which all structurally extend drizzle's `Table`
+  // but TS won't accept the union as-is).
+  const tableNames = (Object.values(schema) as unknown[])
+    .filter(isTable)
+    .map((t) => getTableName(t));
+
+  if (tableNames.length === 0) return;
+
+  // Quote each identifier so camelCase Drizzle-generated names (e.g.
+  // `"user"` — a reserved word in some SQL dialects) round-trip safely.
+  // `TRUNCATE ... RESTART IDENTITY CASCADE` resets sequences too so seed
+  // ids start at 1 on every reseed, which keeps screenshot/bug-report
+  // identifiers stable across reruns.
+  const quoted = tableNames.map((n) => `"${n}"`).join(", ");
+  await db.execute(
+    sql.raw(`TRUNCATE TABLE ${quoted} RESTART IDENTITY CASCADE`)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// User + PAT
+// ---------------------------------------------------------------------------
+
+export type SeedUserOptions = {
+  email?: string;
+  name?: string;
+  isAdmin?: boolean;
+  // Permission scopes for the minted PAT. Defaults to `["*"]` so the
+  // returned token can hit every v1 route — matches the historical test
+  // behavior. Pass an explicit list to exercise scope enforcement.
+  scopes?: string[];
+  // Optional PAT expiry. NULL (the default) means no expiry.
+  expiresAt?: Date | null;
+};
+
+export type SeedUserResult = {
+  userId: string;
+  email: string;
+  token: string;
+};
+
+export async function seedDevUser(
+  db: Db,
+  options: SeedUserOptions = {}
+): Promise<SeedUserResult> {
+  const userId = crypto.randomUUID();
+  const email = options.email ?? `test-${userId.slice(0, 8)}@example.com`;
+
+  await db.insert(schema.users).values({
+    id: userId,
+    name: options.name ?? "Test User",
+    email,
+    isAdmin: options.isAdmin ?? false,
+  });
+
+  const plaintext = generateToken();
+  await db.insert(schema.personalAccessTokens).values({
+    userId,
+    name: "seeded-token",
+    tokenHash: hashToken(plaintext),
+    tokenPrefix: getTokenPrefix(plaintext),
+    scopes: options.scopes ?? ["*"],
+    expiresAt: options.expiresAt !== undefined ? options.expiresAt : null,
+  });
+
+  return { userId, email, token: plaintext };
+}
+
+// ---------------------------------------------------------------------------
+// Watcher release config — singleton row consulted by the
+// `/api/v1/watchers/:id/update-check` endpoint. Tests and the dev seed both
+// want a stable baseline so the endpoint returns deterministic values.
+// ---------------------------------------------------------------------------
+
+export async function seedWatcherReleaseConfig(db: Db): Promise<void> {
+  await db.execute(
+    sql`INSERT INTO watcher_release_config
+       (id, latest_version, min_supported_version, channel, mandatory)
+     VALUES
+       (true, '9.9.9', '0.1.0', 'stable', false)
+     ON CONFLICT (id) DO UPDATE SET
+       latest_version = EXCLUDED.latest_version,
+       min_supported_version = EXCLUDED.min_supported_version,
+       channel = EXCLUDED.channel,
+       mandatory = EXCLUDED.mandatory,
+       updated_at = now(),
+       updated_by = NULL`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Instruments — one row per value in `instrumentTypeEnum.enumValues` so the
+// dashboard exercises every instrument-type-specific UI variant. One
+// instrument is seeded as `pending` so the activation flow shows up.
+// ---------------------------------------------------------------------------
+
+export type SeededInstrument = {
+  id: string;
+  displayName: string;
+  instrumentType: schema.InstrumentType;
+  status: "pending" | "active" | "inactive";
+};
+
+const INSTRUMENT_LABELS: Record<schema.InstrumentType, string> = {
+  generic: "Generic Lab Instrument",
+  plate_reader: "SpectraMax iD3 Plate Reader",
+  gel_doc: "Azure 600 Gel Doc",
+  qpcr: "Azure Cielo qPCR",
+  tape_station: "Agilent TapeStation",
+  hina_microscope: "Hina Microscope",
+  epson_v700_scanner: "Epson V700 Scanner",
+  instant_raman: "Instant Raman Spectrometer",
+};
+
+export async function seedInstruments(db: Db): Promise<SeededInstrument[]> {
+  const rows: SeededInstrument[] = schema.VALID_INSTRUMENT_TYPES.map(
+    (type, idx) => ({
+      id: `seed-${type.replace(/_/g, "-")}`,
+      displayName: INSTRUMENT_LABELS[type],
+      instrumentType: type,
+      // First row pending so the "activate instrument" admin flow is
+      // exercised; everything else active.
+      status: idx === 0 ? ("pending" as const) : ("active" as const),
+    })
+  );
+
+  await db.insert(schema.instruments).values(rows);
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Watchers + heartbeats + events
+// ---------------------------------------------------------------------------
+
+export type SeededWatcher = {
+  id: string;
+  instrumentId: string;
+  status: "registered" | "watching" | "stopped";
+};
+
+const WATCHER_STATUSES = ["watching", "registered", "stopped"] as const;
+
+export async function seedWatchers(
+  db: Db,
+  instrumentIds: string[]
+): Promise<SeededWatcher[]> {
+  if (instrumentIds.length === 0) return [];
+
+  const now = new Date();
+  const watcherValues = instrumentIds.map((instrumentId, idx) => {
+    const status = WATCHER_STATUSES[idx % WATCHER_STATUSES.length];
+    return {
+      id: crypto.randomUUID(),
+      instrumentId,
+      hostname: `seed-host-${idx + 1}`,
+      osInfo: "Windows 11 23H2",
+      watcherVersion: "9.9.9",
+      configChecksum: `seed-checksum-${idx + 1}`,
+      configYaml: "# seeded watcher config\n",
+      lastHeartbeatAt: status === "watching" ? now : null,
+      status,
+    };
+  });
+
+  const inserted = await db
+    .insert(schema.watchers)
+    .values(watcherValues)
+    .returning({
+      id: schema.watchers.id,
+      instrumentId: schema.watchers.instrumentId,
+      status: schema.watchers.status,
+    });
+
+  const watchingIds = inserted
+    .filter((w) => w.status === "watching")
+    .map((w) => w.id);
+
+  if (watchingIds.length > 0) {
+    // 10 heartbeats spread over the last hour for each watching watcher.
+    const heartbeatRows = watchingIds.flatMap((watcherId) =>
+      Array.from({ length: 10 }, (_, i) => ({
+        watcherId,
+        timestamp: new Date(now.getTime() - i * 5 * 60_000),
+        status: "watching",
+        uploadMode: "auto" as const,
+        filesUploadedSinceLast: i === 0 ? 0 : 1,
+        runsReportedSinceLast: 0,
+        errorsSinceLast: 0,
+        uptimeSeconds: 3600 - i * 300,
+      }))
+    );
+    await db.insert(schema.watcherHeartbeats).values(heartbeatRows);
+
+    const eventRows = watchingIds.flatMap((watcherId) => [
+      {
+        watcherId,
+        eventType: "watcher_started" as const,
+        message: "Watcher started",
+        details: {},
+        timestamp: new Date(now.getTime() - 60 * 60_000),
+      },
+      {
+        watcherId,
+        eventType: "config_synced" as const,
+        message: "Config synced from server",
+        details: {},
+        timestamp: new Date(now.getTime() - 50 * 60_000),
+      },
+      {
+        watcherId,
+        eventType: "file_uploaded" as const,
+        message: "Uploaded data_001.csv to S3",
+        details: { filename: "data_001.csv" },
+        timestamp: new Date(now.getTime() - 10 * 60_000),
+      },
+    ]);
+    await db.insert(schema.watcherEvents).values(eventRows);
+  }
+
+  return inserted;
+}
+
+// ---------------------------------------------------------------------------
+// Runs + files — fake S3 keys under a `test-raw-data-bucket` namespace so
+// signed-URL generation works locally (signing is HMAC-only). Actually
+// fetching the files won't work without real S3, which is documented in
+// docs/local-development.md.
+// ---------------------------------------------------------------------------
+
+export type SeededRun = {
+  id: string;
+  instrumentId: string;
+  runId: string;
+};
+
+const FILE_STATUSES = ["uploaded", "completed", "failed"] as const;
+
+export async function seedRuns(
+  db: Db,
+  instrumentId: string,
+  count: number = 5
+): Promise<SeededRun[]> {
+  if (count <= 0) return [];
+
+  const now = new Date();
+  const runValues = Array.from({ length: count }, (_, i) => {
+    const acquiredAt = new Date(now.getTime() - (i + 1) * 24 * 60 * 60_000);
+    return {
+      instrumentId,
+      runId: `seed-run-${i + 1}`,
+      source: (i % 2 === 0 ? "lambda" : "watcher") as "lambda" | "watcher",
+      metadata: { seeded: true, sample_count: 96 - i },
+      acquiredAt,
+    };
+  });
+
+  const runs = await db
+    .insert(schema.instrumentRuns)
+    .values(runValues)
+    .returning({
+      id: schema.instrumentRuns.id,
+      instrumentId: schema.instrumentRuns.instrumentId,
+      runId: schema.instrumentRuns.runId,
+    });
+
+  const fileRows = runs.flatMap((run, runIdx) =>
+    Array.from({ length: 3 }, (_, fi) => {
+      const status = FILE_STATUSES[(runIdx + fi) % FILE_STATUSES.length];
+      const category = fi === 2 ? ("processed" as const) : ("raw" as const);
+      const filename = `${category}_${fi + 1}.csv`;
+      return {
+        instrumentRunId: run.id,
+        relativePath: filename,
+        s3Bucket: "test-raw-data-bucket",
+        s3Key: `${run.instrumentId}/${run.runId}/${filename}`,
+        filename,
+        contentType: "text/csv",
+        sizeBytes: 1024 * (fi + 1),
+        category,
+        status,
+        metadata: { seeded: true },
+        errorMessage:
+          status === "failed" ? "Seeded failure for UI exercise" : null,
+        uploadedAt: status !== "failed" ? new Date() : null,
+        processedAt: status === "completed" ? new Date() : null,
+      };
+    })
+  );
+  await db.insert(schema.files).values(fileRows);
+
+  return runs;
+}
+
+// ---------------------------------------------------------------------------
+// Run comments + attributions
+// ---------------------------------------------------------------------------
+
+export async function seedRunComments(
+  db: Db,
+  runs: SeededRun[],
+  userId: string
+): Promise<void> {
+  if (runs.length === 0) return;
+  const rows = runs.map((run, i) => ({
+    runId: run.id,
+    userId,
+    body: `Seeded comment ${i + 1} on **${run.runId}** — looks good!`,
+  }));
+  await db.insert(schema.runComments).values(rows);
+}
+
+export async function seedRunAttributions(
+  db: Db,
+  runs: SeededRun[],
+  userId: string
+): Promise<void> {
+  if (runs.length === 0) return;
+  const rows = runs.map((run) => ({ runId: run.id, userId }));
+  await db.insert(schema.runAttributions).values(rows);
+}
+
+// ---------------------------------------------------------------------------
+// Archive jobs — one row in each lifecycle state so the download-archive UI
+// renders every variant.
+// ---------------------------------------------------------------------------
+
+export async function seedArchiveJobs(
+  db: Db,
+  runs: SeededRun[],
+  createdBy?: string
+): Promise<void> {
+  if (runs.length === 0) return;
+
+  const statuses = ["ready", "building", "failed"] as const;
+  const rows = statuses.slice(0, runs.length).map((status, i) => {
+    const run = runs[i];
+    return {
+      instrumentRunId: run.id,
+      fingerprint: `seed-fingerprint-${run.runId}`,
+      archiveBucket: status === "ready" ? "test-archives-bucket" : null,
+      archiveKey:
+        status === "ready"
+          ? `runs/${run.instrumentId}/${run.runId}/seed.zip`
+          : null,
+      sizeBytes: status === "ready" ? 1_048_576 : null,
+      status,
+      errorMessage: status === "failed" ? "Seeded archive build failure" : null,
+      createdBy: createdBy ?? null,
+      completedAt:
+        status === "ready" || status === "failed" ? new Date() : null,
+    };
+  });
+  await db.insert(schema.archiveJobs).values(rows);
+}

--- a/web/lib/db/seed.ts
+++ b/web/lib/db/seed.ts
@@ -271,9 +271,13 @@ export async function seedRuns(
 ): Promise<SeededRun[]> {
   if (count <= 0) return [];
 
+  // Spread runs across the last ~2 weeks (3, 6, 9, 12, 15 days back for
+  // count = 5) so UI date filters like "last 7 days" / "last 14 days"
+  // return non-empty, differing result sets.
   const now = new Date();
+  const dayMs = 24 * 60 * 60_000;
   const runValues = Array.from({ length: count }, (_, i) => {
-    const acquiredAt = new Date(now.getTime() - (i + 1) * 24 * 60 * 60_000);
+    const acquiredAt = new Date(now.getTime() - (i + 1) * 3 * dayMs);
     return {
       instrumentId,
       runId: `seed-run-${i + 1}`,

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,8 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "db:reset": "tsx scripts/reset-database.ts",
+    "db:seed": "tsx scripts/seed-database.ts",
+    "db:reseed": "npm run db:reset && npm run db:push && npm run db:seed",
     "test:mcp": "vitest run --config vitest.config.ts",
     "test:mcp:watch": "vitest --config vitest.config.ts",
     "test:integration": "vitest run --config vitest.integration.config.ts",

--- a/web/scripts/seed-database.ts
+++ b/web/scripts/seed-database.ts
@@ -1,0 +1,88 @@
+// Seed the local development database with a believable steady state:
+// a workspace admin user + PAT, one instrument per type, watchers with
+// heartbeats / events, runs with files, comments, attributions, and
+// archive jobs in each lifecycle state.
+//
+// Usage:
+//   npm run db:seed           # seed on top of whatever's there
+//   npm run db:reseed         # reset → push → seed (the usual loop)
+//
+// Opens its own `postgres` client (instead of importing `@/lib/db`) so
+// the pool closes cleanly at the end of the script — the app-side
+// singleton in `lib/db/index.ts` is wired for long-lived Next.js
+// processes and never calls `.end()`.
+
+import * as schema from "@/lib/db/schema";
+import {
+  clearAll,
+  seedArchiveJobs,
+  seedDevUser,
+  seedInstruments,
+  seedRunAttributions,
+  seedRunComments,
+  seedRuns,
+  seedWatcherReleaseConfig,
+  seedWatchers,
+} from "@/lib/db/seed";
+import "dotenv/config";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  console.error(
+    "DATABASE_URL is not set. Add it to web/.env or export it before running this script."
+  );
+  process.exit(1);
+}
+
+const client = postgres(databaseUrl);
+const db = drizzle(client, { schema });
+
+console.log("Clearing existing rows…");
+await clearAll(db);
+
+console.log("Seeding watcher_release_config…");
+await seedWatcherReleaseConfig(db);
+
+console.log("Seeding dev user…");
+const { userId, email, token } = await seedDevUser(db, {
+  email: "dev@local",
+  name: "Dev User",
+  isAdmin: true,
+});
+
+console.log("Seeding instruments…");
+const instruments = await seedInstruments(db);
+
+console.log("Seeding watchers + heartbeats + events…");
+await seedWatchers(
+  db,
+  instruments.filter((i) => i.status === "active").map((i) => i.id)
+);
+
+console.log("Seeding runs + files…");
+const runs = (
+  await Promise.all(
+    instruments
+      .filter((i) => i.status === "active")
+      .map((i) => seedRuns(db, i.id, 5))
+  )
+).flat();
+
+console.log("Seeding run comments + attributions…");
+await seedRunComments(db, runs, userId);
+await seedRunAttributions(db, runs, userId);
+
+console.log("Seeding archive_jobs…");
+await seedArchiveJobs(db, runs, userId);
+
+await client.end();
+
+console.log("");
+console.log("Done. Sign in at http://localhost:3000/login with:");
+console.log(`  email: ${email}`);
+console.log("");
+console.log("Or call the API with the seeded PAT:");
+console.log(`  curl -H 'Authorization: Bearer ${token}' \\`);
+console.log(`    http://localhost:3000/api/v1/instruments`);

--- a/web/scripts/seed-database.ts
+++ b/web/scripts/seed-database.ts
@@ -23,6 +23,7 @@ import {
   seedRuns,
   seedWatcherReleaseConfig,
   seedWatchers,
+  type SeededRun,
 } from "@/lib/db/seed";
 import "dotenv/config";
 import { drizzle } from "drizzle-orm/postgres-js";
@@ -62,13 +63,11 @@ await seedWatchers(
 );
 
 console.log("Seeding runs + files…");
-const runs = (
-  await Promise.all(
-    instruments
-      .filter((i) => i.status === "active")
-      .map((i) => seedRuns(db, i.id, 5))
-  )
-).flat();
+const activeInstruments = instruments.filter((i) => i.status === "active");
+const runs: SeededRun[] = [];
+for (const instrument of activeInstruments) {
+  runs.push(...(await seedRuns(db, instrument.id, 5)));
+}
 
 console.log("Seeding run comments + attributions…");
 await seedRunComments(db, runs, userId);

--- a/web/tests/integration/helpers.ts
+++ b/web/tests/integration/helpers.ts
@@ -1,6 +1,11 @@
 import * as schema from "@/lib/db/schema";
+import {
+  clearAll,
+  seedDevUser,
+  seedWatcherReleaseConfig,
+  type SeedUserOptions,
+} from "@/lib/db/seed";
 import { drizzle } from "drizzle-orm/postgres-js";
-import { createHash, randomBytes } from "node:crypto";
 import postgres from "postgres";
 
 // ---------------------------------------------------------------------------
@@ -31,79 +36,30 @@ export async function closeTestDb() {
   }
 }
 
-// Tables listed leaf-first (children before parents) to satisfy FK constraints.
-// CASCADE handles any ordering gaps, but explicit order avoids relying on it.
-// Quoted names match Drizzle-generated tables that use camelCase identifiers.
-const TRUNCATE_ORDER = [
-  "notifications",
-  "instrument_notification_subscriptions",
-  "notification_preferences",
-  "files",
-  "run_attributions",
-  "run_comments",
-  "instrument_runs",
-  "watcher_events",
-  "watcher_heartbeats",
-  "watchers",
-  "personal_access_tokens",
-  "session",
-  "account",
-  "instruments",
-  '"user"',
-] as const;
-
+// TRUNCATE every `pgTable` declared in `lib/db/schema.ts`, then re-seed
+// the `watcher_release_config` singleton with the deterministic baseline
+// `9.9.9 / 0.1.0 / stable / false`. Tests previously hard-coded both the
+// table list and the singleton SQL inline; both now live in
+// `@/lib/db/seed` so adding a new table doesn't require touching this
+// file.
+//
+// `clearAll` uses TRUNCATE CASCADE, which ignores the `ON DELETE SET NULL`
+// on `watcher_release_config.updated_by → user.id` and wipes the singleton
+// regardless of whether it's in the TRUNCATE list. Re-seeding it after
+// the clear keeps every test's update-check baseline identical to a
+// fresh global setup.
 export async function resetDb() {
   const db = getTestDb();
-  for (const table of TRUNCATE_ORDER) {
-    await db.execute(
-      `TRUNCATE TABLE ${table} CASCADE` as unknown as Parameters<
-        typeof db.execute
-      >[0]
-    );
-  }
-
-  // Re-seed the `watcher_release_config` singleton with the same
-  // defaults the global setup uses (9.9.9 / 0.1.0 / stable / false).
-  // The TRUNCATE on "user" above cascades through the
-  // `updated_by → user.id` FK and wipes this row even though
-  // `watcher_release_config` is not in TRUNCATE_ORDER — TRUNCATE CASCADE
-  // ignores the ON DELETE SET NULL clause and unconditionally clears
-  // dependent rows. Re-seeding here keeps every test's update-check
-  // baseline identical to a fresh global setup.
-  await db.execute(
-    `INSERT INTO watcher_release_config
-       (id, latest_version, min_supported_version, channel, mandatory)
-     VALUES
-       (true, '9.9.9', '0.1.0', 'stable', false)
-     ON CONFLICT (id) DO UPDATE SET
-       latest_version = EXCLUDED.latest_version,
-       min_supported_version = EXCLUDED.min_supported_version,
-       channel = EXCLUDED.channel,
-       mandatory = EXCLUDED.mandatory,
-       updated_at = now(),
-       updated_by = NULL` as unknown as Parameters<typeof db.execute>[0]
-  );
+  await clearAll(db);
+  await seedWatcherReleaseConfig(db);
 }
 
 // ---------------------------------------------------------------------------
-// Auth seeding — duplicates the token generation logic from @/lib/tokens
-// rather than importing it. This avoids pulling in the app's module graph
-// (which may trigger Next.js-specific side effects) into test workers.
+// Auth seeding — thin wrapper around the shared `seedDevUser` builder in
+// `@/lib/db/seed`. The shared builder is reused by `scripts/seed-database.ts`
+// for the local-dev workflow, so test seeding and dev seeding share the
+// same token-generation and admin-flag logic.
 // ---------------------------------------------------------------------------
-
-const TOKEN_PREFIX = "dhub_";
-
-function generateToken(): string {
-  return TOKEN_PREFIX + randomBytes(32).toString("hex");
-}
-
-function hashToken(plaintext: string): string {
-  return createHash("sha256").update(plaintext).digest("hex");
-}
-
-function getTokenPrefix(plaintext: string): string {
-  return plaintext.slice(0, TOKEN_PREFIX.length + 4);
-}
 
 // Seeds a user + PAT directly in the database. Returns the plaintext token
 // for use in `Authorization: Bearer dhub_...` headers. The server never
@@ -117,32 +73,14 @@ function getTokenPrefix(plaintext: string): string {
 // session-authenticated routes (PAT requests never consult `user.is_admin`),
 // but exposing the option here keeps the seeding helper future-proof for
 // any cookie-based session test harness layered on later.
-export async function seedTestUser(options?: {
-  expiresAt?: Date | null;
-  scopes?: string[];
-  isAdmin?: boolean;
-}) {
-  const db = getTestDb();
-
-  const userId = crypto.randomUUID();
-  await db.insert(schema.users).values({
-    id: userId,
+export async function seedTestUser(
+  options?: Pick<SeedUserOptions, "expiresAt" | "scopes" | "isAdmin">
+) {
+  const { userId, token } = await seedDevUser(getTestDb(), {
+    ...options,
     name: "Test User",
-    email: `test-${userId.slice(0, 8)}@example.com`,
-    isAdmin: options?.isAdmin ?? false,
   });
-
-  const plaintext = generateToken();
-  await db.insert(schema.personalAccessTokens).values({
-    userId,
-    name: "integration-test-token",
-    tokenHash: hashToken(plaintext),
-    tokenPrefix: getTokenPrefix(plaintext),
-    scopes: options?.scopes ?? ["*"],
-    expiresAt: options?.expiresAt !== undefined ? options.expiresAt : null,
-  });
-
-  return { userId, token: plaintext };
+  return { userId, token };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- New shared seed module `web/lib/db/seed.ts` with deterministic builders for users/PATs, instruments, watchers + heartbeats + events, runs + files, comments, attributions, archive jobs, and the `watcher_release_config` singleton, plus a schema-driven `clearAll()` that replaces the static `TRUNCATE_ORDER` maintenance hazard in the integration test helpers.
- New `npm run db:seed` / `npm run db:reseed` scripts and a `make db-reseed` target so a developer can run `createdb data-hub-local && make db-reseed && make dev` and land on a populated dashboard.
- Non-production `Credentials` provider in `web/lib/auth.ts` (id `dev`) plus a matching "Sign in (dev)" affordance on `/login`, both gated by `process.env.NODE_ENV !== "production"`. The existing JWT callback handles `isAdmin` resolution on sign-in, so no extra wiring was needed.
- New `docs/local-development.md` covering the TL;DR, minimal `.env`, dev sign-in, seeded PAT usage, what the seed builds, and what's deliberately missing (S3 round-trips, Lambda invocations, Slack webhooks). Linked from the README guides list and from `docs/getting-started.md`.
- `web/tests/integration/helpers.ts` now delegates to the shared seed module — same behavior, no more duplicated TRUNCATE list or token-generation logic.

## Test plan

- [x] `make check-all` (Python + web format/lint/typecheck) passes locally — confirmed.
- [x] `createdb data-hub-local && make db-reseed` populates the dev DB and prints a usable PAT.
- [x] `make dev` → `/login` shows the "Sign in (dev)" form; submitting `dev@local` lands on a populated dashboard as a workspace admin.
- [x] `curl -H 'Authorization: Bearer <PAT>' http://localhost:3000/api/v1/instruments` returns the seeded instruments.
- [x] `make fe-test-integration` still passes (helpers were refactored, not behavior-changed).
- [x] Production build (`npm run build` with `NODE_ENV=production`) does not include the dev Credentials provider or the dev sign-in form.

Made with [Cursor](https://cursor.com)