### PR TITLE
Add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Data Hub is a multi-component repo (see `README.md`). The component you can run end-to-end
+locally with zero external credentials is the **Next.js web app + REST API + PostgreSQL**
+(`web/`). The `lambda/`, `watcher/`, and `packages/shared/` Python packages are exercised
+via tests and a local S3 mirror — no real AWS is needed for local work.
+
+Standard commands live in the `Makefile`, `web/package.json`, `docs/getting-started.md`, and
+`docs/local-development.md`. The notes below are the non-obvious caveats that those docs don't
+make obvious for a fresh cloud VM (where the update script has already installed deps).
+
+### Starting services (not handled by the update script)
+
+- **PostgreSQL must be started on every fresh VM** — the cluster is installed and the data
+  (roles + databases) persist in the snapshot, but the server process is not running at boot:
+  `sudo pg_ctlcluster 16 main start` (or `sudo service postgresql start`).
+- Postgres is reachable at `postgres://postgres:postgres@127.0.0.1:5432`. Databases
+  `data-hub-local` (dev) and `data_hub_test` (integration tests) already exist. The integration
+  harness (`web/tests/integration/global-setup.ts`) hardcodes these same credentials and creates
+  `data_hub_test` itself if missing.
+- **Web dev server:** `make dev` (Next.js + Turbopack on http://localhost:3000). Sign in at
+  `/login` with the "Sign in (dev)" button using email `dev@local` (workspace admin; no password).
+
+### Environment file
+
+`web/.env` is gitignored and required for `make dev` / seeding. If it is missing on a fresh VM,
+recreate it from the "Minimal `.env`" block in `docs/local-development.md` (the key lines are
+`DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/data-hub-local`, a 32+ char
+`AUTH_SECRET`, dummy `AWS_*` values, and `LOCAL_S3_MIRROR=../lambda/.local-s3`).
+
+### Node / Python toolchain
+
+- Use **Node 24 (npm 11)** — it is the nvm default and is what CI uses. `npm ci` against the
+  committed `web/package-lock.json` **fails under npm 10** ("Missing: esbuild@… from lock file"),
+  so don't downgrade. A clean login shell already selects Node 24 via nvm.
+- Python is managed by `uv` (Python 3.13, pinned in `.python-version`). Run Python tools through
+  `uv run …` (e.g. `uv run pytest`); the Makefile targets already do this.
+
+### Seeding and local file bytes
+
+- `make db-reseed` resets + pushes the Drizzle schema + seeds deterministic data. It prints a
+  personal access token (`dhub_…`) for the dev user — use it for `Authorization: Bearer` API calls.
+- The seed's fixture-processing step is **skipped if the dev server isn't running** (it prints a
+  hint). To populate processed artifacts (gel-doc PNGs, plate-reader CSVs, qPCR metadata), start
+  `make dev` first, then run `npm run db:process-fixtures` from `web/`.
+
+### Testing caveat
+
+- `make fe-test-integration` and `make py-test-integration` run `next build` + `next start`, which
+  writes to `web/.next` and **contends with a running `make dev`** (also using `.next`). Stop the
+  dev server before running integration tests, then restart it afterward.
+- Lint/format/typecheck: `make check-all` (note: `py-format`/`fe-format` auto-rewrite files; use
+  `uv run ruff check .`, `npm run lint`, `npm run typecheck`, `npm run format:check` for read-only checks).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for Data Hub and documents durable, non-obvious startup caveats for future Cursor Cloud agents in a new `AGENTS.md`.

The runnable end-to-end scope verified here is the **Next.js web app + REST API + PostgreSQL** (`web/`), plus the Python packages (`lambda/`, `watcher/`, `packages/shared/`) via their test suites and the local S3 mirror — no real AWS credentials required.

### Environment installed
- `uv` (Python 3.13 workspace via `uv sync --all-packages`)
- PostgreSQL 16 (roles + `data-hub-local` / `data_hub_test` databases)
- Node 24 / npm 11 via nvm (npm 10 fails `npm ci` on the committed lockfile)
- Web app deps via `npm ci`; `web/.env` for zero-credential local dev

### Update script (runs on VM startup)
```
uv sync --all-packages
npm --prefix web ci
```

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Python lint | `uv run ruff check .` | pass |
| Python format | `uv run ruff format --check .` | pass (103 files) |
| Python typecheck | `uv run pyright` | 0 errors |
| Web lint | `npm run lint` | pass |
| Web typecheck | `npm run typecheck` | pass |
| Web format | `npm run format:check` | pass |
| Python unit tests | `uv run pytest -m "not integration"` | 608 passed |
| Python integration | `uv run pytest -m integration` | 66 passed |
| MCP tests | `npm run test:mcp` | 64 passed |
| API integration | `npm run test:integration` | 241 passed |

Ran the web app via `make dev`, signed in with the dev provider (`dev@local`), opened an instrument run, and posted a comment that persisted — confirming the full app + API + DB path works.

[data_hub_signin_and_comment.mp4](https://cursor.com/agents/bc-b72c3840-d19f-4bb1-8235-b1f10286a9d3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdata_hub_signin_and_comment.mp4)

[Comment posted on run detail page](https://cursor.com/agents/bc-b72c3840-d19f-4bb1-8235-b1f10286a9d3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frun_comment_posted.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b72c3840-d19f-4bb1-8235-b1f10286a9d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b72c3840-d19f-4bb1-8235-b1f10286a9d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

