### PR TITLE
SpectraMax: Map Path?/Range? sentinel cells to NaN instead of raising

### DIFF
--- a/lambda/src/data_hub_lambda/spectramax_plate_reader/utils.py
+++ b/lambda/src/data_hub_lambda/spectramax_plate_reader/utils.py
@@ -42,6 +42,31 @@ _OFF_NUM_WELLS = 12
 
 _ROW_LABELS = "ABCDEFGHIJKLMNOP"
 
+# SoftMax Pro substitutes a short non-numeric token for the well value when
+# the instrument couldn't produce a usable reading:
+#
+#   - ``Path?``  PathCheck pathlength correction failed (typically an empty
+#                or low-volume well that breaks the NIR-ratio measurement).
+#   - ``Range?`` Reading was outside the detector's dynamic range.
+#
+# These wells are preserved in the parsed DataFrame with ``value=NaN`` so
+# that downstream code can distinguish a "well was attempted but failed"
+# from a "well was never read" (which remains absent from the output).
+_WELL_VALUE_SENTINELS = frozenset({"Path?", "Range?"})
+
+
+def _parse_well_value(val_str: str) -> float:
+    """Convert a SpectraMax well-cell string to a float.
+
+    Returns ``NaN`` for documented non-numeric sentinels emitted by
+    SoftMax Pro (see :data:`_WELL_VALUE_SENTINELS`). Any other
+    non-numeric token is treated as a parser bug and re-raises
+    :class:`ValueError`.
+    """
+    if val_str in _WELL_VALUE_SENTINELS:
+        return float("nan")
+    return float(val_str)
+
 
 def _parse_wavelengths(raw: str) -> tuple[int, ...]:
     """Parse a space-separated wavelength string like ``'750'`` or ``'750 600'``."""
@@ -236,7 +261,11 @@ def parse_raw_well_data(file_path: Path) -> pd.DataFrame:
     """Parse raw well readings from a SpectraMax `.xls` file into long form.
 
     Each row in the returned DataFrame represents a single well reading.
-    Wells with no data (empty cells) are omitted.
+    Wells with no data (empty cells) are omitted. Wells where SoftMax Pro
+    emitted a non-numeric sentinel (e.g. ``Path?`` for a PathCheck
+    pathlength failure, ``Range?`` for out-of-range) are kept with
+    ``value=NaN`` so the failed well is still visible to downstream
+    consumers.
 
     Returns:
         A :class:`~pandas.DataFrame` with columns:
@@ -249,7 +278,9 @@ def parse_raw_well_data(file_path: Path) -> pd.DataFrame:
         well_position  str     e.g. "A1", "H12"
         temperature_c  float?  Celsius; shared across all wells in a
                                reading group
-        value          float   Raw instrument reading
+        value          float   Raw instrument reading; ``NaN`` for wells
+                               whose value was a SoftMax Pro sentinel
+                               such as ``Path?`` or ``Range?``.
         row_label      str     e.g. "A"
         column_label   int     e.g. 1
         wavelength     int?    Nanometres; `None` when not reported
@@ -303,7 +334,7 @@ def parse_raw_well_data(file_path: Path) -> pd.DataFrame:
                             "plate_name": header.plate_name,
                             "well_position": f"{row_label}{column_label}",
                             "temperature_c": temp_val,
-                            "value": float(val_str),
+                            "value": _parse_well_value(val_str),
                             "row_label": row_label,
                             "column_label": column_label,
                             "wavelength": wl,
@@ -353,7 +384,7 @@ def parse_raw_well_data(file_path: Path) -> pd.DataFrame:
                                     "plate_name": header.plate_name,
                                     "well_position": f"{row_label}{column_label}",
                                     "temperature_c": temp_val,
-                                    "value": float(val_str),
+                                    "value": _parse_well_value(val_str),
                                     "row_label": row_label,
                                     "column_label": column_label,
                                     "wavelength": wl,

--- a/lambda/tests/spectramax_plate_reader/test_parse_raw_well_data.py
+++ b/lambda/tests/spectramax_plate_reader/test_parse_raw_well_data.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import math
 from pathlib import Path
 
 import pytest
@@ -332,6 +333,52 @@ class TestDualWavelength:
         assert (self.df["temperature_c"] == 25.0).all()
 
 
+class TestNonNumericSentinels:
+    """SoftMax Pro emits ``Path?`` (PathCheck pathlength correction failed)
+    and ``Range?`` (out of dynamic range) in place of a numeric value when
+    the instrument couldn't produce a usable reading. Those wells should
+    be preserved with ``value=NaN``, while truly empty cells continue to
+    be omitted entirely.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _load(self, tmp_path: Path) -> None:
+        prefix = "Plate:\tPlate1\t1.3\tPlateFormat"
+        # Use 'Reduced' so the synthetic file matches real pathlength-corrected
+        # exports (where 'Path?' originates) — the parser treats Raw/Reduced
+        # interchangeably, but this keeps the fixture faithful.
+        middle = "\tReduced\tFALSE\t1\t\t\t\t\t\t1"
+        header = f"{prefix}\tEndpoint\tAbsorbance{middle}\t750\t1\t3\t6\t1\t2\n"
+        col_header = "\t\t1\t2\t3\t\n"
+        # A1=numeric, A2=Path?, A3=empty (omitted)
+        # B1=Range?, B2=numeric, B3=Path?
+        row_a = "\t25.0\t0.10\tPath?\t\t\n"
+        row_b = "\t\tRange?\t0.40\tPath?\t\n"
+        content = f"##BLOCKS= 1\n{header}{col_header}{row_a}{row_b}\n~End\n"
+        path = tmp_path / "sentinels.xls"
+        path.write_text(content, encoding="utf-16")
+        self.df = parse_raw_well_data(path)
+
+    def test_empty_cells_omitted_but_sentinels_kept(self) -> None:
+        # 5 wells: A1, A2 (Path?), B1 (Range?), B2, B3 (Path?). A3 is empty.
+        assert self.df["well_position"].tolist() == ["A1", "A2", "B1", "B2", "B3"]
+
+    def test_numeric_values_unaffected(self) -> None:
+        a1 = self.df[self.df["well_position"] == "A1"].iloc[0]
+        b2 = self.df[self.df["well_position"] == "B2"].iloc[0]
+        assert a1["value"] == pytest.approx(0.10)
+        assert b2["value"] == pytest.approx(0.40)
+
+    def test_path_sentinel_becomes_nan(self) -> None:
+        for well in ("A2", "B3"):
+            value = self.df[self.df["well_position"] == well].iloc[0]["value"]
+            assert math.isnan(value), f"expected NaN for {well}, got {value!r}"
+
+    def test_range_sentinel_becomes_nan(self) -> None:
+        value = self.df[self.df["well_position"] == "B1"].iloc[0]["value"]
+        assert math.isnan(value)
+
+
 # ---------------------------------------------------------------------------
 # Error handling
 # ---------------------------------------------------------------------------
