### PR TITLE
Server-side pagination for the run detail files table

### DIFF
--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/download-archive/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/download-archive/route.ts
@@ -1,7 +1,30 @@
 import { authorize } from "@/lib/api/auth";
 import { apiError, INTERNAL_ERROR, NOT_FOUND } from "@/lib/api/errors";
+import {
+  type FilesStatusFilter,
+  getFilteredFileIds,
+  lookupRunByNaturalKey,
+} from "@/lib/api/instrument-runs";
 import { prepareRunArchive } from "@/lib/api/run-archive";
 import type { NextRequest } from "next/server";
+
+const FILES_STATUS_VALUES: ReadonlySet<FilesStatusFilter> = new Set([
+  "all",
+  "raw",
+  "processed",
+  "pending",
+  "uploaded",
+  "processing",
+  "completed",
+  "failed",
+]);
+
+function parseStatusParam(value: string | null): FilesStatusFilter | undefined {
+  if (value && FILES_STATUS_VALUES.has(value as FilesStatusFilter)) {
+    return value as FilesStatusFilter;
+  }
+  return undefined;
+}
 
 type RouteContext = {
   params: Promise<{ instrumentId: string; runId: string }>;
@@ -36,6 +59,40 @@ function parseFileIdsParam(searchParams: URLSearchParams): number[] | null {
   return Array.from(ids);
 }
 
+// Resolve the archive's file-id filter. An explicit `?file_ids=` always wins.
+// Otherwise, the files table's active filters (`search`/`status`/`dismissed`)
+// are resolved to the matching ids server-side so "Download all" honors the
+// filter across every page — non-downloadable ids are dropped downstream by
+// `loadDownloadableFiles`. With neither present we return `null` (the route's
+// default "all downloadable files in the run" path).
+async function resolveFileIdsFilter(
+  request: NextRequest,
+  instrumentId: string,
+  runId: string
+): Promise<number[] | null> {
+  const explicit = parseFileIdsParam(request.nextUrl.searchParams);
+  if (explicit !== null) return explicit;
+
+  const sp = request.nextUrl.searchParams;
+  const search = sp.get("search")?.trim() || undefined;
+  const status = parseStatusParam(sp.get("status"));
+  const includeDismissed = sp.get("dismissed") === "true";
+
+  const hasFilter =
+    search !== undefined ||
+    (status !== undefined && status !== "all") ||
+    includeDismissed;
+  if (!hasFilter) return null;
+
+  // `lookupRunByNaturalKey` is request-cached, so this doesn't double the
+  // lookup `prepareRunArchive` performs. A missing run falls through to the
+  // 404 that helper raises.
+  const run = await lookupRunByNaturalKey(instrumentId, runId);
+  if (!run) return null;
+
+  return getFilteredFileIds(run.id, { search, status, includeDismissed });
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/v1/instruments/:instrumentId/runs/:runId/download-archive
 //
@@ -53,12 +110,15 @@ function parseFileIdsParam(searchParams: URLSearchParams): number[] | null {
 // the canonical "is it ready?" signal regardless of whether the Lambda's
 // PATCH callback to flip the row to `ready` ever lands.
 //
-// Optional `?file_ids=1,2,3` narrows the archive to a specific subset
-// (used by the UI's "Download all" button to honor active table
-// filters). IDs are intersected with the run's own files inside the
-// helper, so callers can't reach files belonging to other runs. The
-// fingerprint includes those IDs, so a filtered archive caches
-// independently of a full-run archive.
+// Optional `?file_ids=1,2,3` narrows the archive to a specific subset. IDs
+// are intersected with the run's own files inside the helper, so callers
+// can't reach files belonging to other runs. The fingerprint includes those
+// IDs, so a filtered archive caches independently of a full-run archive.
+//
+// Alternatively the UI's "Download all" button forwards the files table's
+// active filters (`?search=`, `?status=`, `?dismissed=true`), which are
+// resolved to the matching file ids server-side so the zip honors the filter
+// across every page (not just the rows currently on screen).
 // ---------------------------------------------------------------------------
 export async function GET(request: NextRequest, { params }: RouteContext) {
   const authResult = await authorize(request, "files:read");
@@ -69,7 +129,7 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
   const result = await prepareRunArchive({
     instrumentId,
     runId,
-    fileIdsFilter: parseFileIdsParam(request.nextUrl.searchParams),
+    fileIdsFilter: await resolveFileIdsFilter(request, instrumentId, runId),
     createdBy: authResult.authMethod === "session" ? authResult.userId : null,
   });
 

--- a/web/app/instruments/[instrumentId]/runs/[runId]/page.tsx
+++ b/web/app/instruments/[instrumentId]/runs/[runId]/page.tsx
@@ -4,19 +4,25 @@ import { RunCommentsSection } from "@/components/runs/run-comments-section";
 import { RunDetailVariant } from "@/components/runs/variants";
 import { WatcherStatusProvider } from "@/components/runs/watcher-status-provider";
 import {
+  buildRunFilesQuery,
   getProcessedCsvData,
-  getRunFiles,
+  getRunFileStats,
+  getRunReportFiles,
   lookupRunByNaturalKey,
 } from "@/lib/api/instrument-runs";
 import { getInstrumentById } from "@/lib/api/instruments";
 import { listCommentsForRun } from "@/lib/api/run-comments";
 import { auth } from "@/lib/auth";
 import { formatDate } from "@/lib/date";
+import { runDetailParamsCache } from "@/lib/search-params";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next/types";
 
+const FILES_PER_PAGE = 10;
+
 type Props = {
   params: Promise<{ instrumentId: string; runId: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -33,13 +39,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const dateLabel = run.acquiredAt ? "Acquired" : "Reported";
   const effectiveDate = run.acquiredAt ?? run.createdAt;
 
-  // `getRunFiles` returns every file row (including soft-deleted and
-  // lambda-produced artifacts). The unfurl description only counts the
-  // active raw uploads so deleted files don't inflate the headline.
-  const allFiles = await getRunFiles(run.id);
-  const rawFileCount = allFiles.filter(
-    (f) => f.category === "raw" && f.deletedAt === null
-  ).length;
+  // The unfurl description only counts active raw uploads so deleted files
+  // don't inflate the headline. A single aggregate query avoids loading the
+  // full file list just to count.
+  const { rawActive: rawFileCount } = await getRunFileStats(run.id);
   const fileLabel =
     rawFileCount === 1 ? "1 raw data file" : `${rawFileCount} raw data files`;
 
@@ -52,9 +55,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function RunDetailPage({ params }: Props) {
+export default async function RunDetailPage({ params, searchParams }: Props) {
   const session = await auth();
   const { instrumentId, runId } = await params;
+  const filters = runDetailParamsCache.parse(await searchParams);
 
   // The route is publicly reachable so Slack/Notion unfurlers can read the
   // run + instrument title from `generateMetadata`. Humans without a
@@ -72,12 +76,22 @@ export default async function RunDetailPage({ params }: Props) {
   const run = await lookupRunByNaturalKey(instrumentId, runId);
   if (!run) notFound();
 
-  const [runFiles, instrument, comments] = await Promise.all([
-    getRunFiles(run.id),
-    getInstrumentById(instrumentId),
-    listCommentsForRun(run.id),
-  ]);
-  const wellData = await getProcessedCsvData(runFiles);
+  const [filesPage, fileStats, reportFiles, instrument, comments] =
+    await Promise.all([
+      buildRunFilesQuery(run.id, {
+        page: filters.files_page,
+        perPage: FILES_PER_PAGE,
+        search: filters.files_search || undefined,
+        status: filters.files_status,
+        sort: filters.files_sort,
+        includeDismissed: filters.files_dismissed,
+      }),
+      getRunFileStats(run.id),
+      getRunReportFiles(run.id),
+      getInstrumentById(instrumentId),
+      listCommentsForRun(run.id),
+    ]);
+  const wellData = await getProcessedCsvData(reportFiles);
   // Gate client-side upload actions on watcher availability — a queued
   // upload request is a no-op if no agent is around to action it.
   const isWatcherOnline = (instrument?.watchersOnline ?? 0) > 0;
@@ -87,7 +101,10 @@ export default async function RunDetailPage({ params }: Props) {
       <WatcherStatusProvider isWatcherOnline={isWatcherOnline}>
         <RunDetailVariant
           run={run}
-          files={runFiles}
+          files={filesPage.data}
+          filesPagination={filesPage.pagination}
+          fileStats={fileStats}
+          reportFiles={reportFiles}
           wellData={wellData}
           instrumentId={instrumentId}
           runId={runId}

--- a/web/components/runs/run-detail.ts
+++ b/web/components/runs/run-detail.ts
@@ -7,6 +7,8 @@ import type {
   RawWellRow,
   RunDetail as RunDetailType,
   RunFile,
+  RunFilesPage,
+  RunFileStats,
 } from "@/lib/api/instrument-runs";
 
 export const RunDetail = {
@@ -19,7 +21,13 @@ export const RunDetail = {
 
 export type RunDetailProps = {
   run: RunDetailType;
+  // Current page of the server-paginated files table.
   files: RunFile[];
+  filesPagination: RunFilesPage["pagination"];
+  // Aggregate per-run file counts (footer summary, variant counts).
+  fileStats: RunFileStats;
+  // Processed + PDF files for the report sections and well-data parsing.
+  reportFiles: RunFile[];
   wellData: RawWellRow[];
   instrumentId: string;
   runId: string;

--- a/web/components/runs/run-files-section.tsx
+++ b/web/components/runs/run-files-section.tsx
@@ -26,7 +26,7 @@ import type {
 import { runDetailSearchParams } from "@/lib/search-params";
 import { Download, Search } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useQueryStates } from "nuqs";
+import { debounce, useQueryStates } from "nuqs";
 import { useEffect, useTransition } from "react";
 import { toast } from "sonner";
 import { FileBulkActionBar } from "./file-bulk-action-bar";
@@ -39,6 +39,10 @@ import {
   EditableRunFilesTable,
   ReadOnlyRunFilesTable,
 } from "./run-files-table";
+
+// Wait this long after the last search keystroke before writing the query to
+// the URL and refetching the page.
+const SEARCH_DEBOUNCE_MS = 300;
 
 type RunFilesSectionProps = {
   // Current page of the server-paginated, filtered, sorted file list.
@@ -102,15 +106,15 @@ function RunFilesSectionContent({
   const [isPending, startTransition] = useTransition();
 
   // All search / filter / sort / page state lives in the URL. `shallow:false`
-  // triggers the RSC refetch, `startTransition` ties it to the table's stale
-  // treatment, and `throttleMs` debounces search keystrokes. Every
-  // filter/sort change also resets `files_page` to 1 so the user never lands
-  // on an out-of-range page (default values drop out of the URL via nuqs
-  // clearOnDefault).
+  // triggers the RSC refetch and `startTransition` ties it to the table's
+  // stale treatment. Discrete controls (status/sort/dismissed/page) update
+  // immediately; the free-text search debounces its URL writes per-keystroke
+  // (see the input's onChange below). Every filter/sort change also resets
+  // `files_page` to 1 so the user never lands on an out-of-range page
+  // (default values drop out of the URL via nuqs clearOnDefault).
   const { startTransition: tableStartTransition } = useTablePending();
   const [filters, setFilters] = useQueryStates(runDetailSearchParams, {
     shallow: false,
-    throttleMs: 300,
     startTransition: tableStartTransition,
   });
 
@@ -169,7 +173,13 @@ function RunFilesSectionContent({
               placeholder="Search files..."
               value={filters.files_search}
               onChange={(e) =>
-                setFilters({ files_search: e.target.value, files_page: 1 })
+                setFilters(
+                  { files_search: e.target.value, files_page: 1 },
+                  // Debounce the URL write (and resulting RSC refetch) so we
+                  // only query once the user pauses typing. The input stays
+                  // responsive because nuqs updates `filters` optimistically.
+                  { limitUrlUpdates: debounce(SEARCH_DEBOUNCE_MS) }
+                )
               }
               className="h-8 pl-8 text-xs"
             />

--- a/web/components/runs/run-files-section.tsx
+++ b/web/components/runs/run-files-section.tsx
@@ -1,16 +1,13 @@
 "use client";
 
+import { PaginationNav } from "@/components/pagination-nav";
+import {
+  TablePendingBoundary,
+  TablePendingProvider,
+  useTablePending,
+} from "@/components/table-pending";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination";
 import {
   Select,
   SelectContent,
@@ -19,16 +16,18 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useArchiveDownload } from "@/hooks/use-archive-download";
-import type { RunFile } from "@/lib/api/instrument-runs";
+import type {
+  FilesSortField,
+  FilesStatusFilter,
+  RunFile,
+  RunFilesPage,
+  RunFileStats,
+} from "@/lib/api/instrument-runs";
+import { runDetailSearchParams } from "@/lib/search-params";
 import { Download, Search } from "lucide-react";
 import { useRouter } from "next/navigation";
-import {
-  type MouseEvent,
-  useEffect,
-  useMemo,
-  useState,
-  useTransition,
-} from "react";
+import { useQueryStates } from "nuqs";
+import { useEffect, useTransition } from "react";
 import { toast } from "sonner";
 import { FileBulkActionBar } from "./file-bulk-action-bar";
 import {
@@ -36,78 +35,19 @@ import {
   FileSelectionProvider,
   useFileSelection,
 } from "./file-selection-provider";
-import {
-  EditableRunFilesTable,
-  ReadOnlyRunFilesTable,
-  statusLabel,
-} from "./run-files-table";
+import { EditableRunFilesTable, ReadOnlyRunFilesTable } from "./run-files-table";
 
-const PAGE_SIZE = 10;
-
-function getVisiblePages(
-  page: number,
-  totalPages: number
-): (number | "ellipsis")[] {
-  if (totalPages <= 7)
-    return Array.from({ length: totalPages }, (_, i) => i + 1);
-
-  const pages: (number | "ellipsis")[] = [1];
-  if (page > 3) pages.push("ellipsis");
-  const start = Math.max(2, page - 1);
-  const end = Math.min(totalPages - 1, page + 1);
-  for (let i = start; i <= end; i++) pages.push(i);
-  if (page < totalPages - 2) pages.push("ellipsis");
-  if (totalPages > 1) pages.push(totalPages);
-  return pages;
-}
-
-type StatusFilter =
-  | "all"
-  | "raw"
-  | "processed"
-  | "pending"
-  | "uploaded"
-  | "processing"
-  | "completed"
-  | "failed";
-type SortField = "name" | "size" | "date" | "status";
-
-const PENDING_STATUSES = new Set(["detected", "upload_requested"]);
-
-function matchesFilter(file: RunFile, filter: StatusFilter): boolean {
-  if (filter === "all") return true;
-  if (filter === "raw") return file.category === "raw";
-  if (filter === "processed") return file.category === "processed";
-  if (filter === "pending") return PENDING_STATUSES.has(file.status);
-  return file.status === filter;
-}
-
-function compareByCategory(a: RunFile, b: RunFile): number {
-  if (a.category === b.category) return 0;
-  return a.category === "raw" ? -1 : 1;
-}
-
-function compareByField(a: RunFile, b: RunFile, field: SortField): number {
-  switch (field) {
-    case "name":
-      return a.filename.localeCompare(b.filename);
-    case "size":
-      return (a.sizeBytes ?? 0) - (b.sizeBytes ?? 0);
-    case "date":
-      return (
-        new Date(a.createdAt ?? 0).getTime() -
-        new Date(b.createdAt ?? 0).getTime()
-      );
-    case "status":
-      return statusLabel(a).localeCompare(statusLabel(b));
-    default:
-      return 0;
-  }
-}
-
-function compareFiles(a: RunFile, b: RunFile, field: SortField): number {
-  return compareByCategory(a, b) || compareByField(a, b, field);
-}
+type RunFilesSectionProps = {
+  // Current page of the server-paginated, filtered, sorted file list.
+  files: RunFile[];
+  pagination: RunFilesPage["pagination"];
+  // Aggregate per-run counts used for the footer summary, filter labels, and
+  // the in-flight auto-refresh signal — independent of the current filter.
+  stats: RunFileStats;
+  instrumentId: string;
+  runId: string;
+  isDeleted: boolean;
+};
 
 // Synchronously trigger one anchor-click per file so the browser treats
 // them all as the same user gesture (Chrome silently drops downloads
@@ -126,124 +66,93 @@ function fanOutFileDownload(refs: FileRef[]) {
   }
 }
 
-export function RunFilesSection(props: {
-  files: RunFile[];
-  instrumentId: string;
-  runId: string;
-  isDeleted: boolean;
-}) {
-  // The read-only path doesn't need selection at all. Skip the provider so
-  // we don't pay for the context for runs that can't be modified anyway.
-  if (props.isDeleted) {
-    return <RunFilesSectionContent {...props} />;
-  }
+export function RunFilesSection(props: RunFilesSectionProps) {
+  // TablePendingProvider wraps the whole section so the toolbar's URL updates
+  // and PaginationNav share the same React transition, dimming the table
+  // while the next server page streams in. The read-only path additionally
+  // skips the selection provider since those runs can't be modified.
   return (
-    <FileSelectionProvider>
-      <RunFilesSectionContent {...props} />
-    </FileSelectionProvider>
+    <TablePendingProvider>
+      {props.isDeleted ? (
+        <RunFilesSectionContent {...props} />
+      ) : (
+        <FileSelectionProvider>
+          <RunFilesSectionContent {...props} />
+        </FileSelectionProvider>
+      )}
+    </TablePendingProvider>
   );
 }
 
 function RunFilesSectionContent({
   files,
+  pagination,
+  stats,
   instrumentId,
   runId,
   isDeleted,
-}: {
-  files: RunFile[];
-  instrumentId: string;
-  runId: string;
-  isDeleted: boolean;
-}) {
+}: RunFilesSectionProps) {
   const router = useRouter();
   const { actions: archiveActions } = useArchiveDownload();
+  // Mutation transition (upload/dismiss/reprocess) — distinct from the table's
+  // navigation transition below.
   const [isPending, startTransition] = useTransition();
-  const [showDismissed, setShowDismissed] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
-  const [sortField, setSortField] = useState<SortField>("name");
-  const [page, setPage] = useState(1);
 
-  const activeFiles = useMemo(
-    () => files.filter((f) => f.deletedAt === null),
-    [files]
-  );
+  // All search / filter / sort / page state lives in the URL. `shallow:false`
+  // triggers the RSC refetch, `startTransition` ties it to the table's stale
+  // treatment, and `throttleMs` debounces search keystrokes. Every
+  // filter/sort change also resets `files_page` to 1 so the user never lands
+  // on an out-of-range page (default values drop out of the URL via nuqs
+  // clearOnDefault).
+  const { startTransition: tableStartTransition } = useTablePending();
+  const [filters, setFilters] = useQueryStates(runDetailSearchParams, {
+    shallow: false,
+    throttleMs: 300,
+    startTransition: tableStartTransition,
+  });
 
-  const dismissedFiles = useMemo(
-    () => files.filter((f) => f.deletedAt !== null),
-    [files]
-  );
-
-  // Auto-refresh while any file is in a transient state so the UI picks up
-  // status transitions (e.g. upload_requested → uploaded, processing →
-  // completed) without a manual reload.
-  const hasInFlight = activeFiles.some(
-    (f) => f.status === "processing" || f.status === "upload_requested"
-  );
+  // Auto-refresh while work is genuinely in flight (uploading or processing)
+  // so the UI picks up status transitions without a manual reload. Files that
+  // are merely "detected" (awaiting a manual upload) don't trigger polling.
+  const hasInFlight = stats.processing > 0 || stats.uploadRequested > 0;
   useEffect(() => {
     if (!hasInFlight) return;
     const id = setInterval(() => router.refresh(), 3000);
     return () => clearInterval(id);
   }, [hasInFlight, router]);
 
-  const baseFiles = showDismissed ? files : activeFiles;
-
-  const filteredFiles = useMemo(() => {
-    let result = baseFiles;
-    if (searchQuery) {
-      const q = searchQuery.toLowerCase();
-      result = result.filter((f) => f.filename.toLowerCase().includes(q));
-    }
-    if (statusFilter !== "all") {
-      result = result.filter((f) => matchesFilter(f, statusFilter));
-    }
-    return [...result].sort((a, b) => compareFiles(a, b, sortField));
-  }, [baseFiles, searchQuery, statusFilter, sortField]);
-
-  const totalPages = Math.max(1, Math.ceil(filteredFiles.length / PAGE_SIZE));
-  const currentPage = Math.min(Math.max(1, page), totalPages);
-
-  const paginatedFiles = useMemo(
-    () =>
-      filteredFiles.slice(
-        (currentPage - 1) * PAGE_SIZE,
-        currentPage * PAGE_SIZE
-      ),
-    [filteredFiles, currentPage]
-  );
-
-  const isDownloadable = (f: RunFile) =>
-    ["uploaded", "processing", "completed", "failed"].includes(f.status);
-
-  // Files in the *currently filtered* view that are eligible for the
-  // archive download. The "Download all" button reflects this set so
-  // status/search filters narrow the zip to match what's on screen.
-  const filteredDownloadableFiles = useMemo(
-    () => filteredFiles.filter(isDownloadable),
-    [filteredFiles]
-  );
-
-  // When no filters are active, omit `file_ids` so the URL stays short and
-  // the archive route falls back to its "all downloadable files in run"
-  // path. Otherwise serialize the filtered set so the server zips exactly
-  // what the user sees.
+  // The archive route resolves the active filters to a downloadable file set
+  // server-side, so "Download all" honors search/status/dismissed across every
+  // page (not just the rows currently on screen). With no filters active we
+  // omit the params so the route's default "all downloadable files" path runs.
   const isFilterActive =
-    searchQuery.trim() !== "" || statusFilter !== "all" || showDismissed;
+    filters.files_search.trim() !== "" ||
+    filters.files_status !== "all" ||
+    filters.files_dismissed;
   const archiveBaseHref = `/api/v1/instruments/${instrumentId}/runs/${encodeURIComponent(runId)}/download-archive`;
-  const downloadHref = isFilterActive
-    ? `${archiveBaseHref}?file_ids=${filteredDownloadableFiles.map((f) => f.id).join(",")}`
-    : archiveBaseHref;
+  let downloadHref = archiveBaseHref;
+  if (isFilterActive) {
+    const params = new URLSearchParams();
+    if (filters.files_search.trim()) {
+      params.set("search", filters.files_search.trim());
+    }
+    if (filters.files_status !== "all") {
+      params.set("status", filters.files_status);
+    }
+    if (filters.files_dismissed) params.set("dismissed", "true");
+    downloadHref = `${archiveBaseHref}?${params.toString()}`;
+  }
 
-  // Summary counts
-  const pendingCount = activeFiles.filter((f) =>
-    PENDING_STATUSES.has(f.status)
-  ).length;
-  const uploadedCount = activeFiles.filter(
-    (f) => !PENDING_STATUSES.has(f.status) && f.status !== "processing"
-  ).length;
+  // Count of downloadable active files in the whole run (uploaded/processing/
+  // completed/failed). `stats.uploaded` already folds completed+failed in, so
+  // adding processing covers the full downloadable set.
+  const downloadableCount = stats.uploaded + stats.processing;
 
-  const filterLabel =
-    statusFilter === "all" ? `All (${activeFiles.length})` : undefined;
+  const from =
+    pagination.total === 0
+      ? 0
+      : (pagination.page - 1) * pagination.per_page + 1;
+  const to = Math.min(pagination.page * pagination.per_page, pagination.total);
 
   return (
     <div className="flex flex-col gap-2">
@@ -255,27 +164,32 @@ function RunFilesSectionContent({
             <Search className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
             <Input
               placeholder="Search files..."
-              value={searchQuery}
-              onChange={(e) => {
-                setSearchQuery(e.target.value);
-                setPage(1);
-              }}
+              value={filters.files_search}
+              onChange={(e) =>
+                setFilters({ files_search: e.target.value, files_page: 1 })
+              }
               className="h-8 pl-8 text-xs"
             />
           </div>
           <Select
-            value={statusFilter}
-            onValueChange={(v) => {
-              setStatusFilter(v as StatusFilter);
-              setPage(1);
-            }}
+            value={filters.files_status}
+            onValueChange={(v) =>
+              setFilters({
+                files_status: v as FilesStatusFilter,
+                files_page: 1,
+              })
+            }
           >
             <SelectTrigger size="sm" className="h-8 text-sm">
-              <SelectValue>{filterLabel}</SelectValue>
+              <SelectValue>
+                {filters.files_status === "all"
+                  ? `All (${stats.active})`
+                  : undefined}
+              </SelectValue>
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all" className="text-sm">
-                All ({activeFiles.length})
+                All ({stats.active})
               </SelectItem>
               <SelectItem value="raw" className="text-sm">
                 Raw
@@ -301,20 +215,19 @@ function RunFilesSectionContent({
             </SelectContent>
           </Select>
           <Select
-            value={sortField}
-            onValueChange={(v) => {
-              setSortField(v as SortField);
-              setPage(1);
-            }}
+            value={filters.files_sort}
+            onValueChange={(v) =>
+              setFilters({ files_sort: v as FilesSortField, files_page: 1 })
+            }
           >
             <SelectTrigger size="sm" className="h-8 text-sm">
               <SelectValue>
                 Sort:{" "}
-                {sortField === "name"
+                {filters.files_sort === "name"
                   ? "Name"
-                  : sortField === "size"
+                  : filters.files_sort === "size"
                     ? "Size"
-                    : sortField === "date"
+                    : filters.files_sort === "date"
                       ? "Date"
                       : "Status"}
               </SelectValue>
@@ -334,20 +247,22 @@ function RunFilesSectionContent({
               </SelectItem>
             </SelectContent>
           </Select>
-          {dismissedFiles.length > 0 && (
+          {stats.dismissed > 0 && (
             <Button
-              variant={showDismissed ? "secondary" : "ghost"}
+              variant={filters.files_dismissed ? "secondary" : "ghost"}
               size="sm"
               className="h-8 text-sm"
-              onClick={() => {
-                setShowDismissed((p) => !p);
-                setPage(1);
-              }}
+              onClick={() =>
+                setFilters({
+                  files_dismissed: !filters.files_dismissed,
+                  files_page: 1,
+                })
+              }
             >
-              {showDismissed ? "Hide dismissed" : "Show dismissed"}
+              {filters.files_dismissed ? "Hide dismissed" : "Show dismissed"}
             </Button>
           )}
-          {filteredDownloadableFiles.length > 0 && (
+          {downloadableCount > 0 && (
             <Button
               variant="outline"
               size="sm"
@@ -361,7 +276,9 @@ function RunFilesSectionContent({
               }
             >
               <Download className="size-3" />
-              Download all ({filteredDownloadableFiles.length})
+              {isFilterActive
+                ? "Download filtered"
+                : `Download all (${downloadableCount})`}
             </Button>
           )}
         </div>
@@ -377,116 +294,65 @@ function RunFilesSectionContent({
           />
         )}
 
-        {/* Dense file table */}
-        {filteredFiles.length === 0 ? (
-          <p className="py-8 text-center text-sm text-muted-foreground">
-            No files match your filters.
-          </p>
-        ) : isDeleted ? (
-          <ReadOnlyRunFilesTable
-            files={paginatedFiles}
-            isPending={isPending}
-            onReprocess={(id) =>
-              handleSingleReprocess(id, startTransition, router)
-            }
-          />
-        ) : (
-          <EditableRunFilesTable
-            files={paginatedFiles}
-            isPending={isPending}
-            onUpload={(id) =>
-              handleSingleUpload(
-                id,
-                instrumentId,
-                runId,
-                startTransition,
-                router
-              )
-            }
-            onDismiss={(id) => handleSingleDismiss(id, startTransition, router)}
-            onReprocess={(id) =>
-              handleSingleReprocess(id, startTransition, router)
-            }
-          />
-        )}
+        {/* Dense file table — server-paginated, dimmed while a navigation is
+            in flight. */}
+        <TablePendingBoundary>
+          {files.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              No files match your filters.
+            </p>
+          ) : isDeleted ? (
+            <ReadOnlyRunFilesTable
+              files={files}
+              isPending={isPending}
+              onReprocess={(id) =>
+                handleSingleReprocess(id, startTransition, router)
+              }
+            />
+          ) : (
+            <EditableRunFilesTable
+              files={files}
+              isPending={isPending}
+              onUpload={(id) =>
+                handleSingleUpload(
+                  id,
+                  instrumentId,
+                  runId,
+                  startTransition,
+                  router
+                )
+              }
+              onDismiss={(id) =>
+                handleSingleDismiss(id, startTransition, router)
+              }
+              onReprocess={(id) =>
+                handleSingleReprocess(id, startTransition, router)
+              }
+            />
+          )}
+        </TablePendingBoundary>
 
         {/* Summary footer */}
         <div className="flex items-center justify-between gap-2 border-t px-3 py-2 text-sm text-muted-foreground">
           <span>
-            {filteredFiles.length === 0
-              ? `Showing 0 of ${activeFiles.length}`
-              : `Showing ${(currentPage - 1) * PAGE_SIZE + 1}–${Math.min(
-                  currentPage * PAGE_SIZE,
-                  filteredFiles.length
-                )} of ${filteredFiles.length}`}
-            {dismissedFiles.length > 0 && showDismissed
-              ? ` (+${dismissedFiles.length} dismissed)`
+            {pagination.total === 0
+              ? `Showing 0 of ${stats.active}`
+              : `Showing ${from}–${to} of ${pagination.total}`}
+            {stats.dismissed > 0 && filters.files_dismissed
+              ? ` (+${stats.dismissed} dismissed)`
               : ""}
           </span>
-          {totalPages > 1 && (
-            <Pagination className="mx-0 w-auto justify-end">
-              <PaginationContent>
-                {(() => {
-                  const atPrev = currentPage <= 1;
-                  const atNext = currentPage >= totalPages;
-                  const go = (target: number) => (e: MouseEvent) => {
-                    e.preventDefault();
-                    setPage(Math.min(Math.max(1, target), totalPages));
-                  };
-                  return (
-                    <>
-                      <PaginationItem>
-                        <PaginationPrevious
-                          href="#"
-                          onClick={go(currentPage - 1)}
-                          aria-disabled={atPrev}
-                          className={
-                            atPrev
-                              ? "pointer-events-none opacity-50"
-                              : undefined
-                          }
-                        />
-                      </PaginationItem>
-                      {getVisiblePages(currentPage, totalPages).map((p, i) =>
-                        p === "ellipsis" ? (
-                          <PaginationItem key={`ellipsis-${i}`}>
-                            <PaginationEllipsis />
-                          </PaginationItem>
-                        ) : (
-                          <PaginationItem key={p}>
-                            <PaginationLink
-                              href="#"
-                              isActive={p === currentPage}
-                              onClick={go(p)}
-                            >
-                              {p}
-                            </PaginationLink>
-                          </PaginationItem>
-                        )
-                      )}
-                      <PaginationItem>
-                        <PaginationNext
-                          href="#"
-                          onClick={go(currentPage + 1)}
-                          aria-disabled={atNext}
-                          className={
-                            atNext
-                              ? "pointer-events-none opacity-50"
-                              : undefined
-                          }
-                        />
-                      </PaginationItem>
-                    </>
-                  );
-                })()}
-              </PaginationContent>
-            </Pagination>
-          )}
           <span>
-            {pendingCount} pending &middot; {uploadedCount} uploaded
+            {stats.pending} pending &middot; {stats.uploaded} uploaded
           </span>
         </div>
       </div>
+
+      <PaginationNav
+        page={pagination.page}
+        totalPages={pagination.total_pages}
+        pageParam="files_page"
+      />
     </div>
   );
 }

--- a/web/components/runs/run-files-section.tsx
+++ b/web/components/runs/run-files-section.tsx
@@ -35,7 +35,10 @@ import {
   FileSelectionProvider,
   useFileSelection,
 } from "./file-selection-provider";
-import { EditableRunFilesTable, ReadOnlyRunFilesTable } from "./run-files-table";
+import {
+  EditableRunFilesTable,
+  ReadOnlyRunFilesTable,
+} from "./run-files-table";
 
 type RunFilesSectionProps = {
   // Current page of the server-paginated, filtered, sorted file list.

--- a/web/components/runs/variants/default-run-detail.tsx
+++ b/web/components/runs/variants/default-run-detail.tsx
@@ -10,15 +10,16 @@ import {
 export function DefaultRunDetail({
   run,
   files,
+  filesPagination,
+  fileStats,
+  reportFiles,
   instrumentId,
   runId,
   attributionsSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
-  const activeFileCount = files.filter((f) => f.deletedAt === null).length;
-  const hasProcessedFiles =
-    files.filter((f) => f.category === "processed" && f.deletedAt === null)
-      .length > 0;
+  const activeFileCount = fileStats.active;
+  const hasProcessedFiles = fileStats.processedActive > 0;
 
   return (
     <>
@@ -46,13 +47,15 @@ export function DefaultRunDetail({
         )}
         <RunDetail.Files
           files={files}
+          pagination={filesPagination}
+          stats={fileStats}
           instrumentId={instrumentId}
           runId={runId}
           isDeleted={isDeleted}
         />
       </RunDetail.FilesMetadataLayout>
 
-      <RunDetail.Report files={files} />
+      <RunDetail.Report files={reportFiles} />
     </>
   );
 }

--- a/web/components/runs/variants/epson-scanner-run-detail.tsx
+++ b/web/components/runs/variants/epson-scanner-run-detail.tsx
@@ -10,15 +10,16 @@ import {
 export function EpsonScannerRunDetail({
   run,
   files,
+  filesPagination,
+  fileStats,
+  reportFiles,
   instrumentId,
   runId,
   attributionsSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
-  const activeFileCount = files.filter((f) => f.deletedAt === null).length;
-  const hasProcessedFiles =
-    files.filter((f) => f.category === "processed" && f.deletedAt === null)
-      .length > 0;
+  const activeFileCount = fileStats.active;
+  const hasProcessedFiles = fileStats.processedActive > 0;
 
   return (
     <>
@@ -46,13 +47,15 @@ export function EpsonScannerRunDetail({
         )}
         <RunDetail.Files
           files={files}
+          pagination={filesPagination}
+          stats={fileStats}
           instrumentId={instrumentId}
           runId={runId}
           isDeleted={isDeleted}
         />
       </RunDetail.FilesMetadataLayout>
 
-      <RunDetail.Report files={files} />
+      <RunDetail.Report files={reportFiles} />
     </>
   );
 }

--- a/web/components/runs/variants/gel-doc-run-detail.tsx
+++ b/web/components/runs/variants/gel-doc-run-detail.tsx
@@ -10,15 +10,16 @@ import {
 export function GelDocRunDetail({
   run,
   files,
+  filesPagination,
+  fileStats,
+  reportFiles,
   instrumentId,
   runId,
   attributionsSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
-  const activeFileCount = files.filter((f) => f.deletedAt === null).length;
-  const hasProcessedFiles =
-    files.filter((f) => f.category === "processed" && f.deletedAt === null)
-      .length > 0;
+  const activeFileCount = fileStats.active;
+  const hasProcessedFiles = fileStats.processedActive > 0;
 
   return (
     <>
@@ -46,13 +47,15 @@ export function GelDocRunDetail({
         )}
         <RunDetail.Files
           files={files}
+          pagination={filesPagination}
+          stats={fileStats}
           instrumentId={instrumentId}
           runId={runId}
           isDeleted={isDeleted}
         />
       </RunDetail.FilesMetadataLayout>
 
-      <RunDetail.Report files={files} />
+      <RunDetail.Report files={reportFiles} />
     </>
   );
 }

--- a/web/components/runs/variants/hina-microscope-run-detail.tsx
+++ b/web/components/runs/variants/hina-microscope-run-detail.tsx
@@ -11,15 +11,16 @@ import {
 export function HinaMicroscopeRunDetail({
   run,
   files,
+  filesPagination,
+  fileStats,
+  reportFiles,
   instrumentId,
   runId,
   attributionsSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
-  const activeFileCount = files.filter((f) => f.deletedAt === null).length;
-  const hasProcessedFiles =
-    files.filter((f) => f.category === "processed" && f.deletedAt === null)
-      .length > 0;
+  const activeFileCount = fileStats.active;
+  const hasProcessedFiles = fileStats.processedActive > 0;
 
   return (
     <>
@@ -45,13 +46,15 @@ export function HinaMicroscopeRunDetail({
         )}
         <RunDetail.Files
           files={files}
+          pagination={filesPagination}
+          stats={fileStats}
           instrumentId={instrumentId}
           runId={runId}
           isDeleted={isDeleted}
         />
       </RunDetail.FilesMetadataLayout>
 
-      <HinaReportSection files={files} />
+      <HinaReportSection files={reportFiles} />
     </>
   );
 }

--- a/web/components/runs/variants/instant-raman-run-detail.tsx
+++ b/web/components/runs/variants/instant-raman-run-detail.tsx
@@ -7,20 +7,23 @@ import { RunDetail } from "@/components/runs/run-detail";
 export function InstantRamanRunDetail({
   run,
   files,
+  filesPagination,
+  fileStats,
+  reportFiles,
   instrumentId,
   runId,
   attributionsSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
-  const activeFileCount = files.filter((f) => f.deletedAt === null).length;
-  const hasProcessedFiles =
-    files.filter((f) => f.category === "processed" && f.deletedAt === null)
-      .length > 0;
+  const activeFileCount = fileStats.active;
+  const hasProcessedFiles = fileStats.processedActive > 0;
 
   // Within an InstantRaman run we treat every active CSV as a Raman spectrum.
   // Non-conforming files surface an inline error in the chart area rather than
-  // being silently filtered out, so users always see what's available.
-  const spectra = files
+  // being silently filtered out, so users always see what's available. Sourced
+  // from the report-files set (which includes every active CSV) so the full
+  // spectrum list survives server-side pagination of the files table.
+  const spectra = reportFiles
     .filter((f) => f.deletedAt === null && /\.csv$/i.test(f.filename))
     .map((f) => ({ fileId: f.id, filename: f.filename }))
     .sort((a, b) => a.filename.localeCompare(b.filename));
@@ -44,6 +47,8 @@ export function InstantRamanRunDetail({
       <RunDetail.FilesMetadataLayout>
         <RunDetail.Files
           files={files}
+          pagination={filesPagination}
+          stats={fileStats}
           instrumentId={instrumentId}
           runId={runId}
           isDeleted={isDeleted}

--- a/web/components/runs/variants/plate-reader-run-detail.tsx
+++ b/web/components/runs/variants/plate-reader-run-detail.tsx
@@ -260,16 +260,16 @@ function PlateMapSection({
 export function PlateReaderRunDetail({
   run,
   files,
+  filesPagination,
+  fileStats,
   wellData,
   instrumentId,
   runId,
   attributionsSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
-  const activeFileCount = files.filter((f) => f.deletedAt === null).length;
-  const hasProcessedFiles =
-    files.filter((f) => f.category === "processed" && f.deletedAt === null)
-      .length > 0;
+  const activeFileCount = fileStats.active;
+  const hasProcessedFiles = fileStats.processedActive > 0;
 
   const metadata = run.metadata as Record<string, unknown>;
   const measurementType =
@@ -309,6 +309,8 @@ export function PlateReaderRunDetail({
         )}
         <RunDetail.Files
           files={files}
+          pagination={filesPagination}
+          stats={fileStats}
           instrumentId={instrumentId}
           runId={runId}
           isDeleted={isDeleted}

--- a/web/components/runs/variants/qpcr-run-detail.tsx
+++ b/web/components/runs/variants/qpcr-run-detail.tsx
@@ -10,15 +10,16 @@ import {
 export function QpcrRunDetail({
   run,
   files,
+  filesPagination,
+  fileStats,
+  reportFiles,
   instrumentId,
   runId,
   attributionsSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
-  const activeFileCount = files.filter((f) => f.deletedAt === null).length;
-  const hasProcessedFiles =
-    files.filter((f) => f.category === "processed" && f.deletedAt === null)
-      .length > 0;
+  const activeFileCount = fileStats.active;
+  const hasProcessedFiles = fileStats.processedActive > 0;
 
   return (
     <>
@@ -44,13 +45,15 @@ export function QpcrRunDetail({
         )}
         <RunDetail.Files
           files={files}
+          pagination={filesPagination}
+          stats={fileStats}
           instrumentId={instrumentId}
           runId={runId}
           isDeleted={isDeleted}
         />
       </RunDetail.FilesMetadataLayout>
 
-      <RunDetail.Report files={files} />
+      <RunDetail.Report files={reportFiles} />
     </>
   );
 }

--- a/web/components/runs/variants/tape-station-run-detail.tsx
+++ b/web/components/runs/variants/tape-station-run-detail.tsx
@@ -10,15 +10,16 @@ import {
 export function TapeStationRunDetail({
   run,
   files,
+  filesPagination,
+  fileStats,
+  reportFiles,
   instrumentId,
   runId,
   attributionsSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
-  const activeFileCount = files.filter((f) => f.deletedAt === null).length;
-  const hasProcessedFiles =
-    files.filter((f) => f.category === "processed" && f.deletedAt === null)
-      .length > 0;
+  const activeFileCount = fileStats.active;
+  const hasProcessedFiles = fileStats.processedActive > 0;
 
   return (
     <>
@@ -46,13 +47,15 @@ export function TapeStationRunDetail({
         )}
         <RunDetail.Files
           files={files}
+          pagination={filesPagination}
+          stats={fileStats}
           instrumentId={instrumentId}
           runId={runId}
           isDeleted={isDeleted}
         />
       </RunDetail.FilesMetadataLayout>
 
-      <RunDetail.Report files={files} />
+      <RunDetail.Report files={reportFiles} />
     </>
   );
 }

--- a/web/lib/api/instrument-runs.ts
+++ b/web/lib/api/instrument-runs.ts
@@ -490,28 +490,251 @@ export type RunListRow = Awaited<
 >["data"][number];
 
 // ---------------------------------------------------------------------------
-// Per-run file list — all files (including soft-deleted) ordered by creation.
+// Per-run file list — server-side filtering, sorting, and pagination for the
+// run detail files table. The web UI is URL-driven (nuqs) and only ever
+// fetches a single page, so runs with thousands of files never load the whole
+// list into memory.
 // ---------------------------------------------------------------------------
 
-// Wrapped in `cache()` so the run detail page's `generateMetadata` (which
-// needs the raw-file count) and the page component (which renders the full
-// file list) share a single DB hit per request.
-export const getRunFiles = cache(async function getRunFiles(
+// Mirrors the client-side filter/sort unions the files table exposes.
+export type FilesStatusFilter =
+  | "all"
+  | "raw"
+  | "processed"
+  | "pending"
+  | "uploaded"
+  | "processing"
+  | "completed"
+  | "failed";
+
+export type FilesSortField = "name" | "size" | "date" | "status";
+
+// Filter inputs shared by the paginated query and the archive-download
+// "download what you filtered" resolution.
+export type RunFilesFilter = {
+  search?: string;
+  status?: FilesStatusFilter;
+  includeDismissed?: boolean;
+};
+
+export type RunFilesListFilters = RunFilesFilter & {
+  page: number;
+  perPage: number;
+  sort?: FilesSortField;
+};
+
+// "Pending" in the UI collapses the two pre-upload statuses.
+const PENDING_FILE_STATUSES = ["detected", "upload_requested"] as const;
+
+// Status-label sort order. Mirrors the alphabetical ordering produced by the
+// client's `statusLabel` localeCompare (Completed, Dismissed, Failed, Pending,
+// Processing, Uploaded, Uploading) so server-side sort matches what the table
+// rendered before. Dismissed (soft-deleted) rows rank by their label too.
+const statusSortRank = sql`case
+  when ${files.deletedAt} is not null then 2
+  when ${files.status} = 'completed' then 1
+  when ${files.status} = 'failed' then 3
+  when ${files.status} = 'detected' then 4
+  when ${files.status} = 'processing' then 5
+  when ${files.status} = 'uploaded' then 6
+  when ${files.status} = 'upload_requested' then 7
+  else 8
+end`;
+
+// Build the WHERE conditions for a run's file list. Exported so the archive
+// route can resolve the same filtered set the table is showing.
+export function runFilesWhere(
+  runInternalId: string,
+  filters: RunFilesFilter
+): SQL[] {
+  const conditions: SQL[] = [eq(files.instrumentRunId, runInternalId)];
+
+  if (!filters.includeDismissed) {
+    conditions.push(isNull(files.deletedAt));
+  }
+
+  if (filters.search) {
+    // Escape LIKE wildcards so user input is treated as literal text.
+    const escaped = filters.search
+      .replace(/\\/g, "\\\\")
+      .replace(/%/g, "\\%")
+      .replace(/_/g, "\\_");
+    conditions.push(ilike(files.filename, `%${escaped}%`));
+  }
+
+  switch (filters.status) {
+    case "raw":
+    case "processed":
+      conditions.push(eq(files.category, filters.status));
+      break;
+    case "pending":
+      conditions.push(inArray(files.status, [...PENDING_FILE_STATUSES]));
+      break;
+    case "uploaded":
+    case "processing":
+    case "completed":
+    case "failed":
+      conditions.push(eq(files.status, filters.status));
+      break;
+    default:
+      // "all" / undefined — no status condition.
+      break;
+  }
+
+  return conditions;
+}
+
+// Category-first ordering (raw before processed, matching the old
+// `compareByCategory`) then the chosen field. Date sorts on
+// coalesce(file_created_at, created_at) to match the displayed "Created"
+// column; size coalesces NULL to 0 like the old numeric comparator.
+function runFilesOrderBy(sort: FilesSortField): SQL[] {
+  const categoryFirst = sql`(${files.category} = 'raw') desc`;
+  switch (sort) {
+    case "size":
+      return [categoryFirst, sql`coalesce(${files.sizeBytes}, 0) asc`];
+    case "date":
+      return [
+        categoryFirst,
+        sql`coalesce(${files.fileCreatedAt}, ${files.createdAt}) asc`,
+      ];
+    case "status":
+      return [categoryFirst, sql`${statusSortRank} asc`];
+    default:
+      return [categoryFirst, sql`${files.filename} asc`];
+  }
+}
+
+export type RunFilesPage = {
+  data: RunFile[];
+  pagination: {
+    page: number;
+    per_page: number;
+    total: number;
+    total_pages: number;
+  };
+};
+
+export async function buildRunFilesQuery(
+  runInternalId: string,
+  filters: RunFilesListFilters
+): Promise<RunFilesPage> {
+  const safePerPage = Math.min(Math.max(filters.perPage, 1), MAX_PER_PAGE);
+  const safePage = Math.max(filters.page, 1);
+  const offset = (safePage - 1) * safePerPage;
+
+  const where = and(...runFilesWhere(runInternalId, filters));
+
+  const [{ total }] = await db
+    .select({ total: sql<number>`cast(count(*) as int)` })
+    .from(files)
+    .where(where);
+
+  const data = await db
+    .select()
+    .from(files)
+    .where(where)
+    .orderBy(...runFilesOrderBy(filters.sort ?? "name"))
+    .limit(safePerPage)
+    .offset(offset);
+
+  return {
+    data,
+    pagination: {
+      page: safePage,
+      per_page: safePerPage,
+      total,
+      total_pages: Math.ceil(total / safePerPage),
+    },
+  };
+}
+
+// Aggregate per-run file counts in a single query. Replaces the client-side
+// summary counting that used to scan the full file list, and feeds the table
+// footer, the in-flight auto-refresh signal, the per-variant counts, and the
+// run detail page's `generateMetadata`.
+export type RunFileStats = {
+  active: number;
+  dismissed: number;
+  rawActive: number;
+  processedActive: number;
+  pending: number;
+  uploaded: number;
+  processing: number;
+  // Files actively uploading to S3 (status = upload_requested). Tracked
+  // separately from `pending` so the table only auto-refreshes while work is
+  // genuinely in flight (not while files merely await a manual upload).
+  uploadRequested: number;
+};
+
+export async function getRunFileStats(
+  runInternalId: string
+): Promise<RunFileStats> {
+  const activeNotDeleted = sql`${files.deletedAt} is null`;
+  const [row] = await db
+    .select({
+      active: sql<number>`cast(count(*) filter (where ${activeNotDeleted}) as int)`,
+      dismissed: sql<number>`cast(count(*) filter (where ${files.deletedAt} is not null) as int)`,
+      rawActive: sql<number>`cast(count(*) filter (where ${files.category} = 'raw' and ${activeNotDeleted}) as int)`,
+      processedActive: sql<number>`cast(count(*) filter (where ${files.category} = 'processed' and ${activeNotDeleted}) as int)`,
+      pending: sql<number>`cast(count(*) filter (where ${files.status} in ('detected', 'upload_requested') and ${activeNotDeleted}) as int)`,
+      uploaded: sql<number>`cast(count(*) filter (where ${files.status} not in ('detected', 'upload_requested', 'processing') and ${activeNotDeleted}) as int)`,
+      processing: sql<number>`cast(count(*) filter (where ${files.status} = 'processing' and ${activeNotDeleted}) as int)`,
+      uploadRequested: sql<number>`cast(count(*) filter (where ${files.status} = 'upload_requested' and ${activeNotDeleted}) as int)`,
+    })
+    .from(files)
+    .where(eq(files.instrumentRunId, runInternalId));
+
+  return row;
+}
+
+// Report-relevant files for a run: processed artifacts, any PDFs, and any
+// CSVs. The report sections render these inline (processed images, CSV
+// tables, PDF previews); `getProcessedCsvData` parses the processed CSVs; and
+// the InstantRaman variant treats every active CSV (raw or processed) as a
+// spectrum. CSVs/PDFs are matched by content type or extension so raw uploads
+// are included. Scoped to report-relevant outputs (typically few) rather than
+// the thousands of raw files that motivated server-side pagination.
+export async function getRunReportFiles(
   runInternalId: string
 ): Promise<RunFile[]> {
   return db
     .select()
     .from(files)
-    .where(eq(files.instrumentRunId, runInternalId))
+    .where(
+      and(
+        eq(files.instrumentRunId, runInternalId),
+        isNull(files.deletedAt),
+        sql`(
+          ${files.category} = 'processed'
+          or ${files.contentType} in ('application/pdf', 'text/csv')
+          or lower(${files.filename}) like '%.pdf'
+          or lower(${files.filename}) like '%.csv'
+        )`
+      )
+    )
     .orderBy(files.createdAt);
-});
+}
+
+// Resolve the file IDs matching the current table filters, used by the
+// archive route so "Download all" honors active filters across every page.
+export async function getFilteredFileIds(
+  runInternalId: string,
+  filters: RunFilesFilter
+): Promise<number[]> {
+  const rows = await db
+    .select({ id: files.id })
+    .from(files)
+    .where(and(...runFilesWhere(runInternalId, filters)));
+  return rows.map((r) => r.id);
+}
 
 // ---------------------------------------------------------------------------
 // Per-run file list, paginated. Used by the MCP `list_run_files` tool so that
 // runs with thousands of files don't dump every row into a single response.
 // Mirrors the page/per_page/total/total_pages shape returned by
 // `buildRunListQuery`. Not wrapped in `cache()` — callers pass distinct
-// (page, perPage) keys, and the UI uses the unbounded `getRunFiles` above.
+// (page, perPage) keys.
 // ---------------------------------------------------------------------------
 
 export async function getRunFilesPage(

--- a/web/lib/search-params.ts
+++ b/web/lib/search-params.ts
@@ -4,6 +4,7 @@ import {
   parseAsBoolean,
   parseAsInteger,
   parseAsString,
+  parseAsStringLiteral,
 } from "nuqs/server";
 
 // All dashboard filter/pagination state lives in the URL via nuqs. This makes
@@ -74,6 +75,36 @@ export const watcherDetailSearchParams = {
 
 export const watcherDetailParamsCache = createSearchParamsCache(
   watcherDetailSearchParams
+);
+
+// Run detail page: the files table is server-paginated, so its search /
+// filter / sort / page state lives in the URL. Keys are prefixed `files_` so
+// they don't collide with the comments section or future run-detail params.
+// This single object is the source of truth for both the server cache below
+// and the client `useQueryStates` in the files toolbar.
+const FILES_STATUS_VALUES = [
+  "all",
+  "raw",
+  "processed",
+  "pending",
+  "uploaded",
+  "processing",
+  "completed",
+  "failed",
+] as const;
+
+const FILES_SORT_VALUES = ["name", "size", "date", "status"] as const;
+
+export const runDetailSearchParams = {
+  files_page: parseAsInteger.withDefault(1),
+  files_search: parseAsString.withDefault(""),
+  files_status: parseAsStringLiteral(FILES_STATUS_VALUES).withDefault("all"),
+  files_sort: parseAsStringLiteral(FILES_SORT_VALUES).withDefault("name"),
+  files_dismissed: parseAsBoolean.withDefault(false),
+};
+
+export const runDetailParamsCache = createSearchParamsCache(
+  runDetailSearchParams
 );
 
 export function hasActiveFilters(params: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The run detail page previously loaded **every** file row for a run via the unbounded `getRunFiles` and passed the whole list into a client component that did all filtering, sorting, and pagination in memory. For runs with thousands of files this loaded the entire table into the RSC payload.

This PR replaces that with true server-side pagination for the files table (URL-driven, mirroring the existing runs-list table) and bounded queries for the page's other file consumers, eliminating the full-table fetch entirely. `getRunFiles` is removed.

## What changed

**API layer (`web/lib/api/instrument-runs.ts`)**
- `runFilesWhere` — shared WHERE builder (run scope, dismissed toggle, filename search with escaped wildcards, status/category mapping).
- `buildRunFilesQuery` — paginated/filtered/sorted page query. Category-first ordering (raw before processed) preserved; date sorts on `coalesce(file_created_at, created_at)` to match the displayed column; status sorts via a `CASE` matching the old `statusLabel` ordering. `perPage` clamped to `MAX_PER_PAGE`.
- `getRunFileStats` — single aggregate query (`FILTER (WHERE …)`) for footer counts, the in-flight auto-refresh signal, per-variant counts, and `generateMetadata`.
- `getRunReportFiles` — bounded query for processed artifacts + PDFs + CSVs (feeds the report sections, `getProcessedCsvData`, and the InstantRaman spectra list).
- `getFilteredFileIds` — resolves the active table filters to ids for the archive route.
- Removed `getRunFiles`.

**URL state (`web/lib/search-params.ts`)**
- Added `runDetailSearchParams` / `runDetailParamsCache` (`files_page`, `files_search`, `files_status`, `files_sort`, `files_dismissed`). Enums use `parseAsStringLiteral`; all keys have non-nullable defaults so default values stay out of the URL.

**Page + variants**
- `page.tsx` parses search params, uses `getRunFileStats` in `generateMetadata`, and parallel-fetches the paginated page + stats + report files; `wellData` now derives from `reportFiles`.
- `RunDetailProps` gains `filesPagination`, `fileStats`, `reportFiles`. All 8 variants use `fileStats` for counts and pass `reportFiles` to their report sections (InstantRaman derives spectra from `reportFiles`).

**Files table (`run-files-section.tsx`)**
- Rewritten to be URL-driven via `useQueryStates` (`shallow:false`, `throttleMs:300`, `startTransition` from `TablePendingProvider`), rendering the server page. Footer counts come from `fileStats`; pagination via the shared `PaginationNav`. Bulk selection now scopes to the current page.
- "Download all" forwards the active filters to the archive route instead of a client-computed `file_ids` list.

**Archive route**
- `download-archive` resolves `?search`/`?status`/`?dismissed` to file ids via `getFilteredFileIds` (when no explicit `?file_ids` is given), so a filtered download honors the filter across every page. The 503/auth ordering is unchanged (no DB lookup when no filter is present).

## Testing

- `make fe-check` (prettier, eslint, tsc) — clean.
- `npm run test:mcp` — 58 passed.
- `npm run test:integration` — 235 passed (15 files), including the `download-archive` route tests.

The Python half of `make check-all` was not run because `uv` is unavailable in this environment; no Python files were changed.

## Notes

- The MCP `list_run_files` tool and its `getRunFilesPage` helper are unchanged.
- `getRunReportFiles` is scoped to report-relevant outputs (processed/PDF/CSV, typically few) rather than the thousands of raw files that motivated this change; the report inherently renders each match inline, so it is not paginated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eadcc6b8-5fcc-45a4-a6b3-515bf902c0ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eadcc6b8-5fcc-45a4-a6b3-515bf902c0ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

