### PR TITLE
Web: Enhance notifications with date buckets and per-instrument grouping

### DIFF
--- a/web/app/api/v1/notifications/route.ts
+++ b/web/app/api/v1/notifications/route.ts
@@ -45,7 +45,9 @@ export async function GET(request: NextRequest) {
       run_display_id: n.runDisplayId,
       instrument_id: n.instrumentId,
       instrument_display_name: n.instrumentDisplayName,
+      instrument_type: n.instrumentType,
       comment_id: n.commentId,
+      comment_body: n.commentBody,
       actor: n.actor,
     })),
   });

--- a/web/components/notifications/notification-bell-content.tsx
+++ b/web/components/notifications/notification-bell-content.tsx
@@ -5,29 +5,80 @@ import {
   type NotificationItem,
 } from "@/components/notifications/notifications-provider";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { avatarColor } from "@/lib/avatar-color";
+import type { InstrumentType } from "@/lib/db/schema";
 import { cn, formatRelativeTime } from "@/lib/utils";
-import { BellOff } from "lucide-react";
+import {
+  Activity,
+  BellOff,
+  ChevronDown,
+  FlaskConical,
+  Image as ImageIcon,
+  Microscope,
+  Radar,
+  ScanLine,
+  Settings,
+  TestTube,
+  type LucideIcon,
+} from "lucide-react";
 import Link from "next/link";
+import { useMemo, useState } from "react";
 
