### PR TITLE
Watcher: Switchable API environments with per-environment state

### DIFF
--- a/docs/guides/installing-a-watcher.md
+++ b/docs/guides/installing-a-watcher.md
@@ -67,6 +67,8 @@ The wizard will walk you through:
 
 The wizard saves configuration to `~/.data-hub/config.yaml`, the API key to `~/.data-hub/.env.<environment>`, and syncs the config to the server.
 
+> **Heads-up on the existing backlog.** On `staging` and `preview`, the watcher does *not* upload files that are already in the watch directory when you first run `init` — it records them as a baseline and uploads only files created afterwards. This keeps test environments from ingesting a PC's entire history. `production` uploads the existing backlog as normal. To force a full upload on staging/preview, set `initial_scan: full` in `~/.data-hub/config.yaml` before starting the watcher (see the [watcher reference](../reference/watcher.md#initial-scan-and-the-backlog)).
+
 ## Starting the watcher
 
 First, verify your setup with a dry run:

--- a/docs/reference/watcher.md
+++ b/docs/reference/watcher.md
@@ -52,6 +52,8 @@ Interactive setup wizard that:
 
 The wizard normalizes the pasted API key (stripping zero-width and non-breaking-space characters that Windows clipboards routinely inject) and rejects values that don't start with `dhub_`, so a paste mistake surfaces as a clear error rather than a confusing 401 later. Pass `--show-key` if your terminal mangles hidden input on paste.
 
+The initial scan mode defaults by environment: a fresh `init` on `production` uploads whatever is already in the watch directory, while `staging` and `preview` skip the pre-existing backlog and upload only files created afterwards. This guards a test environment from ingesting a PC's entire history. Set `initial_scan` in the config to override — see [Initial scan and the backlog](#initial-scan-and-the-backlog).
+
 ### `watch`
 
 Starts the file monitoring loop. Before entering the loop it:
@@ -193,12 +195,14 @@ A switch validates the target API with the resolved key, reuses the stored `watc
 
 #### Initial scan and the backlog
 
-Each environment keeps its own local state database (see [Local state](#local-state)), so switching never re-uploads files across environments. To avoid flooding a non-production environment with a PC's historical data, the initial scan mode defaults by environment:
+Each environment keeps its own local state database (see [Local state](#local-state)), so switching never re-uploads files across environments. The first time an environment is entered — whether by `init` or by `config set-environment` — the initial scan mode decides what happens to files already sitting in the watch directory. It defaults by environment:
 
 - `production` → `full`: the existing backlog is uploaded (production is the source of truth).
-- `staging` / `preview` → `new-only`: the files already on disk when the environment is first entered are recorded as a baseline and skipped; only files created after the switch flow to the target.
+- `staging` / `preview` → `new-only`: the files already on disk when the environment is first entered are recorded as a baseline and skipped; only files created afterwards are uploaded.
 
-Set `initial_scan` explicitly in the config to override (e.g. `full` to deliberately populate a staging environment). Switching a preview to a different deployment URL resets that environment's local state so the new target gets a clean baseline.
+This means a **fresh `init` on `staging` or `preview` does not upload the pre-existing backlog** — a deliberate guard so a test environment isn't flooded with a PC's entire history. Set `initial_scan: full` in the config to opt back in (e.g. to deliberately populate a staging environment), or `initial_scan: new-only` on production to suppress its backlog.
+
+Upgrading an existing watcher is unaffected: the environment's database already carries upload/run history, so the one-shot baseline seeding is skipped and detection continues exactly as before. Switching a preview to a different deployment URL resets that environment's local state so the new target gets a clean baseline.
 
 ### Upload modes
 

--- a/docs/reference/watcher.md
+++ b/docs/reference/watcher.md
@@ -58,7 +58,7 @@ Starts the file monitoring loop. Before entering the loop it:
 
 - Validates the config and checks that the instrument is active (not pending).
 - Syncs the config checksum with the API.
-- Initializes the local state database (`~/.data-hub/watcher.db`).
+- Initializes the local state database for the active environment (`~/.data-hub/watcher-<environment>.db`).
 - Hydrates in-memory run state from the local DB so the initial scan skips files that were already reported in a previous session.
 
 While running:
@@ -95,6 +95,7 @@ Subcommands for managing the YAML config file:
 | --- | --- |
 | `config show` | Pretty-print the current config |
 | `config validate` | Validate the config file (offline) |
+| `config set-environment ENV` | Switch the active API environment (see [Switching environments](#switching-environments)) |
 | `config edit` | Re-prompt each field with current values as defaults |
 | `config open` | Open the config in your editor, then re-validate |
 | `config path` | Print the resolved config file path |
@@ -134,7 +135,9 @@ The config file lives at `~/.data-hub/config.yaml` by default. Override with `--
 version: 1
 environment: production          # "staging", "production", or "preview"
 api_base_url: null               # required when environment is "preview"
-watcher_id: <assigned-by-api>
+watcher_ids:                     # one registration id per environment
+  production: <assigned-by-api>
+initial_scan: null               # null (default), "full", or "new-only"
 instrument:
   id: akta-fplc                  # kebab-case instrument ID
   watch_directory: /path/to/data
