### PR TITLE
Improve navigation: run switcher + recently viewed instruments and watchers

### DIFF
--- a/web/components/app-sidebar/main-nav.tsx
+++ b/web/components/app-sidebar/main-nav.tsx
@@ -3,6 +3,7 @@
 import { ChevronRight, Cpu, Home, type LucideIcon, Radio } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useMemo } from "react";
 import {
   Collapsible,
   CollapsibleContent,
@@ -19,7 +20,10 @@ import {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
 } from "@/components/ui/sidebar";
+import { useRecentInstruments } from "@/hooks/use-recent-instruments";
 import type { SidebarInstrument, SidebarWatcher } from "@/lib/api/sidebar";
+
+const SIDEBAR_RECENT_INSTRUMENTS_LIMIT = 10;
 
 interface MainNavProps {
   instruments: SidebarInstrument[];
@@ -28,6 +32,29 @@ interface MainNavProps {
 
 export function MainNav({ instruments, watchers }: MainNavProps) {
   const pathname = usePathname();
+  const { recent: recentInstruments } = useRecentInstruments();
+
+  const recentlyViewedInstruments = useMemo(
+    () => recentInstruments.slice(0, SIDEBAR_RECENT_INSTRUMENTS_LIMIT),
+    [recentInstruments]
+  );
+
+  const recentlyViewedIds = useMemo(
+    () => new Set(recentlyViewedInstruments.map((entry) => entry.instrumentId)),
+    [recentlyViewedInstruments]
+  );
+
+  const sidebarInstruments = useMemo(
+    () =>
+      instruments
+        .filter((instrument) => !recentlyViewedIds.has(instrument.id))
+        .map((instrument) => ({
+          key: instrument.id,
+          href: `/instruments/${instrument.id}`,
+          label: instrument.displayName,
+        })),
+    [instruments, recentlyViewedIds]
+  );
 
   return (
     <SidebarGroup>
@@ -51,12 +78,15 @@ export function MainNav({ instruments, watchers }: MainNavProps) {
             basePath="/instruments"
             currentPath={pathname}
             icon={Cpu}
-            items={instruments.map((instrument) => ({
-              key: instrument.id,
-              href: `/instruments/${instrument.id}`,
-              label: instrument.displayName,
-            }))}
+            items={sidebarInstruments}
             label="Instruments"
+            recentlyViewedItems={recentlyViewedInstruments.map(
+              (instrument) => ({
+                key: instrument.instrumentId,
+                href: `/instruments/${instrument.instrumentId}`,
+                label: instrument.displayName,
+              })
+            )}
             viewAllHref="/instruments"
           />
 
@@ -88,8 +118,13 @@ interface CollapsibleNavSectionProps {
   icon: LucideIcon;
   items: Array<{ key: string; href: string; label: string }>;
   label: string;
+  recentlyViewedItems?: Array<{ key: string; href: string; label: string }>;
   /** Href for the trailing "View all" sub-item that opens the full list. */
   viewAllHref: string;
+}
+
+function isNavItemActive(currentPath: string, href: string): boolean {
+  return currentPath === href || currentPath.startsWith(`${href}/`);
 }
 
 function CollapsibleNavSection({
@@ -98,6 +133,7 @@ function CollapsibleNavSection({
   basePath,
   viewAllHref,
   items,
+  recentlyViewedItems = [],
   currentPath,
 }: CollapsibleNavSectionProps) {
   // Open the section by default whenever the user is anywhere within it so
@@ -121,11 +157,32 @@ function CollapsibleNavSection({
         </CollapsibleTrigger>
         <CollapsibleContent>
           <SidebarMenuSub>
+            {recentlyViewedItems.length > 0 ? (
+              <>
+                <SidebarMenuSubItem>
+                  <span className="px-2 py-1 font-medium text-muted-foreground text-xs">
+                    Recently viewed
+                  </span>
+                </SidebarMenuSubItem>
+                {recentlyViewedItems.map((item) => (
+                  <SidebarMenuSubItem key={`recent-${item.key}`}>
+                    <SidebarMenuSubButton
+                      asChild
+                      isActive={isNavItemActive(currentPath, item.href)}
+                    >
+                      <Link href={item.href}>
+                        <span className="truncate">{item.label}</span>
+                      </Link>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                ))}
+              </>
+            ) : null}
             {items.map((item) => (
               <SidebarMenuSubItem key={item.key}>
                 <SidebarMenuSubButton
                   asChild
-                  isActive={currentPath === item.href}
+                  isActive={isNavItemActive(currentPath, item.href)}
                 >
                   <Link href={item.href}>
                     <span className="truncate">{item.label}</span>

--- a/web/components/app-sidebar/main-nav.tsx
+++ b/web/components/app-sidebar/main-nav.tsx
@@ -21,9 +21,14 @@ import {
   SidebarMenuSubItem,
 } from "@/components/ui/sidebar";
 import { useRecentInstruments } from "@/hooks/use-recent-instruments";
+import {
+  useRecentWatchers,
+  watcherNavLabel,
+} from "@/hooks/use-recent-watchers";
 import type { SidebarInstrument, SidebarWatcher } from "@/lib/api/sidebar";
 
 const SIDEBAR_RECENT_INSTRUMENTS_LIMIT = 10;
+const SIDEBAR_RECENT_WATCHERS_LIMIT = 10;
 
 interface MainNavProps {
   instruments: SidebarInstrument[];
@@ -33,6 +38,7 @@ interface MainNavProps {
 export function MainNav({ instruments, watchers }: MainNavProps) {
   const pathname = usePathname();
   const { recent: recentInstruments } = useRecentInstruments();
+  const { recent: recentWatchers } = useRecentWatchers();
 
   const recentlyViewedInstruments = useMemo(
     () => recentInstruments.slice(0, SIDEBAR_RECENT_INSTRUMENTS_LIMIT),
@@ -54,6 +60,28 @@ export function MainNav({ instruments, watchers }: MainNavProps) {
           label: instrument.displayName,
         })),
     [instruments, recentlyViewedIds]
+  );
+
+  const recentlyViewedWatchers = useMemo(
+    () => recentWatchers.slice(0, SIDEBAR_RECENT_WATCHERS_LIMIT),
+    [recentWatchers]
+  );
+
+  const recentlyViewedWatcherIds = useMemo(
+    () => new Set(recentlyViewedWatchers.map((entry) => entry.watcherId)),
+    [recentlyViewedWatchers]
+  );
+
+  const sidebarWatchers = useMemo(
+    () =>
+      watchers
+        .filter((watcher) => !recentlyViewedWatcherIds.has(watcher.id))
+        .map((watcher) => ({
+          key: watcher.id,
+          href: `/watchers/${watcher.id}`,
+          label: watcherNavLabel(watcher.id, watcher.hostname),
+        })),
+    [watchers, recentlyViewedWatcherIds]
   );
 
   return (
@@ -94,15 +122,13 @@ export function MainNav({ instruments, watchers }: MainNavProps) {
             basePath="/watchers"
             currentPath={pathname}
             icon={Radio}
-            items={watchers.map((watcher) => ({
-              key: watcher.id,
-              href: `/watchers/${watcher.id}`,
-              // Hostname is the canonical identifier for a watcher in the
-              // table view; fall back to the short id when missing so the
-              // row never collapses to an empty label.
-              label: watcher.hostname ?? `${watcher.id.slice(0, 8)}…`,
-            }))}
+            items={sidebarWatchers}
             label="Watchers"
+            recentlyViewedItems={recentlyViewedWatchers.map((watcher) => ({
+              key: watcher.watcherId,
+              href: `/watchers/${watcher.watcherId}`,
+              label: watcher.label,
+            }))}
             viewAllHref="/watchers"
           />
         </SidebarMenu>
@@ -157,14 +183,8 @@ function CollapsibleNavSection({
         </CollapsibleTrigger>
         <CollapsibleContent>
           <SidebarMenuSub>
-            {recentlyViewedItems.length > 0 ? (
-              <>
-                <SidebarMenuSubItem>
-                  <span className="px-2 py-1 font-medium text-muted-foreground text-xs">
-                    Recently viewed
-                  </span>
-                </SidebarMenuSubItem>
-                {recentlyViewedItems.map((item) => (
+            {recentlyViewedItems.length > 0
+              ? recentlyViewedItems.map((item) => (
                   <SidebarMenuSubItem key={`recent-${item.key}`}>
                     <SidebarMenuSubButton
                       asChild
@@ -175,9 +195,8 @@ function CollapsibleNavSection({
                       </Link>
                     </SidebarMenuSubButton>
                   </SidebarMenuSubItem>
-                ))}
-              </>
-            ) : null}
+                ))
+              : null}
             {items.map((item) => (
               <SidebarMenuSubItem key={item.key}>
                 <SidebarMenuSubButton

--- a/web/components/instruments/instrument-header.tsx
+++ b/web/components/instruments/instrument-header.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { InstrumentNotificationSwitch } from "@/components/notifications/instrument-notification-switch";
+import { RecordInstrumentVisit } from "@/components/recent-instrument-visit";
 import { Badge } from "@/components/ui/badge";
 import {
   Breadcrumb,
@@ -33,6 +34,10 @@ export function InstrumentHeader({
 
   return (
     <div className="flex flex-col gap-2">
+      <RecordInstrumentVisit
+        displayName={instrument.displayName}
+        instrumentId={instrument.id}
+      />
       <Breadcrumb className="mb-2">
         <BreadcrumbList>
           <BreadcrumbItem>

--- a/web/components/recent-instrument-visit.tsx
+++ b/web/components/recent-instrument-visit.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRecentInstruments } from "@/hooks/use-recent-instruments";
+
+export function RecordInstrumentVisit({
+  instrumentId,
+  displayName,
+}: {
+  instrumentId: string;
+  displayName: string;
+}) {
+  const { recordVisit } = useRecentInstruments();
+
+  useEffect(() => {
+    recordVisit({
+      instrumentId,
+      displayName,
+      visitedAt: Date.now(),
+    });
+  }, [displayName, instrumentId, recordVisit]);
+
+  return null;
+}

--- a/web/components/recent-watcher-visit.tsx
+++ b/web/components/recent-watcher-visit.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  useRecentWatchers,
+  watcherNavLabel,
+} from "@/hooks/use-recent-watchers";
+
+export function RecordWatcherVisit({
+  watcherId,
+  hostname,
+}: {
+  watcherId: string;
+  hostname: string | null;
+}) {
+  const { recordVisit } = useRecentWatchers();
+  const label = watcherNavLabel(watcherId, hostname);
+
+  useEffect(() => {
+    recordVisit({
+      watcherId,
+      label,
+      visitedAt: Date.now(),
+    });
+  }, [label, recordVisit, watcherId]);
+
+  return null;
+}

--- a/web/components/runs/run-header.tsx
+++ b/web/components/runs/run-header.tsx
@@ -2,6 +2,7 @@
 
 import { Trash2 } from "lucide-react";
 import Link from "next/link";
+import { RecordInstrumentVisit } from "@/components/recent-instrument-visit";
 import { RunSwitcher } from "@/components/runs/run-switcher";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
@@ -29,6 +30,10 @@ export function RunHeader({
 }) {
   return (
     <div className="flex flex-col gap-4">
+      <RecordInstrumentVisit
+        displayName={run.instrumentDisplayName}
+        instrumentId={run.instrumentId}
+      />
       <Breadcrumb>
         <BreadcrumbList>
           <BreadcrumbItem>

--- a/web/components/runs/run-header.tsx
+++ b/web/components/runs/run-header.tsx
@@ -2,13 +2,13 @@
 
 import { Trash2 } from "lucide-react";
 import Link from "next/link";
+import { RunSwitcher } from "@/components/runs/run-switcher";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbLink,
   BreadcrumbList,
-  BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import type { RunDetail } from "@/lib/api/instrument-runs";
@@ -51,9 +51,7 @@ export function RunHeader({
             </BreadcrumbLink>
           </BreadcrumbItem>
           <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbPage className="font-mono">{run.runId}</BreadcrumbPage>
-          </BreadcrumbItem>
+          <RunSwitcher run={run} />
         </BreadcrumbList>
       </Breadcrumb>
 

--- a/web/components/runs/run-switcher.tsx
+++ b/web/components/runs/run-switcher.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { Check, ChevronsUpDown } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { BreadcrumbItem } from "@/components/ui/breadcrumb";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { useRecentRuns } from "@/hooks/use-recent-runs";
+import type { RunDetail } from "@/lib/api/instrument-runs";
+import { cn } from "@/lib/utils";
+
+interface RunSearchRow {
+  instrumentDisplayName: string;
+  instrumentId: string;
+  runId: string;
+}
+
+interface RunListResponse {
+  data: Array<{
+    instrument_display_name: string;
+    instrument_id: string;
+    run_id: string;
+  }>;
+}
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+function toRunHref(instrumentId: string, runId: string): string {
+  return `/instruments/${instrumentId}/runs/${encodeURIComponent(runId)}`;
+}
+
+export function RunSwitcher({ run }: { run: RunDetail }) {
+  const router = useRouter();
+  const { recent, recordVisit } = useRecentRuns();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<RunSearchRow[]>([]);
+  const [recentRuns, setRecentRuns] = useState<RunSearchRow[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [isLoadingRecentRuns, setIsLoadingRecentRuns] = useState(false);
+
+  useEffect(() => {
+    recordVisit({
+      instrumentId: run.instrumentId,
+      runId: run.runId,
+      instrumentDisplayName: run.instrumentDisplayName,
+      visitedAt: Date.now(),
+    });
+  }, [recordVisit, run.instrumentDisplayName, run.instrumentId, run.runId]);
+
+  const recentlyViewed = useMemo(
+    () =>
+      recent
+        .filter((entry) => entry.instrumentId === run.instrumentId)
+        .slice(0, 10)
+        .map((entry) => ({
+          instrumentId: entry.instrumentId,
+          runId: entry.runId,
+          instrumentDisplayName: entry.instrumentDisplayName,
+        })),
+    [recent, run.instrumentId]
+  );
+
+  const recentlyViewedKeys = useMemo(
+    () =>
+      new Set(
+        recentlyViewed.map((entry) => `${entry.instrumentId}:${entry.runId}`)
+      ),
+    [recentlyViewed]
+  );
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setSearchResults([]);
+      setRecentRuns([]);
+      setIsSearching(false);
+      setIsLoadingRecentRuns(false);
+      return;
+    }
+
+    if (query.trim()) {
+      setRecentRuns([]);
+      setIsLoadingRecentRuns(false);
+
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(async () => {
+        setIsSearching(true);
+        try {
+          const params = new URLSearchParams({
+            instrument_id: run.instrumentId,
+            search: query.trim(),
+            per_page: "10",
+          });
+          const res = await fetch(
+            `/api/v1/instrument-runs?${params.toString()}`,
+            { signal: controller.signal }
+          );
+          if (!res.ok) {
+            setSearchResults([]);
+            return;
+          }
+          const body = (await res.json()) as RunListResponse;
+          setSearchResults(
+            body.data.map((row) => ({
+              instrumentId: row.instrument_id,
+              runId: row.run_id,
+              instrumentDisplayName: row.instrument_display_name,
+            }))
+          );
+        } catch (error) {
+          if (error instanceof DOMException && error.name === "AbortError") {
+            return;
+          }
+          setSearchResults([]);
+        } finally {
+          if (!controller.signal.aborted) {
+            setIsSearching(false);
+          }
+        }
+      }, SEARCH_DEBOUNCE_MS);
+
+      return () => {
+        controller.abort();
+        window.clearTimeout(timeoutId);
+      };
+    }
+
+    setSearchResults([]);
+    setIsSearching(false);
+
+    const controller = new AbortController();
+    setIsLoadingRecentRuns(true);
+
+    void (async () => {
+      try {
+        const params = new URLSearchParams({
+          instrument_id: run.instrumentId,
+          per_page: "10",
+          sort: "acquired_at",
+          order: "desc",
+        });
+        const res = await fetch(
+          `/api/v1/instrument-runs?${params.toString()}`,
+          { signal: controller.signal }
+        );
+        if (!res.ok) {
+          setRecentRuns([]);
+          return;
+        }
+        const body = (await res.json()) as RunListResponse;
+        setRecentRuns(
+          body.data.map((row) => ({
+            instrumentId: row.instrument_id,
+            runId: row.run_id,
+            instrumentDisplayName: row.instrument_display_name,
+          }))
+        );
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+        setRecentRuns([]);
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoadingRecentRuns(false);
+        }
+      }
+    })();
+
+    return () => {
+      controller.abort();
+    };
+  }, [open, query, run.instrumentId]);
+
+  const recentRunsForInstrument = useMemo(
+    () =>
+      recentRuns.filter(
+        (entry) =>
+          !recentlyViewedKeys.has(`${entry.instrumentId}:${entry.runId}`)
+      ),
+    [recentRuns, recentlyViewedKeys]
+  );
+
+  function selectRun(instrumentId: string, runId: string) {
+    setOpen(false);
+    if (instrumentId === run.instrumentId && runId === run.runId) {
+      return;
+    }
+    router.push(toRunHref(instrumentId, runId));
+  }
+
+  function renderRunItem(item: RunSearchRow) {
+    const isActive =
+      item.instrumentId === run.instrumentId && item.runId === run.runId;
+    return (
+      <CommandItem
+        data-checked={isActive}
+        key={`${item.instrumentId}:${item.runId}`}
+        onSelect={() => selectRun(item.instrumentId, item.runId)}
+        value={item.runId}
+      >
+        <Check
+          className={cn(
+            "size-4 shrink-0",
+            isActive ? "opacity-100" : "opacity-0"
+          )}
+        />
+        <span className="truncate font-mono">{item.runId}</span>
+      </CommandItem>
+    );
+  }
+
+  const hasRecentlyViewed = recentlyViewed.length > 0;
+  const hasRecentRuns = recentRunsForInstrument.length > 0;
+  const showEmptyState = !(
+    query.trim() ||
+    hasRecentlyViewed ||
+    hasRecentRuns ||
+    isLoadingRecentRuns
+  );
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <BreadcrumbItem>
+        <PopoverTrigger asChild>
+          <button
+            aria-expanded={open}
+            aria-label="Switch run"
+            className="inline-flex items-center gap-1 font-mono font-normal text-foreground transition-colors hover:text-foreground/80"
+            role="combobox"
+            type="button"
+          >
+            <span aria-current="page" className="font-mono">
+              {run.runId}
+            </span>
+            <ChevronsUpDown className="size-3.5 shrink-0 opacity-50" />
+          </button>
+        </PopoverTrigger>
+      </BreadcrumbItem>
+      <PopoverContent align="start" className="w-80 p-0">
+        <Command shouldFilter={false}>
+          <CommandInput
+            onValueChange={setQuery}
+            placeholder="Search runs..."
+            value={query}
+          />
+          <CommandList>
+            {query.trim() ? (
+              isSearching ? (
+                <div className="py-6 text-center text-muted-foreground text-sm">
+                  Searching...
+                </div>
+              ) : searchResults.length === 0 ? (
+                <CommandEmpty>No matching runs.</CommandEmpty>
+              ) : (
+                <CommandGroup heading="Results">
+                  {searchResults.map((item) => renderRunItem(item))}
+                </CommandGroup>
+              )
+            ) : (
+              <>
+                {showEmptyState ? (
+                  <CommandEmpty>No recent runs.</CommandEmpty>
+                ) : null}
+                {hasRecentlyViewed ? (
+                  <CommandGroup heading="Recently viewed">
+                    {recentlyViewed.map((item) => renderRunItem(item))}
+                  </CommandGroup>
+                ) : null}
+                {isLoadingRecentRuns ? (
+                  <div className="py-4 text-center text-muted-foreground text-sm">
+                    Loading recent runs...
+                  </div>
+                ) : hasRecentRuns ? (
+                  <CommandGroup heading="Recent runs">
+                    {recentRunsForInstrument.map((item) => renderRunItem(item))}
+                  </CommandGroup>
+                ) : null}
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/components/watchers/watcher-header.tsx
+++ b/web/components/watchers/watcher-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { RecordWatcherVisit } from "@/components/recent-watcher-visit";
 import { Badge } from "@/components/ui/badge";
 import {
   Breadcrumb,
@@ -24,6 +25,7 @@ export function WatcherHeader({ watcher }: { watcher: WatcherDetail }) {
 
   return (
     <div className="flex flex-col gap-4">
+      <RecordWatcherVisit hostname={watcher.hostname} watcherId={watcher.id} />
       <Breadcrumb>
         <BreadcrumbList>
           <BreadcrumbItem>

--- a/web/hooks/use-recent-instruments.ts
+++ b/web/hooks/use-recent-instruments.ts
@@ -1,0 +1,130 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export interface RecentInstrument {
+  displayName: string;
+  instrumentId: string;
+  visitedAt: number;
+}
+
+const STORAGE_KEY = "data-hub:recent-instruments";
+const UPDATE_EVENT = "data-hub:recent-instruments-updated";
+const MAX_RECENT = 50;
+
+function readRecentInstruments(): RecentInstrument[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(
+      (entry): entry is RecentInstrument =>
+        typeof entry === "object" &&
+        entry !== null &&
+        typeof (entry as RecentInstrument).instrumentId === "string" &&
+        typeof (entry as RecentInstrument).displayName === "string" &&
+        typeof (entry as RecentInstrument).visitedAt === "number"
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeRecentInstruments(instruments: RecentInstrument[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(instruments));
+    window.dispatchEvent(new Event(UPDATE_EVENT));
+  } catch {
+    // Private browsing or quota exceeded — ignore.
+  }
+}
+
+function dedupeAndCap(instruments: RecentInstrument[]): RecentInstrument[] {
+  const seen = new Set<string>();
+  const next: RecentInstrument[] = [];
+
+  for (const instrument of instruments) {
+    if (seen.has(instrument.instrumentId)) {
+      continue;
+    }
+    seen.add(instrument.instrumentId);
+    next.push(instrument);
+    if (next.length >= MAX_RECENT) {
+      break;
+    }
+  }
+
+  return next;
+}
+
+function resolveDisplayName(
+  instrumentId: string,
+  displayName: string,
+  existing: RecentInstrument | undefined
+): string {
+  if (displayName !== instrumentId) {
+    return displayName;
+  }
+  return existing?.displayName ?? displayName;
+}
+
+export function useRecentInstruments() {
+  const [recent, setRecent] = useState<RecentInstrument[]>([]);
+
+  useEffect(() => {
+    setRecent(readRecentInstruments());
+  }, []);
+
+  useEffect(() => {
+    function refreshRecent() {
+      setRecent(readRecentInstruments());
+    }
+
+    function onStorage(event: StorageEvent) {
+      if (event.key === STORAGE_KEY) {
+        refreshRecent();
+      }
+    }
+
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(UPDATE_EVENT, refreshRecent);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(UPDATE_EVENT, refreshRecent);
+    };
+  }, []);
+
+  const recordVisit = useCallback((instrument: RecentInstrument) => {
+    setRecent((current) => {
+      const existing = current.find(
+        (entry) => entry.instrumentId === instrument.instrumentId
+      );
+      const entry: RecentInstrument = {
+        instrumentId: instrument.instrumentId,
+        displayName: resolveDisplayName(
+          instrument.instrumentId,
+          instrument.displayName,
+          existing
+        ),
+        visitedAt: instrument.visitedAt,
+      };
+      const filtered = current.filter(
+        (item) => item.instrumentId !== instrument.instrumentId
+      );
+      const next = dedupeAndCap([entry, ...filtered]);
+      writeRecentInstruments(next);
+      return next;
+    });
+  }, []);
+
+  return { recent, recordVisit };
+}

--- a/web/hooks/use-recent-runs.ts
+++ b/web/hooks/use-recent-runs.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export interface RecentRun {
+  instrumentDisplayName: string;
+  instrumentId: string;
+  runId: string;
+  visitedAt: number;
+}
+
+const STORAGE_KEY = "data-hub:recent-runs";
+const MAX_RECENT = 50;
+
+function readRecentRuns(): RecentRun[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(
+      (entry): entry is RecentRun =>
+        typeof entry === "object" &&
+        entry !== null &&
+        typeof (entry as RecentRun).instrumentId === "string" &&
+        typeof (entry as RecentRun).runId === "string" &&
+        typeof (entry as RecentRun).instrumentDisplayName === "string" &&
+        typeof (entry as RecentRun).visitedAt === "number"
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeRecentRuns(runs: RecentRun[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(runs));
+  } catch {
+    // Private browsing or quota exceeded — ignore.
+  }
+}
+
+function dedupeAndCap(runs: RecentRun[]): RecentRun[] {
+  const seen = new Set<string>();
+  const next: RecentRun[] = [];
+
+  for (const run of runs) {
+    const key = `${run.instrumentId}:${run.runId}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    next.push(run);
+    if (next.length >= MAX_RECENT) {
+      break;
+    }
+  }
+
+  return next;
+}
+
+export function useRecentRuns() {
+  const [recent, setRecent] = useState<RecentRun[]>([]);
+
+  useEffect(() => {
+    setRecent(readRecentRuns());
+  }, []);
+
+  useEffect(() => {
+    function onStorage(event: StorageEvent) {
+      if (event.key === STORAGE_KEY) {
+        setRecent(readRecentRuns());
+      }
+    }
+
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  const recordVisit = useCallback((run: RecentRun) => {
+    setRecent((current) => {
+      const key = `${run.instrumentId}:${run.runId}`;
+      const filtered = current.filter(
+        (entry) => `${entry.instrumentId}:${entry.runId}` !== key
+      );
+      const next = dedupeAndCap([run, ...filtered]);
+      writeRecentRuns(next);
+      return next;
+    });
+  }, []);
+
+  return { recent, recordVisit };
+}

--- a/web/hooks/use-recent-watchers.ts
+++ b/web/hooks/use-recent-watchers.ts
@@ -1,0 +1,137 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export interface RecentWatcher {
+  label: string;
+  visitedAt: number;
+  watcherId: string;
+}
+
+const STORAGE_KEY = "data-hub:recent-watchers";
+const UPDATE_EVENT = "data-hub:recent-watchers-updated";
+const MAX_RECENT = 50;
+
+function watcherFallbackLabel(watcherId: string): string {
+  return `${watcherId.slice(0, 8)}…`;
+}
+
+function readRecentWatchers(): RecentWatcher[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(
+      (entry): entry is RecentWatcher =>
+        typeof entry === "object" &&
+        entry !== null &&
+        typeof (entry as RecentWatcher).watcherId === "string" &&
+        typeof (entry as RecentWatcher).label === "string" &&
+        typeof (entry as RecentWatcher).visitedAt === "number"
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeRecentWatchers(watchers: RecentWatcher[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(watchers));
+    window.dispatchEvent(new Event(UPDATE_EVENT));
+  } catch {
+    // Private browsing or quota exceeded — ignore.
+  }
+}
+
+function dedupeAndCap(watchers: RecentWatcher[]): RecentWatcher[] {
+  const seen = new Set<string>();
+  const next: RecentWatcher[] = [];
+
+  for (const watcher of watchers) {
+    if (seen.has(watcher.watcherId)) {
+      continue;
+    }
+    seen.add(watcher.watcherId);
+    next.push(watcher);
+    if (next.length >= MAX_RECENT) {
+      break;
+    }
+  }
+
+  return next;
+}
+
+function resolveLabel(
+  watcherId: string,
+  label: string,
+  existing: RecentWatcher | undefined
+): string {
+  if (label !== watcherFallbackLabel(watcherId)) {
+    return label;
+  }
+  return existing?.label ?? label;
+}
+
+export function useRecentWatchers() {
+  const [recent, setRecent] = useState<RecentWatcher[]>([]);
+
+  useEffect(() => {
+    setRecent(readRecentWatchers());
+  }, []);
+
+  useEffect(() => {
+    function refreshRecent() {
+      setRecent(readRecentWatchers());
+    }
+
+    function onStorage(event: StorageEvent) {
+      if (event.key === STORAGE_KEY) {
+        refreshRecent();
+      }
+    }
+
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(UPDATE_EVENT, refreshRecent);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(UPDATE_EVENT, refreshRecent);
+    };
+  }, []);
+
+  const recordVisit = useCallback((watcher: RecentWatcher) => {
+    setRecent((current) => {
+      const existing = current.find(
+        (entry) => entry.watcherId === watcher.watcherId
+      );
+      const entry: RecentWatcher = {
+        watcherId: watcher.watcherId,
+        label: resolveLabel(watcher.watcherId, watcher.label, existing),
+        visitedAt: watcher.visitedAt,
+      };
+      const filtered = current.filter(
+        (item) => item.watcherId !== watcher.watcherId
+      );
+      const next = dedupeAndCap([entry, ...filtered]);
+      writeRecentWatchers(next);
+      return next;
+    });
+  }, []);
+
+  return { recent, recordVisit };
+}
+
+export function watcherNavLabel(
+  watcherId: string,
+  hostname: string | null
+): string {
+  return hostname ?? watcherFallbackLabel(watcherId);
+}


### PR DESCRIPTION
## Summary

- Add a run switcher dropdown to the run-detail breadcrumb: a search bar (scoped to the current instrument) plus a "Recently viewed" group (from `localStorage`) and a server-fetched "Recent runs" group, with the active run checked and navigation on select.
- Show recently viewed instruments at the top of the sidebar Instruments menu, recorded whenever `/instruments/[instrumentId]` or `/instruments/[instrumentId]/runs/[runId]` is visited.
- Show recently viewed watchers at the top of the sidebar Watchers menu, recorded whenever `/watchers/[watcherId]` is visited.

## Implementation notes

- Three small `localStorage`-backed hooks (`use-recent-runs`, `use-recent-instruments`, `use-recent-watchers`) keep recents newest-first, deduped, and capped, with same-tab and cross-tab sync. They degrade gracefully in private mode / on quota errors.
- Visit tracking is done via lightweight client components (`RecordInstrumentVisit`, `RecordWatcherVisit`) mounted in the page headers.
- Recents are deduped against the server-provided sidebar lists so entries don't appear twice.
- No new dependencies or API endpoints; the run switcher reuses `GET /api/v1/instrument-runs`.

## Test plan

- [ ] Visit several runs of one instrument; open the run-name dropdown — recently viewed and recent runs appear, search filters within the instrument, selecting navigates, current run is checked.
- [ ] Visit a few instrument and run pages; confirm recently viewed instruments appear at the top of the sidebar in descending visit order and persist across reloads.
- [ ] Visit a few watcher pages; confirm recently viewed watchers behave the same way.
- [ ] `make check-all` passes.

Made with [Cursor](https://cursor.com)