### PR TITLE
Cancel pending upload requests on watch-directory change

### DIFF
--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -172,6 +172,11 @@ In YAML, prefer single-quoted strings for patterns so that backslash sequences l
 - **`auto`**: Files are uploaded to S3 immediately after run detection.
 - **`manual`**: Runs are reported to the API without uploading. The server decides which files to upload via a queue, polled on each heartbeat tick. Useful when uploads need human approval.
 
+Queued files are resolved against the current `watch_directory` (each queue entry carries a `relative_path` anchored to the root that was active when the file was detected). Two safeguards keep a stale queue entry from erroring forever (ENG-1397):
+
+- **On `watch_directory` change**: the server reverts every pending upload request for that instrument back to `detected` (clearing `upload_requested_at`) as soon as the new config is pushed, so the queue drains immediately. The reverted files remain re-requestable detections; an operator can queue them again from their new location.
+- **Per-file 3-try cap (`MAX_QUEUE_FILE_ATTEMPTS`)**: a queued file that keeps failing — missing on disk or failing to upload — is retried on at most three heartbeat polls. After that the watcher cancels the request server-side (revert to `detected`) so the file leaves the queue instead of re-erroring each tick. The attempt count resets on watcher restart, so a transient outage longer than three ticks is recovered on the next start.
+
 ## Local state
 
 The watcher maintains a SQLite database at `~/.data-hub/watcher.db` with three tables:
@@ -204,7 +209,7 @@ The watcher's primary observability surface is the per-watcher event log served 
 | Event type | When |
 | --- | --- |
 | `watcher_started` / `watcher_stopped` | Process lifecycle. The stopped message distinguishes a normal stop from an upgrade-driven restart. |
-| `config_synced` | Local config differed from the remote checksum and was pushed. Triggered by `init`, `config edit`, `config open`, and on watcher startup. |
+| `config_synced` | Local config differed from the remote checksum and was pushed. Triggered by `init`, `config edit`, `config open`, and on watcher startup. The server also emits one with `details.kind="upload_requests_cancelled"` (and `cancelled_count`) when a `watch_directory` change drained pending upload requests. |
 | `run_reported` | A run was POSTed to the API for the first time. |
 | `file_uploaded` / `upload_failed` | Per-file upload outcome. `upload_failed` carries the S3 key and last error. |
 | `update_started` / `update_succeeded` / `update_failed` | Auto-update lifecycle. `update_succeeded` is emitted from the *next* process startup once the new version is confirmed to be loaded. |
@@ -224,6 +229,8 @@ The watcher's primary observability surface is the per-watcher event log served 
 | `events_dropped` | Synthetic event prepended after one or more prior batches were dropped. `details.dropped_count` reports the gap size. |
 | `heartbeat_recovered` | First successful heartbeat after one or more consecutive failures. `details.gap_seconds` reports the outage length. |
 | `upload_queue_poll_failed` | `GET /watchers/:id/upload-queue` failed in manual mode. Emitted on the 1st failure and every 10th repeat. |