-// Mapping a notification row to a human-readable summary line. Kept here
-// (rather than at the API boundary) so the trigger taxonomy in the DB
-// stays separate from the presentational copy.
-function renderSummary(n: NotificationItem): string {
-  switch (n.type) {
-    case "run_created":
-      return `New run on ${n.instrumentDisplayName}`;
-    case "comment_attributed":
-      return n.actor
-        ? `${n.actor.displayName} commented on a run you ran`
-        : "New comment on a run you ran";
-    case "comment_participated":
-      return n.actor
-        ? `${n.actor.displayName} replied on a run you commented on`
-        : "New reply on a run you commented on";
-  }
-}
+// ---------------------------------------------------------------------------
+// Bell popover content. The provider is the single source of truth for
+// raw notification rows; this module owns presentation — date bucketing,
+// per-instrument grouping of `run_created` rows, and the variant-specific
+// row layouts. Splitting the variants into their own components keeps the
+// top-level render flat and avoids the `isCommentRow` / `isGroupedRow`
+// boolean flag explosion an "all-in-one" row would invite.
+// ---------------------------------------------------------------------------
+
+// Lookup map for the per-instrument-type icon used on grouped `run_created`
+// rows. Defined at module scope so we don't rebuild the map on every render
+// (per `js-index-maps`). `generic` is the safe fallback for any future
+// instrument-type the enum gains before this map catches up.
+const INSTRUMENT_TYPE_ICON: Record<InstrumentType, LucideIcon> = {
+  generic: FlaskConical,
+  plate_reader: Activity,
+  gel_doc: ImageIcon,
+  qpcr: TestTube,
+  tape_station: Microscope,
+  hina_microscope: Microscope,
+  epson_v700_scanner: ScanLine,
+  instant_raman: Radar,
+};
+
+// Bucket labels live alongside the buckets themselves so the section
+// renderer can iterate `BUCKET_ORDER` and stay in lockstep with the
+// grouping logic below.
+const BUCKET_ORDER = ["today", "yesterday", "earlier"] as const;
+type Bucket = (typeof BUCKET_ORDER)[number];
+const BUCKET_LABEL: Record<Bucket, string> = {
+  today: "Today",
+  yesterday: "Yesterday",
+  earlier: "Earlier",
+};
+
+type CommentEntry = {
+  kind: "comment";
+  id: string;
+  notification: NotificationItem;
+};
+
+type RunGroupEntry = {
+  kind: "run_group";
+  id: string;
+  instrumentId: string;
+  instrumentType: InstrumentType;
+  instrumentDisplayName: string;
+  runs: NotificationItem[];
+  latestCreatedAt: string;
+};
+
+type Entry = CommentEntry | RunGroupEntry;
+type BucketedEntries = Record<Bucket, Entry[]>;
 
 function notificationHref(n: NotificationItem): string {
   // Anchor to the comment id when present so the destination page can
@@ -38,6 +89,89 @@ function notificationHref(n: NotificationItem): string {
   return n.commentId ? `${base}#comment-${n.commentId}` : base;
 }
 
+function commentActionLabel(n: NotificationItem): string {
+  // The actor is nullable at the type level (deleted user, etc.); fall
+  // back to a generic phrasing so the row still reads cleanly.
+  const actor = n.actor?.displayName ?? "Someone";
+  switch (n.type) {
+    case "comment_attributed":
+      return `${actor} mentioned you in`;
+    case "comment_participated":
+      return `${actor} commented on`;
+    case "run_created":
+      // Unreachable — `run_created` never flows into the comment row
+      // renderer — but exhaustive switches keep TS honest.
+      return `${actor} created`;
+  }
+}
+
+function bucketOf(createdAt: string, now: Date): Bucket {
+  const created = new Date(createdAt);
+  const startOfToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate()
+  );
+  if (created >= startOfToday) return "today";
+  const startOfYesterday = new Date(startOfToday);
+  startOfYesterday.setDate(startOfYesterday.getDate() - 1);
+  if (created >= startOfYesterday) return "yesterday";
+  return "earlier";
+}
+
+// Builds the bucketed + grouped entry list from the raw notification feed.
+// Pure function — extracted so the main component's `useMemo` body stays
+// declarative and the grouping logic is unit-testable in isolation.
+function buildEntries(items: NotificationItem[], now: Date): BucketedEntries {
+  const buckets: BucketedEntries = { today: [], yesterday: [], earlier: [] };
+  // Track the active run-group per (bucket, instrumentId) so out-of-order
+  // run_created rows within the same instrument still collapse into one
+  // row. Items themselves arrive sorted desc by createdAt so the first
+  // hit is the newest.
+  const groupIndex = new Map<string, RunGroupEntry>();
+
+  for (const n of items) {
+    const bucket = bucketOf(n.createdAt, now);
+    if (n.type === "run_created") {
+      const key = `${bucket}:${n.instrumentId}`;
+      const existing = groupIndex.get(key);
+      if (existing) {
+        existing.runs.push(n);
+        // The list is desc-sorted, so `latestCreatedAt` is set on the
+        // first hit and never needs to advance — leave it alone.
+      } else {
+        const group: RunGroupEntry = {
+          kind: "run_group",
+          id: `group:${key}`,
+          instrumentId: n.instrumentId,
+          instrumentType: n.instrumentType,
+          instrumentDisplayName: n.instrumentDisplayName,
+          runs: [n],
+          latestCreatedAt: n.createdAt,
+        };
+        groupIndex.set(key, group);
+        buckets[bucket].push(group);
+      }
+    } else {
+      buckets[bucket].push({ kind: "comment", id: n.id, notification: n });
+    }
+  }
+
+  return buckets;
+}
+
+// Hoisted outside the component so the empty-state JSX subtree is created
+// once at module load instead of on every render (per `rendering-hoist-jsx`).
+const EMPTY_STATE = (
+  <div className="flex flex-col items-center justify-center gap-2 px-3 py-12 text-center">
+    <BellOff className="size-6 text-muted-foreground/60" />
+    <p className="text-sm text-muted-foreground">You&apos;re all caught up.</p>
+    <p className="text-xs text-muted-foreground/70">
+      New runs and replies will show up here when you have something subscribed.
+    </p>
+  </div>
+);
+
 export function NotificationBellContent({
   onNavigate,
 }: {
@@ -45,97 +179,389 @@ export function NotificationBellContent({
 }) {
   const { recent, markAllRead, markOneRead, unreadCount } = useNotifications();
 
+  // `now` only changes when `recent` does — the bucket boundary doesn't
+  // need to drift in real time inside an open popover. Recomputing on
+  // every render would otherwise re-bucket items the moment the clock
+  // ticked past midnight and the popover was still open, which is
+  // visually disruptive.
+  const buckets = useMemo(() => buildEntries(recent, new Date()), [recent]);
+
+  const isEmpty = recent.length === 0;
+  const hasUnread = unreadCount > 0;
+
   return (
     <div className="flex flex-col">
-      <div className="flex items-center justify-between gap-2 border-b pb-2">
-        <p className="text-sm font-medium">Notifications</p>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={() => {
-            void markAllRead();
-          }}
-          disabled={unreadCount === 0}
-        >
-          Mark all as read
-        </Button>
-      </div>
-
-      {recent.length === 0 ? (
-        <div className="flex flex-col items-center justify-center gap-2 py-8 text-center">
-          <BellOff className="size-6 text-muted-foreground/60" />
-          <p className="text-sm text-muted-foreground">
-            You&apos;re all caught up.
-          </p>
-          <p className="text-xs text-muted-foreground/70">
-            New runs and replies will show up here when you have something
-            subscribed.
-          </p>
-        </div>
+      <NotificationsHeader
+        unreadCount={unreadCount}
+        hasUnread={hasUnread}
+        onMarkAllRead={() => {
+          void markAllRead();
+        }}
+        onNavigate={onNavigate}
+      />
+      {isEmpty ? (
+        EMPTY_STATE
       ) : (
-        <ul className="-mx-1 max-h-[60vh] overflow-y-auto py-1">
-          {recent.map((n) => {
-            const isUnread = n.readAt === null;
+        <div className="max-h-[60vh] overflow-y-auto">
+          {BUCKET_ORDER.map((bucket) => {
+            const entries = buckets[bucket];
+            if (entries.length === 0) return null;
             return (
-              <li key={n.id}>
-                <Link
-                  href={notificationHref(n)}
-                  onClick={() => {
-                    // Mark this row read as the user navigates into it —
-                    // gated on `isUnread` so re-clicking a read row
-                    // doesn't fire a pointless POST. The provider
-                    // handles its own optimistic update + error toast.
-                    if (isUnread) void markOneRead(n.id);
-                    onNavigate?.();
-                  }}
-                  className={cn(
-                    "flex items-start gap-3 rounded-md px-3 py-2 hover:bg-muted",
-                    isUnread && "bg-primary/5"
-                  )}
-                >
-                  {n.actor ? (
-                    <Avatar size="sm">
-                      {n.actor.avatarUrl ? (
-                        <AvatarImage
-                          src={n.actor.avatarUrl}
-                          alt={n.actor.displayName}
-                        />
-                      ) : null}
-                      <AvatarFallback className={avatarColor(n.actor.id)}>
-                        {n.actor.initials}
-                      </AvatarFallback>
-                    </Avatar>
+              <NotificationSection key={bucket} label={BUCKET_LABEL[bucket]}>
+                {entries.map((entry) =>
+                  entry.kind === "comment" ? (
+                    <CommentNotificationRow
+                      key={entry.id}
+                      notification={entry.notification}
+                      onActivate={() => {
+                        if (entry.notification.readAt === null) {
+                          void markOneRead(entry.notification.id);
+                        }
+                        onNavigate?.();
+                      }}
+                    />
                   ) : (
-                    <span
-                      aria-hidden
-                      className="mt-1.5 inline-block size-2 shrink-0 rounded-full bg-primary"
+                    <RunGroupNotificationRow
+                      key={entry.id}
+                      group={entry}
+                      onActivate={(notificationId) => {
+                        void markOneRead(notificationId);
+                      }}
+                      onNavigate={onNavigate}
                     />
-                  )}
-                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    <span className="text-sm leading-snug">
-                      {renderSummary(n)}
-                    </span>
-                    <span className="truncate text-xs text-muted-foreground">
-                      <span className="font-mono">{n.runDisplayId}</span>
-                      {" · "}
-                      <span suppressHydrationWarning>
-                        {formatRelativeTime(n.createdAt)}
-                      </span>
-                    </span>
-                  </span>
-                  {isUnread ? (
-                    <span
-                      aria-label="Unread"
-                      className="mt-1.5 inline-block size-2 shrink-0 rounded-full bg-primary"
-                    />
-                  ) : null}
-                </Link>
-              </li>
+                  )
+                )}
+              </NotificationSection>
             );
           })}
-        </ul>
+        </div>
       )}
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Header — title + unread count pill + per-user settings shortcut + mark
+// all read action. Lifted out so the popover content has a single,
+// predictable header surface regardless of empty/populated state.
+// ---------------------------------------------------------------------------
+
+function NotificationsHeader({
+  unreadCount,
+  hasUnread,
+  onMarkAllRead,
+  onNavigate,
+}: {
+  unreadCount: number;
+  hasUnread: boolean;
+  onMarkAllRead: () => void;
+  onNavigate?: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2 border-b px-4 py-3">
+      <div className="flex items-center gap-2">
+        <h2 className="text-sm font-semibold tracking-tight">Notifications</h2>
+        {hasUnread ? (
+          <Badge
+            variant="secondary"
+            className="bg-primary/10 text-primary"
+            aria-label={`${unreadCount} unread`}
+          >
+            {unreadCount > 99 ? "99+" : unreadCount} new
+          </Badge>
+        ) : null}
+      </div>
+      <div className="flex items-center gap-1">
+        <Button
+          asChild
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Notification settings"
+        >
+          <Link href="/settings/notifications" onClick={() => onNavigate?.()}>
+            <Settings />
+          </Link>
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onMarkAllRead}
+          disabled={!hasUnread}
+        >
+          Mark all read
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section wrapper — sticky-ish header above its rows. Each row underneath
+// is responsible for its own unread styling so the section itself stays
+// agnostic to row state.
+// ---------------------------------------------------------------------------
+
+function NotificationSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <div className="border-b bg-muted px-4 py-1.5 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase">
+        {label}
+      </div>
+      <ul className="divide-y divide-border">{children}</ul>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Row wrapper — owns the shared unread treatment (background tint + left
+// rail accent) and the focus/hover affordances. Variant components stay
+// focused on their own content.
+// ---------------------------------------------------------------------------
+
+function NotificationRowShell({
+  isUnread,
+  children,
+}: {
+  isUnread: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <li
+      className={cn(
+        "group/notification relative border-l-2 transition-colors",
+        isUnread
+          ? "border-l-primary bg-primary/5 hover:bg-primary/10"
+          : "border-l-transparent hover:bg-muted/60"
+      )}
+    >
+      {children}
+    </li>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Comment notification — actor avatar + summary line + body quote. The
+// entire row is a single Link so click + keyboard activation hit the
+// same target.
+// ---------------------------------------------------------------------------
+
+function CommentNotificationRow({
+  notification: n,
+  onActivate,
+}: {
+  notification: NotificationItem;
+  onActivate: () => void;
+}) {
+  const isUnread = n.readAt === null;
+  const href = notificationHref(n);
+
+  return (
+    <NotificationRowShell isUnread={isUnread}>
+      <Link
+        href={href}
+        onClick={onActivate}
+        className="flex items-start gap-3 px-4 py-3 outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      >
+        {n.actor ? (
+          <Avatar size="sm">
+            {n.actor.avatarUrl ? (
+              <AvatarImage src={n.actor.avatarUrl} alt={n.actor.displayName} />
+            ) : null}
+            <AvatarFallback className={avatarColor(n.actor.id)}>
+              {n.actor.initials}
+            </AvatarFallback>
+          </Avatar>
+        ) : (
+          <Avatar size="sm">
+            <AvatarFallback>?</AvatarFallback>
+          </Avatar>
+        )}
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <p className="text-sm leading-snug">
+            <span className="font-medium">{commentActionLabel(n)}</span>{" "}
+            <span className="font-medium text-primary">
+              run {n.runDisplayId}
+            </span>
+          </p>
+          {n.commentBody ? (
+            <p className="line-clamp-2 text-sm text-muted-foreground italic">
+              &ldquo;{n.commentBody}&rdquo;
+            </p>
+          ) : null}
+          <p
+            className="text-xs text-muted-foreground/80"
+            suppressHydrationWarning
+          >
+            {formatRelativeTime(n.createdAt)}
+          </p>
+        </div>
+      </Link>
+    </NotificationRowShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Grouped `run_created` row — single line per (bucket, instrument).
+//
+// Two variants share the icon + summary layout but diverge on what's
+// clickable:
+//   - Single-run: the entire row is a Link to the run page (the chevron
+//     is omitted; there's nothing to expand).
+//   - Multi-run: the icon + summary text + chevron together form a
+//     single <button> that toggles expansion. The body below (collapsed
+//     comma-list or expanded per-run links) and the timestamp are
+//     non-interactive so they don't compete with the toggle.
+// Expansion state is local — there's nothing for the provider to know
+// about it.
+// ---------------------------------------------------------------------------
+
+function RunGroupNotificationRow({
+  group,
+  onActivate,
+  onNavigate,
+}: {
+  group: RunGroupEntry;
+  onActivate: (notificationId: string) => void;
+  onNavigate?: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const Icon = INSTRUMENT_TYPE_ICON[group.instrumentType];
+  const isUnread = group.runs.some((r) => r.readAt === null);
+  const count = group.runs.length;
+  const isSingle = count === 1;
+  // Reverse so the rendered list flows oldest→newest within the group;
+  // the provider feed is desc but reading "16-02, 16-42, 17-03" matches
+  // typical run-id chronology better than the inverse.
+  const orderedRuns = useMemo(() => [...group.runs].reverse(), [group.runs]);
+
+  // Shared icon block — reused between the single-run Link and the
+  // multi-run toggle so the visual position stays identical between
+  // variants.
+  const iconBlock = (
+    <span
+      aria-hidden
+      className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md bg-foreground/10 text-muted-foreground"
+    >
+      <Icon className="size-3.5" />
+    </span>
+  );
+
+  if (isSingle) {
+    const onlyRun = group.runs[0];
+    return (
+      <NotificationRowShell isUnread={isUnread}>
+        <Link
+          href={notificationHref(onlyRun)}
+          onClick={() => {
+            if (onlyRun.readAt === null) onActivate(onlyRun.id);
+            onNavigate?.();
+          }}
+          className="flex cursor-pointer items-start gap-3 px-4 py-3 outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        >
+          {iconBlock}
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <p className="text-sm leading-snug">
+              <span className="font-medium">1 new run</span> on{" "}
+              {group.instrumentDisplayName}
+            </p>
+            <p className="line-clamp-2 font-mono text-xs text-muted-foreground">
+              {onlyRun.runDisplayId}
+            </p>
+            <p
+              className="text-xs text-muted-foreground/80"
+              suppressHydrationWarning
+            >
+              {formatRelativeTime(group.latestCreatedAt)}
+            </p>
+          </div>
+        </Link>
+      </NotificationRowShell>
+    );
+  }
+
+  return (
+    <NotificationRowShell isUnread={isUnread}>
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-label={
+          expanded
+            ? `Collapse ${count} runs on ${group.instrumentDisplayName}`
+            : `Expand ${count} runs on ${group.instrumentDisplayName}`
+        }
+        onClick={() => setExpanded((prev) => !prev)}
+        className="flex w-full cursor-pointer items-start gap-3 px-4 pt-3 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      >
+        {iconBlock}
+        <span className="flex min-w-0 flex-1 items-start justify-between gap-2">
+          <span className="text-sm leading-snug">
+            <span className="font-medium">{count} new runs</span> on{" "}
+            {group.instrumentDisplayName}
+          </span>
+          <ChevronDown
+            aria-hidden
+            className={cn(
+              "mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform",
+              expanded && "rotate-180"
+            )}
+          />
+        </span>
+      </button>
+
+      {/* Spacer column re-uses the same `size-6 + gap-3` rhythm as the
+          button above so the body content lines up under the summary
+          text without resorting to a hard-coded indent value. */}
+      <div className="flex items-start gap-3 px-4 pb-3">
+        <span aria-hidden className="size-6 shrink-0" />
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          {expanded ? (
+            <ul className="flex flex-col gap-0.5">
+              {orderedRuns.map((run) => (
+                <li key={run.id}>
+                  <Link
+                    href={notificationHref(run)}
+                    onClick={() => {
+                      if (run.readAt === null) onActivate(run.id);
+                      onNavigate?.();
+                    }}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 font-mono text-xs hover:bg-muted/80 focus-visible:bg-muted/80 focus-visible:outline-none",
+                      run.readAt === null
+                        ? "text-foreground"
+                        : "text-muted-foreground"
+                    )}
+                  >
+                    <span className="truncate">{run.runDisplayId}</span>
+                    {run.readAt === null ? (
+                      <span
+                        aria-label="Unread"
+                        className="ml-auto inline-block size-1.5 shrink-0 rounded-full bg-primary"
+                      />
+                    ) : null}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="line-clamp-2 font-mono text-xs text-muted-foreground">
+              {orderedRuns.map((r) => r.runDisplayId).join(", ")}
+            </p>
+          )}
+          <p
+            className="text-xs text-muted-foreground/80"
+            suppressHydrationWarning
+          >
+            {formatRelativeTime(group.latestCreatedAt)}
+          </p>
+        </div>
+      </div>
+    </NotificationRowShell>
   );
 }

--- a/web/components/notifications/notification-bell.tsx
+++ b/web/components/notifications/notification-bell.tsx
@@ -54,7 +54,11 @@ export function NotificationBell() {
           ) : null}
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="end" sideOffset={8} className="w-96 p-4">
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        className="w-104 gap-0 overflow-hidden p-0"
+      >
         <NotificationBellContent onNavigate={() => setOpen(false)} />
       </PopoverContent>
     </Popover>

--- a/web/components/notifications/notifications-provider.tsx
+++ b/web/components/notifications/notifications-provider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { InstrumentType } from "@/lib/db/schema";
 import {
   createContext,
   use,
@@ -35,7 +36,9 @@ export type NotificationItem = {
   runDisplayId: string;
   instrumentId: string;
   instrumentDisplayName: string;
+  instrumentType: InstrumentType;
   commentId: string | null;
+  commentBody: string | null;
   actor: NotificationActor | null;
 };
 
@@ -71,7 +74,9 @@ type ApiNotification = {
   run_display_id: string;
   instrument_id: string;
   instrument_display_name: string;
+  instrument_type: InstrumentType;
   comment_id: string | null;
+  comment_body: string | null;
   actor: NotificationActor | null;
 };
 
@@ -85,7 +90,9 @@ function fromApi(n: ApiNotification): NotificationItem {
     runDisplayId: n.run_display_id,
     instrumentId: n.instrument_id,
     instrumentDisplayName: n.instrument_display_name,
+    instrumentType: n.instrument_type,
     commentId: n.comment_id,
+    commentBody: n.comment_body,
     actor: n.actor,
   };
 }

--- a/web/lib/api/notifications.ts
+++ b/web/lib/api/notifications.ts
@@ -1,5 +1,6 @@
 import { db } from "@/lib/db";
 import {
+  type InstrumentType,
   instrumentNotificationSubscriptions,
   instrumentRuns,
   instruments,
@@ -153,6 +154,11 @@ export async function setInstrumentSubscription(
 // need follow-up requests.
 // ---------------------------------------------------------------------------
 
+// Hard cap on the comment-body snippet returned in the popover payload —
+// the full body is never needed for the bell list and we don't want
+// kilobyte-sized markdown blobs piggy-backing on every poll.
+const COMMENT_BODY_PREVIEW_LENGTH = 240;
+
 export type NotificationDto = {
   id: string;
   type: "run_created" | "comment_attributed" | "comment_participated";
@@ -164,7 +170,14 @@ export type NotificationDto = {
   instrumentId: string;
   runDisplayId: string;
   instrumentDisplayName: string;
+  // Surfaced so the bell can render a type-specific icon for grouped
+  // `run_created` rows (microscope / gel doc / plate reader).
+  instrumentType: InstrumentType;
   commentId: string | null;
+  // Truncated markdown body of the originating comment — only populated
+  // when `commentId` is set. NULL for `run_created` rows and for comment
+  // rows whose comment has been soft-deleted.
+  commentBody: string | null;
   actor: {
     id: string;
     displayName: string;
@@ -190,7 +203,12 @@ export async function listNotifications(
       runDisplayId: instrumentRuns.runId,
       instrumentId: instrumentRuns.instrumentId,
       instrumentDisplayName: instruments.displayName,
+      instrumentType: instruments.instrumentType,
       commentId: notifications.commentId,
+      // Soft-deleted comments are surfaced as `null` body via the join
+      // filter below; the row still exists so the user can navigate to
+      // the run, the popover just renders without a preview.
+      commentBody: runComments.body,
       actorId: actor.id,
       actorName: actor.name,
       actorEmail: actor.email,
@@ -200,6 +218,13 @@ export async function listNotifications(
     .innerJoin(instrumentRuns, eq(instrumentRuns.id, notifications.runId))
     .innerJoin(instruments, eq(instruments.id, instrumentRuns.instrumentId))
     .leftJoin(actor, eq(actor.id, notifications.actorUserId))
+    .leftJoin(
+      runComments,
+      and(
+        eq(runComments.id, notifications.commentId),
+        isNull(runComments.deletedAt)
+      )
+    )
     .where(
       opts.unreadOnly
         ? and(eq(notifications.userId, userId), isNull(notifications.readAt))
@@ -212,6 +237,10 @@ export async function listNotifications(
     const actorDisplayName = row.actorId
       ? (row.actorName ?? row.actorEmail ?? "Unknown")
       : null;
+    const previewBody =
+      row.commentBody && row.commentBody.length > COMMENT_BODY_PREVIEW_LENGTH
+        ? `${row.commentBody.slice(0, COMMENT_BODY_PREVIEW_LENGTH).trimEnd()}…`
+        : row.commentBody;
     return {
       id: row.id,
       type: row.type,
@@ -221,7 +250,9 @@ export async function listNotifications(
       runDisplayId: row.runDisplayId,
       instrumentId: row.instrumentId,
       instrumentDisplayName: row.instrumentDisplayName,
+      instrumentType: row.instrumentType,
       commentId: row.commentId,
+      commentBody: previewBody,
       actor:
         row.actorId && actorDisplayName
           ? {

--- a/web/lib/db/seed.ts
+++ b/web/lib/db/seed.ts
@@ -353,6 +353,238 @@ export async function seedRunAttributions(
 }
 
 // ---------------------------------------------------------------------------
+// Teammates — additional users (no PATs) that act as comment authors so the
+// dev user receives `comment_attributed` / `comment_participated`
+// notifications with realistic actor avatars + names. PATs are skipped on
+// purpose: these accounts are populated for UI exercise, not for API
+// scripting.
+// ---------------------------------------------------------------------------
+
+export type SeededTeammate = { id: string; name: string; email: string };
+
+// Fixed preset list (rather than randomized) so reseeds produce stable
+// identities — screenshots / bug reports referencing "Lucy" keep matching
+// after a `db:reseed`.
+const TEAMMATE_PRESETS: Array<Omit<SeededTeammate, "id">> = [
+  { name: "Lucy Hurlbut", email: "lucy@local" },
+  { name: "Marcus Chen", email: "marcus@local" },
+  { name: "Priya Patel", email: "priya@local" },
+];
+
+export async function seedTeammates(
+  db: Db,
+  count: number = 2
+): Promise<SeededTeammate[]> {
+  const chosen = TEAMMATE_PRESETS.slice(0, Math.max(0, count));
+  if (chosen.length === 0) return [];
+  const rows = chosen.map((preset) => ({
+    id: crypto.randomUUID(),
+    name: preset.name,
+    email: preset.email,
+    isAdmin: false,
+  }));
+  await db.insert(schema.users).values(rows);
+  return rows.map((r) => ({ id: r.id, name: r.name, email: r.email }));
+}
+
+// ---------------------------------------------------------------------------
+// Per-(user, instrument) `run_created` subscriptions. Seeded so the
+// /settings/notifications form renders with a believable mix of enabled +
+// disabled toggles instead of every row defaulting to off.
+// ---------------------------------------------------------------------------
+
+export async function seedInstrumentSubscriptions(
+  db: Db,
+  userId: string,
+  instrumentIds: string[],
+  enabledCount?: number
+): Promise<void> {
+  if (instrumentIds.length === 0) return;
+  // Default: roughly the first half of the list enabled, the rest left as
+  // explicit `enabled = false` rows so the toggle is materialised in the
+  // settings page (rather than relying on the missing-row fallback).
+  const cutoff = enabledCount ?? Math.ceil(instrumentIds.length / 2);
+  const rows = instrumentIds.map((instrumentId, idx) => ({
+    userId,
+    instrumentId,
+    enabled: idx < cutoff,
+  }));
+  await db.insert(schema.instrumentNotificationSubscriptions).values(rows);
+}
+
+// ---------------------------------------------------------------------------
+// Notifications — a believable steady state for the bell popover:
+//   - Today bucket: two comment notifications from the same teammate so the
+//     "mentioned you" + follow-up pattern (mirroring the design mock) lands
+//     under the TODAY header.
+//   - Yesterday bucket: three groups of `run_created` notifications (3 + 3
+//     + 2 rows across three different instruments) so the grouped-row
+//     variant of the popover renders with a comma-separated run-id list
+//     under each instrument heading.
+//   - Earlier bucket: one already-read `comment_participated` row so the
+//     read-vs-unread visual contrast and the "Earlier" section both show
+//     up after the first popover open.
+//
+// All notifications target a single recipient (the dev user). Comments
+// authored by the teammates are inserted here as well so the popover can
+// surface their body preview without depending on `seedRunComments`
+// having already inserted teammate comments — that builder only seeds
+// dev-user comments to satisfy the comment_participated precondition.
+// ---------------------------------------------------------------------------
+
+export type SeededNotifications = {
+  total: number;
+  unread: number;
+};
+
+export async function seedNotifications(
+  db: Db,
+  input: {
+    recipientUserId: string;
+    runs: SeededRun[];
+    teammates: SeededTeammate[];
+  }
+): Promise<SeededNotifications> {
+  const { recipientUserId, runs, teammates } = input;
+  if (runs.length === 0 || teammates.length === 0) {
+    return { total: 0, unread: 0 };
+  }
+
+  const now = new Date();
+  const HOUR = 60 * 60_000;
+  const DAY = 24 * HOUR;
+  // Anchor against the calendar boundary so the seeded `createdAt`s always
+  // land in the intended popover bucket regardless of the wall-clock time
+  // a developer runs `db:seed`.
+  const startOfToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate()
+  );
+
+  // Group seeded runs by instrument so we can carve out per-instrument
+  // batches for the grouped `run_created` rows.
+  const runsByInstrument = new Map<string, SeededRun[]>();
+  for (const run of runs) {
+    const list = runsByInstrument.get(run.instrumentId) ?? [];
+    list.push(run);
+    runsByInstrument.set(run.instrumentId, list);
+  }
+  const instrumentIds = [...runsByInstrument.keys()];
+
+  type NotifInsert = typeof schema.notifications.$inferInsert;
+  const notifRows: NotifInsert[] = [];
+
+  // -------------------------------------------------------------------------
+  // Teammate-authored comments + matching `comment_attributed` rows.
+  // Pre-allocating the comment UUIDs lets us batch the notification insert
+  // below without a round-trip to fetch the comment ids back.
+  // -------------------------------------------------------------------------
+
+  const primaryTeammate = teammates[0];
+  const todayCommentTargets = runs.slice(0, 2);
+  const todayCommentBodies = [
+    `@dev can you take a look at the OD readings on plate 3? Something looks off…`,
+    `Nevermind — I see what happened. The well was contaminated.`,
+  ];
+
+  type CommentInsert = typeof schema.runComments.$inferInsert;
+  const todayComments: CommentInsert[] = todayCommentTargets.map((run, i) => ({
+    id: crypto.randomUUID(),
+    runId: run.id,
+    userId: primaryTeammate.id,
+    body: todayCommentBodies[i],
+    // Both ~20h ago — same actor + same day mirrors the design mock.
+    createdAt: new Date(now.getTime() - (20 - i * 0.25) * HOUR),
+  }));
+  await db.insert(schema.runComments).values(todayComments);
+
+  for (const comment of todayComments) {
+    notifRows.push({
+      userId: recipientUserId,
+      type: "comment_attributed",
+      runId: comment.runId,
+      commentId: comment.id ?? null,
+      actorUserId: comment.userId,
+      createdAt: comment.createdAt,
+      readAt: null,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Yesterday: grouped `run_created` rows across three instruments. The
+  // popover collapses notifications sharing (bucket, instrumentId) into a
+  // single row, so emitting 3 / 3 / 2 here yields three grouped rows.
+  // -------------------------------------------------------------------------
+
+  // Within "yesterday" the bell sorts the group by latest createdAt; we
+  // stamp these between 6PM and 6AM yesterday so the bucket assignment is
+  // unambiguous regardless of `now`.
+  const yesterdayBaseline = new Date(startOfToday.getTime() - 6 * HOUR);
+
+  const groupBatches: Array<{ instrumentIdx: number; count: number }> = [
+    { instrumentIdx: 0, count: 3 },
+    { instrumentIdx: 1, count: 3 },
+    { instrumentIdx: 2, count: 2 },
+  ];
+
+  groupBatches.forEach((batch, batchIdx) => {
+    const instrumentId = instrumentIds[batch.instrumentIdx];
+    if (!instrumentId) return;
+    const pool = runsByInstrument.get(instrumentId) ?? [];
+    const picks = pool.slice(0, batch.count);
+    picks.forEach((run, i) => {
+      notifRows.push({
+        userId: recipientUserId,
+        type: "run_created",
+        runId: run.id,
+        // Stagger each group's stamps within a separate ~1h window so the
+        // grouped row's "latest" anchor differs between batches and the
+        // ordering inside the popover stays deterministic.
+        createdAt: new Date(
+          yesterdayBaseline.getTime() - (batchIdx * HOUR + i * 5 * 60_000)
+        ),
+        readAt: null,
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Earlier: one already-read `comment_participated` row to exercise both
+  // the "Earlier" bucket and the read-row treatment (dimmed background, no
+  // left rail). The dev user has a seeded comment on every run via
+  // `seedRunComments`, so any run qualifies for the participated trigger.
+  // -------------------------------------------------------------------------
+
+  const earlierTarget = runs[Math.min(4, runs.length - 1)];
+  const earlierReply: CommentInsert = {
+    id: crypto.randomUUID(),
+    runId: earlierTarget.id,
+    userId: primaryTeammate.id,
+    body: "Following up — do you want to re-run with fresh standards before we sign this off?",
+    createdAt: new Date(startOfToday.getTime() - 3 * DAY),
+  };
+  await db.insert(schema.runComments).values([earlierReply]);
+
+  notifRows.push({
+    userId: recipientUserId,
+    type: "comment_participated",
+    runId: earlierTarget.id,
+    commentId: earlierReply.id ?? null,
+    actorUserId: primaryTeammate.id,
+    createdAt: earlierReply.createdAt,
+    // Marked read so the popover renders both a read and the unread rows
+    // above for visual contrast.
+    readAt: new Date(startOfToday.getTime() - 2 * DAY),
+  });
+
+  await db.insert(schema.notifications).values(notifRows);
+
+  const unread = notifRows.filter((r) => r.readAt == null).length;
+  return { total: notifRows.length, unread };
+}
+
+// ---------------------------------------------------------------------------
 // Archive jobs — one row in each lifecycle state so the download-archive UI
 // renders every variant.
 // ---------------------------------------------------------------------------

--- a/web/scripts/README.md
+++ b/web/scripts/README.md
@@ -2,6 +2,20 @@
 
 All scripts require the `DATABASE_URL` environment variable (loaded automatically from `.env` via `dotenv`).
 
+## Local-only safety gate
+
+`reset-database.ts` and `seed-database.ts` are destructive. They refuse to run
+unless `DATABASE_URL` is exactly:
+
+```
+postgres://postgres:postgres@127.0.0.1:5432/data-hub-local
+```
+
+This guard lives in `assert-local-db.ts` and protects `db:reseed` as well
+(which chains reset → push → seed). If you genuinely need to run these
+against a different database, update the expected URL in
+`assert-local-db.ts` rather than removing the check.
+
 ## `reset-database.ts`
 
 Drops and recreates the `public` schema, wiping all tables and data. Used as the first step in a full database rebuild.

--- a/web/scripts/assert-local-db.ts
+++ b/web/scripts/assert-local-db.ts
@@ -1,0 +1,50 @@
+// Safety gate for destructive database scripts (reset / seed / reseed).
+//
+// These scripts wipe and repopulate the schema, so we refuse to run unless
+// `DATABASE_URL` points at the canonical local Postgres instance. This
+// prevents accidentally pointing a script at staging/prod by leaking
+// `DATABASE_URL` from the shell, a `.env.production`, Vercel `env pull`,
+// etc.
+
+const EXPECTED_DATABASE_URL =
+  "postgres://postgres:postgres@127.0.0.1:5432/data-hub-local";
+
+export function assertLocalDatabaseUrl(scriptName: string): string {
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    console.error(
+      `${scriptName}: DATABASE_URL is not set. Add it to web/.env or export it before running this script.`
+    );
+    console.error(`Expected: ${EXPECTED_DATABASE_URL}`);
+    process.exit(1);
+  }
+
+  if (databaseUrl !== EXPECTED_DATABASE_URL) {
+    console.error(
+      `${scriptName}: refusing to run against a non-local database.`
+    );
+    console.error(`  Expected DATABASE_URL: ${EXPECTED_DATABASE_URL}`);
+    console.error(`  Actual   DATABASE_URL: ${redact(databaseUrl)}`);
+    console.error(
+      "  This script is destructive and may only target the local dev Postgres."
+    );
+    process.exit(1);
+  }
+
+  return databaseUrl;
+}
+
+// Hide the password before echoing the URL back to the terminal in case
+// the operator screen-shares the output.
+function redact(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.password) {
+      parsed.password = "***";
+    }
+    return parsed.toString();
+  } catch {
+    return "<unparseable DATABASE_URL>";
+  }
+}

--- a/web/scripts/reset-database.ts
+++ b/web/scripts/reset-database.ts
@@ -2,8 +2,11 @@ import "dotenv/config";
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import { assertLocalDatabaseUrl } from "./assert-local-db";
 
-const client = postgres(process.env.DATABASE_URL!);
+const databaseUrl = assertLocalDatabaseUrl("db:reset");
+
+const client = postgres(databaseUrl);
 const db = drizzle(client);
 
 console.log("Dropping public schema…");

--- a/web/scripts/seed-database.ts
+++ b/web/scripts/seed-database.ts
@@ -31,14 +31,9 @@ import {
 import "dotenv/config";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import { assertLocalDatabaseUrl } from "./assert-local-db";
 
-const databaseUrl = process.env.DATABASE_URL;
-if (!databaseUrl) {
-  console.error(
-    "DATABASE_URL is not set. Add it to web/.env or export it before running this script."
-  );
-  process.exit(1);
-}
+const databaseUrl = assertLocalDatabaseUrl("db:seed");
 
 const client = postgres(databaseUrl);
 const db = drizzle(client, { schema });

--- a/web/scripts/seed-database.ts
+++ b/web/scripts/seed-database.ts
@@ -17,10 +17,13 @@ import {
   clearAll,
   seedArchiveJobs,
   seedDevUser,
+  seedInstrumentSubscriptions,
   seedInstruments,
+  seedNotifications,
   seedRunAttributions,
   seedRunComments,
   seedRuns,
+  seedTeammates,
   seedWatcherReleaseConfig,
   seedWatchers,
   type SeededRun,
@@ -75,6 +78,26 @@ await seedRunAttributions(db, runs, userId);
 
 console.log("Seeding archive_jobs…");
 await seedArchiveJobs(db, runs, userId);
+
+console.log("Seeding teammate users (notification actors)…");
+const teammates = await seedTeammates(db, 2);
+
+console.log("Seeding instrument subscriptions for the dev user…");
+await seedInstrumentSubscriptions(
+  db,
+  userId,
+  activeInstruments.map((i) => i.id)
+);
+
+console.log("Seeding notifications (run_created + comment rows)…");
+const notifResult = await seedNotifications(db, {
+  recipientUserId: userId,
+  runs,
+  teammates,
+});
+console.log(
+  `  ${notifResult.total} notifications inserted (${notifResult.unread} unread).`
+);
 
 await client.end();
 


### PR DESCRIPTION
## Summary

- Restructures the bell popover into a sticky header (title + unread count pill + settings shortcut + mark-all-read) above **Today / Yesterday / Earlier** date buckets. Each bucket renders comment notifications with a quoted body preview and collapses `run_created` rows from the same instrument into a single grouped row with a per-instrument-type icon, comma-separated run-id summary, and expand chevron.
- Surfaces `comment_body` (LEFT JOIN on `run_comments`, ≤ 240 char preview, soft-deleted comments fall through as `null`) and `instrument_type` through `NotificationDto` and the `/api/v1/notifications` wire shape so the popover renders without a follow-up request.
- For grouped multi-run rows, the entire top region (icon + "X new runs on Instrument" + chevron) is the toggle target with `cursor-pointer`; single-run rows are entirely clickable and navigate straight to the run page.
- Adds three seed builders (`seedTeammates`, `seedInstrumentSubscriptions`, `seedNotifications`) and wires them into the dev seed script so `npm run db:reseed` produces a believable mix that exercises every popover variant: two comment notifications today from the same teammate, three grouped run-created sets yesterday across different instruments, and one already-read `comment_participated` row in Earlier.

## Test plan

- [ ] `make check-all` — ruff/pyright + prettier/eslint/tsc all green.
- [ ] `npm run test:integration` in `web/` — all 228 tests pass (notifications API additive, no regressions).
- [ ] `npm run db:reseed` then sign in as `dev@local` — bell badge shows the seeded unread count; popover renders Today / Yesterday / Earlier headers with the comment preview, grouped run rows, and a read row.
- [ ] Click a single-run group → navigates to the run page and the row reads as read on next open.
- [ ] Click the top region of a multi-run group → expands to per-run links; clicking the chevron or the summary text both toggle.
- [ ] Click "Mark all read" → unread pill disappears, badge clears, rows reset to the read treatment.
- [ ] Click the settings gear → lands on `/settings/notifications` with subscription toggles already populated.


Made with [Cursor](https://cursor.com)