@@ -167,6 +170,36 @@ The `init` wizard offers the following presets (you can also supply a custom reg
 
 In YAML, prefer single-quoted strings for patterns so that backslash sequences like `\d` don't need escaping.
 
+A config written by an older watcher used a single top-level `watcher_id`. It is migrated transparently on load: the value is lifted into `watcher_ids` under the active `environment`, and the legacy key is dropped on the next save.
+
+### Switching environments
+
+A single PC can move between `staging`, `production`, and `preview` and back. Because staging and production are separate Data Hub deployments with separate databases, each holds its own watcher registration — `watcher_ids` stores one id per environment, and the credentials live in per-environment `~/.data-hub/.env.<environment>` files.
+
+Switch with:
+
+```sh
+# Switch to staging (reuses a stored registration, or registers one).
+uv run data-hub-watcher config set-environment staging
+
+# Point at a preview deployment (the base URL is required).
+uv run data-hub-watcher config set-environment preview \
+  --api-base-url https://data-hub-git-my-branch.vercel.app/api/v1
+```
+
+`config edit` also re-prompts for the environment and runs the same switch flow when it changes. Useful flags: `--api-key` (otherwise the key is read from the env file or prompted), `--show-key`, and `--no-register` (fail instead of registering a new watcher if none is stored for the target).
+
+A switch validates the target API with the resolved key, reuses the stored `watcher_id` for that environment (or registers a new one), pushes the config to the target, and leaves a `watcher_stopped` breadcrumb in the old environment. The running `watch` process or Windows service keeps using the old environment until restarted — on Windows the service registry env path is rewritten and you must `service stop && service start`; elsewhere restart the `watch` process.
+
+#### Initial scan and the backlog
+
+Each environment keeps its own local state database (see [Local state](#local-state)), so switching never re-uploads files across environments. To avoid flooding a non-production environment with a PC's historical data, the initial scan mode defaults by environment:
+
+- `production` → `full`: the existing backlog is uploaded (production is the source of truth).
+- `staging` / `preview` → `new-only`: the files already on disk when the environment is first entered are recorded as a baseline and skipped; only files created after the switch flow to the target.
+
+Set `initial_scan` explicitly in the config to override (e.g. `full` to deliberately populate a staging environment). Switching a preview to a different deployment URL resets that environment's local state so the new target gets a clean baseline.
+
 ### Upload modes
 
 - **`auto`**: Files are uploaded to S3 immediately after run detection.
@@ -179,11 +212,13 @@ Queued files are resolved against the current `watch_directory` (each queue entr
 
 ## Local state
 
-The watcher maintains a SQLite database at `~/.data-hub/watcher.db` with three tables:
+The watcher maintains one SQLite database per environment at `~/.data-hub/watcher-<environment>.db` (e.g. `watcher-production.db`). Isolating state per environment is what lets a PC switch back and forth without one environment's uploads being recorded against another. A pre-multi-environment `~/.data-hub/watcher.db` is renamed to the active environment's file on first start. Each database has the following tables:
 
 - `uploaded_files` — one row per successful S3 upload, keyed on `(filename, sha256, s3_key)`. Used by the uploader to skip re-uploads on retry and by the initial scan to skip files that have already been sent. Records older than 90 days are pruned automatically.
 - `runs` — tracks which run IDs have been reported and (in auto mode) when their files finished uploading. The most recent `reported_at` timestamp is what the auto-updater consults to gate restarts on a quiet-instrument window.
 - `detected_files` — the file manifest for every reported run, keyed on `(run_id, relative_path)`. Lets the initial scan skip files that are already part of a reported run even in manual mode (where `uploaded_files` stays empty), and lets the run detector hydrate its in-memory state on startup so a restart doesn't re-POST runs the API has already seen.
+- `baseline_files` — files that already existed on disk when a `new-only` environment was first entered, keyed on `relative_path`. A baseline row means "skip" (never uploaded), as opposed to `uploaded_files` which means "sent". Unlike `uploaded_files`, baseline rows are never pruned. Empty in `full`-scan (production) environments.
+- `meta` — a small key/value store. Currently holds the preview deployment URL the database was seeded against, so the watcher can reset local state when a preview is redeployed to a new URL.
 
 Logs are written to `C:\ProgramData\DataHubWatcher\watcher.log` on Windows and `~/.data-hub/watcher.log` on macOS/Linux (10 MB rotating, 5 backups). Both the CLI `watch` command and the Windows service write to the same file so a single `Get-Content -Wait` (or `tail -F`) covers all entry points.
 
@@ -200,6 +235,8 @@ Practical consequences:
 - If a run's parent folder is renamed or moved, its files look "new" to the next scan and will be re-enqueued. The uploader's own SHA-based dedup prevents a redundant S3 PUT, but it will pay the cost of hashing each affected file once.
 - Upgrading from a pre-`relative_path`/`size_bytes`/`mtime` state DB is a silent, self-healing migration: legacy rows miss the stat lookup, so files are re-enqueued once and then recorded with full stat data on their next upload.
 
+In a `new-only` environment (staging/preview by default — see [Switching environments](#switching-environments)), the first start also seeds `baseline_files` with everything currently on disk so the historical backlog is skipped rather than uploaded. The seeding is one-shot: it only runs when the environment's database has no upload, run, or baseline history yet.
+
 ## Observability
 
 The watcher's primary observability surface is the per-watcher event log served by `POST /watchers/:id/events`. Events are queued in memory by the long-running components (uploader, run detector, monitor, heartbeat, updater) and flushed in batches on every heartbeat tick. The queue is bounded to 500 events; on overflow the oldest are dropped (FIFO) and surfaced via a synthetic `events_dropped` event prepended to the next successful flush, so an outage that loses observability data is itself observable when the link recovers.
@@ -208,7 +245,7 @@ The watcher's primary observability surface is the per-watcher event log served 
 
 | Event type | When |
 | --- | --- |
-| `watcher_started` / `watcher_stopped` | Process lifecycle. The stopped message distinguishes a normal stop from an upgrade-driven restart. |
+| `watcher_started` / `watcher_stopped` | Process lifecycle. The stopped message distinguishes a normal stop from an upgrade-driven restart. `watcher_stopped` is also emitted in the *old* environment as a breadcrumb when the watcher switches environments. |
 | `config_synced` | Local config differed from the remote checksum and was pushed. Triggered by `init`, `config edit`, `config open`, and on watcher startup. The server also emits one with `details.kind="upload_requests_cancelled"` (and `cancelled_count`) when a `watch_directory` change drained pending upload requests. |
 | `run_reported` | A run was POSTed to the API for the first time. |
 | `file_uploaded` / `upload_failed` | Per-file upload outcome. `upload_failed` carries the S3 key and last error. |

--- a/uv.lock
+++ b/uv.lock
@@ -416,7 +416,7 @@ requires-dist = [
 
 [[package]]
 name = "data-hub-watcher"
-version = "0.2.9"
+version = "0.3.0"
 source = { editable = "watcher" }
 dependencies = [
     { name = "click" },

--- a/watcher/pyproject.toml
+++ b/watcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-hub-watcher"
-version = "0.2.9"
+version = "0.3.0"
 description = "File-watcher agent for lab instrument PCs that ingests data into Data Hub."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -19,13 +19,15 @@ from data_hub_watcher.constants import (
     DEFAULT_CONFIG_DIR,
     DEFAULT_STABILITY_PERIOD_SECONDS,
     RUN_DETECTION_PRESETS,
-    STATE_DB_FILENAME,
     SUPPORTED_ENVIRONMENTS,
     WATCHER_VERSION,
     env_file_path,
     load_env,
+    reset_state_db,
     resolve_config_path,
+    resolve_state_db_path,
     save_api_key,
+    state_db_path,
 )
 from data_hub_watcher.events import EventReporter, EventType, WatcherEvent
 from data_hub_watcher.heartbeat import WatcherCounters
@@ -327,7 +329,7 @@ def init(ctx: click.Context, show_key: bool) -> None:
         version=1,
         environment=environment,
         api_base_url=api_base_url,
-        watcher_id=watcher_id,
+        watcher_ids={environment: watcher_id},
         instrument=InstrumentConfig(
             id=selected.id,
             watch_directory=watch_dir,
@@ -478,6 +480,175 @@ def _push_config_to_api(
         )
 
 
+def _register_watcher_for_switch(client: DataHubClient, instrument_id: str) -> str:
+    """Register a watcher for *instrument_id*, mirroring `init`'s 409 handling."""
+    try:
+        reg = client.register_watcher(
+            instrument_id=instrument_id,
+            hostname=platform.node(),
+            os_info=f"{platform.system()} {platform.release()}",
+        )
+    except ApiError as exc:
+        if exc.status_code == 409:
+            existing_id = ""
+            if exc.detail and exc.detail.details:
+                existing_id = str(exc.detail.details.get("existing_watcher_id") or "")
+            id_suffix = f" (id: {existing_id})" if existing_id else ""
+            raise click.ClickException(
+                f"Instrument '{instrument_id}' already has an active watcher{id_suffix} "
+                "in the target environment. Deregister it there first, then retry."
+            ) from exc
+        raise click.ClickException(f"Failed to register watcher: {exc.message}") from exc
+    return reg.watcher_id
+
+
+def _emit_switch_breadcrumb(old_cfg: WatcherConfig, target: str) -> None:
+    """Best-effort breadcrumb in the old environment that the watcher left.
+
+    Reuses `WATCHER_STOPPED` because the event enum has no generic INFO type;
+    the matching `WATCHER_STARTED` lands in the new environment on the next
+    `watch` start. Never raised — a switch must not fail on a missing key or
+    an unreachable old API.
+    """
+    old_id = old_cfg.watcher_id
+    if not old_id:
+        return
+    try:
+        load_env(old_cfg.environment)
+        old_client = _make_client(old_cfg.environment, api_base_url=old_cfg.api_base_url)
+        reporter = EventReporter(old_client, old_id)
+        reporter.queue_event(
+            WatcherEvent(
+                event_type=EventType.WATCHER_STOPPED,
+                message=f"Environment switched: {old_cfg.environment} -> {target}",
+                details={"from": old_cfg.environment, "to": target},
+            )
+        )
+        reporter.flush()
+    except Exception:
+        logger.debug("Could not emit environment-switch breadcrumb", exc_info=True)
+
+
+def _switch_environment(
+    path: Path,
+    cfg: WatcherConfig,
+    target: str,
+    *,
+    api_base_url: str | None = None,
+    api_key: str | None = None,
+    show_key: bool = False,
+    no_register: bool = False,
+) -> WatcherConfig:
+    """Switch the active environment, registering for the target if needed.
+
+    Returns the persisted config for *target* (so `config edit` can continue
+    editing from it). Raises `ClickException` and leaves the on-disk config
+    untouched on any validation or registration failure.
+    """
+    inst = cfg.instrument
+    config_dir = path.parent
+
+    if target == "preview":
+        if not api_base_url:
+            raise click.ClickException("--api-base-url is required when switching to 'preview'.")
+        api_base_url = api_base_url.rstrip("/")
+
+    # A preview redeploy points at a brand-new database server-side, so the
+    # stored registration won't exist there and local state must be reset.
+    preview_redeploy = (
+        target == "preview"
+        and cfg.environment == "preview"
+        and api_base_url is not None
+        and api_base_url != cfg.api_base_url
+    )
+
+    if cfg.environment == target and not preview_redeploy:
+        click.echo(f"Already on environment '{target}'.")
+        return cfg
+
+    load_env(target)
+    if api_key is not None:
+        api_key = _clean_api_key(api_key)
+        save_api_key(api_key, target)
+    else:
+        existing = os.environ.get("DATA_HUB_API_KEY", "")
+        if existing:
+            api_key = existing
+        else:
+            api_key = _clean_api_key(click.prompt("DATA_HUB_API_KEY", hide_input=not show_key))
+            save_api_key(api_key, target)
+
+    client = _make_client(target, api_key=api_key, api_base_url=api_base_url)
+    try:
+        client.list_instruments()
+    except ApiError as exc:
+        raise click.ClickException(
+            f"Could not reach the {target} API with the provided key: {exc.message}\n"
+            "The environment was not switched."
+        ) from exc
+
+    watcher_ids = dict(cfg.watcher_ids)
+    if preview_redeploy:
+        watcher_ids.pop(target, None)
+        reset_state_db(config_dir, target)
+
+    existing_id = watcher_ids.get(target)
+    if existing_id:
+        try:
+            client.get_instrument(inst.id)
+        except ApiError as exc:
+            raise click.ClickException(
+                f"Stored {target} watcher_id is no longer valid: {exc.message}"
+            ) from exc
+        watcher_id = existing_id
+    elif no_register:
+        raise click.ClickException(
+            f"No watcher is registered for '{target}' and --no-register was set."
+        )
+    else:
+        watcher_id = _register_watcher_for_switch(client, inst.id)
+        watcher_ids[target] = watcher_id
+        click.echo(f"Registered watcher for {target}: {watcher_id}")
+
+    new_cfg = WatcherConfig(
+        version=cfg.version,
+        environment=target,  # type: ignore[arg-type]  # validated by click.Choice
+        api_base_url=api_base_url if target == "preview" else None,
+        watcher_ids=watcher_ids,
+        initial_scan=cfg.initial_scan,
+        instrument=inst,
+    )
+    save_config(new_cfg, path)
+    click.echo(f"Config saved to {path}")
+
+    # Remember which preview deployment the state DB was seeded against so a
+    # later URL change triggers a reset (see `preview_redeploy`).
+    if target == "preview" and api_base_url is not None:
+        try:
+            db = StateDB(state_db_path(config_dir, target))
+            db.set_meta("preview_api_base_url", api_base_url)
+            db.close()
+        except Exception:
+            logger.debug("Could not record preview deployment URL", exc_info=True)
+
+    _push_config_to_api(client, watcher_id, path, trigger="env-switch")
+    _emit_switch_breadcrumb(cfg, target)
+
+    if sys.platform == "win32":
+        from data_hub_watcher.service import _rewrite_service_env_path
+
+        _rewrite_service_env_path(env_file_path(target))
+        click.echo(
+            "Service env-file updated. Restart to apply: "
+            "`data-hub-watcher service stop && data-hub-watcher service start`."
+        )
+    else:
+        click.echo("Restart the running `watch` process to apply the new environment.")
+
+    click.echo(click.style(f"\n✓ Switched to '{target}'.", fg="green", bold=True))
+    return new_cfg
+
+
 def _dry_run_scan(cfg: WatcherConfig) -> None:
     """Scan the watch directory and log what `watch` would do, without side effects."""
     inst = cfg.instrument
@@ -590,12 +761,72 @@ def config_validate(ctx: click.Context) -> None:
     click.echo(click.style(f"✓ Config is valid: {path}", fg="green"))
 
 
+@config.command("set-environment")
+@click.argument(
+    "environment",
+    type=click.Choice(list(SUPPORTED_ENVIRONMENTS), case_sensitive=False),
+)
+@click.option("--api-base-url", default=None, help="Required when environment is 'preview'.")
+@click.option("--api-key", default=None, help="API key for the target environment.")
+@click.option(
+    "--show-key",
+    is_flag=True,
+    help="Echo the API key as typed (useful on Windows terminals).",
+)
+@click.option(
+    "--no-register",
+    is_flag=True,
+    help="Fail instead of registering a new watcher if none is stored for the target env.",
+)
+@click.pass_context
+def config_set_environment(
+    ctx: click.Context,
+    environment: str,
+    api_base_url: str | None,
+    api_key: str | None,
+    show_key: bool,
+    no_register: bool,
+) -> None:
+    """Switch the watcher to a different API environment."""
+    path = _resolve_path(ctx)
+    cfg = load_config(path)
+    _switch_environment(
+        path,
+        cfg,
+        environment,
+        api_base_url=api_base_url,
+        api_key=api_key,
+        show_key=show_key,
+        no_register=no_register,
+    )
+
+
 @config.command("edit")
 @click.pass_context
 def config_edit(ctx: click.Context) -> None:
     """Re-prompt each config field with current values as defaults."""
     path = _resolve_path(ctx)
     cfg = load_config(path)
+
+    # Re-prompt for environment first; a change delegates to the full switch
+    # flow (re-registration, key resolution, state reset) before the rest of
+    # the edit runs against the freshly-saved config.
+    target_env = click.prompt(
+        "Environment",
+        type=click.Choice(list(SUPPORTED_ENVIRONMENTS), case_sensitive=False),
+        default=cfg.environment,
+    )
+    preview_url: str | None = None
+    if target_env == "preview":
+        preview_url = click.prompt(
+            "Preview deployment base URL",
+            default=cfg.api_base_url,
+        )
+    if target_env != cfg.environment or (
+        target_env == "preview" and preview_url is not None and preview_url != cfg.api_base_url
+    ):
+        cfg = _switch_environment(path, cfg, target_env, api_base_url=preview_url)
+
     inst = cfg.instrument
 
     watch_dir_str = click.prompt("Watch directory", default=str(inst.watch_directory))
@@ -633,7 +864,8 @@ def config_edit(ctx: click.Context) -> None:
         version=cfg.version,
         environment=cfg.environment,
         api_base_url=cfg.api_base_url,
-        watcher_id=cfg.watcher_id,
+        watcher_ids=cfg.watcher_ids,
+        initial_scan=cfg.initial_scan,
         instrument=InstrumentConfig(
             id=inst.id,
             watch_directory=watch_dir,
@@ -743,7 +975,7 @@ def watch(ctx: click.Context, dry_run: bool) -> None:
     # Step 4: Build the shared runtime (state DB, uploader, detector,
     # monitor, heartbeat — all wired identically to the Windows-service
     # path via data_hub_watcher.runtime).
-    db_path = DEFAULT_CONFIG_DIR / STATE_DB_FILENAME
+    db_path = resolve_state_db_path(DEFAULT_CONFIG_DIR, cfg.environment)
     rt = build_runtime(client=client, cfg=cfg, db_path=db_path)
 
     # Step 5: sync config (now that we have a reporter, failures are
@@ -835,7 +1067,7 @@ def upload(ctx: click.Context, file_path: str | None, run_id: str | None, dry_ru
     if detail.status == "pending":
         raise click.ClickException(f"Instrument {inst.id!r} is pending. Cannot upload yet.")
 
-    db_path = DEFAULT_CONFIG_DIR / STATE_DB_FILENAME
+    db_path = resolve_state_db_path(DEFAULT_CONFIG_DIR, cfg.environment)
     state_db = StateDB(db_path)
     counters = WatcherCounters()
     reporter = EventReporter(client, cfg.watcher_id)

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -97,6 +97,10 @@ def _resolve_path(ctx: click.Context) -> Path:
 
 API_KEY_PREFIX = "dhub_"
 
+# `meta` key holding the preview deployment URL the local preview DB was
+# seeded against. Read on the next switch to detect a redeploy to a new URL.
+PREVIEW_SEED_URL_META_KEY = "preview_api_base_url"
+
 # Invisible characters that some Windows clipboards (Outlook, Teams, Word, etc.)
 # silently inject when an operator copies an API key. Stripping them here
 # avoids 401s caused by a hash mismatch on the server.
@@ -529,6 +533,27 @@ def _emit_switch_breadcrumb(old_cfg: WatcherConfig, target: str) -> None:
         logger.debug("Could not emit environment-switch breadcrumb", exc_info=True)
 
 
+def _preview_seed_url(config_dir: Path) -> str | None:
+    """The preview deployment URL the local preview state DB was seeded against.
+
+    Returns None when no preview DB exists yet or the meta is absent (a DB
+    predating the key). Opens the DB only when present so the lookup never
+    creates an empty database as a side effect.
+    """
+    db_file = state_db_path(config_dir, "preview")
+    if not db_file.exists():
+        return None
+    try:
+        db = StateDB(db_file)
+        try:
+            return db.get_meta(PREVIEW_SEED_URL_META_KEY)
+        finally:
+            db.close()
+    except Exception:
+        logger.debug("Could not read preview seed URL", exc_info=True)
+        return None
+
+
 def _switch_environment(
     path: Path,
     cfg: WatcherConfig,
@@ -543,7 +568,10 @@ def _switch_environment(
 
     Returns the persisted config for *target* (so `config edit` can continue
     editing from it). Raises `ClickException` and leaves the on-disk config
-    untouched on any validation or registration failure.
+    untouched on any validation or registration failure. The config is saved
+    before the (non-fatal) push to the target API, so a push failure leaves
+    the on-disk config updated while the API copy lags behind — by design,
+    since a push failure is a warning, not a hard error.
     """
     inst = cfg.instrument
     config_dir = path.parent
@@ -553,14 +581,13 @@ def _switch_environment(
             raise click.ClickException("--api-base-url is required when switching to 'preview'.")
         api_base_url = api_base_url.rstrip("/")
 
-    # A preview redeploy points at a brand-new database server-side, so the
-    # stored registration won't exist there and local state must be reset.
-    preview_redeploy = (
-        target == "preview"
-        and cfg.environment == "preview"
-        and api_base_url is not None
-        and api_base_url != cfg.api_base_url
-    )
+    # A preview redeploy points at a new database server-side, so the stored
+    # registration won't exist and local state must be reset. Compare against
+    # the URL the DB was seeded against (`meta`), falling back to the config.
+    preview_redeploy = False
+    if target == "preview" and cfg.environment == "preview" and api_base_url is not None:
+        seeded_url = _preview_seed_url(config_dir) or cfg.api_base_url
+        preview_redeploy = seeded_url is not None and api_base_url != seeded_url
 
     if cfg.environment == target and not preview_redeploy:
         click.echo(f"Already on environment '{target}'.")
@@ -594,6 +621,9 @@ def _switch_environment(
 
     existing_id = watcher_ids.get(target)
     if existing_id:
+        # No per-watcher GET exists, so validate indirectly: a reachable
+        # instrument confirms credentials and target. A watcher deregistered
+        # server-side isn't caught here; re-registering is the recovery.
         try:
             client.get_instrument(inst.id)
         except ApiError as exc:
@@ -621,18 +651,23 @@ def _switch_environment(
     save_config(new_cfg, path)
     click.echo(f"Config saved to {path}")
 
-    # Remember which preview deployment the state DB was seeded against so a
-    # later URL change triggers a reset (see `preview_redeploy`).
+    # Record which preview deployment this state DB was seeded against; the
+    # next switch reads it back via `_preview_seed_url` to decide whether the
+    # URL changed and the DB must be reset (see `preview_redeploy`).
     if target == "preview" and api_base_url is not None:
         try:
             db = StateDB(state_db_path(config_dir, target))
-            db.set_meta("preview_api_base_url", api_base_url)
+            db.set_meta(PREVIEW_SEED_URL_META_KEY, api_base_url)
             db.close()
         except Exception:
             logger.debug("Could not record preview deployment URL", exc_info=True)
 
     _push_config_to_api(client, watcher_id, path, trigger="env-switch")
     _emit_switch_breadcrumb(cfg, target)
+    # The breadcrumb reloads the old env's `.env` with override, so restore the
+    # target key; otherwise a same-process follow-up like `config edit`'s
+    # post-edit push would hit the new env with the old key and fail silently.
+    os.environ["DATA_HUB_API_KEY"] = api_key
 
     if sys.platform == "win32":
         from data_hub_watcher.service import _rewrite_service_env_path

--- a/watcher/src/data_hub_watcher/constants.py
+++ b/watcher/src/data_hub_watcher/constants.py
@@ -197,6 +197,50 @@ def save_api_key(api_key: str, environment: str | None = None) -> Path:
     return env_path
 
 
+# Sidecars SQLite creates alongside the main DB file in WAL mode; they must
+# travel with it on rename and be removed on reset or the DB is left corrupt.
+_SQLITE_SIDECAR_SUFFIXES: tuple[str, ...] = ("", "-wal", "-shm")
+
+
+def state_db_path(config_dir: Path, environment: str) -> Path:
+    """Per-environment state DB path.
+
+    Keyed by `environment` (not `watcher_id`) so a deregister/re-register on
+    the same host reuses the existing dedup history instead of re-uploading
+    the whole backlog. See `docs/watcher.md` for the rationale.
+    """
+    return config_dir / f"watcher-{environment}.db"
+
+
+def resolve_state_db_path(config_dir: Path, environment: str) -> Path:
+    """Return the per-environment state DB path, migrating the legacy file once.
+
+    The pre-multi-env single `watcher.db` belongs to whatever environment was
+    active before the upgrade, i.e. the one being resolved now. Renaming it
+    (rather than starting fresh) preserves that environment's dedup state so
+    the first post-upgrade scan does not re-upload everything.
+    """
+    target = state_db_path(config_dir, environment)
+    legacy = config_dir / STATE_DB_FILENAME
+    if not target.exists() and legacy.exists():
+        for suffix in _SQLITE_SIDECAR_SUFFIXES:
+            src = legacy.with_name(legacy.name + suffix)
+            if src.exists():
+                src.rename(target.with_name(target.name + suffix))
+    return target
+
+
+def reset_state_db(config_dir: Path, environment: str) -> None:
+    """Delete an environment's state DB (and WAL sidecars).
+
+    Used when a preview deployment changes so the next start reseeds a clean
+    baseline against the new target instead of inheriting the old one's state.
+    """
+    target = state_db_path(config_dir, environment)
+    for suffix in _SQLITE_SIDECAR_SUFFIXES:
+        target.with_name(target.name + suffix).unlink(missing_ok=True)
+
+
 def resolve_config_path(cli_override: str | None = None) -> Path:
     """Return the config file path, checking CLI flag, env var, then default."""
     if cli_override:

--- a/watcher/src/data_hub_watcher/models.py
+++ b/watcher/src/data_hub_watcher/models.py
@@ -4,7 +4,7 @@ import logging
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -73,8 +73,44 @@ class WatcherConfig(BaseModel):
     version: Literal[1]
     environment: Literal["staging", "production", "preview"]
     api_base_url: str | None = None
-    watcher_id: str | None = None
+    # One watcher_id per environment so a single PC can switch between
+    # staging/production/preview without losing the registration it already
+    # holds in each. Keyed by the `environment` literal.
+    watcher_ids: dict[str, str] = Field(default_factory=dict)
+    # When None, the effective mode is derived from `environment` (see
+    # `resolve_initial_scan`): production uploads its existing backlog, other
+    # environments skip it. Set explicitly to override per host.
+    initial_scan: Literal["full", "new-only"] | None = None
     instrument: InstrumentConfig
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_watcher_id(cls, data: Any) -> Any:
+        # Pre-multi-env configs (and pre-multi-env constructor calls) carry a
+        # single top-level `watcher_id`. Lift it into `watcher_ids` under the
+        # active environment so on-disk configs migrate transparently on load.
+        if isinstance(data, dict) and "watcher_id" in data and "watcher_ids" not in data:
+            legacy = data.pop("watcher_id")
+            env = data.get("environment")
+            if legacy and env:
+                data["watcher_ids"] = {env: legacy}
+        return data
+
+    @property
+    def watcher_id(self) -> str | None:
+        """The watcher_id registered for the active environment, if any."""
+        return self.watcher_ids.get(self.environment)
+
+    def resolve_initial_scan(self) -> Literal["full", "new-only"]:
+        """Effective initial-scan mode, defaulting by environment when unset.
+
+        Production is the source of truth and must upload everything on disk;
+        staging/preview only want activity that happens after the switch, so
+        they default to skipping the pre-existing backlog.
+        """
+        if self.initial_scan is not None:
+            return self.initial_scan
+        return "full" if self.environment == "production" else "new-only"
 
     @model_validator(mode="after")
     def _validate_preview_url(self) -> WatcherConfig:

--- a/watcher/src/data_hub_watcher/monitor.py
+++ b/watcher/src/data_hub_watcher/monitor.py
@@ -115,6 +115,12 @@ class FileMonitor:
     recursive:
         Whether to monitor subdirectories (`True` for directory-mode run
         detection, `False` otherwise).
+    seed_baseline:
+        When `True`, the initial scan records every matching file already on
+        disk as `baseline_files` (skip, never uploaded) instead of enqueuing
+        it. Set by `runtime.build_runtime` on the first start of a `new-only`
+        environment so the pre-existing backlog is suppressed in a single
+        directory walk rather than a separate seeding pass plus a scan.
     """
 
     def __init__(
@@ -126,9 +132,11 @@ class FileMonitor:
         state_db: StateDB,
         recursive: bool = False,
         event_reporter: EventReporter | None = None,
+        seed_baseline: bool = False,
     ) -> None:
         self._watch_dir = watch_directory
         self._patterns = file_patterns
+        self._seed_baseline = seed_baseline
         # Compile the patterns once and reuse for both the initial scan
         # and the watchdog event handler. Hot-path scans of large
         # directories used to do ``len(file_patterns)`` fnmatch calls
@@ -288,7 +296,15 @@ class FileMonitor:
         one ``entry.stat()`` + two SQL ``SELECT`` s per file" pattern
         with "one cached ``DirEntry.stat()`` + one Python dict lookup"
         -- typically a 5-10x speedup on lab-PC sized trees.
+
+        On the first start of a `new-only` environment (`seed_baseline`)
+        the same walk records the backlog as `baseline_files` instead of
+        enqueuing it -- see :meth:`_seed_baseline_scan` -- so startup costs
+        one directory walk, not one to seed and one to scan it back.
         """
+        if self._seed_baseline:
+            self._seed_baseline_scan()
+            return
         logger.info(
             "Initial scan starting (dir=%s, patterns=%s, recursive=%s)…",
             self._watch_dir,
@@ -347,6 +363,50 @@ class FileMonitor:
             queued,
             skipped,
         )
+
+    def _seed_baseline_scan(self) -> int:
+        """Record every matching file on disk as baseline, enqueue nothing.
+
+        Runs in place of the normal initial scan on the first start of a
+        `new-only` environment (see :class:`FileMonitor`'s ``seed_baseline``).
+        A baseline row means "skip, never uploaded"; the rows also feed
+        :meth:`_load_dedup_index` so future restarts skip the same backlog.
+
+        Reuses :meth:`_iter_dir_entries` -- the very walker the normal scan
+        uses -- so the traversal and stat semantics match exactly and the
+        first start pays for a single directory walk. Returns the count of
+        baselined files.
+        """
+        rows: list[tuple[str, int, float]] = []
+        for entry in self._iter_dir_entries(self._watch_dir):
+            try:
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+            except OSError:
+                continue
+            if not self._matches_name(entry.name):
+                continue
+            try:
+                st = entry.stat(follow_symlinks=False)
+            except OSError:
+                continue
+            entry_path = Path(entry.path)
+            try:
+                rel_path = entry_path.relative_to(self._watch_dir).as_posix()
+            except ValueError:
+                rel_path = entry.name
+            rows.append((rel_path, st.st_size, st.st_mtime))
+
+        self._state_db.record_baseline_files(rows)
+        # Mark even when zero files matched so an empty watch dir isn't
+        # re-walked on every start (the gate in `build_runtime` reads this).
+        self._state_db.mark_baseline_seeded()
+        logger.info(
+            "Baseline seeded: %d existing file(s) under %s marked as skip (new-only env)",
+            len(rows),
+            self._watch_dir,
+        )
+        return len(rows)
 
     # ------------------------------------------------------------------
     # stability tracking
@@ -442,65 +502,6 @@ class FileMonitor:
                         path=str(path),
                         error=str(exc),
                     )
-
-
-def seed_baseline_files(
-    state_db: StateDB,
-    watch_directory: Path,
-    file_patterns: list[str],
-    recursive: bool,
-) -> int:
-    """Record every matching file currently on disk as baseline, no upload.
-
-    Called once when a `new-only` environment is first started so the initial
-    scan and ongoing detection skip the pre-existing backlog. Returns the
-    number of files recorded.
-
-    Walks via `os.scandir` with an explicit stack (same approach as
-    `FileMonitor._iter_dir_entries`) to avoid the recursion-depth cap on deep
-    run trees and to reuse `DirEntry`'s cached stat.
-    """
-    matches = _compile_pattern_matcher(file_patterns)
-    rows: list[tuple[str, int, float]] = []
-    stack: list[Path] = [watch_directory]
-    while stack:
-        current = stack.pop()
-        try:
-            it = os.scandir(current)
-        except OSError as exc:
-            logger.warning("baseline scandir failed for %s: %s", current, exc)
-            continue
-        with it:
-            for entry in it:
-                try:
-                    if entry.is_dir(follow_symlinks=False):
-                        if recursive:
-                            stack.append(Path(entry.path))
-                        continue
-                    # Mirror `FileMonitor._initial_scan`: it only enqueues real
-                    # files (`is_file(follow_symlinks=False)`), so only those
-                    # belong in the baseline or membership would diverge.
-                    if not entry.is_file(follow_symlinks=False):
-                        continue
-                    if not matches(entry.name):
-                        continue
-                    st = entry.stat(follow_symlinks=False)
-                except OSError:
-                    continue
-                entry_path = Path(entry.path)
-                try:
-                    rel_path = entry_path.relative_to(watch_directory).as_posix()
-                except ValueError:
-                    rel_path = entry.name
-                rows.append((rel_path, st.st_size, st.st_mtime))
-
-    state_db.record_baseline_files(rows)
-    logger.info(
-        "Baseline seeded: %d existing file(s) under %s marked as skip (new-only env)",
-        len(rows),
-        watch_directory,
-    )
-    return len(rows)
 
 
 def _stat_in_dedup_index(

--- a/watcher/src/data_hub_watcher/monitor.py
+++ b/watcher/src/data_hub_watcher/monitor.py
@@ -252,6 +252,10 @@ class FileMonitor:
             index.setdefault(rel_path, []).append((size_bytes, mtime))
         for rel_path, size_bytes, mtime in self._state_db.iter_detected_stat_keys():
             index.setdefault(rel_path, []).append((size_bytes, mtime))
+        # Baseline rows mark the pre-existing backlog of a `new-only`
+        # environment as already-handled so the scan skips it without upload.
+        for rel_path, size_bytes, mtime in self._state_db.iter_baseline_stat_keys():
+            index.setdefault(rel_path, []).append((size_bytes, mtime))
         return index
 
     def _initial_scan(self) -> None:
@@ -438,6 +442,60 @@ class FileMonitor:
                         path=str(path),
                         error=str(exc),
                     )
+
+
+def seed_baseline_files(
+    state_db: StateDB,
+    watch_directory: Path,
+    file_patterns: list[str],
+    recursive: bool,
+) -> int:
+    """Record every matching file currently on disk as baseline, no upload.
+
+    Called once when a `new-only` environment is first started so the initial
+    scan and ongoing detection skip the pre-existing backlog. Returns the
+    number of files recorded.
+
+    Walks via `os.scandir` with an explicit stack (same approach as
+    `FileMonitor._iter_dir_entries`) to avoid the recursion-depth cap on deep
+    run trees and to reuse `DirEntry`'s cached stat.
+    """
+    matches = _compile_pattern_matcher(file_patterns)
+    rows: list[tuple[str, int, float]] = []
+    stack: list[Path] = [watch_directory]
+    while stack:
+        current = stack.pop()
+        try:
+            it = os.scandir(current)
+        except OSError as exc:
+            logger.warning("baseline scandir failed for %s: %s", current, exc)
+            continue
+        with it:
+            for entry in it:
+                try:
+                    if entry.is_dir(follow_symlinks=False):
+                        if recursive:
+                            stack.append(Path(entry.path))
+                        continue
+                    if not matches(entry.name):
+                        continue
+                    st = entry.stat(follow_symlinks=False)
+                except OSError:
+                    continue
+                entry_path = Path(entry.path)
+                try:
+                    rel_path = entry_path.relative_to(watch_directory).as_posix()
+                except ValueError:
+                    rel_path = entry.name
+                rows.append((rel_path, st.st_size, st.st_mtime))
+
+    state_db.record_baseline_files(rows)
+    logger.info(
+        "Baseline seeded: %d existing file(s) under %s marked as skip (new-only env)",
+        len(rows),
+        watch_directory,
+    )
+    return len(rows)
 
 
 def _stat_in_dedup_index(

--- a/watcher/src/data_hub_watcher/monitor.py
+++ b/watcher/src/data_hub_watcher/monitor.py
@@ -477,6 +477,11 @@ def seed_baseline_files(
                         if recursive:
                             stack.append(Path(entry.path))
                         continue
+                    # Mirror `FileMonitor._initial_scan`: it only enqueues real
+                    # files (`is_file(follow_symlinks=False)`), so only those
+                    # belong in the baseline or membership would diverge.
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
                     if not matches(entry.name):
                         continue
                     st = entry.stat(follow_symlinks=False)

--- a/watcher/src/data_hub_watcher/runtime.py
+++ b/watcher/src/data_hub_watcher/runtime.py
@@ -26,7 +26,7 @@ from data_hub_watcher.constants import (
 from data_hub_watcher.events import EventReporter, EventType, WatcherEvent
 from data_hub_watcher.heartbeat import HeartbeatLoop, WatcherCounters
 from data_hub_watcher.models import WatcherConfig
-from data_hub_watcher.monitor import FileMonitor
+from data_hub_watcher.monitor import FileMonitor, seed_baseline_files
 from data_hub_watcher.run_detector import RunDetector
 from data_hub_watcher.state import StateDB
 from data_hub_watcher.updater import Updater, evaluate_upgrade_marker
@@ -218,6 +218,18 @@ def build_runtime(
 
     state_db = StateDB(db_path)
     state_db.prune_uploaded_files(PRUNE_DAYS)
+
+    # In a `new-only` environment (staging/preview by default), record the
+    # pre-existing backlog as skip on first start so the initial scan doesn't
+    # flood the target with historical data. Gated on an empty DB so we never
+    # re-baseline once real uploads/runs exist for this environment.
+    if cfg.resolve_initial_scan() == "new-only" and not state_db.baseline_established():
+        seed_baseline_files(
+            state_db,
+            inst.watch_directory,
+            inst.file_patterns,
+            inst.run_detection.recursive,
+        )
 
     counters = WatcherCounters()
     reporter = EventReporter(client, watcher_id)

--- a/watcher/src/data_hub_watcher/runtime.py
+++ b/watcher/src/data_hub_watcher/runtime.py
@@ -26,7 +26,7 @@ from data_hub_watcher.constants import (
 from data_hub_watcher.events import EventReporter, EventType, WatcherEvent
 from data_hub_watcher.heartbeat import HeartbeatLoop, WatcherCounters
 from data_hub_watcher.models import WatcherConfig
-from data_hub_watcher.monitor import FileMonitor, seed_baseline_files
+from data_hub_watcher.monitor import FileMonitor
 from data_hub_watcher.run_detector import RunDetector
 from data_hub_watcher.state import StateDB
 from data_hub_watcher.updater import Updater, evaluate_upgrade_marker
@@ -219,19 +219,11 @@ def build_runtime(
     state_db = StateDB(db_path)
     state_db.prune_uploaded_files(PRUNE_DAYS)
 
-    # Record the pre-existing backlog as skip on a `new-only` environment's
-    # first start so the initial scan doesn't flood the target. Gated on an
-    # empty DB so a real upload/run history is never re-baselined.
-    if cfg.resolve_initial_scan() == "new-only" and not state_db.baseline_established():
-        seed_baseline_files(
-            state_db,
-            inst.watch_directory,
-            inst.file_patterns,
-            inst.run_detection.recursive,
-        )
-        # Mark even when zero files matched so an empty watch dir isn't
-        # re-walked on every start.
-        state_db.mark_baseline_seeded()
+    # On a `new-only` environment's first start, the monitor folds backlog
+    # baselining into its initial scan (one walk) instead of uploading the
+    # pre-existing files. Gated on an empty DB so a real upload/run history is
+    # never re-baselined; the gate is read once here, before the scan runs.
+    seed_baseline = cfg.resolve_initial_scan() == "new-only" and not state_db.baseline_established()
 
     counters = WatcherCounters()
     reporter = EventReporter(client, watcher_id)
@@ -292,6 +284,7 @@ def build_runtime(
         state_db=state_db,
         recursive=inst.run_detection.recursive,
         event_reporter=reporter,
+        seed_baseline=seed_baseline,
     )
 
     # The heartbeat's `on_tick` hook is now multi-purpose:

--- a/watcher/src/data_hub_watcher/runtime.py
+++ b/watcher/src/data_hub_watcher/runtime.py
@@ -219,10 +219,9 @@ def build_runtime(
     state_db = StateDB(db_path)
     state_db.prune_uploaded_files(PRUNE_DAYS)
 
-    # In a `new-only` environment (staging/preview by default), record the
-    # pre-existing backlog as skip on first start so the initial scan doesn't
-    # flood the target with historical data. Gated on an empty DB so we never
-    # re-baseline once real uploads/runs exist for this environment.
+    # Record the pre-existing backlog as skip on a `new-only` environment's
+    # first start so the initial scan doesn't flood the target. Gated on an
+    # empty DB so a real upload/run history is never re-baselined.
     if cfg.resolve_initial_scan() == "new-only" and not state_db.baseline_established():
         seed_baseline_files(
             state_db,
@@ -230,6 +229,9 @@ def build_runtime(
             inst.file_patterns,
             inst.run_detection.recursive,
         )
+        # Mark even when zero files matched so an empty watch dir isn't
+        # re-walked on every start.
+        state_db.mark_baseline_seeded()
 
     counters = WatcherCounters()
     reporter = EventReporter(client, watcher_id)

--- a/watcher/src/data_hub_watcher/service.py
+++ b/watcher/src/data_hub_watcher/service.py
@@ -195,6 +195,20 @@ def _store_paths_in_registry(config_path: Path, env_path: Path) -> None:
         winreg.CloseKey(key)  # type: ignore[attr-defined]
 
 
+def _rewrite_service_env_path(env_path: Path) -> None:
+    """Point the installed service at a new env file, keeping `ConfigPath`.
+
+    Called after an environment switch so a service restart loads the target
+    environment's `.env.<env>`. A host without an installed service (no
+    registry key) is a no-op so the switch still succeeds on CLI-only PCs.
+    """
+    try:
+        config_path, _ = _read_paths_from_registry()
+    except OSError:
+        return
+    _store_paths_in_registry(config_path, env_path)
+
+
 def _read_paths_from_registry() -> tuple[Path, Path]:
     """Read config & env paths previously stored by ``install_service``."""
     import winreg  # type: ignore[import-untyped]
@@ -581,8 +595,8 @@ def _run_service_loop(stop_event: threading.Event, sm: Any) -> None:
     from data_hub_watcher.config_io import load_config
     from data_hub_watcher.constants import (
         API_URLS,
-        STATE_DB_FILENAME,
         env_file_path,
+        resolve_state_db_path,
     )
     from data_hub_watcher.logging_setup import (
         attach_servicemanager_handler,
@@ -673,7 +687,7 @@ def _run_service_loop(stop_event: threading.Event, sm: Any) -> None:
         logger.error("No watcher_id in config. Run 'data-hub-watcher init' first.")
         raise SystemExit(1)
 
-    db_path = path.parent / STATE_DB_FILENAME
+    db_path = resolve_state_db_path(path.parent, cfg.environment)
     # Pass the registry-resolved config directory through to the
     # runtime so the auto-update sentinels land where the SYSTEM-owned
     # upgrade worker (whose paths were baked in at install time

--- a/watcher/src/data_hub_watcher/state.py
+++ b/watcher/src/data_hub_watcher/state.py
@@ -75,7 +75,7 @@ class DetectedFileRecord:
 
 
 class StateDB:
-    """Thin wrapper around a SQLite database with three tables.
+    """Thin wrapper around a SQLite database, one file per environment.
 
     - `uploaded_files` — tracks files already sent to S3.
     - `runs` — tracks runs reported to and uploaded via the API.
@@ -83,6 +83,12 @@ class StateDB:
       reported to the API, so subsequent restarts can hydrate
       `RunDetector._runs` and skip files in the initial scan even in
       manual mode (where `uploaded_files` stays empty).
+    - `baseline_files` — files that existed on disk when a `new-only`
+      environment was first entered and were deliberately skipped (never
+      uploaded). Distinct from `uploaded_files`: a baseline row means
+      "ignore", not "sent". Never pruned, unlike `uploaded_files`.
+    - `meta` — small key/value store (e.g. the preview deployment URL this
+      DB was seeded against) used to decide when to reset on a redeploy.
     """
 
     def __init__(self, db_path: Path) -> None:
@@ -225,6 +231,17 @@ class StateDB:
 
                 CREATE INDEX IF NOT EXISTS idx_detected_files_stat
                     ON detected_files (relative_path, size_bytes, mtime);
+
+                CREATE TABLE IF NOT EXISTS baseline_files (
+                    relative_path TEXT PRIMARY KEY,
+                    size_bytes    INTEGER NOT NULL,
+                    mtime         REAL NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS meta (
+                    key   TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                );
                 """
             )
             # Additive migration: older state DBs predate the stat-based
@@ -450,6 +467,66 @@ class StateDB:
         """
         cur = self._conn.execute("SELECT DISTINCT run_id FROM detected_files ORDER BY run_id")
         return [row[0] for row in cur.fetchall()]
+
+    # ------------------------------------------------------------------
+    # baseline_files
+    # ------------------------------------------------------------------
+
+    def record_baseline_files(self, files: Iterable[tuple[str, int, float]]) -> None:
+        """Record `(relative_path, size_bytes, mtime)` rows as baseline.
+
+        Used by `seed_baseline_files` when entering a `new-only` environment:
+        the rows feed the initial-scan dedup index so the pre-existing backlog
+        is skipped without ever being uploaded.
+        """
+        rows = list(files)
+        if not rows:
+            return
+        with self._write_lock:
+            self._conn.executemany(
+                "INSERT OR REPLACE INTO baseline_files "
+                "(relative_path, size_bytes, mtime) VALUES (?, ?, ?)",
+                rows,
+            )
+            self._conn.commit()
+
+    def iter_baseline_stat_keys(self) -> Iterator[tuple[str, int, float]]:
+        """Yield `(relative_path, size_bytes, mtime)` for every baseline row."""
+        cur = self._conn.execute("SELECT relative_path, size_bytes, mtime FROM baseline_files")
+        for row in cur:
+            yield row[0], row[1], row[2]
+
+    def baseline_established(self) -> bool:
+        """Whether this DB already has baseline or real upload/run history.
+
+        Gate for one-shot baseline seeding: if any of `baseline_files`,
+        `uploaded_files`, or `detected_files` is non-empty we must not reseed,
+        or we would mark genuinely-new files as skippable backlog.
+        """
+        cur = self._conn.execute(
+            "SELECT "
+            "EXISTS(SELECT 1 FROM baseline_files) OR "
+            "EXISTS(SELECT 1 FROM uploaded_files) OR "
+            "EXISTS(SELECT 1 FROM detected_files)"
+        )
+        return bool(cur.fetchone()[0])
+
+    # ------------------------------------------------------------------
+    # meta
+    # ------------------------------------------------------------------
+
+    def get_meta(self, key: str) -> str | None:
+        cur = self._conn.execute("SELECT value FROM meta WHERE key = ?", (key,))
+        row = cur.fetchone()
+        return None if row is None else str(row[0])
+
+    def set_meta(self, key: str, value: str) -> None:
+        with self._write_lock:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+                (key, value),
+            )
+            self._conn.commit()
 
     # ------------------------------------------------------------------
     # runs

--- a/watcher/src/data_hub_watcher/state.py
+++ b/watcher/src/data_hub_watcher/state.py
@@ -34,6 +34,11 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+# `meta` key set once `seed_baseline_files` has run for a `new-only`
+# environment, so the one-shot seed gate survives an empty-at-first-start
+# watch directory. See `StateDB.baseline_established`.
+BASELINE_SEEDED_META_KEY = "baseline_seeded"
+
 
 class _PerThreadHandle:
     """Owns a single ``sqlite3.Connection`` for the thread that opened it.
@@ -501,8 +506,13 @@ class StateDB:
 
         Gate for one-shot baseline seeding: if any of `baseline_files`,
         `uploaded_files`, or `detected_files` is non-empty we must not reseed,
-        or we would mark genuinely-new files as skippable backlog.
+        or we would mark genuinely-new files as skippable backlog. Also true
+        once seeding has run via the `baseline_seeded` meta sentinel — without
+        it a `new-only` watch dir that was empty at first start would re-walk
+        the whole tree on every restart until the first file appears.
         """
+        if self.get_meta(BASELINE_SEEDED_META_KEY) is not None:
+            return True
         cur = self._conn.execute(
             "SELECT "
             "EXISTS(SELECT 1 FROM baseline_files) OR "
@@ -510,6 +520,14 @@ class StateDB:
             "EXISTS(SELECT 1 FROM detected_files)"
         )
         return bool(cur.fetchone()[0])
+
+    def mark_baseline_seeded(self) -> None:
+        """Record that `seed_baseline_files` has run for this environment.
+
+        Makes the one-shot seed gate hold even when the initial scan matched
+        zero files (see `baseline_established`).
+        """
+        self.set_meta(BASELINE_SEEDED_META_KEY, "1")
 
     # ------------------------------------------------------------------
     # meta

--- a/watcher/src/data_hub_watcher/state.py
+++ b/watcher/src/data_hub_watcher/state.py
@@ -34,9 +34,9 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-# `meta` key set once `seed_baseline_files` has run for a `new-only`
-# environment, so the one-shot seed gate survives an empty-at-first-start
-# watch directory. See `StateDB.baseline_established`.
+# `meta` key set once `FileMonitor._seed_baseline_scan` has run for a
+# `new-only` environment, so the one-shot seed gate survives an
+# empty-at-first-start watch directory. See `StateDB.baseline_established`.
 BASELINE_SEEDED_META_KEY = "baseline_seeded"
 
 
@@ -480,9 +480,9 @@ class StateDB:
     def record_baseline_files(self, files: Iterable[tuple[str, int, float]]) -> None:
         """Record `(relative_path, size_bytes, mtime)` rows as baseline.
 
-        Used by `seed_baseline_files` when entering a `new-only` environment:
-        the rows feed the initial-scan dedup index so the pre-existing backlog
-        is skipped without ever being uploaded.
+        Used by `FileMonitor._seed_baseline_scan` when entering a `new-only`
+        environment: the rows feed the initial-scan dedup index so the
+        pre-existing backlog is skipped without ever being uploaded.
         """
         rows = list(files)
         if not rows:
@@ -522,7 +522,7 @@ class StateDB:
         return bool(cur.fetchone()[0])
 
     def mark_baseline_seeded(self) -> None:
-        """Record that `seed_baseline_files` has run for this environment.
+        """Record that baseline seeding has run for this environment.
 
         Makes the one-shot seed gate hold even when the initial scan matched
         zero files (see `baseline_established`).

--- a/watcher/tests/test_cli_self_update.py
+++ b/watcher/tests/test_cli_self_update.py
@@ -43,7 +43,7 @@ def _make_config(tmp_path: Path) -> WatcherConfig:
     return WatcherConfig(
         version=1,
         environment="staging",
-        watcher_id="w-test",
+        watcher_ids={"staging": "w-test"},
         instrument=InstrumentConfig(
             id="test-instrument",
             watch_directory=watch_dir,

--- a/watcher/tests/test_cli_service_reinstall.py
+++ b/watcher/tests/test_cli_service_reinstall.py
@@ -31,7 +31,7 @@ def _make_config(tmp_path: Path) -> WatcherConfig:
     return WatcherConfig(
         version=1,
         environment="staging",
-        watcher_id="w-test",
+        watcher_ids={"staging": "w-test"},
         instrument=InstrumentConfig(
             id="test-instrument",
             watch_directory=watch_dir,

--- a/watcher/tests/test_cli_set_environment.py
+++ b/watcher/tests/test_cli_set_environment.py
@@ -7,6 +7,7 @@ config's parent directory is the config dir.
 """
 
 from __future__ import annotations
+import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -225,3 +226,98 @@ class TestPreviewRedeploy:
             assert [k[0] for k in db.iter_baseline_stat_keys()] == ["old-backlog.csv"]
         finally:
             db.close()
+
+
+def _env_key_client_factory(captured: list[tuple[str, str]]) -> object:
+    """A `_make_client` replacement that records `(environment, key)` per call.
+
+    The key is whatever `DataHubClient` would resolve at call time: the
+    explicit `api_key` if given, else the live `DATA_HUB_API_KEY`. Recording it
+    is how the tests below catch a process env left pointing at the wrong
+    environment after a switch.
+    """
+
+    def make_client(
+        environment: str, api_key: str | None = None, api_base_url: str | None = None
+    ) -> MagicMock:
+        client = MagicMock()
+        client.list_instruments.return_value = [MagicMock(id="test-instrument")]
+        client.get_instrument.return_value = MagicMock(status="active")
+        client.register_watcher.return_value = MagicMock(watcher_id="w-prod")
+        client.get_config_checksum.return_value = None
+        captured.append((environment, api_key or os.environ.get("DATA_HUB_API_KEY", "")))
+        return client
+
+    return make_client
+
+
+def _fake_load_env(environment: str | None = None) -> None:
+    """Mirror `load_env`'s override semantics: set the env's key into os.environ."""
+    if environment:
+        os.environ["DATA_HUB_API_KEY"] = f"key-{environment}"
+
+
+class TestSwitchLeavesProcessEnvConsistent:
+    """The switch must leave `DATA_HUB_API_KEY` pointing at the target env.
+
+    `_emit_switch_breadcrumb` reloads the *old* env's `.env` last, so without a
+    restore the process env is left on the old key and any same-process
+    follow-up (e.g. `config edit`'s post-edit push) hits the new env's API with
+    the wrong key. Called directly because `CliRunner` restores `os.environ`.
+    """
+
+    def test_switch_restores_target_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(cli_module, "load_env", _fake_load_env)
+        monkeypatch.setattr(cli_module, "save_api_key", lambda *a, **k: tmp_path / ".env")
+        monkeypatch.setattr(cli_module, "_make_client", _env_key_client_factory([]))
+        monkeypatch.setenv("DATA_HUB_API_KEY", "key-staging")
+
+        path = _write_config(
+            tmp_path,
+            environment="staging",
+            watcher_ids={"staging": "w-staging", "production": "w-prod-existing"},
+        )
+        cfg = load_config(path)
+
+        new_cfg = cli_module._switch_environment(path, cfg, "production")
+
+        assert new_cfg.environment == "production"
+        assert os.environ["DATA_HUB_API_KEY"] == "key-production"
+
+
+class TestConfigEditWithSwitch:
+    """`config edit` re-prompting the environment delegates to the switch flow."""
+
+    def test_edit_with_switch_pushes_to_new_env_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: list[tuple[str, str]] = []
+        monkeypatch.setattr(cli_module, "load_env", _fake_load_env)
+        monkeypatch.setattr(cli_module, "save_api_key", lambda *a, **k: tmp_path / ".env")
+        monkeypatch.setattr(cli_module, "_make_client", _env_key_client_factory(captured))
+        # Pin run-detection so the edit only needs the simple prompts below.
+        monkeypatch.setattr(
+            cli_module, "_prompt_run_detection", lambda *a, **k: (r"^([^_]+)", False)
+        )
+        path = _write_config(
+            tmp_path,
+            environment="staging",
+            watcher_ids={"staging": "w-staging", "production": "w-prod-existing"},
+        )
+        monkeypatch.setattr(cli_module, "resolve_config_path", lambda _override: path)
+        monkeypatch.setenv("DATA_HUB_API_KEY", "key-staging")
+
+        # Prompts in order: environment, watch dir, file patterns, stability,
+        # upload mode, enabled. Empty lines accept the current defaults.
+        user_input = "\n".join(["production", "", "", "", "", ""]) + "\n"
+        runner = CliRunner()
+        result = runner.invoke(cli_module.cli, ["config", "edit"], input=user_input)
+
+        assert result.exit_code == 0, result.output
+        assert load_config(path).environment == "production"
+        # The last client built is the post-edit push; it must target the new
+        # environment with the new environment's key (the fix for the
+        # breadcrumb leaving the old key in os.environ).
+        assert captured[-1] == ("production", "key-production")

--- a/watcher/tests/test_cli_set_environment.py
+++ b/watcher/tests/test_cli_set_environment.py
@@ -1,0 +1,227 @@
+"""Tests for `data-hub-watcher config set-environment` and the switch helper.
+
+Network and credential side effects are mocked: `_make_client` returns a
+`MagicMock`, and `load_env` / `save_api_key` are stubbed so the tests never
+touch the real `~/.data-hub`. The state DBs live under `tmp_path` because the
+config's parent directory is the config dir.
+"""
+
+from __future__ import annotations
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner, Result
+
+from data_hub_watcher import cli as cli_module
+from data_hub_watcher.api_client import ApiError
+from data_hub_watcher.config_io import load_config, save_config
+from data_hub_watcher.constants import state_db_path
+from data_hub_watcher.models import InstrumentConfig, RunDetectionConfig, WatcherConfig
+from data_hub_watcher.state import StateDB
+
+PREVIEW_A = "https://data-hub-git-branch-a.vercel.app/api/v1"
+PREVIEW_B = "https://data-hub-git-branch-b.vercel.app/api/v1"
+
+
+def _write_config(
+    tmp_path: Path,
+    *,
+    environment: str,
+    watcher_ids: dict[str, str],
+    api_base_url: str | None = None,
+) -> Path:
+    watch_dir = tmp_path / "data"
+    watch_dir.mkdir(exist_ok=True)
+    (watch_dir / "RUN001_sample.csv").write_text("a,b\n1,2\n")
+    cfg = WatcherConfig(
+        version=1,
+        environment=environment,  # type: ignore[arg-type]
+        api_base_url=api_base_url,
+        watcher_ids=watcher_ids,
+        instrument=InstrumentConfig(
+            id="test-instrument",
+            watch_directory=watch_dir,
+            file_patterns=["*.csv"],
+            run_detection=RunDetectionConfig(pattern=r"^([^_]+)", recursive=False),
+        ),
+    )
+    path = tmp_path / "config.yaml"
+    save_config(cfg, path)
+    return path
+
+
+@pytest.fixture
+def fake_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> MagicMock:
+    """Stub out network + credential IO and return the shared fake client."""
+    monkeypatch.setattr(cli_module, "load_env", lambda *a, **k: None)
+    monkeypatch.setattr(cli_module, "save_api_key", lambda *a, **k: tmp_path / ".env")
+
+    client = MagicMock()
+    client.list_instruments.return_value = [MagicMock(id="test-instrument")]
+    client.get_instrument.return_value = MagicMock(status="active")
+    client.register_watcher.return_value = MagicMock(watcher_id="w-prod")
+    client.get_config_checksum.return_value = None
+    monkeypatch.setattr(cli_module, "_make_client", lambda *a, **k: client)
+    return client
+
+
+def _invoke(path: Path, monkeypatch: pytest.MonkeyPatch, args: list[str]) -> Result:
+    monkeypatch.setattr(cli_module, "resolve_config_path", lambda _override: path)
+    runner = CliRunner()
+    return runner.invoke(cli_module.cli, ["config", "set-environment", *args])
+
+
+class TestSwitchRegistration:
+    def test_reuses_stored_id_without_registering(
+        self, tmp_path: Path, fake_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = _write_config(
+            tmp_path,
+            environment="staging",
+            watcher_ids={"staging": "w-staging", "production": "w-prod-existing"},
+        )
+
+        result = _invoke(path, monkeypatch, ["production", "--api-key", "dhub_key"])
+
+        assert result.exit_code == 0, result.output
+        fake_client.register_watcher.assert_not_called()
+        fake_client.get_instrument.assert_called()  # validates the stored id
+        cfg = load_config(path)
+        assert cfg.environment == "production"
+        assert cfg.watcher_id == "w-prod-existing"
+
+    def test_registers_when_no_stored_id_and_keeps_other_ids(
+        self, tmp_path: Path, fake_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = _write_config(tmp_path, environment="staging", watcher_ids={"staging": "w-staging"})
+
+        result = _invoke(path, monkeypatch, ["production", "--api-key", "dhub_key"])
+
+        assert result.exit_code == 0, result.output
+        fake_client.register_watcher.assert_called_once()
+        cfg = load_config(path)
+        assert cfg.environment == "production"
+        assert cfg.watcher_ids == {"staging": "w-staging", "production": "w-prod"}
+
+
+class TestSwitchFailures:
+    def test_preview_without_url_fails_before_any_call(
+        self, tmp_path: Path, fake_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = _write_config(tmp_path, environment="staging", watcher_ids={"staging": "w-staging"})
+
+        result = _invoke(path, monkeypatch, ["preview"])
+
+        assert result.exit_code != 0
+        assert "api-base-url is required" in result.output
+        fake_client.list_instruments.assert_not_called()
+        assert load_config(path).environment == "staging"
+
+    def test_no_register_unknown_target_leaves_config_untouched(
+        self, tmp_path: Path, fake_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = _write_config(tmp_path, environment="staging", watcher_ids={"staging": "w-staging"})
+
+        result = _invoke(
+            path, monkeypatch, ["production", "--api-key", "dhub_key", "--no-register"]
+        )
+
+        assert result.exit_code != 0
+        fake_client.register_watcher.assert_not_called()
+        cfg = load_config(path)
+        assert cfg.environment == "staging"
+        assert cfg.watcher_ids == {"staging": "w-staging"}
+
+    def test_api_error_leaves_config_untouched(
+        self, tmp_path: Path, fake_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_client.list_instruments.side_effect = ApiError("unauthorized", status_code=401)
+        path = _write_config(tmp_path, environment="staging", watcher_ids={"staging": "w-staging"})
+
+        result = _invoke(path, monkeypatch, ["production", "--api-key", "dhub_key"])
+
+        assert result.exit_code != 0
+        cfg = load_config(path)
+        assert cfg.environment == "staging"
+        assert cfg.watcher_ids == {"staging": "w-staging"}
+
+
+class TestWindowsServiceSync:
+    def test_rewrites_registry_env_path_on_windows(
+        self, tmp_path: Path, fake_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "platform", "win32")
+        env_path = tmp_path / ".env.production"
+        monkeypatch.setattr(cli_module, "env_file_path", lambda _env: env_path)
+
+        fake_service = MagicMock(name="data_hub_watcher.service")
+        monkeypatch.setitem(sys.modules, "data_hub_watcher.service", fake_service)
+
+        path = _write_config(tmp_path, environment="staging", watcher_ids={"staging": "w-staging"})
+
+        result = _invoke(path, monkeypatch, ["production", "--api-key", "dhub_key"])
+
+        assert result.exit_code == 0, result.output
+        fake_service._rewrite_service_env_path.assert_called_once_with(env_path)
+
+
+class TestPreviewRedeploy:
+    def _seed_preview_db(self, tmp_path: Path, url: str) -> None:
+        db = StateDB(state_db_path(tmp_path, "preview"))
+        db.set_meta("preview_api_base_url", url)
+        db.record_baseline_files([("old-backlog.csv", 10, 1.0)])
+        db.close()
+
+    def test_changed_url_resets_db_and_reregisters(
+        self, tmp_path: Path, fake_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._seed_preview_db(tmp_path, PREVIEW_A)
+        path = _write_config(
+            tmp_path,
+            environment="preview",
+            watcher_ids={"preview": "w-prev-a"},
+            api_base_url=PREVIEW_A,
+        )
+
+        result = _invoke(
+            path, monkeypatch, ["preview", "--api-base-url", PREVIEW_B, "--api-key", "dhub_key"]
+        )
+
+        assert result.exit_code == 0, result.output
+        fake_client.register_watcher.assert_called_once()
+        cfg = load_config(path)
+        assert cfg.api_base_url == PREVIEW_B
+
+        db = StateDB(state_db_path(tmp_path, "preview"))
+        try:
+            # Reset wiped the old backlog; only the new deployment URL remains.
+            assert list(db.iter_baseline_stat_keys()) == []
+            assert db.get_meta("preview_api_base_url") == PREVIEW_B
+        finally:
+            db.close()
+
+    def test_unchanged_url_preserves_db(
+        self, tmp_path: Path, fake_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._seed_preview_db(tmp_path, PREVIEW_A)
+        path = _write_config(
+            tmp_path,
+            environment="preview",
+            watcher_ids={"preview": "w-prev-a"},
+            api_base_url=PREVIEW_A,
+        )
+
+        result = _invoke(
+            path, monkeypatch, ["preview", "--api-base-url", PREVIEW_A, "--api-key", "dhub_key"]
+        )
+
+        assert result.exit_code == 0, result.output
+        fake_client.register_watcher.assert_not_called()
+
+        db = StateDB(state_db_path(tmp_path, "preview"))
+        try:
+            assert [k[0] for k in db.iter_baseline_stat_keys()] == ["old-backlog.csv"]
+        finally:
+            db.close()

--- a/watcher/tests/test_config_migration.py
+++ b/watcher/tests/test_config_migration.py
@@ -1,0 +1,131 @@
+"""Per-environment `watcher_ids` schema, legacy migration, and scan-mode defaults."""
+
+from __future__ import annotations
+from pathlib import Path
+
+import yaml
+
+from data_hub_watcher.config_io import load_config, save_config
+from data_hub_watcher.models import InstrumentConfig, RunDetectionConfig, WatcherConfig
+
+
+def _instrument(tmp_path: Path) -> InstrumentConfig:
+    watch_dir = tmp_path / "data"
+    watch_dir.mkdir(exist_ok=True)
+    (watch_dir / "RUN001_sample.csv").write_text("a,b\n1,2\n")
+    return InstrumentConfig(
+        id="test-instrument",
+        watch_directory=watch_dir,
+        file_patterns=["*.csv"],
+        run_detection=RunDetectionConfig(pattern=r"^([^_]+)", recursive=False),
+    )
+
+
+def _legacy_yaml(watch_dir: Path) -> dict:
+    return {
+        "version": 1,
+        "environment": "production",
+        "watcher_id": "w-legacy",
+        "instrument": {
+            "id": "test-instrument",
+            "watch_directory": str(watch_dir),
+            "file_patterns": ["*.csv"],
+            "run_detection": {"pattern": "^([^_]+)", "recursive": False},
+        },
+    }
+
+
+class TestLegacyMigration:
+    def test_yaml_legacy_watcher_id_lifts_into_map(self, tmp_path: Path) -> None:
+        watch_dir = tmp_path / "data"
+        watch_dir.mkdir()
+        (watch_dir / "RUN001_sample.csv").write_text("a,b\n1,2\n")
+        path = tmp_path / "config.yaml"
+        path.write_text(yaml.dump(_legacy_yaml(watch_dir)), encoding="utf-8")
+
+        cfg = load_config(path)
+
+        assert cfg.watcher_ids == {"production": "w-legacy"}
+        assert cfg.watcher_id == "w-legacy"
+
+    def test_model_validate_legacy_watcher_id_lifts_into_map(self, tmp_path: Path) -> None:
+        # `watcher_id` is no longer a field, so exercise the legacy shape via
+        # `model_validate` (what `load_config` uses) rather than a kwarg.
+        cfg = WatcherConfig.model_validate(
+            {
+                "version": 1,
+                "environment": "staging",
+                "watcher_id": "w-old",
+                "instrument": _instrument(tmp_path).model_dump(mode="json"),
+            }
+        )
+        assert cfg.watcher_ids == {"staging": "w-old"}
+        assert cfg.watcher_id == "w-old"
+
+    def test_legacy_key_dropped_on_save(self, tmp_path: Path) -> None:
+        watch_dir = tmp_path / "data"
+        watch_dir.mkdir()
+        (watch_dir / "RUN001_sample.csv").write_text("a,b\n1,2\n")
+        path = tmp_path / "config.yaml"
+        path.write_text(yaml.dump(_legacy_yaml(watch_dir)), encoding="utf-8")
+
+        save_config(load_config(path), path)
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+        assert "watcher_id" not in data
+        assert data["watcher_ids"] == {"production": "w-legacy"}
+
+
+class TestWatcherIdProperty:
+    def test_returns_id_for_active_environment(self, tmp_path: Path) -> None:
+        cfg = WatcherConfig(
+            version=1,
+            environment="staging",
+            watcher_ids={"staging": "w-staging", "production": "w-prod"},
+            instrument=_instrument(tmp_path),
+        )
+        assert cfg.watcher_id == "w-staging"
+
+    def test_returns_none_when_unregistered_for_environment(self, tmp_path: Path) -> None:
+        cfg = WatcherConfig(
+            version=1,
+            environment="production",
+            watcher_ids={"staging": "w-staging"},
+            instrument=_instrument(tmp_path),
+        )
+        assert cfg.watcher_id is None
+
+
+class TestMultiEnvRoundTrip:
+    def test_round_trip_preserves_all_ids(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.yaml"
+        original = WatcherConfig(
+            version=1,
+            environment="production",
+            watcher_ids={"staging": "w-staging", "production": "w-prod"},
+            instrument=_instrument(tmp_path),
+        )
+
+        save_config(original, path)
+        loaded = load_config(path)
+
+        assert loaded.watcher_ids == {"staging": "w-staging", "production": "w-prod"}
+
+
+class TestResolveInitialScan:
+    def test_production_defaults_to_full(self, tmp_path: Path) -> None:
+        cfg = WatcherConfig(version=1, environment="production", instrument=_instrument(tmp_path))
+        assert cfg.resolve_initial_scan() == "full"
+
+    def test_staging_defaults_to_new_only(self, tmp_path: Path) -> None:
+        cfg = WatcherConfig(version=1, environment="staging", instrument=_instrument(tmp_path))
+        assert cfg.resolve_initial_scan() == "new-only"
+
+    def test_explicit_override_wins(self, tmp_path: Path) -> None:
+        cfg = WatcherConfig(
+            version=1,
+            environment="production",
+            initial_scan="new-only",
+            instrument=_instrument(tmp_path),
+        )
+        assert cfg.resolve_initial_scan() == "new-only"

--- a/watcher/tests/test_monitor_initial_scan.py
+++ b/watcher/tests/test_monitor_initial_scan.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from data_hub_watcher.monitor import FileMonitor, _stat_in_dedup_index, seed_baseline_files
+from data_hub_watcher.monitor import FileMonitor, _stat_in_dedup_index
 from data_hub_watcher.state import StateDB
 
 
@@ -38,6 +38,7 @@ def _make_monitor(
     state_db: StateDB,
     *,
     recursive: bool = False,
+    seed_baseline: bool = False,
 ) -> FileMonitor:
     return FileMonitor(
         watch_directory=watch_dir,
@@ -46,6 +47,7 @@ def _make_monitor(
         on_stable_file=MagicMock(),
         state_db=state_db,
         recursive=recursive,
+        seed_baseline=seed_baseline,
     )
 
 
@@ -318,8 +320,13 @@ class TestInitialScan:
         assert b in monitor._pending
 
 
-class TestSeedBaselineFiles:
-    """`seed_baseline_files` records the backlog so the scan skips it."""
+class TestSeedBaselineScan:
+    """In `seed_baseline` mode the initial scan records the backlog as skip.
+
+    This is the first start of a `new-only` environment: one directory walk
+    records every matching file as `baseline_files` and enqueues nothing,
+    instead of a separate seeding pass followed by a scan.
+    """
 
     def test_records_matching_files_without_marking_upload(
         self, state_db: StateDB, watch_dir: Path
@@ -328,10 +335,12 @@ class TestSeedBaselineFiles:
         (watch_dir / "b.nd2").write_bytes(b"x" * 200)
         (watch_dir / "skip.txt").write_text("nope")
 
-        count = seed_baseline_files(state_db, watch_dir, ["*.nd2"], recursive=False)
+        monitor = _make_monitor(watch_dir, state_db, seed_baseline=True)
+        monitor._initial_scan()
 
-        assert count == 2
         assert {k[0] for k in state_db.iter_baseline_stat_keys()} == {"a.nd2", "b.nd2"}
+        # Backlog is baselined, not enqueued for upload.
+        assert monitor._pending == {}
         # A baseline row is an "ignore" marker, not an upload record.
         assert list(state_db.iter_uploaded_stat_keys()) == []
 
@@ -341,9 +350,9 @@ class TestSeedBaselineFiles:
         (watch_dir / "run-a").mkdir()
         (watch_dir / "run-a" / "out.nd2").write_bytes(b"x" * 10)
 
-        count = seed_baseline_files(state_db, watch_dir, ["*.nd2"], recursive=True)
+        monitor = _make_monitor(watch_dir, state_db, recursive=True, seed_baseline=True)
+        monitor._initial_scan()
 
-        assert count == 1
         assert [k[0] for k in state_db.iter_baseline_stat_keys()] == ["run-a/out.nd2"]
 
     def test_non_recursive_ignores_subdirectories(self, state_db: StateDB, watch_dir: Path) -> None:
@@ -351,16 +360,29 @@ class TestSeedBaselineFiles:
         (watch_dir / "sub").mkdir()
         (watch_dir / "sub" / "nested.nd2").write_bytes(b"x" * 10)
 
-        count = seed_baseline_files(state_db, watch_dir, ["*.nd2"], recursive=False)
+        monitor = _make_monitor(watch_dir, state_db, seed_baseline=True)
+        monitor._initial_scan()
 
-        assert count == 1
         assert [k[0] for k in state_db.iter_baseline_stat_keys()] == ["top.nd2"]
 
-    def test_initial_scan_skips_baseline_files(self, state_db: StateDB, watch_dir: Path) -> None:
+    def test_empty_dir_marks_seeded_so_it_isnt_rewalked(
+        self, state_db: StateDB, watch_dir: Path
+    ) -> None:
+        monitor = _make_monitor(watch_dir, state_db, seed_baseline=True)
+        monitor._initial_scan()
+
+        assert list(state_db.iter_baseline_stat_keys()) == []
+        assert state_db.baseline_established() is True
+
+    def test_later_normal_scan_skips_seeded_baseline(
+        self, state_db: StateDB, watch_dir: Path
+    ) -> None:
         f = watch_dir / "backlog.nd2"
         f.write_bytes(b"x" * 512)
-        seed_baseline_files(state_db, watch_dir, ["*.nd2"], recursive=False)
+        _make_monitor(watch_dir, state_db, seed_baseline=True)._initial_scan()
 
+        # A subsequent restart runs the normal scan (seed_baseline=False) and
+        # must skip the baselined backlog via the dedup index.
         monitor = _make_monitor(watch_dir, state_db)
         monitor._initial_scan()
 

--- a/watcher/tests/test_monitor_initial_scan.py
+++ b/watcher/tests/test_monitor_initial_scan.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from data_hub_watcher.monitor import FileMonitor, _stat_in_dedup_index
+from data_hub_watcher.monitor import FileMonitor, _stat_in_dedup_index, seed_baseline_files
 from data_hub_watcher.state import StateDB
 
 
@@ -316,6 +316,55 @@ class TestInitialScan:
 
         assert a not in monitor._pending
         assert b in monitor._pending
+
+
+class TestSeedBaselineFiles:
+    """`seed_baseline_files` records the backlog so the scan skips it."""
+
+    def test_records_matching_files_without_marking_upload(
+        self, state_db: StateDB, watch_dir: Path
+    ) -> None:
+        (watch_dir / "a.nd2").write_bytes(b"x" * 100)
+        (watch_dir / "b.nd2").write_bytes(b"x" * 200)
+        (watch_dir / "skip.txt").write_text("nope")
+
+        count = seed_baseline_files(state_db, watch_dir, ["*.nd2"], recursive=False)
+
+        assert count == 2
+        assert {k[0] for k in state_db.iter_baseline_stat_keys()} == {"a.nd2", "b.nd2"}
+        # A baseline row is an "ignore" marker, not an upload record.
+        assert list(state_db.iter_uploaded_stat_keys()) == []
+
+    def test_recursive_records_nested_relative_path(
+        self, state_db: StateDB, watch_dir: Path
+    ) -> None:
+        (watch_dir / "run-a").mkdir()
+        (watch_dir / "run-a" / "out.nd2").write_bytes(b"x" * 10)
+
+        count = seed_baseline_files(state_db, watch_dir, ["*.nd2"], recursive=True)
+
+        assert count == 1
+        assert [k[0] for k in state_db.iter_baseline_stat_keys()] == ["run-a/out.nd2"]
+
+    def test_non_recursive_ignores_subdirectories(self, state_db: StateDB, watch_dir: Path) -> None:
+        (watch_dir / "top.nd2").write_bytes(b"x" * 10)
+        (watch_dir / "sub").mkdir()
+        (watch_dir / "sub" / "nested.nd2").write_bytes(b"x" * 10)
+
+        count = seed_baseline_files(state_db, watch_dir, ["*.nd2"], recursive=False)
+
+        assert count == 1
+        assert [k[0] for k in state_db.iter_baseline_stat_keys()] == ["top.nd2"]
+
+    def test_initial_scan_skips_baseline_files(self, state_db: StateDB, watch_dir: Path) -> None:
+        f = watch_dir / "backlog.nd2"
+        f.write_bytes(b"x" * 512)
+        seed_baseline_files(state_db, watch_dir, ["*.nd2"], recursive=False)
+
+        monitor = _make_monitor(watch_dir, state_db)
+        monitor._initial_scan()
+
+        assert f not in monitor._pending
 
 
 class TestDetectedFilesApi:

--- a/watcher/tests/test_preview_environment.py
+++ b/watcher/tests/test_preview_environment.py
@@ -85,7 +85,7 @@ class TestConfigRoundTrip:
             version=1,
             environment="preview",
             api_base_url=PREVIEW_URL,
-            watcher_id="w-123",
+            watcher_ids={"preview": "w-123"},
             instrument=_make_instrument(tmp_path),
         )
 

--- a/watcher/tests/test_runtime.py
+++ b/watcher/tests/test_runtime.py
@@ -316,6 +316,21 @@ class TestBuildRuntimeBaselineSeeding:
         finally:
             rt.state_db.close()
 
+    def test_empty_new_only_dir_marks_seeded_so_it_isnt_rewalked(
+        self, tmp_path: Path, db_path: Path
+    ) -> None:
+        cfg = self._cfg(tmp_path, environment="staging")
+        # Remove the sample so nothing matches; the one-shot gate must still
+        # flip via the sentinel rather than re-walking on every start.
+        (tmp_path / "data" / "RUN001_sample.csv").unlink()
+
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+        try:
+            assert list(rt.state_db.iter_baseline_stat_keys()) == []
+            assert rt.state_db.baseline_established() is True
+        finally:
+            rt.state_db.close()
+
 
 class TestBuildRuntimeConfigDir:
     """Plumbing of the explicit ``config_dir`` parameter through the runtime.

--- a/watcher/tests/test_runtime.py
+++ b/watcher/tests/test_runtime.py
@@ -276,11 +276,14 @@ class TestBuildRuntimeBaselineSeeding:
             ),
         )
 
-    def test_new_only_env_seeds_existing_backlog(self, tmp_path: Path, db_path: Path) -> None:
+    def test_new_only_env_enables_baseline_seeding(self, tmp_path: Path, db_path: Path) -> None:
+        # Seeding itself happens in the monitor's initial scan; `build_runtime`
+        # only decides whether to arm it. The scan effect is covered by
+        # `test_monitor_initial_scan.TestSeedBaselineScan`.
         cfg = self._cfg(tmp_path, environment="staging")
         rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
         try:
-            assert {k[0] for k in rt.state_db.iter_baseline_stat_keys()} == {"RUN001_sample.csv"}
+            assert rt.monitor._seed_baseline is True
         finally:
             rt.state_db.close()
 
@@ -288,7 +291,7 @@ class TestBuildRuntimeBaselineSeeding:
         cfg = self._cfg(tmp_path, environment="production")
         rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
         try:
-            assert list(rt.state_db.iter_baseline_stat_keys()) == []
+            assert rt.monitor._seed_baseline is False
         finally:
             rt.state_db.close()
 
@@ -304,7 +307,7 @@ class TestBuildRuntimeBaselineSeeding:
         cfg = self._cfg(tmp_path, environment="staging")
         rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
         try:
-            assert list(rt.state_db.iter_baseline_stat_keys()) == []
+            assert rt.monitor._seed_baseline is False
         finally:
             rt.state_db.close()
 
@@ -312,24 +315,32 @@ class TestBuildRuntimeBaselineSeeding:
         cfg = self._cfg(tmp_path, environment="staging", initial_scan="full")
         rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
         try:
-            assert list(rt.state_db.iter_baseline_stat_keys()) == []
+            assert rt.monitor._seed_baseline is False
         finally:
             rt.state_db.close()
 
-    def test_empty_new_only_dir_marks_seeded_so_it_isnt_rewalked(
+    def test_seeded_history_disarms_seeding_on_next_build(
         self, tmp_path: Path, db_path: Path
     ) -> None:
+        # First start seeds (and marks the sentinel) via the monitor scan; a
+        # later `build_runtime` against the same DB must not re-arm seeding,
+        # even for an empty dir where the sentinel is the only signal.
         cfg = self._cfg(tmp_path, environment="staging")
-        # Remove the sample so nothing matches; the one-shot gate must still
-        # flip via the sentinel rather than re-walking on every start.
         (tmp_path / "data" / "RUN001_sample.csv").unlink()
 
-        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+        first = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
         try:
-            assert list(rt.state_db.iter_baseline_stat_keys()) == []
-            assert rt.state_db.baseline_established() is True
+            assert first.monitor._seed_baseline is True
+            first.monitor._initial_scan()
+            assert first.state_db.baseline_established() is True
         finally:
-            rt.state_db.close()
+            first.state_db.close()
+
+        second = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+        try:
+            assert second.monitor._seed_baseline is False
+        finally:
+            second.state_db.close()
 
 
 class TestBuildRuntimeConfigDir:

--- a/watcher/tests/test_runtime.py
+++ b/watcher/tests/test_runtime.py
@@ -65,7 +65,7 @@ def _make_config(
     return WatcherConfig(
         version=1,
         environment="staging",
-        watcher_id=watcher_id,
+        watcher_ids={"staging": watcher_id} if watcher_id else {},
         instrument=instrument,
     )
 
@@ -247,6 +247,74 @@ class TestBuildRuntimeErrors:
         cfg = _make_config(tmp_path, upload_mode="auto", watcher_id=None)
         with pytest.raises(ValueError, match="watcher_id"):
             build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+
+
+class TestBuildRuntimeBaselineSeeding:
+    """Baseline seeding gating: only `new-only` envs with no history seed."""
+
+    def _cfg(
+        self,
+        tmp_path: Path,
+        *,
+        environment: str,
+        initial_scan: Literal["full", "new-only"] | None = None,
+    ) -> WatcherConfig:
+        watch_dir = tmp_path / "data"
+        watch_dir.mkdir(exist_ok=True)
+        (watch_dir / "RUN001_sample.csv").write_text("a,b\n1,2\n")
+        return WatcherConfig(
+            version=1,
+            environment=environment,  # type: ignore[arg-type]
+            api_base_url="https://x.example/api/v1" if environment == "preview" else None,
+            watcher_ids={environment: "w-test"},
+            initial_scan=initial_scan,
+            instrument=InstrumentConfig(
+                id="test-instrument",
+                watch_directory=watch_dir,
+                file_patterns=["*.csv"],
+                run_detection=RunDetectionConfig(pattern=r"^([^_]+)", recursive=False),
+            ),
+        )
+
+    def test_new_only_env_seeds_existing_backlog(self, tmp_path: Path, db_path: Path) -> None:
+        cfg = self._cfg(tmp_path, environment="staging")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+        try:
+            assert {k[0] for k in rt.state_db.iter_baseline_stat_keys()} == {"RUN001_sample.csv"}
+        finally:
+            rt.state_db.close()
+
+    def test_production_does_not_seed_baseline(self, tmp_path: Path, db_path: Path) -> None:
+        cfg = self._cfg(tmp_path, environment="production")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+        try:
+            assert list(rt.state_db.iter_baseline_stat_keys()) == []
+        finally:
+            rt.state_db.close()
+
+    def test_does_not_reseed_when_history_exists(self, tmp_path: Path, db_path: Path) -> None:
+        # An existing upload row means this environment already has real
+        # state; reseeding would wrongly mark genuinely-new files as backlog.
+        pre = StateDB(db_path)
+        pre.record_upload(
+            "old.csv", "sha", "s3/old.csv", relative_path="old.csv", size_bytes=1, mtime=1.0
+        )
+        pre.close()
+
+        cfg = self._cfg(tmp_path, environment="staging")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+        try:
+            assert list(rt.state_db.iter_baseline_stat_keys()) == []
+        finally:
+            rt.state_db.close()
+
+    def test_explicit_full_override_skips_seeding(self, tmp_path: Path, db_path: Path) -> None:
+        cfg = self._cfg(tmp_path, environment="staging", initial_scan="full")
+        rt = build_runtime(client=MagicMock(), cfg=cfg, db_path=db_path)
+        try:
+            assert list(rt.state_db.iter_baseline_stat_keys()) == []
+        finally:
+            rt.state_db.close()
 
 
 class TestBuildRuntimeConfigDir:

--- a/watcher/tests/test_service.py
+++ b/watcher/tests/test_service.py
@@ -206,6 +206,43 @@ class TestRegistryRoundTrip:
         ]
 
 
+class TestRewriteServiceEnvPath:
+    """`_rewrite_service_env_path` updates only `EnvPath`, keeping `ConfigPath`."""
+
+    def test_rewrites_env_path_preserving_config_path(self, service_module: ModuleType) -> None:
+        winreg = sys.modules["winreg"]
+        stored: dict[str, str] = {}
+        winreg.OpenKey.return_value = MagicMock(name="reg_key")
+
+        def _set(key: Any, name: str, _reserved: int, _type: int, value: str) -> None:
+            stored[name] = value
+
+        def _query(key: Any, name: str) -> tuple[str, int]:
+            return stored[name], _REG_SZ
+
+        winreg.SetValueEx.side_effect = _set
+        winreg.QueryValueEx.side_effect = _query
+
+        service_module._store_paths_in_registry(
+            Path("C:/data-hub/config.yaml"), Path("C:/data-hub/.env.staging")
+        )
+
+        service_module._rewrite_service_env_path(Path("C:/data-hub/.env.production"))
+
+        config_path, env_path = service_module._read_paths_from_registry()
+        assert config_path == Path("C:/data-hub/config.yaml")
+        assert env_path == Path("C:/data-hub/.env.production")
+
+    def test_no_installed_service_is_a_noop(self, service_module: ModuleType) -> None:
+        # A CLI-only host has no registry key; the switch must not fail there.
+        winreg = sys.modules["winreg"]
+        winreg.OpenKey.side_effect = OSError("key not found")
+
+        service_module._rewrite_service_env_path(Path("C:/data-hub/.env.production"))
+
+        winreg.SetValueEx.assert_not_called()
+
+
 # --- install_service argument shape -----------------------------------------
 
 
@@ -969,7 +1006,7 @@ def _make_config(
     return WatcherConfig(
         version=1,
         environment=environment,  # type: ignore[arg-type]
-        watcher_id=watcher_id,
+        watcher_ids={environment: watcher_id} if watcher_id else {},
         instrument=instrument,
     )
 

--- a/watcher/tests/test_state_db_baseline.py
+++ b/watcher/tests/test_state_db_baseline.py
@@ -54,6 +54,14 @@ class TestBaselineFiles:
         state_db.prune_uploaded_files(days=0)
         assert list(state_db.iter_baseline_stat_keys()) == [("a.csv", 1, 1.0)]
 
+    def test_mark_baseline_seeded_establishes_without_rows(self, state_db: StateDB) -> None:
+        # The sentinel makes the one-shot seed gate hold for an empty watch dir
+        # (zero matched files) so the tree isn't re-walked on every start.
+        assert state_db.baseline_established() is False
+        state_db.mark_baseline_seeded()
+        assert state_db.baseline_established() is True
+        assert list(state_db.iter_baseline_stat_keys()) == []
+
 
 class TestMeta:
     def test_get_missing_returns_none(self, state_db: StateDB) -> None:

--- a/watcher/tests/test_state_db_baseline.py
+++ b/watcher/tests/test_state_db_baseline.py
@@ -1,0 +1,69 @@
+"""Tests for the `baseline_files` and `meta` tables on `StateDB`."""
+
+from __future__ import annotations
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from data_hub_watcher.state import StateDB
+
+
+@pytest.fixture()
+def state_db(tmp_path: Path) -> Generator[StateDB, None, None]:
+    db = StateDB(tmp_path / "test.db")
+    yield db
+    db.close()
+
+
+class TestBaselineFiles:
+    def test_record_and_iter_roundtrip(self, state_db: StateDB) -> None:
+        state_db.record_baseline_files(
+            [("a/one.csv", 1024, 1_700_000_000.0), ("b/two.csv", 2048, 1_700_000_001.0)]
+        )
+        assert sorted(state_db.iter_baseline_stat_keys()) == [
+            ("a/one.csv", 1024, 1_700_000_000.0),
+            ("b/two.csv", 2048, 1_700_000_001.0),
+        ]
+
+    def test_record_empty_is_noop(self, state_db: StateDB) -> None:
+        state_db.record_baseline_files([])
+        assert list(state_db.iter_baseline_stat_keys()) == []
+
+    def test_established_false_on_empty_db(self, state_db: StateDB) -> None:
+        assert state_db.baseline_established() is False
+
+    def test_established_true_with_baseline_rows(self, state_db: StateDB) -> None:
+        state_db.record_baseline_files([("a.csv", 1, 1.0)])
+        assert state_db.baseline_established() is True
+
+    def test_established_true_with_upload_history(self, state_db: StateDB) -> None:
+        state_db.record_upload(
+            "a.csv", "sha", "s3/a.csv", relative_path="a.csv", size_bytes=1, mtime=1.0
+        )
+        assert state_db.baseline_established() is True
+
+    def test_established_true_with_detected_history(self, state_db: StateDB) -> None:
+        state_db.record_detected_files("run-1", [("a.csv", "a.csv", 1, 1.0, None)])
+        assert state_db.baseline_established() is True
+
+    def test_baseline_survives_prune(self, state_db: StateDB) -> None:
+        # The backlog must stay skipped forever; unlike `uploaded_files`,
+        # `baseline_files` is never pruned.
+        state_db.record_baseline_files([("a.csv", 1, 1.0)])
+        state_db.prune_uploaded_files(days=0)
+        assert list(state_db.iter_baseline_stat_keys()) == [("a.csv", 1, 1.0)]
+
+
+class TestMeta:
+    def test_get_missing_returns_none(self, state_db: StateDB) -> None:
+        assert state_db.get_meta("preview_api_base_url") is None
+
+    def test_set_then_get(self, state_db: StateDB) -> None:
+        state_db.set_meta("preview_api_base_url", "https://x.example/api/v1")
+        assert state_db.get_meta("preview_api_base_url") == "https://x.example/api/v1"
+
+    def test_set_overwrites(self, state_db: StateDB) -> None:
+        state_db.set_meta("k", "v1")
+        state_db.set_meta("k", "v2")
+        assert state_db.get_meta("k") == "v2"

--- a/watcher/tests/test_state_db_path.py
+++ b/watcher/tests/test_state_db_path.py
@@ -1,0 +1,66 @@
+"""Per-environment state DB path resolution, legacy migration, and reset."""
+
+from __future__ import annotations
+from pathlib import Path
+
+from data_hub_watcher.constants import (
+    STATE_DB_FILENAME,
+    reset_state_db,
+    resolve_state_db_path,
+    state_db_path,
+)
+
+
+def test_path_is_environment_scoped(tmp_path: Path) -> None:
+    assert state_db_path(tmp_path, "production") == tmp_path / "watcher-production.db"
+    assert state_db_path(tmp_path, "staging") == tmp_path / "watcher-staging.db"
+
+
+def test_resolve_creates_no_file_when_nothing_exists(tmp_path: Path) -> None:
+    target = resolve_state_db_path(tmp_path, "staging")
+    assert target == tmp_path / "watcher-staging.db"
+    assert not target.exists()
+
+
+def test_resolve_migrates_legacy_db_with_sidecars_once(tmp_path: Path) -> None:
+    (tmp_path / STATE_DB_FILENAME).write_text("main")
+    (tmp_path / f"{STATE_DB_FILENAME}-wal").write_text("wal")
+    (tmp_path / f"{STATE_DB_FILENAME}-shm").write_text("shm")
+
+    target = resolve_state_db_path(tmp_path, "production")
+
+    assert target == tmp_path / "watcher-production.db"
+    assert target.read_text() == "main"
+    assert (tmp_path / "watcher-production.db-wal").read_text() == "wal"
+    assert (tmp_path / "watcher-production.db-shm").read_text() == "shm"
+    assert not (tmp_path / STATE_DB_FILENAME).exists()
+
+    # Idempotent: a second resolve is a no-op now that the target exists.
+    assert resolve_state_db_path(tmp_path, "production").read_text() == "main"
+
+
+def test_resolve_does_not_clobber_existing_target(tmp_path: Path) -> None:
+    (tmp_path / STATE_DB_FILENAME).write_text("legacy")
+    (tmp_path / "watcher-production.db").write_text("existing")
+
+    resolved = resolve_state_db_path(tmp_path, "production")
+
+    assert resolved.read_text() == "existing"
+    # Legacy is left untouched so a different environment can still claim it.
+    assert (tmp_path / STATE_DB_FILENAME).exists()
+
+
+def test_reset_removes_db_and_sidecars(tmp_path: Path) -> None:
+    (tmp_path / "watcher-preview.db").write_text("db")
+    (tmp_path / "watcher-preview.db-wal").write_text("wal")
+    (tmp_path / "watcher-preview.db-shm").write_text("shm")
+
+    reset_state_db(tmp_path, "preview")
+
+    assert not (tmp_path / "watcher-preview.db").exists()
+    assert not (tmp_path / "watcher-preview.db-wal").exists()
+    assert not (tmp_path / "watcher-preview.db-shm").exists()
+
+
+def test_reset_missing_is_noop(tmp_path: Path) -> None:
+    reset_state_db(tmp_path, "preview")

--- a/watcher/tests/test_updater.py
+++ b/watcher/tests/test_updater.py
@@ -80,7 +80,7 @@ def _make_config(
         version=1,
         environment=environment,  # type: ignore[arg-type]
         api_base_url="https://example.test/api/v1" if environment == "preview" else None,
-        watcher_id="w-test",
+        watcher_ids={environment: "w-test"},
         instrument=instrument,
     )
 


### PR DESCRIPTION
## Summary

Lets a watcher on a lab PC switch between `staging`, `production`, and `preview` (and back) without re-uploading its multi-TB historical backlog or corrupting one environment's upload history with another's.

- **Per-environment registration** — `WatcherConfig.watcher_id` becomes a `watcher_ids` map (one id per environment) with transparent migration from the legacy single `watcher_id`. A derived `watcher_id` property returns the active environment's id.
- **Per-environment local state** — state now lives in `~/.data-hub/watcher-<environment>.db` instead of a shared `watcher.db`; the legacy file is renamed to the active environment on first start.
- **Baseline instead of an upload cap** — new `initial_scan` mode (`resolve_initial_scan()` defaults production→`full`, staging/preview→`new-only`). In `new-only`, `seed_baseline_files()` records the existing on-disk backlog into a new `baseline_files` table so the initial scan skips it without uploading. Seeding is one-shot, gated on `baseline_established()`.
- **Preview isolation** — a `meta` table tracks the preview deployment URL; switching a preview to a new URL resets that env's DB so the new target gets a clean baseline.
- **Switching UX** — new `config set-environment ENV` command plus an environment re-prompt in `config edit`. The switch validates the target API, reuses or registers a watcher, pushes config to the target, drops a `watcher_stopped` breadcrumb in the old environment, and on Windows rewrites only the service registry `EnvPath`.
- **Docs** — `docs/reference/watcher.md` gains a "Switching environments" section, updated YAML/subcommand table, and refreshed local-state and initial-scan sections.

## Test plan

New/updated tests cover: legacy config migration, per-env DB path + legacy rename + reset, `baseline_files`/`meta` tables and scan-skip, `build_runtime` baseline gating, the `set-environment` CLI matrix (reuse/register/no-register/api-error/preview redeploy), and the Windows registry env-path rewrite.

- [x] `ruff check .` and `ruff format --check watcher` — clean
- [x] `pyright` — 0 errors
- [x] `pytest watcher/tests -m "not integration"` — 420 passed

Made with [Cursor](https://cursor.com)