@@ -342,4 +389,19 @@ class TestParseRawWellDataValidation:
         path = tmp_path / "empty.xls"
         path.write_text("##BLOCKS= 1\n~End\n", encoding="utf-16")
         with pytest.raises(ValueError, match="No 'Plate:' header line found"):
+            parse_raw_well_data(path)
+
+    def test_unknown_non_numeric_token_still_raises(self, tmp_path: Path) -> None:
+        # Anything that isn't a documented SoftMax Pro sentinel (Path?,
+        # Range?) should still surface as a ValueError — silently swallowing
+        # arbitrary garbage would hide real parser bugs.
+        prefix = "Plate:\tPlate1\t1.3\tPlateFormat"
+        middle = "\tRaw\tFALSE\t1\t\t\t\t\t\t1"
+        header = f"{prefix}\tEndpoint\tAbsorbance{middle}\t750\t1\t1\t1\t1\t1\n"
+        col_header = "\t\t1\t\n"
+        row_a = "\t25.0\tnotanumber\t\n"
+        content = f"##BLOCKS= 1\n{header}{col_header}{row_a}\n~End\n"
+        path = tmp_path / "garbage.xls"
+        path.write_text(content, encoding="utf-16")
+        with pytest.raises(ValueError, match="could not convert string to float"):
             parse_raw_well_data(path)


### PR DESCRIPTION
## Summary

- SoftMax Pro emits non-numeric tokens in well cells when the instrument couldn't produce a usable reading — `Path?` for PathCheck pathlength-correction failures (e.g. empty/low-volume wells that break the NIR-ratio measurement) and `Range?` for out-of-range readings. The SpectraMax parser previously crashed on these with `float("Path?")` `ValueError`s, failing the entire run.
- Now those wells are preserved in the long-form DataFrame with `value=NaN`, so a "well was attempted but failed" stays visible to downstream consumers; truly empty cells continue to be omitted as before.
- Conservative on purpose: unknown non-numeric tokens still raise `ValueError` so a real parser bug doesn't get silently swallowed as NaN.

## Implementation notes

- Added `_WELL_VALUE_SENTINELS = frozenset({"Path?", "Range?"})` and a small `_parse_well_value()` helper in `lambda/src/data_hub_lambda/spectramax_plate_reader/utils.py`; swapped both `float(val_str)` call sites (flat layout and grid layout) to go through it.
- Updated the `parse_raw_well_data` docstring so the new contract (sentinel → NaN, empty → omitted, garbage → raise) is documented.
- Downstream is unaffected: `process_file.py` writes the DataFrame to CSV (pandas serializes NaN as an empty cell by default), and the frontend's `coerceNumeric` + `PlateMapGrid` already render non-numeric well values as blank cells with no tooltip.

## Test plan

- [x] New `TestNonNumericSentinels` covers: empty cells still omitted, sentinels preserved, numeric values unaffected, `Path?` → NaN, `Range?` → NaN.
- [x] New `test_unknown_non_numeric_token_still_raises` locks in the "don't swallow garbage" guarantee.
- [x] All 67 tests in `lambda/tests/spectramax_plate_reader/test_parse_raw_well_data.py` pass.
- [x] `make check-all` is green (ruff, pyright, prettier, eslint, tsc).
- [x] End-to-end re-run on the original failing file (`05212026_CM_Controls_OD750_CC125_48hr.xls`) now exits 0 and produces 96 rows for `Plate13`, with the partial half-plate rendered as a mix of numeric values and NaN where the source had `Path?` cells.


Made with [Cursor](https://cursor.com)