+| `queued_file_missing` | A manual-mode queued file was not found on disk at its resolved path. Emitted once per file (throttled across polls). `details` includes `file_id`, `expected_path`. |
+| `upload_request_cancelled` | The watcher gave up on a queued file after `MAX_QUEUE_FILE_ATTEMPTS` failed polls (missing or upload error) and reverted it to `detected` server-side. `details` includes `file_id`, `attempts`, `reason`. |
 | `update_check_failed` | `GET /watchers/:id/update-check` failed for 3 consecutive attempts (~3 hours of going dark on the update channel). |
 
 ### File timestamps

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -416,7 +416,7 @@ requires-dist = [
 
 [[package]]
 name = "data-hub-watcher"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "watcher" }
 dependencies = [
     { name = "click" },

--- a/watcher/pyproject.toml
+++ b/watcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-hub-watcher"
-version = "0.2.8"
+version = "0.2.9"
 description = "File-watcher agent for lab instrument PCs that ingests data into Data Hub."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/watcher/src/data_hub_watcher/api_client.py
+++ b/watcher/src/data_hub_watcher/api_client.py
@@ -235,3 +235,15 @@ class DataHubClient:
     def mark_file_uploaded(self, file_id: int, s3_info: dict[str, Any]) -> FileResponse:
         resp = self._request("PATCH", f"/files/{file_id}", json=s3_info)
         return FileResponse.model_validate(resp.json())
+
+    def cancel_upload_request(self, file_id: int) -> FileResponse:
+        """Revert a queued file to ``detected`` so it leaves the upload queue.
+
+        Called after the watcher gives up on a queued file (missing on disk
+        or persistently failing to upload) so the server stops serving it in
+        the upload queue and the watcher stops re-erroring on it every
+        heartbeat poll (ENG-1397). The file stays a re-requestable detection
+        rather than being deleted, so an operator can queue it again later.
+        """
+        resp = self._request("PATCH", f"/files/{file_id}", json={"status": "detected"})
+        return FileResponse.model_validate(resp.json())

--- a/watcher/src/data_hub_watcher/constants.py
+++ b/watcher/src/data_hub_watcher/constants.py
@@ -115,6 +115,12 @@ RUN_DETECTION_PRESETS: list[tuple[str, str, str, bool]] = [
 MAX_STABILITY_WAIT_SECONDS = 300
 UPLOAD_RETRY_MAX = 3
 UPLOAD_RETRY_BASE_DELAY = 1
+# How many manual-mode heartbeat polls re-attempt the same queued file
+# (missing or failing to upload) before the watcher gives up and cancels the
+# request server-side. Distinct from `UPLOAD_RETRY_MAX` (per-upload S3 PUT
+# retries). ~3 min at the 60s heartbeat: long enough to ride out a blip,
+# short enough that a stale entry from a dir change self-clears (ENG-1397).
+MAX_QUEUE_FILE_ATTEMPTS = 3
 # Upload records older than this are pruned from the local state DB
 # to prevent unbounded growth on long-running watcher instances.
 PRUNE_DAYS = 90

--- a/watcher/src/data_hub_watcher/events.py
+++ b/watcher/src/data_hub_watcher/events.py
@@ -41,6 +41,13 @@ a database migration. Known ``kind`` values, with their per-kind
 * ``update_check_failed`` -- ``GET /watchers/:id/update-check`` failed.
   Emitted only after 3 consecutive failures so we don't alert on a
   single hourly blip. ``details = {"kind", "error", "consecutive_failures"}``.
+* ``queued_file_missing`` -- a manual-mode upload-queue file was not found
+  on disk at its resolved path. Emitted once per file id (throttled across
+  heartbeat polls). ``details = {"kind", "file_id", "expected_path"}``.
+* ``upload_request_cancelled`` -- the watcher gave up on a queued file
+  after ``MAX_QUEUE_FILE_ATTEMPTS`` failed polls (missing or upload error)
+  and reverted it to ``detected`` server-side so it leaves the queue.
+  ``details = {"kind", "file_id", "attempts", "reason"}``.
 """
 
 from __future__ import annotations

--- a/watcher/src/data_hub_watcher/uploader.py
+++ b/watcher/src/data_hub_watcher/uploader.py
@@ -13,6 +13,7 @@ import mimetypes
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, wait
+from dataclasses import dataclass
 from pathlib import Path
 
 import requests as http_requests
@@ -20,16 +21,31 @@ from requests.adapters import HTTPAdapter
 
 from data_hub_watcher.api_client import ApiError, DataHubClient
 from data_hub_watcher.constants import (
+    MAX_QUEUE_FILE_ATTEMPTS,
     UPLOAD_RETRY_BASE_DELAY,
     UPLOAD_RETRY_MAX,
 )
 from data_hub_watcher.events import EventReporter, EventType, WatcherEvent
 from data_hub_watcher.heartbeat import WatcherCounters
+from data_hub_watcher.models import UploadQueueFile
 from data_hub_watcher.run_detector import FileInfo, file_created_at
 from data_hub_watcher.state import StateDB
 from data_hub_watcher.util import file_sha256
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _QueueAttempt:
+    """Per-file bookkeeping for manual-mode upload-queue retries.
+
+    ``count`` is the number of consecutive heartbeat polls that have failed
+    to upload the file (missing on disk or upload error); ``reason`` is the
+    most recent failure cause, surfaced in the give-up event.
+    """
+
+    count: int
+    reason: str
 
 
 def _guess_content_type(path: Path) -> str | None:
@@ -108,6 +124,11 @@ class Uploader:
         # Mutated only from the heartbeat thread (manual mode), so
         # not under any explicit lock.
         self._consecutive_queue_poll_failures = 0
+        # Per-file upload-queue attempt bookkeeping, keyed by server file id.
+        # Bounds retries before giving up (see ``_process_queued_file``) and
+        # doubles as the emit-once throttle for the missing-file error. Pruned
+        # each poll, so a re-requested id starts fresh. Heartbeat thread only.
+        self._queue_attempts: dict[int, _QueueAttempt] = {}
         # Single ``requests.Session`` shared across every S3 PUT
         # (parallel or serial). Keeps TLS connections alive between
         # presigned URLs that target the same S3 bucket -- avoids
@@ -243,25 +264,114 @@ class Uploader:
         # Reset on any success -- the next failure starts a fresh
         # outage window so the throttled emissions are accurate.
         self._consecutive_queue_poll_failures = 0
+
+        # Prune attempt records for files no longer pending (uploaded,
+        # cancelled, or dismissed) so the dict tracks only the live queue
+        # and a re-requested id starts a fresh attempt window.
+        current_ids = {qf.id for qf in queue.files}
+        self._queue_attempts = {
+            fid: rec for fid, rec in self._queue_attempts.items() if fid in current_ids
+        }
+
         if not queue.files:
             return
 
         logger.info("Upload queue has %d file(s)", len(queue.files))
         for qf in queue.files:
-            local_path = self._watch_dir / (qf.relative_path or qf.filename)
-            if not local_path.exists():
+            self._process_queued_file(qf)
+
+    def _process_queued_file(self, qf: UploadQueueFile) -> None:
+        """Attempt one queued file, bounding retries across heartbeat polls.
+
+        Manual-mode polling runs every heartbeat, so a file that can't be
+        uploaded -- missing on disk after a watch-directory change, or a
+        persistent upload error -- would otherwise re-error forever. We cap
+        attempts at ``MAX_QUEUE_FILE_ATTEMPTS`` and then cancel the request
+        server-side (revert to ``detected``) so it leaves the queue. The
+        "Queued file missing" error is emitted only on the first miss; the
+        upload path emits its own per-attempt events via ``_upload_single``.
+        """
+        attempt = self._queue_attempts.get(qf.id)
+        attempt_count = attempt.count if attempt else 0
+
+        # Already exhausted: a prior poll's cancel may have failed, so keep
+        # retrying the cancel until the file drops out of the queue.
+        if attempt_count >= MAX_QUEUE_FILE_ATTEMPTS:
+            self._cancel_queued_file(qf, attempt.reason if attempt else "unknown")
+            return
+
+        local_path = self._watch_dir / (qf.relative_path or qf.filename)
+        if local_path.exists():
+            ok = self._upload_single(local_path, qf.run_id)
+            reason = "upload_failed"
+        else:
+            ok = False
+            reason = "missing"
+            # Throttle: surface the visible "missing" error only on the
+            # first miss for this file; later misses are debug-only until
+            # the give-up threshold cancels the request.
+            if attempt_count == 0:
                 logger.error("Queued file not found locally: %s", local_path)
                 self._reporter.queue_event(
                     WatcherEvent(
                         event_type=EventType.ERROR,
                         message=f"Queued file missing: {qf.filename}",
-                        details={"file_id": qf.id, "expected_path": str(local_path)},
+                        details={
+                            "kind": "queued_file_missing",
+                            "file_id": qf.id,
+                            "expected_path": str(local_path),
+                        },
                     )
                 )
                 self._bump_errors()
-                continue
+            else:
+                logger.debug("Queued file still missing (already reported): %s", local_path)
 
-            self._upload_single(local_path, qf.run_id)
+        if ok:
+            self._queue_attempts.pop(qf.id, None)
+            return
+
+        attempt_count += 1
+        self._queue_attempts[qf.id] = _QueueAttempt(count=attempt_count, reason=reason)
+        if attempt_count >= MAX_QUEUE_FILE_ATTEMPTS:
+            self._cancel_queued_file(qf, reason)
+
+    def _cancel_queued_file(self, qf: UploadQueueFile, reason: str) -> None:
+        """Cancel a persistently-failing queued file's upload request.
+
+        Reverts the file to ``detected`` server-side so it leaves the upload
+        queue. On API failure the attempt record is left in place so the next
+        poll retries the cancel; the give-up event fires only on a successful
+        cancel, so a retried cancel doesn't re-flood the log.
+        """
+        try:
+            self._client.cancel_upload_request(qf.id)
+        except ApiError as exc:
+            logger.warning(
+                "Failed to cancel upload request for %s (file_id=%s): %s",
+                qf.filename,
+                qf.id,
+                exc.message,
+            )
+            self._bump_errors()
+            return
+
+        logger.warning(
+            "Gave up on queued file after %d attempts: %s (reason=%s)",
+            MAX_QUEUE_FILE_ATTEMPTS,
+            qf.filename,
+            reason,
+        )
+        self._reporter.report_error(
+            "upload_request_cancelled",
+            (
+                f"Gave up uploading {qf.filename} after {MAX_QUEUE_FILE_ATTEMPTS} "
+                "attempts; cancelled upload request"
+            ),
+            file_id=qf.id,
+            attempts=MAX_QUEUE_FILE_ATTEMPTS,
+            reason=reason,
+        )
 
     # ------------------------------------------------------------------
     # Presigned PUT helper

--- a/watcher/tests/test_uploader.py
+++ b/watcher/tests/test_uploader.py
@@ -12,9 +12,14 @@ import pytest
 from requests.adapters import HTTPAdapter
 
 from data_hub_watcher.api_client import ApiError
+from data_hub_watcher.constants import MAX_QUEUE_FILE_ATTEMPTS
 from data_hub_watcher.events import EventReporter
 from data_hub_watcher.heartbeat import WatcherCounters
-from data_hub_watcher.models import PresignedUploadResponse
+from data_hub_watcher.models import (
+    PresignedUploadResponse,
+    UploadQueueFile,
+    UploadQueueResponse,
+)
 from data_hub_watcher.state import StateDB
 from data_hub_watcher.uploader import Uploader
 
@@ -588,3 +593,152 @@ class TestPollUploadQueueCounterLocking:
 
         spy.assert_called_once()
         assert uploader._counters.errors == 1
+
+
+class TestPollUploadQueueAttemptCap:
+    """A persistently-failing queued file is bounded, then cancelled.
+
+    Manual-mode polling runs every heartbeat, so a stale queue entry (e.g.
+    one left pointing at the old root after the watch directory changed, or
+    a file that keeps failing to upload) would otherwise re-error forever.
+    The watcher surfaces the visible error once, retries up to
+    ``MAX_QUEUE_FILE_ATTEMPTS`` polls, then cancels the request server-side
+    so it leaves the queue (ENG-1397).
+    """
+
+    @staticmethod
+    def _ghost_queue() -> UploadQueueResponse:
+        """A one-file queue pointing at a path that doesn't exist on disk."""
+        return UploadQueueResponse(
+            files=[
+                UploadQueueFile(
+                    id=1,
+                    instrument_id="test-instrument",
+                    run_id="RUN-X",
+                    filename="ghost.csv",
+                    relative_path="ghost.csv",
+                )
+            ]
+        )
+
+    def test_missing_file_errors_once_then_cancels(
+        self,
+        uploader: Uploader,
+        mock_client: MagicMock,
+    ) -> None:
+        mock_client.get_upload_queue.return_value = self._ghost_queue()
+
+        for _ in range(MAX_QUEUE_FILE_ATTEMPTS):
+            uploader.poll_upload_queue()
+
+        reporter_mock = cast(MagicMock, uploader._reporter)
+
+        # Visible "missing" error and the error counter fire exactly once
+        # across all polls (throttled), not once per heartbeat.
+        assert reporter_mock.queue_event.call_count == 1
+        assert uploader._counters.errors == 1
+
+        # On the final poll the watcher gives up and cancels server-side.
+        mock_client.cancel_upload_request.assert_called_once_with(1)
+        reporter_mock.report_error.assert_called_once()
+        assert reporter_mock.report_error.call_args.args[0] == "upload_request_cancelled"
+        assert reporter_mock.report_error.call_args.kwargs["reason"] == "missing"
+
+    def test_upload_failure_cancels_after_threshold(
+        self,
+        uploader: Uploader,
+        mock_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / "data.csv").write_text("x")
+        mock_client.get_upload_queue.return_value = UploadQueueResponse(
+            files=[
+                UploadQueueFile(
+                    id=2,
+                    instrument_id="test-instrument",
+                    run_id="RUN-Y",
+                    filename="data.csv",
+                    relative_path="data.csv",
+                )
+            ]
+        )
+
+        # The file exists but every upload attempt fails -> cap applies to
+        # upload failures too, not just missing files.
+        with patch.object(uploader, "_upload_single", return_value=False):
+            for _ in range(MAX_QUEUE_FILE_ATTEMPTS):
+                uploader.poll_upload_queue()
+
+        reporter_mock = cast(MagicMock, uploader._reporter)
+        mock_client.cancel_upload_request.assert_called_once_with(2)
+        assert reporter_mock.report_error.call_args.kwargs["reason"] == "upload_failed"
+
+    def test_successful_upload_prunes_without_cancel(
+        self,
+        uploader: Uploader,
+        mock_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / "data.csv").write_text("x")
+        mock_client.get_upload_queue.return_value = UploadQueueResponse(
+            files=[
+                UploadQueueFile(
+                    id=3,
+                    instrument_id="test-instrument",
+                    run_id="RUN-Z",
+                    filename="data.csv",
+                    relative_path="data.csv",
+                )
+            ]
+        )
+
+        with patch.object(uploader, "_upload_single", return_value=True):
+            uploader.poll_upload_queue()
+
+        assert 3 not in uploader._queue_attempts
+        mock_client.cancel_upload_request.assert_not_called()
+
+    def test_requeued_id_rearms_after_leaving_queue(
+        self,
+        uploader: Uploader,
+        mock_client: MagicMock,
+    ) -> None:
+        mock_client.get_upload_queue.return_value = self._ghost_queue()
+        reporter_mock = cast(MagicMock, uploader._reporter)
+
+        # Two misses (stay under the threshold): error fires once, count grows.
+        uploader.poll_upload_queue()
+        uploader.poll_upload_queue()
+        assert uploader._queue_attempts[1].count == 2
+        assert reporter_mock.queue_event.call_count == 1
+
+        # File leaves the queue -> its attempt record is pruned.
+        mock_client.get_upload_queue.return_value = UploadQueueResponse(files=[])
+        uploader.poll_upload_queue()
+        assert 1 not in uploader._queue_attempts
+
+        # It comes back (re-requested): the throttle re-arms and fires again.
+        mock_client.get_upload_queue.return_value = self._ghost_queue()
+        uploader.poll_upload_queue()
+        assert reporter_mock.queue_event.call_count == 2
+
+    def test_cancel_failure_is_retried_next_poll(
+        self,
+        uploader: Uploader,
+        mock_client: MagicMock,
+    ) -> None:
+        mock_client.get_upload_queue.return_value = self._ghost_queue()
+        mock_client.cancel_upload_request.side_effect = ApiError("boom", status_code=500)
+
+        for _ in range(MAX_QUEUE_FILE_ATTEMPTS):
+            uploader.poll_upload_queue()
+
+        # Cancel attempted once on the threshold poll and it failed, so the
+        # attempt record stays put and no give-up event is emitted yet.
+        assert mock_client.cancel_upload_request.call_count == 1
+        assert uploader._queue_attempts[1].count == MAX_QUEUE_FILE_ATTEMPTS
+        cast(MagicMock, uploader._reporter).report_error.assert_not_called()
+
+        # The next poll retries the cancel rather than re-erroring on upload.
+        uploader.poll_upload_queue()
+        assert mock_client.cancel_upload_request.call_count == 2

--- a/web/app/api/v1/files/[fileId]/route.ts
+++ b/web/app/api/v1/files/[fileId]/route.ts
@@ -18,9 +18,12 @@ type RouteContext = {
 //   Watcher flow:   detected → [upload_requested →] uploaded → processing → completed|failed
 //   Lambda flow:    (created as "uploaded" via POST .../files) → processing → completed|failed
 //   Reprocessing:   completed|failed → processing → completed|failed
+//   Cancel request: upload_requested → detected (watcher gave up locating
+//                   the local file after repeated polls; clears the queue
+//                   entry — see ENG-1397)
 const VALID_TRANSITIONS: Record<string, string[]> = {
   detected: ["uploaded"],
-  upload_requested: ["uploaded"],
+  upload_requested: ["uploaded", "detected"],
   uploaded: ["processing"],
   processing: ["processing", "completed", "failed"],
   completed: ["processing"],
@@ -103,6 +106,12 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
 
     if (body.status === "uploaded") {
       updates.uploadedAt = now;
+    }
+    // Reverting a pending request back to detected (watcher cancel): clear
+    // upload_requested_at so the row leaves the upload queue, whose filter
+    // requires upload_requested_at to be non-null.
+    if (body.status === "detected") {
+      updates.uploadRequestedAt = null;
     }
     if (body.status === "completed" || body.status === "failed") {
       updates.processedAt = now;

--- a/web/app/api/v1/watchers/[watcherId]/config/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/config/route.ts
@@ -1,9 +1,13 @@
 import { authorize } from "@/lib/api/auth";
 import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { isValidUUID } from "@/lib/api/validators";
-import { findActiveWatcher } from "@/lib/api/watchers";
+import {
+  extractWatchDirectory,
+  findActiveWatcher,
+  revertPendingUploadRequests,
+} from "@/lib/api/watchers";
 import { db } from "@/lib/db";
-import { watchers } from "@/lib/db/schema";
+import { watcherEvents, watchers } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 
@@ -42,6 +46,9 @@ export async function PUT(
     );
   }
 
+  const previousWatchDir = extractWatchDirectory(watcher.configYaml);
+  const nextWatchDir = extractWatchDirectory(body.config_yaml);
+
   await db
     .update(watchers)
     .set({
@@ -49,6 +56,29 @@ export async function PUT(
       configYaml: body.config_yaml,
     })
     .where(eq(watchers.id, watcherId));
+
+  // A watch_directory change orphans every pending request: each carries a
+  // relative_path under the old root that no longer resolves. Revert them to
+  // `detected` to drain the queue instead of erroring each poll (ENG-1397).
+  // Gated on a known previous dir so first-push / unrelated edits don't
+  // revert spuriously.
+  if (previousWatchDir && nextWatchDir && previousWatchDir !== nextWatchDir) {
+    const revertedIds = await revertPendingUploadRequests(watcher.instrumentId);
+    if (revertedIds.length > 0) {
+      await db.insert(watcherEvents).values({
+        watcherId,
+        eventType: "config_synced",
+        message: `Cancelled ${revertedIds.length} pending upload request(s) after watch directory changed`,
+        details: {
+          kind: "upload_requests_cancelled",
+          cancelled_count: revertedIds.length,
+          previous_watch_directory: previousWatchDir,
+          watch_directory: nextWatchDir,
+        },
+        timestamp: new Date(),
+      });
+    }
+  }
 
   return Response.json({ config_checksum: body.config_checksum });
 }

--- a/web/lib/api/watchers.ts
+++ b/web/lib/api/watchers.ts
@@ -1,5 +1,7 @@
 import { db } from "@/lib/db";
 import {
+  files,
+  instrumentRuns,
   instruments,
   watcherEventTypeEnum,
   watcherEvents,
@@ -8,6 +10,7 @@ import {
 } from "@/lib/db/schema";
 import { and, asc, count, desc, eq, gte, inArray, isNull } from "drizzle-orm";
 import { cache } from "react";
+import YAML from "yaml";
 
 export const STALE_THRESHOLD_MS = 5 * 60 * 1000;
 
@@ -19,6 +22,57 @@ export async function findActiveWatcher(watcherId: string) {
     .limit(1);
 
   return watcher ?? null;
+}
+
+/**
+ * Extracts `instrument.watch_directory` from a watcher's stored config YAML.
+ * Returns null when the YAML is missing or unparseable. Mirrors the
+ * `extractFilePatterns` helper in `lib/api/instruments.ts`.
+ */
+export function extractWatchDirectory(
+  configYaml: string | null
+): string | null {
+  if (!configYaml) return null;
+  try {
+    const doc = YAML.parse(configYaml);
+    const dir = doc?.instrument?.watch_directory;
+    return typeof dir === "string" ? dir : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reverts an instrument's pending upload requests back to `detected`,
+ * clearing `upload_requested_at` so they drop out of the upload queue.
+ *
+ * Called when a watcher's `watch_directory` changes: every queued file's
+ * `relative_path` was anchored to the old root, so none resolve under the
+ * new one and the watcher would otherwise re-error on each heartbeat poll
+ * (ENG-1397). Returns the reverted file ids (for event reporting).
+ */
+export async function revertPendingUploadRequests(
+  instrumentId: string
+): Promise<number[]> {
+  const reverted = await db
+    .update(files)
+    .set({ status: "detected", uploadRequestedAt: null })
+    .where(
+      and(
+        inArray(
+          files.instrumentRunId,
+          db
+            .select({ id: instrumentRuns.id })
+            .from(instrumentRuns)
+            .where(eq(instrumentRuns.instrumentId, instrumentId))
+        ),
+        eq(files.status, "upload_requested"),
+        isNull(files.uploadedAt),
+        isNull(files.deletedAt)
+      )
+    )
+    .returning({ id: files.id });
+  return reverted.map((row) => row.id);
 }
 
 type WatcherLike = {

--- a/web/tests/integration/files.test.ts
+++ b/web/tests/integration/files.test.ts
@@ -1,4 +1,4 @@
-import { instruments } from "@/lib/db/schema";
+import { instruments, files as schemaFiles } from "@/lib/db/schema";
 import {
   api,
   closeTestDb,
@@ -6,6 +6,7 @@ import {
   resetDb,
   seedTestUser,
 } from "@/tests/integration/helpers";
+import { eq } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 // Files have two distinct lifecycle paths through the status state machine:
@@ -375,6 +376,27 @@ describe("Files API", () => {
       body: { status: "uploaded" },
     });
     expect(res.status).toBe(404);
+  });
+
+  // Watcher cancel path (ENG-1397): after giving up on a queued file the
+  // watcher reverts it upload_requested → detected, which must clear
+  // upload_requested_at so the row leaves the upload queue.
+  it("PATCH transitions upload_requested → detected and clears upload_requested_at", async () => {
+    const db = getTestDb();
+    await db
+      .update(schemaFiles)
+      .set({ status: "upload_requested", uploadRequestedAt: new Date() })
+      .where(eq(schemaFiles.id, thirdFileId));
+
+    const res = await api(`/api/v1/files/${thirdFileId}`, {
+      method: "PATCH",
+      token,
+      body: { status: "detected" },
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe("detected");
+    expect(data.upload_requested_at).toBeNull();
   });
 
   // -------------------------------------------------------------------------

--- a/web/tests/integration/upload-request-cancellation.test.ts
+++ b/web/tests/integration/upload-request-cancellation.test.ts
@@ -1,0 +1,179 @@
+import { files, instruments } from "@/lib/db/schema";
+import {
+  api,
+  closeTestDb,
+  getTestDb,
+  resetDb,
+  seedTestUser,
+} from "@/tests/integration/helpers";
+import { inArray } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// When a watcher's watch_directory changes, every still-pending upload
+// request points at a relative path anchored to the old root and can no
+// longer be resolved by the watcher. The config PUT handler reverts those
+// files to `detected` (clearing upload_requested_at) so they drop out of the
+// upload queue instead of erroring on every heartbeat poll (ENG-1397).
+describe("Upload request cancellation on watch-directory change", () => {
+  let token: string;
+  let watcherId: string;
+  const instrumentId = "cancel-on-dirchange-instrument";
+  const runId = "cancel-on-dirchange-run";
+
+  const configYamlFor = (dir: string): string =>
+    [
+      "version: 1",
+      "instrument:",
+      `  id: ${instrumentId}`,
+      `  watch_directory: ${dir}`,
+      "  file_patterns:",
+      '    - "*.csv"',
+      "",
+    ].join("\n");
+
+  beforeAll(async () => {
+    await resetDb();
+    ({ token } = await seedTestUser());
+
+    const db = getTestDb();
+    await db.insert(instruments).values({
+      id: instrumentId,
+      displayName: "Cancel-on-dir-change Instrument",
+      status: "active",
+    });
+
+    const reg = await api("/api/v1/watchers/register", {
+      method: "POST",
+      token,
+      body: { instrument_id: instrumentId, hostname: "lab-pc" },
+    });
+    watcherId = (await reg.json()).watcher_id;
+
+    // First config push establishes the baseline watch directory. It must not
+    // trigger a revert (no previous directory to diff against).
+    await api(`/api/v1/watchers/${watcherId}/config`, {
+      method: "PUT",
+      token,
+      body: {
+        config_checksum: "sum-a",
+        config_yaml: configYamlFor("/data/old"),
+      },
+    });
+
+    await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: {
+        run_id: runId,
+        source: "watcher",
+        detected_files: [
+          { relative_path: "a.csv", filename: "a.csv", size_bytes: 1 },
+          { relative_path: "b.csv", filename: "b.csv", size_bytes: 1 },
+        ],
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  async function fileIdsByName(): Promise<Record<string, number>> {
+    const res = await api(`/api/v1/instruments/${instrumentId}/runs/${runId}`, {
+      token,
+    });
+    const data = await res.json();
+    const map: Record<string, number> = {};
+    for (const f of data.files as { id: number; filename: string }[]) {
+      map[f.filename] = f.id;
+    }
+    return map;
+  }
+
+  // Simulate a user requesting upload via the web UI (sets upload_requested_at)
+  // by writing the queue state directly — the request-upload route is exercised
+  // by its own suite; here we only need files in the queue to cancel.
+  async function queueForUpload(ids: number[]): Promise<void> {
+    await getTestDb()
+      .update(files)
+      .set({ status: "upload_requested", uploadRequestedAt: new Date() })
+      .where(inArray(files.id, ids));
+  }
+
+  it("reverts pending requests to detected when watch_directory changes", async () => {
+    const ids = await fileIdsByName();
+    await queueForUpload([ids["a.csv"], ids["b.csv"]]);
+
+    const before = await api(`/api/v1/watchers/${watcherId}/upload-queue`, {
+      token,
+    });
+    expect((await before.json()).files).toHaveLength(2);
+
+    const res = await api(`/api/v1/watchers/${watcherId}/config`, {
+      method: "PUT",
+      token,
+      body: {
+        config_checksum: "sum-b",
+        config_yaml: configYamlFor("/data/new"),
+      },
+    });
+    expect(res.status).toBe(200);
+
+    // Queue drained.
+    const after = await api(`/api/v1/watchers/${watcherId}/upload-queue`, {
+      token,
+    });
+    expect((await after.json()).files).toHaveLength(0);
+
+    // Files reverted to detected with upload_requested_at cleared.
+    const detail = await api(
+      `/api/v1/instruments/${instrumentId}/runs/${runId}`,
+      { token }
+    );
+    const detailData = await detail.json();
+    for (const f of detailData.files as {
+      status: string;
+      upload_requested_at: string | null;
+    }[]) {
+      expect(f.status).toBe("detected");
+      expect(f.upload_requested_at).toBeNull();
+    }
+
+    // A config_synced event records the cancellation for observability.
+    const events = await api(
+      `/api/v1/watchers/${watcherId}/events?event_type=config_synced`,
+      { token }
+    );
+    const eventsData = await events.json();
+    const cancelEvent = eventsData.data.find(
+      (e: { details?: { kind?: string } }) =>
+        e.details?.kind === "upload_requests_cancelled"
+    );
+    expect(cancelEvent).toBeTruthy();
+    expect(cancelEvent.details.cancelled_count).toBe(2);
+    expect(cancelEvent.details.previous_watch_directory).toBe("/data/old");
+    expect(cancelEvent.details.watch_directory).toBe("/data/new");
+  });
+
+  it("does not revert when watch_directory is unchanged", async () => {
+    const ids = await fileIdsByName();
+    await queueForUpload([ids["a.csv"]]);
+
+    // Same watch directory (only the checksum differs, as an unrelated config
+    // edit would) — pending requests must survive.
+    const res = await api(`/api/v1/watchers/${watcherId}/config`, {
+      method: "PUT",
+      token,
+      body: {
+        config_checksum: "sum-c",
+        config_yaml: configYamlFor("/data/new"),
+      },
+    });
+    expect(res.status).toBe(200);
+
+    const queue = await api(`/api/v1/watchers/${watcherId}/upload-queue`, {
+      token,
+    });
+    expect((await queue.json()).files).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

In manual mode the uploader resolves each queued file as `watch_dir / relative_path`, but `relative_path` is anchored to the watch directory active at detection time. After an operator changes a watcher's `watch_directory`, every pending request becomes unresolvable and the queue re-poll re-emits a `Queued file missing` error on every heartbeat tick forever (the reported flood was 8611+ events).

Two coordinated fixes plus a per-file give-up path:

- **Server — revert on dir change:** when `PUT /watchers/:id/config` changes `watch_directory`, all of that instrument's `upload_requested` files are reverted to `detected` (clearing `upload_requested_at`) so the queue drains immediately. Gated on a known previous directory so the first config push and unrelated config edits never revert spuriously. A `config_synced` event with `details.kind="upload_requests_cancelled"` records the cancellation.
- **Server — single-file cancel:** `PATCH /files/:id` now allows `upload_requested -> detected` (clearing `upload_requested_at`) so the watcher can remove one stuck request from the queue.
- **Watcher — bounded retries:** queued files are retried at most `MAX_QUEUE_FILE_ATTEMPTS=3` heartbeat polls, covering both missing-on-disk and upload/network failures. The `Queued file missing` error is emitted once per file (throttled), and after the cap the watcher cancels the request server-side (`cancel_upload_request`) and emits an `upload_request_cancelled` give-up event. Attempt counters reset on restart, so a transient outage longer than ~3 ticks is recovered on the next start.

### Trade-off

A transient failure that lasts longer than ~3 heartbeat ticks (~3 min) causes the file to be reverted to `detected` until a human re-requests it or the watcher re-detects it. This is the chosen behavior over retrying forever.

## Changes

- `web/lib/api/watchers.ts`: `extractWatchDirectory` + `revertPendingUploadRequests` helpers.
- `web/app/api/v1/watchers/[watcherId]/config/route.ts`: revert + cancellation event on `watch_directory` change.
- `web/app/api/v1/files/[fileId]/route.ts`: allow `upload_requested -> detected`, clear `upload_requested_at`.
- `watcher/`: `cancel_upload_request` client method, `MAX_QUEUE_FILE_ATTEMPTS` constant, per-file attempt cap in `Uploader`, new event kinds in the taxonomy.
- Tests (`watcher/tests/test_uploader.py`, `web/tests/integration/{files,upload-request-cancellation}.test.ts`) and `docs/watcher.md`.

## Test plan

- [x] `make check-all` (ruff lint/format, pyright, prettier, eslint, tsc)
- [x] Python unit tests: 613 passed (incl. 5 new uploader cases)
- [x] Web integration suite: 244 passed (incl. dir-change revert, no-op-otherwise, and `upload_requested -> detected` cases)

Made with [Cursor](https://cursor.com)