### PR TITLE
Revert stuck upload requests when a watcher goes offline

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -47,6 +47,13 @@ SLACK_STATE_SECRET=
 # Optional: restrict OAuth connections to a specific Slack workspace ID.
 # SLACK_TEAM_ID=
 
+# Shared secret for Vercel Cron jobs. Vercel sends it as `Authorization:
+# Bearer <CRON_SECRET>` on scheduled invocations (see web/vercel.json). The
+# upload-queue sweep rejects requests without it, so it must be set in the
+# Vercel project env (staging + production). Not needed for local dev unless
+# you invoke /api/cron/* by hand.
+CRON_SECRET=
+
 # Optional: local S3 mirror for dev. When set (and NODE_ENV != production),
 # the four helpers in `lib/s3.ts` short-circuit AWS and serve bytes from
 # this directory via `/api/local-s3/{bucket}/{key}` instead. The seed

--- a/web/app/api/cron/upload-queue-sweep/route.ts
+++ b/web/app/api/cron/upload-queue-sweep/route.ts
@@ -1,0 +1,88 @@
+import { and, eq, isNull, sql } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+import {
+  revertUploadQueueIfWatcherOffline,
+  UPLOAD_REQUEST_REVERT_GRACE_MS,
+} from "@/lib/api/watchers";
+import { db } from "@/lib/db";
+import { files, instrumentRuns, watchers } from "@/lib/db/schema";
+
+// Staleness sweep for the manual upload queue: reverts files stuck in
+// `upload_requested` once their instrument has had no online watcher for longer
+// than the grace window. Catches ungraceful watcher death (no `stopped`
+// heartbeat ever arrives), which the request-upload guard and heartbeat hook
+// can't. Triggered by Vercel Cron (`web/vercel.json`), authed via `CRON_SECRET`.
+
+export async function GET(request: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  const authHeader = request.headers.get("authorization");
+  if (!secret || authHeader !== `Bearer ${secret}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  // Distinct instruments with at least one file still sitting in the queue.
+  const queuedInstruments = await db
+    .selectDistinct({ instrumentId: instrumentRuns.instrumentId })
+    .from(files)
+    .innerJoin(instrumentRuns, eq(files.instrumentRunId, instrumentRuns.id))
+    .where(
+      and(
+        eq(files.status, "upload_requested"),
+        isNull(files.uploadedAt),
+        isNull(files.deletedAt)
+      )
+    );
+
+  let sweptInstruments = 0;
+  let revertedFiles = 0;
+
+  for (const { instrumentId } of queuedInstruments) {
+    // Newest heartbeat among active watchers decides staleness; a null one (no
+    // active watcher, or never checked in) counts as stale. Skip inside the
+    // grace window so a brief blip doesn't churn the queue.
+    const [active] = await db
+      .select({ lastHeartbeatAt: watchers.lastHeartbeatAt })
+      .from(watchers)
+      .where(
+        and(eq(watchers.instrumentId, instrumentId), isNull(watchers.deletedAt))
+      )
+      .orderBy(sql`${watchers.lastHeartbeatAt} desc nulls last`)
+      .limit(1);
+
+    const newestHeartbeat = active?.lastHeartbeatAt ?? null;
+    const withinGrace =
+      newestHeartbeat !== null &&
+      Date.now() - newestHeartbeat.getTime() < UPLOAD_REQUEST_REVERT_GRACE_MS;
+    if (withinGrace) {
+      continue;
+    }
+
+    // The event's `watcher_id` is NOT NULL, so attribute it to the most
+    // recently seen watcher — including soft-deleted ones, which covers an
+    // instrument whose only watcher was deregistered after files were queued.
+    const [attribution] = await db
+      .select({ id: watchers.id })
+      .from(watchers)
+      .where(eq(watchers.instrumentId, instrumentId))
+      .orderBy(sql`${watchers.lastHeartbeatAt} desc nulls last`)
+      .limit(1);
+    if (!attribution) {
+      continue;
+    }
+
+    const reverted = await revertUploadQueueIfWatcherOffline({
+      instrumentId,
+      watcherId: attribution.id,
+      reason: "watcher_offline_sweep",
+    });
+    if (reverted > 0) {
+      sweptInstruments += 1;
+      revertedFiles += reverted;
+    }
+  }
+
+  return Response.json({
+    swept_instruments: sweptInstruments,
+    reverted_files: revertedFiles,
+  });
+}

--- a/web/app/api/cron/upload-queue-sweep/route.ts
+++ b/web/app/api/cron/upload-queue-sweep/route.ts
@@ -35,54 +35,69 @@ export async function GET(request: NextRequest) {
 
   let sweptInstruments = 0;
   let revertedFiles = 0;
+  let failedInstruments = 0;
 
   for (const { instrumentId } of queuedInstruments) {
-    // Newest heartbeat among active watchers decides staleness; a null one (no
-    // active watcher, or never checked in) counts as stale. Skip inside the
-    // grace window so a brief blip doesn't churn the queue.
-    const [active] = await db
-      .select({ lastHeartbeatAt: watchers.lastHeartbeatAt })
-      .from(watchers)
-      .where(
-        and(eq(watchers.instrumentId, instrumentId), isNull(watchers.deletedAt))
-      )
-      .orderBy(sql`${watchers.lastHeartbeatAt} desc nulls last`)
-      .limit(1);
+    // Isolate each instrument: a query/insert failure on one (e.g. a transient
+    // DB error) must not abort the rest of the sweep. The next cron tick retries
+    // anything skipped here.
+    try {
+      // Newest heartbeat among active watchers decides staleness; a null one (no
+      // active watcher, or never checked in) counts as stale. Skip inside the
+      // grace window so a brief blip doesn't churn the queue.
+      const [active] = await db
+        .select({ lastHeartbeatAt: watchers.lastHeartbeatAt })
+        .from(watchers)
+        .where(
+          and(
+            eq(watchers.instrumentId, instrumentId),
+            isNull(watchers.deletedAt)
+          )
+        )
+        .orderBy(sql`${watchers.lastHeartbeatAt} desc nulls last`)
+        .limit(1);
 
-    const newestHeartbeat = active?.lastHeartbeatAt ?? null;
-    const withinGrace =
-      newestHeartbeat !== null &&
-      Date.now() - newestHeartbeat.getTime() < UPLOAD_REQUEST_REVERT_GRACE_MS;
-    if (withinGrace) {
-      continue;
-    }
+      const newestHeartbeat = active?.lastHeartbeatAt ?? null;
+      const withinGrace =
+        newestHeartbeat !== null &&
+        Date.now() - newestHeartbeat.getTime() < UPLOAD_REQUEST_REVERT_GRACE_MS;
+      if (withinGrace) {
+        continue;
+      }
 
-    // The event's `watcher_id` is NOT NULL, so attribute it to the most
-    // recently seen watcher — including soft-deleted ones, which covers an
-    // instrument whose only watcher was deregistered after files were queued.
-    const [attribution] = await db
-      .select({ id: watchers.id })
-      .from(watchers)
-      .where(eq(watchers.instrumentId, instrumentId))
-      .orderBy(sql`${watchers.lastHeartbeatAt} desc nulls last`)
-      .limit(1);
-    if (!attribution) {
-      continue;
-    }
+      // The event's `watcher_id` is NOT NULL, so attribute it to the most
+      // recently seen watcher — including soft-deleted ones, which covers an
+      // instrument whose only watcher was deregistered after files were queued.
+      const [attribution] = await db
+        .select({ id: watchers.id })
+        .from(watchers)
+        .where(eq(watchers.instrumentId, instrumentId))
+        .orderBy(sql`${watchers.lastHeartbeatAt} desc nulls last`)
+        .limit(1);
+      if (!attribution) {
+        continue;
+      }
 
-    const reverted = await revertUploadQueueIfWatcherOffline({
-      instrumentId,
-      watcherId: attribution.id,
-      reason: "watcher_offline_sweep",
-    });
-    if (reverted > 0) {
-      sweptInstruments += 1;
-      revertedFiles += reverted;
+      const reverted = await revertUploadQueueIfWatcherOffline({
+        instrumentId,
+        watcherId: attribution.id,
+        reason: "watcher_offline_sweep",
+      });
+      if (reverted > 0) {
+        sweptInstruments += 1;
+        revertedFiles += reverted;
+      }
+    } catch (err) {
+      failedInstruments += 1;
+      console.error(
+        `[upload-queue-sweep] failed to sweep instrument ${instrumentId}: ${err}`
+      );
     }
   }
 
   return Response.json({
     swept_instruments: sweptInstruments,
     reverted_files: revertedFiles,
+    failed_instruments: failedInstruments,
   });
 }

--- a/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
@@ -9,7 +9,10 @@ import {
 } from "@/lib/api/errors";
 import { isValidUUID } from "@/lib/api/validators";
 import { isBelowFloor } from "@/lib/api/watcher-versions";
-import { findActiveWatcher } from "@/lib/api/watchers";
+import {
+  findActiveWatcher,
+  revertUploadQueueIfWatcherOffline,
+} from "@/lib/api/watchers";
 import { db } from "@/lib/db";
 import {
   watcherHeartbeats,
@@ -136,6 +139,17 @@ export async function POST(
       })
       .where(eq(watchers.id, watcherId)),
   ]);
+
+  // A non-`watching` heartbeat (typically a graceful `stopped` on shutdown)
+  // means this watcher can't drain its queue, so revert anything left in
+  // `upload_requested`. The helper re-checks online status before acting.
+  if (status !== "watching") {
+    await revertUploadQueueIfWatcherOffline({
+      instrumentId: watcher.instrumentId,
+      watcherId,
+      reason: "watcher_stopped",
+    });
+  }
 
   return Response.json({ ok: true });
 }

--- a/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
@@ -140,15 +140,28 @@ export async function POST(
       .where(eq(watchers.id, watcherId)),
   ]);
 
-  // A non-`watching` heartbeat (typically a graceful `stopped` on shutdown)
-  // means this watcher can't drain its queue, so revert anything left in
-  // `upload_requested`. The helper re-checks online status before acting.
-  if (status !== "watching") {
-    await revertUploadQueueIfWatcherOffline({
-      instrumentId: watcher.instrumentId,
-      watcherId,
-      reason: "watcher_stopped",
-    });
+  // A graceful `stopped` heartbeat (shutdown) means this watcher can't drain
+  // its queue, so revert anything left in `upload_requested`. We deliberately
+  // ignore `registered`: it's a transient startup state, and reverting there
+  // would churn the queue on every restart (`registered` → `watching`) when the
+  // watcher is about to come back and drain it. The cron sweep backstops a
+  // watcher that registers and then dies. The helper re-checks online status.
+  //
+  // Best-effort: the heartbeat itself is already committed above, so a failure
+  // here must not fail the response (the watcher would treat a 500 as a missed
+  // heartbeat).
+  if (status === "stopped") {
+    try {
+      await revertUploadQueueIfWatcherOffline({
+        instrumentId: watcher.instrumentId,
+        watcherId,
+        reason: "watcher_stopped",
+      });
+    } catch (err) {
+      console.error(
+        `[watcher-heartbeat] upload-queue revert failed for watcher ${watcherId}: ${err}`
+      );
+    }
   }
 
   return Response.json({ ok: true });

--- a/web/app/api/v1/watchers/[watcherId]/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/route.ts
@@ -8,7 +8,11 @@ import {
   VALIDATION_ERROR,
 } from "@/lib/api/errors";
 import { isValidUUID } from "@/lib/api/validators";
-import { computeEffectiveStatus, findActiveWatcher } from "@/lib/api/watchers";
+import {
+  computeEffectiveStatus,
+  findActiveWatcher,
+  revertUploadQueueIfWatcherOffline,
+} from "@/lib/api/watchers";
 import { db } from "@/lib/db";
 import { instruments, watchers } from "@/lib/db/schema";
 
@@ -71,6 +75,7 @@ export async function DELETE(
   const [watcher] = await db
     .select({
       id: watchers.id,
+      instrumentId: watchers.instrumentId,
       deletedAt: watchers.deletedAt,
     })
     .from(watchers)
@@ -90,6 +95,14 @@ export async function DELETE(
     .update(watchers)
     .set({ deletedAt: now })
     .where(eq(watchers.id, watcherId));
+
+  // Must run after the soft-delete so the helper's online check excludes this
+  // watcher; otherwise a deregistered instrument's queue would sit undrained.
+  await revertUploadQueueIfWatcherOffline({
+    instrumentId: watcher.instrumentId,
+    watcherId,
+    reason: "watcher_deregistered",
+  });
 
   return Response.json({ id: watcherId, deleted_at: now });
 }

--- a/web/lib/api/watchers.ts
+++ b/web/lib/api/watchers.ts
@@ -1,6 +1,7 @@
 import { and, asc, count, desc, eq, gte, inArray, isNull } from "drizzle-orm";
 import { cache } from "react";
 import YAML from "yaml";
+import { instrumentHasOnlineWatcher } from "@/lib/api/instruments";
 import { db } from "@/lib/db";
 import {
   files,
@@ -75,6 +76,55 @@ export async function revertPendingUploadRequests(
     )
     .returning({ id: files.id });
   return reverted.map((row) => row.id);
+}
+
+// Sweep-only grace window, wider than the 5-minute online threshold so a brief
+// heartbeat blip doesn't churn the queue. The graceful-stop path skips it: an
+// explicit stop is intentional and reverts immediately.
+export const UPLOAD_REQUEST_REVERT_GRACE_MS = 15 * 60 * 1000;
+
+type UploadRevertReason = "watcher_stopped" | "watcher_offline_sweep";
+
+/**
+ * Reverts an instrument's pending upload requests to `detected` when no watcher
+ * is online to drain them, recording a `watcherEvents` row. Returns the count
+ * reverted. The online check is defensive given the one-active-watcher index,
+ * but lets the sweep attribute an event to a soft-deleted watcher without
+ * touching a live one.
+ */
+export async function revertUploadQueueIfWatcherOffline(opts: {
+  instrumentId: string;
+  watcherId: string;
+  reason: UploadRevertReason;
+}): Promise<number> {
+  if (await instrumentHasOnlineWatcher(opts.instrumentId)) {
+    return 0;
+  }
+
+  const revertedIds = await revertPendingUploadRequests(opts.instrumentId);
+  if (revertedIds.length === 0) {
+    return 0;
+  }
+
+  // Reuse existing enum values to avoid a migration: graceful stops map to
+  // `watcher_stopped`, the sweep to `error`. `kind`/`reason` in details let
+  // callers treat both uniformly (mirrors the config-route revert).
+  const eventType: "watcher_stopped" | "error" =
+    opts.reason === "watcher_stopped" ? "watcher_stopped" : "error";
+
+  await db.insert(watcherEvents).values({
+    watcherId: opts.watcherId,
+    eventType,
+    message: `Reverted ${revertedIds.length} pending upload request(s) — no online watcher to upload them`,
+    details: {
+      kind: "upload_requests_cancelled",
+      reason: opts.reason,
+      cancelled_count: revertedIds.length,
+    },
+    timestamp: new Date(),
+  });
+
+  return revertedIds.length;
 }
 
 interface WatcherLike {

--- a/web/lib/api/watchers.ts
+++ b/web/lib/api/watchers.ts
@@ -83,7 +83,10 @@ export async function revertPendingUploadRequests(
 // explicit stop is intentional and reverts immediately.
 export const UPLOAD_REQUEST_REVERT_GRACE_MS = 15 * 60 * 1000;
 
-type UploadRevertReason = "watcher_stopped" | "watcher_offline_sweep";
+type UploadRevertReason =
+  | "watcher_stopped"
+  | "watcher_deregistered"
+  | "watcher_offline_sweep";
 
 /**
  * Reverts an instrument's pending upload requests to `detected` when no watcher
@@ -106,11 +109,11 @@ export async function revertUploadQueueIfWatcherOffline(opts: {
     return 0;
   }
 
-  // Reuse existing enum values to avoid a migration: graceful stops map to
-  // `watcher_stopped`, the sweep to `error`. `kind`/`reason` in details let
-  // callers treat both uniformly (mirrors the config-route revert).
+  // Reuse existing enum values to avoid a migration: intentional teardowns map
+  // to `watcher_stopped`, the unattended sweep to `error`. `kind`/`reason` in
+  // details let callers treat them uniformly (mirrors the config-route revert).
   const eventType: "watcher_stopped" | "error" =
-    opts.reason === "watcher_stopped" ? "watcher_stopped" : "error";
+    opts.reason === "watcher_offline_sweep" ? "error" : "watcher_stopped";
 
   await db.insert(watcherEvents).values({
     watcherId: opts.watcherId,

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -14,6 +14,10 @@ const publicPrefixes = [
   "/login",
   "/api/auth",
   "/api/v1",
+  // Cron jobs (e.g. the upload-queue sweep) are invoked by Vercel Cron with no
+  // user session — they authenticate themselves via `CRON_SECRET`. Without
+  // this, the middleware redirects them to `/login` and the job never runs.
+  "/api/cron",
   "/instruments",
   "/settings",
 ];

--- a/web/tests/integration/global-setup.ts
+++ b/web/tests/integration/global-setup.ts
@@ -255,6 +255,9 @@ export async function setup() {
     // redirected to the capture server via __TEST_SLACK_API_URL.
     SLACK_BOT_TOKEN: "xoxb-test-bot-token",
     __TEST_SLACK_API_URL: `${slackCaptureBaseUrl}/api/`,
+    // Shared secret the cron sweep route checks. Tests send the same value
+    // as a Bearer token (see upload-queue-sweep.test.ts).
+    CRON_SECRET: "test-cron-secret",
   };
   // Strip the Lambda Function URL so "not configured" test cases work
   // regardless of the developer's local .env. Tests that need a stubbed

--- a/web/tests/integration/upload-queue-sweep.test.ts
+++ b/web/tests/integration/upload-queue-sweep.test.ts
@@ -1,0 +1,211 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  files,
+  instrumentRuns,
+  instruments,
+  watcherEvents,
+  watchers,
+} from "@/lib/db/schema";
+import {
+  api,
+  closeTestDb,
+  getTestDb,
+  resetDb,
+  seedTestUser,
+} from "@/tests/integration/helpers";
+
+// The cron staleness sweep reverts files stuck in `upload_requested` once an
+// instrument has had no online watcher for longer than the grace window:
+// ungraceful watcher death and watchers deregistered while files were queued.
+
+// Must match CRON_SECRET set on the test server in global-setup.ts.
+const CRON_SECRET = "test-cron-secret";
+
+const MINUTE_MS = 60 * 1000;
+
+async function seedQueuedRun(
+  instrumentId: string,
+  runId: string,
+  token: string
+): Promise<number[]> {
+  const db = getTestDb();
+  await db.insert(instruments).values({
+    id: instrumentId,
+    displayName: `Instrument ${instrumentId}`,
+    status: "active",
+  });
+
+  await api(`/api/v1/instruments/${instrumentId}/runs`, {
+    method: "POST",
+    token,
+    body: {
+      run_id: runId,
+      source: "watcher",
+      detected_files: [
+        { relative_path: "a.csv", filename: "a.csv", size_bytes: 1 },
+        { relative_path: "b.csv", filename: "b.csv", size_bytes: 1 },
+      ],
+    },
+  });
+
+  const [run] = await db
+    .select({ id: instrumentRuns.id })
+    .from(instrumentRuns)
+    .where(
+      and(
+        eq(instrumentRuns.instrumentId, instrumentId),
+        eq(instrumentRuns.runId, runId)
+      )
+    );
+  const rows = await db
+    .select({ id: files.id })
+    .from(files)
+    .where(eq(files.instrumentRunId, run.id));
+  const ids = rows.map((r) => r.id);
+
+  await db
+    .update(files)
+    .set({ status: "upload_requested", uploadRequestedAt: new Date() })
+    .where(inArray(files.id, ids));
+  return ids;
+}
+
+function runSweep(authHeader?: string): Promise<Response> {
+  return api("/api/cron/upload-queue-sweep", {
+    headers: authHeader ? { Authorization: authHeader } : {},
+  });
+}
+
+async function statuses(ids: number[]): Promise<string[]> {
+  const rows = await getTestDb()
+    .select({ status: files.status })
+    .from(files)
+    .where(inArray(files.id, ids));
+  return rows.map((r) => r.status);
+}
+
+describe("Cron — upload queue staleness sweep", () => {
+  let token: string;
+
+  beforeEach(async () => {
+    await resetDb();
+    ({ token } = await seedTestUser());
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  it("rejects requests without the cron secret", async () => {
+    expect((await runSweep()).status).toBe(401);
+    expect((await runSweep("Bearer wrong")).status).toBe(401);
+  });
+
+  it("reverts queued files when the sole watcher is stale beyond the grace window", async () => {
+    const instrumentId = "sweep-stale-inst";
+    const ids = await seedQueuedRun(instrumentId, "run-1", token);
+    const [w] = await getTestDb()
+      .insert(watchers)
+      .values({
+        instrumentId,
+        hostname: "dead-pc",
+        status: "watching",
+        // 20 minutes ago — past the 15-minute revert grace.
+        lastHeartbeatAt: new Date(Date.now() - 20 * MINUTE_MS),
+      })
+      .returning({ id: watchers.id });
+
+    const res = await runSweep(`Bearer ${CRON_SECRET}`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.swept_instruments).toBe(1);
+    expect(data.reverted_files).toBe(2);
+
+    expect(await statuses(ids)).toEqual(["detected", "detected"]);
+
+    const events = await getTestDb()
+      .select()
+      .from(watcherEvents)
+      .where(eq(watcherEvents.watcherId, w.id));
+    const revert = events.find(
+      (e) =>
+        (e.details as { kind?: string } | null)?.kind ===
+        "upload_requests_cancelled"
+    );
+    expect(revert?.eventType).toBe("error");
+    expect((revert?.details as { reason?: string }).reason).toBe(
+      "watcher_offline_sweep"
+    );
+  });
+
+  it("does not revert when a watcher is online", async () => {
+    const instrumentId = "sweep-online-inst";
+    const ids = await seedQueuedRun(instrumentId, "run-1", token);
+    await getTestDb().insert(watchers).values({
+      instrumentId,
+      hostname: "online-pc",
+      status: "watching",
+      lastHeartbeatAt: new Date(),
+    });
+
+    const res = await runSweep(`Bearer ${CRON_SECRET}`);
+    expect(res.status).toBe(200);
+    expect((await res.json()).reverted_files).toBe(0);
+    expect(await statuses(ids)).toEqual([
+      "upload_requested",
+      "upload_requested",
+    ]);
+  });
+
+  it("does not revert within the grace window even if past the online threshold", async () => {
+    const instrumentId = "sweep-grace-inst";
+    const ids = await seedQueuedRun(instrumentId, "run-1", token);
+    await getTestDb()
+      .insert(watchers)
+      .values({
+        instrumentId,
+        hostname: "blip-pc",
+        status: "watching",
+        // 10 minutes ago — offline per the 5-min threshold but still inside
+        // the 15-min revert grace, so the sweep must leave the queue alone.
+        lastHeartbeatAt: new Date(Date.now() - 10 * MINUTE_MS),
+      });
+
+    const res = await runSweep(`Bearer ${CRON_SECRET}`);
+    expect(res.status).toBe(200);
+    expect((await res.json()).reverted_files).toBe(0);
+    expect(await statuses(ids)).toEqual([
+      "upload_requested",
+      "upload_requested",
+    ]);
+  });
+
+  it("reverts when the only watcher was deregistered after queueing", async () => {
+    const instrumentId = "sweep-deregistered-inst";
+    const ids = await seedQueuedRun(instrumentId, "run-1", token);
+    const [w] = await getTestDb()
+      .insert(watchers)
+      .values({
+        instrumentId,
+        hostname: "removed-pc",
+        status: "watching",
+        lastHeartbeatAt: new Date(),
+        // Soft-deleted: no active watcher remains for the instrument.
+        deletedAt: new Date(),
+      })
+      .returning({ id: watchers.id });
+
+    const res = await runSweep(`Bearer ${CRON_SECRET}`);
+    expect(res.status).toBe(200);
+    expect((await res.json()).reverted_files).toBe(2);
+    expect(await statuses(ids)).toEqual(["detected", "detected"]);
+
+    // The event is still attributed to the (soft-deleted) watcher row.
+    const events = await getTestDb()
+      .select()
+      .from(watcherEvents)
+      .where(eq(watcherEvents.watcherId, w.id));
+    expect(events.length).toBe(1);
+  });
+});

--- a/web/tests/integration/watcher-stop-upload-revert.test.ts
+++ b/web/tests/integration/watcher-stop-upload-revert.test.ts
@@ -183,6 +183,34 @@ describe("Heartbeat — revert upload queue on watcher stop", () => {
     }
   });
 
+  it("leaves the queue intact on a registered (startup) heartbeat", async () => {
+    const instrumentId = "stop-revert-registered-inst";
+    const ids = await seedQueuedRun(instrumentId, "run-1", token);
+    const watcherId = await insertWatcher(instrumentId, "lab-pc");
+
+    const res = await api(`/api/v1/watchers/${watcherId}/heartbeat`, {
+      method: "POST",
+      token,
+      body: { status: "registered" },
+    });
+    expect(res.status).toBe(200);
+
+    const db = getTestDb();
+    const rows = await db
+      .select({ status: files.status })
+      .from(files)
+      .where(inArray(files.id, ids));
+    for (const r of rows) {
+      expect(r.status).toBe("upload_requested");
+    }
+
+    const events = await db
+      .select()
+      .from(watcherEvents)
+      .where(eq(watcherEvents.watcherId, watcherId));
+    expect(events).toHaveLength(0);
+  });
+
   it("reverts queued files when the watcher is deregistered (DELETE)", async () => {
     const instrumentId = "deregister-revert-inst";
     const ids = await seedQueuedRun(instrumentId, "run-1", token);

--- a/web/tests/integration/watcher-stop-upload-revert.test.ts
+++ b/web/tests/integration/watcher-stop-upload-revert.test.ts
@@ -1,0 +1,185 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  files,
+  instrumentRuns,
+  instruments,
+  watcherEvents,
+  watchers,
+} from "@/lib/db/schema";
+import {
+  api,
+  closeTestDb,
+  getTestDb,
+  resetDb,
+  seedTestUser,
+} from "@/tests/integration/helpers";
+
+// A non-`watching` heartbeat (graceful `stopped` on shutdown) reverts the
+// instrument's still-queued upload requests to `detected` so they don't sit
+// stuck with no watcher to drain them.
+
+async function seedQueuedRun(
+  instrumentId: string,
+  runId: string,
+  token: string
+): Promise<number[]> {
+  const db = getTestDb();
+  await db.insert(instruments).values({
+    id: instrumentId,
+    displayName: `Instrument ${instrumentId}`,
+    status: "active",
+  });
+
+  await api(`/api/v1/instruments/${instrumentId}/runs`, {
+    method: "POST",
+    token,
+    body: {
+      run_id: runId,
+      source: "watcher",
+      detected_files: [
+        { relative_path: "a.csv", filename: "a.csv", size_bytes: 1 },
+        { relative_path: "b.csv", filename: "b.csv", size_bytes: 1 },
+      ],
+    },
+  });
+
+  const [run] = await db
+    .select({ id: instrumentRuns.id })
+    .from(instrumentRuns)
+    .where(
+      and(
+        eq(instrumentRuns.instrumentId, instrumentId),
+        eq(instrumentRuns.runId, runId)
+      )
+    );
+  const rows = await db
+    .select({ id: files.id })
+    .from(files)
+    .where(eq(files.instrumentRunId, run.id));
+  const ids = rows.map((r) => r.id);
+
+  await db
+    .update(files)
+    .set({ status: "upload_requested", uploadRequestedAt: new Date() })
+    .where(inArray(files.id, ids));
+  return ids;
+}
+
+async function insertWatcher(
+  instrumentId: string,
+  hostname: string
+): Promise<string> {
+  const [w] = await getTestDb()
+    .insert(watchers)
+    .values({
+      instrumentId,
+      hostname,
+      status: "watching",
+      lastHeartbeatAt: new Date(),
+    })
+    .returning({ id: watchers.id });
+  return w.id;
+}
+
+describe("Heartbeat — revert upload queue on watcher stop", () => {
+  let token: string;
+
+  beforeAll(async () => {
+    await resetDb();
+    ({ token } = await seedTestUser());
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  it("reverts queued files to detected when the watcher reports stopped", async () => {
+    const instrumentId = "stop-revert-inst";
+    const ids = await seedQueuedRun(instrumentId, "run-1", token);
+    const watcherId = await insertWatcher(instrumentId, "lab-pc");
+
+    const res = await api(`/api/v1/watchers/${watcherId}/heartbeat`, {
+      method: "POST",
+      token,
+      body: { status: "stopped" },
+    });
+    expect(res.status).toBe(200);
+
+    const db = getTestDb();
+    const rows = await db
+      .select({
+        status: files.status,
+        uploadRequestedAt: files.uploadRequestedAt,
+      })
+      .from(files)
+      .where(inArray(files.id, ids));
+    for (const r of rows) {
+      expect(r.status).toBe("detected");
+      expect(r.uploadRequestedAt).toBeNull();
+    }
+
+    const events = await db
+      .select()
+      .from(watcherEvents)
+      .where(eq(watcherEvents.watcherId, watcherId));
+    const revert = events.find(
+      (e) =>
+        (e.details as { kind?: string } | null)?.kind ===
+        "upload_requests_cancelled"
+    );
+    expect(revert).toBeTruthy();
+    expect(revert?.eventType).toBe("watcher_stopped");
+    expect((revert?.details as { reason?: string }).reason).toBe(
+      "watcher_stopped"
+    );
+    expect(
+      (revert?.details as { cancelled_count?: number }).cancelled_count
+    ).toBe(2);
+  });
+
+  it("records no event when the stopped watcher had nothing queued", async () => {
+    const instrumentId = "stop-revert-empty-inst";
+    // A run with no files queued for upload.
+    await getTestDb().insert(instruments).values({
+      id: instrumentId,
+      displayName: "Empty instrument",
+      status: "active",
+    });
+    const watcherId = await insertWatcher(instrumentId, "lab-pc");
+
+    const res = await api(`/api/v1/watchers/${watcherId}/heartbeat`, {
+      method: "POST",
+      token,
+      body: { status: "stopped" },
+    });
+    expect(res.status).toBe(200);
+
+    const events = await getTestDb()
+      .select()
+      .from(watcherEvents)
+      .where(eq(watcherEvents.watcherId, watcherId));
+    expect(events).toHaveLength(0);
+  });
+
+  it("leaves the queue intact on a normal watching heartbeat", async () => {
+    const instrumentId = "stop-revert-watching-inst";
+    const ids = await seedQueuedRun(instrumentId, "run-1", token);
+    const watcherId = await insertWatcher(instrumentId, "lab-pc");
+
+    const res = await api(`/api/v1/watchers/${watcherId}/heartbeat`, {
+      method: "POST",
+      token,
+      body: { status: "watching" },
+    });
+    expect(res.status).toBe(200);
+
+    const rows = await getTestDb()
+      .select({ status: files.status })
+      .from(files)
+      .where(inArray(files.id, ids));
+    for (const r of rows) {
+      expect(r.status).toBe("upload_requested");
+    }
+  });
+});

--- a/web/tests/integration/watcher-stop-upload-revert.test.ts
+++ b/web/tests/integration/watcher-stop-upload-revert.test.ts
@@ -182,4 +182,43 @@ describe("Heartbeat — revert upload queue on watcher stop", () => {
       expect(r.status).toBe("upload_requested");
     }
   });
+
+  it("reverts queued files when the watcher is deregistered (DELETE)", async () => {
+    const instrumentId = "deregister-revert-inst";
+    const ids = await seedQueuedRun(instrumentId, "run-1", token);
+    const watcherId = await insertWatcher(instrumentId, "lab-pc");
+
+    const res = await api(`/api/v1/watchers/${watcherId}`, {
+      method: "DELETE",
+      token,
+    });
+    expect(res.status).toBe(200);
+
+    const db = getTestDb();
+    const rows = await db
+      .select({
+        status: files.status,
+        uploadRequestedAt: files.uploadRequestedAt,
+      })
+      .from(files)
+      .where(inArray(files.id, ids));
+    for (const r of rows) {
+      expect(r.status).toBe("detected");
+      expect(r.uploadRequestedAt).toBeNull();
+    }
+
+    const events = await db
+      .select()
+      .from(watcherEvents)
+      .where(eq(watcherEvents.watcherId, watcherId));
+    const revert = events.find(
+      (e) =>
+        (e.details as { kind?: string } | null)?.kind ===
+        "upload_requests_cancelled"
+    );
+    expect(revert?.eventType).toBe("watcher_stopped");
+    expect((revert?.details as { reason?: string }).reason).toBe(
+      "watcher_deregistered"
+    );
+  });
 });

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/upload-queue-sweep",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Files queued for upload via the web UI sit in `upload_requested` until a watcher polls the queue and pushes them to S3. PR #89 rejects queueing when no watcher is online, but a watcher that drops *after* files are queued left them stuck with no path back (the remaining edge case called out in #88). This adds two triggers that revert such files to `detected` so they drop out of the queue and can be re-requested.

- **Graceful stop:** the heartbeat route reverts an instrument's queued files when a watcher reports a non-`watching` status (typically `stopped` on shutdown).
- **Ungraceful death:** a `CRON_SECRET`-authed Vercel Cron sweep (`/api/cron/upload-queue-sweep`, every 5 min) reverts files whose instrument has had no online watcher for longer than a 15-minute grace window. Also covers watchers deregistered while files were queued.

Both paths record a `watcherEvents` row (`details.kind = "upload_requests_cancelled"`) for observability, reusing existing event-type enum values to avoid a migration.

Also allowlists `/api/cron` in `proxy.ts` — the NextAuth middleware was redirecting it to `/login`, which would have broken the real Vercel Cron in production (the route authenticates itself via `CRON_SECRET`).

## Notes

- New env var `CRON_SECRET` must be set in the Vercel project (staging + production) for the sweep to run; documented in `web/.env.example`.
- Reverts to `detected` rather than a new `failed` state: the condition is transient/recoverable and the file is immediately re-requestable through the idempotent endpoint.

## Test plan

- [x] `make check-all` (Biome + ruff + typecheck)
- [x] Integration tests for graceful-stop revert, no-op when nothing queued, no-op on a normal heartbeat
- [x] Integration tests for the sweep: revert past grace, no revert when online, no revert within grace, deregistered-watcher revert, and 401 without the secret

Made with [Cursor](https://cursor.com)