### PR TITLE
UI/UX improvements: Filled badges, run-detail redesign, and run navigation

### DIFF
--- a/web/app/instruments/[instrumentId]/runs/[runId]/page.tsx
+++ b/web/app/instruments/[instrumentId]/runs/[runId]/page.tsx
@@ -126,6 +126,7 @@ export default async function RunDetailPage({ params, searchParams }: Props) {
           }
           fileStats={fileStats}
           files={filesPage.data}
+          filesDownloadableCount={filesPage.downloadableCount}
           filesPagination={filesPage.pagination}
           instrumentId={instrumentId}
           reportFiles={reportFiles}

--- a/web/app/instruments/[instrumentId]/runs/[runId]/page.tsx
+++ b/web/app/instruments/[instrumentId]/runs/[runId]/page.tsx
@@ -3,10 +3,12 @@ import type { Metadata } from "next/types";
 import { SignInRequired } from "@/components/auth/sign-in-required";
 import { RunAttributionsSection } from "@/components/runs/run-attributions-section";
 import { RunCommentsSection } from "@/components/runs/run-comments-section";
+import { RunNav } from "@/components/runs/run-nav";
 import { RunDetailVariant } from "@/components/runs/variants";
 import { WatcherStatusProvider } from "@/components/runs/watcher-status-provider";
 import {
   buildRunFilesQuery,
+  getAdjacentRunIds,
   getProcessedCsvData,
   getRunFileStats,
   getRunImageFiles,
@@ -93,6 +95,7 @@ export default async function RunDetailPage({ params, searchParams }: Props) {
     reportImages,
     instrument,
     comments,
+    adjacentRuns,
   ] = await Promise.all([
     buildRunFilesQuery(run.id, {
       page: filters.files_page,
@@ -107,11 +110,15 @@ export default async function RunDetailPage({ params, searchParams }: Props) {
     isImagingInstrument ? getRunImageFiles(run.id) : Promise.resolve([]),
     getInstrumentById(instrumentId),
     listCommentsForRun(run.id),
+    getAdjacentRunIds(run),
   ]);
   const wellData = await getProcessedCsvData(reportFiles);
   // Gate client-side upload actions on watcher availability — a queued
   // upload request is a no-op if no agent is around to action it.
   const isWatcherOnline = (instrument?.watchersOnline ?? 0) > 0;
+
+  const toRunHref = (rid: string) =>
+    `/instruments/${instrumentId}/runs/${encodeURIComponent(rid)}`;
 
   return (
     <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-6 2xl:w-7xl">
@@ -133,6 +140,20 @@ export default async function RunDetailPage({ params, searchParams }: Props) {
           reportImages={reportImages}
           run={run}
           runId={runId}
+          runNavSlot={
+            <RunNav
+              nextHref={
+                adjacentRuns.nextRunId
+                  ? toRunHref(adjacentRuns.nextRunId)
+                  : null
+              }
+              previousHref={
+                adjacentRuns.previousRunId
+                  ? toRunHref(adjacentRuns.previousRunId)
+                  : null
+              }
+            />
+          }
           wellData={wellData}
         />
         <RunCommentsSection

--- a/web/app/instruments/[instrumentId]/runs/[runId]/page.tsx
+++ b/web/app/instruments/[instrumentId]/runs/[runId]/page.tsx
@@ -142,14 +142,20 @@ export default async function RunDetailPage({ params, searchParams }: Props) {
           runId={runId}
           runNavSlot={
             <RunNav
-              nextHref={
+              next={
                 adjacentRuns.nextRunId
-                  ? toRunHref(adjacentRuns.nextRunId)
+                  ? {
+                      href: toRunHref(adjacentRuns.nextRunId),
+                      runId: adjacentRuns.nextRunId,
+                    }
                   : null
               }
-              previousHref={
+              previous={
                 adjacentRuns.previousRunId
-                  ? toRunHref(adjacentRuns.previousRunId)
+                  ? {
+                      href: toRunHref(adjacentRuns.previousRunId),
+                      runId: adjacentRuns.previousRunId,
+                    }
                   : null
               }
             />

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -121,7 +121,7 @@ export default async function RootLayout({
       lang="en"
       suppressHydrationWarning
     >
-      <body>
+      <body suppressHydrationWarning>
         <SessionProvider session={session}>
           <ThemeProvider>
             <NuqsAdapter>

--- a/web/app/settings/tokens/page.tsx
+++ b/web/app/settings/tokens/page.tsx
@@ -4,7 +4,6 @@ import type { Metadata } from "next/types";
 import { SignInRequired } from "@/components/auth/sign-in-required";
 import { CreateTokenDialog } from "@/components/tokens/create-token-dialog";
 import { DeleteTokenDialog } from "@/components/tokens/delete-token-dialog";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -19,8 +18,9 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { UserAvatar } from "@/components/user-avatar";
 import { auth } from "@/lib/auth";
-import { avatarColor, toInitials } from "@/lib/avatar-color";
+import { toInitials } from "@/lib/avatar-color";
 import { db } from "@/lib/db";
 import { personalAccessTokens, users } from "@/lib/db/schema";
 import { formatRelativeTime } from "@/lib/utils";
@@ -209,19 +209,15 @@ export default async function TokensPage() {
                       <TableCell>
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <Avatar size="sm">
-                              {token.user.image ? (
-                                <AvatarImage
-                                  alt={displayName}
-                                  src={token.user.image}
-                                />
-                              ) : null}
-                              <AvatarFallback
-                                className={avatarColor(token.user.id)}
-                              >
-                                {toInitials(displayName)}
-                              </AvatarFallback>
-                            </Avatar>
+                            <UserAvatar
+                              size="sm"
+                              user={{
+                                userId: token.user.id,
+                                displayName,
+                                initials: toInitials(displayName),
+                                avatarUrl: token.user.image,
+                              }}
+                            />
                           </TooltipTrigger>
                           <TooltipContent>{displayName}</TooltipContent>
                         </Tooltip>

--- a/web/components/dashboard/dashboard-stats.tsx
+++ b/web/components/dashboard/dashboard-stats.tsx
@@ -59,7 +59,7 @@ export function DashboardStatsCards({ stats }: { stats: DashboardStats }) {
   const pendingHasBacklog = pendingUploads.count > 0;
 
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+    <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
       <StatCard
         label="Runs in the last 24 hours"
         subline={

--- a/web/components/dashboard/dashboard-stats.tsx
+++ b/web/components/dashboard/dashboard-stats.tsx
@@ -59,7 +59,7 @@ export function DashboardStatsCards({ stats }: { stats: DashboardStats }) {
   const pendingHasBacklog = pendingUploads.count > 0;
 
   return (
-    <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
+    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
       <StatCard
         label="Runs in the last 24 hours"
         subline={

--- a/web/components/instruments/instrument-header.tsx
+++ b/web/components/instruments/instrument-header.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { InstrumentNotificationSwitch } from "@/components/notifications/instrument-notification-switch";
 import { RecordInstrumentVisit } from "@/components/recent-instrument-visit";
-import { Badge } from "@/components/ui/badge";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -22,8 +21,8 @@ export function InstrumentHeader({
   /**
    * Per-viewer notification state for this instrument. When omitted
    * (e.g. unauthenticated callers, or contexts that don't want to
-   * surface the switch), the action row falls back to the original
-   * watcher-status + run-count layout.
+   * surface the switch), the action row falls back to the watcher-status
+   * layout.
    */
   notifications?: {
     enabled: boolean;
@@ -59,11 +58,9 @@ export function InstrumentHeader({
       </Breadcrumb>
 
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3">
-          <h1 className="font-semibold text-2xl tracking-tight">
-            {instrument.displayName}
-          </h1>
-        </div>
+        <h1 className="font-semibold text-2xl tracking-tight">
+          {instrument.displayName}
+        </h1>
 
         <div className="flex items-center gap-2">
           {notifications ? (
@@ -90,15 +87,14 @@ export function InstrumentHeader({
               verbose
             />
           )}
-          <Badge className="px-2 py-3 font-mono text-xs" variant="outline">
-            {instrument.runCount} {instrument.runCount === 1 ? "run" : "runs"}
-          </Badge>
         </div>
       </div>
 
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-muted-foreground text-sm">
-        <span className="font-mono">{instrument.id}</span>
-        {instrument.activeWatcherId && instrument.activeWatcherHostname && (
+        <span>
+          {instrument.runCount} {instrument.runCount === 1 ? "run" : "runs"}
+        </span>
+        {instrument.activeWatcherId && instrument.activeWatcherHostname ? (
           <>
             <span>·</span>
             <Link
@@ -108,7 +104,7 @@ export function InstrumentHeader({
               {instrument.activeWatcherHostname}
             </Link>
           </>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/web/components/instruments/runs-table/ran-by-cell.tsx
+++ b/web/components/instruments/runs-table/ran-by-cell.tsx
@@ -5,52 +5,16 @@ import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { type MouseEvent, useOptimistic, useTransition } from "react";
 import { toast } from "sonner";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { UserAvatar } from "@/components/user-avatar";
 import type { RunAttribution } from "@/lib/api/instrument-runs";
+import { toInitials } from "@/lib/avatar-color";
 import { cn } from "@/lib/utils";
-
-// A small, deterministic palette keyed by userId hash so the same user always
-// gets the same color across rows. Tailwind tokens are baked in (we can't
-// interpolate class names safely).
-const AVATAR_PALETTE = [
-  "bg-blue-200 text-blue-900 dark:bg-blue-800 dark:text-blue-100",
-  "bg-emerald-200 text-emerald-900 dark:bg-emerald-800 dark:text-emerald-100",
-  "bg-violet-200 text-violet-900 dark:bg-violet-800 dark:text-violet-100",
-  "bg-amber-200 text-amber-900 dark:bg-amber-800 dark:text-amber-100",
-  "bg-rose-200 text-rose-900 dark:bg-rose-800 dark:text-rose-100",
-  "bg-teal-200 text-teal-900 dark:bg-teal-800 dark:text-teal-100",
-  "bg-fuchsia-200 text-fuchsia-900 dark:bg-fuchsia-800 dark:text-fuchsia-100",
-  "bg-orange-200 text-orange-900 dark:bg-orange-800 dark:text-orange-100",
-];
-
-function avatarColor(userId: string): string {
-  let hash = 0;
-  for (let i = 0; i < userId.length; i++) {
-    // biome-ignore lint/suspicious/noBitwiseOperators: | 0 coerces the hash to a 32-bit integer
-    hash = (hash * 31 + userId.charCodeAt(i)) | 0;
-  }
-  return AVATAR_PALETTE[Math.abs(hash) % AVATAR_PALETTE.length];
-}
-
-// Mirrors the server-side helper in lib/api/instrument-runs.ts so optimistic
-// attributions render with the same initials the server will echo back,
-// avoiding a fallback flip on reconcile.
-function toInitials(displayName: string): string {
-  const parts = displayName.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) {
-    return "?";
-  }
-  if (parts.length === 1) {
-    return parts[0].slice(0, 2).toUpperCase();
-  }
-  return (parts[0][0] + parts.at(-1)?.[0]).toUpperCase();
-}
 
 type Action =
   | { kind: "claim"; user: RunAttribution }
@@ -69,14 +33,112 @@ function applyOptimistic(
   return current.filter((a) => a.userId !== action.userId);
 }
 
+function AttributionAvatars({
+  attributions,
+  currentUserId,
+  showName,
+  compact,
+}: {
+  attributions: RunAttribution[];
+  currentUserId: string | null;
+  showName: boolean;
+  compact: boolean;
+}) {
+  const avatarClassName = cn(
+    compact
+      ? "size-5 ring-1 ring-background [&_[data-slot=avatar-fallback]]:text-[10px]"
+      : "ring-2 ring-background"
+  );
+  const nameClassName = compact
+    ? "font-medium text-foreground text-xs"
+    : "font-medium text-foreground text-sm";
+  const rowClassName = compact
+    ? "inline-flex h-5 items-center gap-1.5"
+    : "inline-flex items-center gap-2";
+
+  if (showName && attributions.length === 1) {
+    const attribution = attributions[0];
+    const isSelf = attribution.userId === currentUserId;
+    return (
+      <span className={rowClassName}>
+        <UserAvatar
+          className={cn(avatarClassName, isSelf && "ring-primary/30")}
+          data-self-attribution={isSelf || undefined}
+          size="sm"
+          user={attribution}
+        />
+        <span className={nameClassName}>{attribution.displayName}</span>
+      </span>
+    );
+  }
+
+  if (showName && attributions.length > 1) {
+    const hiddenCount = attributions.length - 1;
+    return (
+      <span className={rowClassName}>
+        <span className={cn("flex", compact ? "-space-x-1" : "-space-x-1.5")}>
+          {attributions.map((attribution) => {
+            const isSelf = attribution.userId === currentUserId;
+            return (
+              <Tooltip key={attribution.userId}>
+                <TooltipTrigger asChild>
+                  <UserAvatar
+                    className={cn(avatarClassName, isSelf && "ring-primary/30")}
+                    data-self-attribution={isSelf || undefined}
+                    size="sm"
+                    user={attribution}
+                  />
+                </TooltipTrigger>
+                <TooltipContent>{attribution.displayName}</TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </span>
+        <span className={nameClassName}>
+          {attributions[0].displayName}
+          <span className="text-muted-foreground"> +{hiddenCount}</span>
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex -space-x-1.5">
+      {attributions.map((attribution) => {
+        const isSelf = attribution.userId === currentUserId;
+        return (
+          <Tooltip key={attribution.userId}>
+            <TooltipTrigger asChild>
+              <UserAvatar
+                className={cn(
+                  "ring-2 ring-background",
+                  isSelf && "ring-primary/30"
+                )}
+                data-self-attribution={isSelf || undefined}
+                size="sm"
+                user={attribution}
+              />
+            </TooltipTrigger>
+            <TooltipContent>{attribution.displayName}</TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+}
+
 export function RanByCell({
   instrumentId,
   runId,
   attributions,
+  showName = false,
+  compact = false,
 }: {
   instrumentId: string;
   runId: string;
   attributions: RunAttribution[];
+  showName?: boolean;
+  compact?: boolean;
 }) {
   const { data: session } = useSession();
   const currentUserId = session?.user?.id ?? null;
@@ -98,9 +160,6 @@ export function RanByCell({
     if (!currentUserId) {
       return;
     }
-    // Optimistic shape mirrors what the server will send back so the avatar
-    // bubble doesn't flip from a colored "YO" fallback to the real photo on
-    // reconcile. Pulls displayName / image straight from the session.
     const displayName = session?.user?.name ?? session?.user?.email ?? "You";
     const me: RunAttribution = {
       userId: currentUserId,
@@ -143,24 +202,28 @@ export function RanByCell({
     });
   }
 
-  // Each action is an icon-only button; its label lives in a tooltip so the
-  // cell width is naturally fixed. Both branches share the same wrapper height
-  // so rows don't reflow depending on whether a run has attributions.
+  const actionButtonSize = compact ? "size-5" : showName ? "size-7" : "size-6";
+  const actionIconSize = compact ? "size-3" : showName ? "size-4" : "size-3.5";
+  const rowHeight = compact ? "h-5" : "h-7";
+
   return optimistic.length === 0 ? (
-    <div className="flex h-7 items-center">
+    <div className={cn("flex items-center", rowHeight)}>
       {currentUserId ? (
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
               aria-label="I ran this"
-              className="size-7 text-muted-foreground/70 hover:text-foreground"
+              className={cn(
+                actionButtonSize,
+                "text-muted-foreground/70 hover:text-foreground"
+              )}
               disabled={isPending}
               onClick={handleClaim}
               size="icon"
               type="button"
               variant="ghost"
             >
-              <UserPlus className="size-4" />
+              <UserPlus className={actionIconSize} />
             </Button>
           </TooltipTrigger>
           <TooltipContent>I ran this</TooltipContent>
@@ -168,8 +231,13 @@ export function RanByCell({
       ) : (
         <Tooltip>
           <TooltipTrigger asChild>
-            <span className="inline-flex size-7 items-center justify-center text-muted-foreground/60">
-              <UserPlus aria-hidden="true" className="size-4" />
+            <span
+              className={cn(
+                "inline-flex items-center justify-center text-muted-foreground/60",
+                actionButtonSize
+              )}
+            >
+              <UserPlus aria-hidden="true" className={actionIconSize} />
               <span className="sr-only">Unattributed</span>
             </span>
           </TooltipTrigger>
@@ -178,44 +246,21 @@ export function RanByCell({
       )}
     </div>
   ) : (
-    <div className="group/ranby flex h-7 items-center gap-1">
-      <div className="flex -space-x-1.5">
-        {optimistic.map((attribution) => {
-          const isSelf = attribution.userId === currentUserId;
-          return (
-            <Tooltip key={attribution.userId}>
-              <TooltipTrigger asChild>
-                <Avatar
-                  className={cn(
-                    "ring-2 ring-background",
-                    isSelf && "ring-primary/30"
-                  )}
-                  data-self-attribution={isSelf || undefined}
-                  size="sm"
-                >
-                  {attribution.avatarUrl ? (
-                    <AvatarImage
-                      alt={attribution.displayName}
-                      src={attribution.avatarUrl}
-                    />
-                  ) : null}
-                  <AvatarFallback className={avatarColor(attribution.userId)}>
-                    {attribution.initials}
-                  </AvatarFallback>
-                </Avatar>
-              </TooltipTrigger>
-              <TooltipContent>{attribution.displayName}</TooltipContent>
-            </Tooltip>
-          );
-        })}
-      </div>
+    <div className={cn("group/ranby flex items-center gap-1", rowHeight)}>
+      <AttributionAvatars
+        attributions={optimistic}
+        compact={compact}
+        currentUserId={currentUserId}
+        showName={showName}
+      />
       {isSelfAttributed ? (
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
               aria-label="Remove my attribution"
               className={cn(
-                "size-6 text-muted-foreground/70 hover:text-foreground",
+                actionButtonSize,
+                "text-muted-foreground/70 hover:text-foreground",
                 "opacity-0 transition-opacity",
                 "group-has-[[data-self-attribution]:hover]/ranby:opacity-100",
                 "hover:opacity-100 focus-visible:opacity-100"
@@ -226,7 +271,7 @@ export function RanByCell({
               type="button"
               variant="ghost"
             >
-              <X className="size-3.5" />
+              <X className={actionIconSize} />
             </Button>
           </TooltipTrigger>
           <TooltipContent>Remove my attribution</TooltipContent>
@@ -236,14 +281,17 @@ export function RanByCell({
           <TooltipTrigger asChild>
             <Button
               aria-label="I ran this too"
-              className="size-6 text-muted-foreground/70 hover:text-foreground"
+              className={cn(
+                actionButtonSize,
+                "text-muted-foreground/70 hover:text-foreground"
+              )}
               disabled={isPending}
               onClick={handleClaim}
               size="icon"
               type="button"
               variant="ghost"
             >
-              <UserPlus className="size-3.5" />
+              <UserPlus className={actionIconSize} />
             </Button>
           </TooltipTrigger>
           <TooltipContent>I ran this too</TooltipContent>

--- a/web/components/members/members-table.tsx
+++ b/web/components/members/members-table.tsx
@@ -1,5 +1,4 @@
 import { AdminToggle } from "@/components/members/admin-toggle";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -9,7 +8,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { avatarColor, toInitials } from "@/lib/avatar-color";
+import { UserAvatar } from "@/components/user-avatar";
+import { toInitials } from "@/lib/avatar-color";
 
 export interface MemberRow {
   email: string | null;
@@ -48,14 +48,15 @@ export function MembersTable({ data, currentUserId }: MembersTableProps) {
               <TableRow key={member.id}>
                 <TableCell>
                   <div className="flex items-center gap-3">
-                    <Avatar size="sm">
-                      {member.image ? (
-                        <AvatarImage alt={displayName} src={member.image} />
-                      ) : null}
-                      <AvatarFallback className={avatarColor(member.id)}>
-                        {toInitials(displayName)}
-                      </AvatarFallback>
-                    </Avatar>
+                    <UserAvatar
+                      size="sm"
+                      user={{
+                        userId: member.id,
+                        displayName,
+                        initials: toInitials(displayName),
+                        avatarUrl: member.image,
+                      }}
+                    />
                     <div className="flex flex-col">
                       <span className="font-medium">
                         {displayName}

--- a/web/components/members/members-table.tsx
+++ b/web/components/members/members-table.tsx
@@ -74,11 +74,11 @@ export function MembersTable({ data, currentUserId }: MembersTableProps) {
                 </TableCell>
                 <TableCell>
                   {member.isAdmin ? (
-                    <Badge variant="secondary">Admin</Badge>
-                  ) : (
-                    <Badge className="text-muted-foreground" variant="outline">
-                      Member
+                    <Badge className="bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-300">
+                      Admin
                     </Badge>
+                  ) : (
+                    <Badge variant="outline">Member</Badge>
                   )}
                 </TableCell>
                 <TableCell className="text-right">

--- a/web/components/notifications/notification-bell-content.tsx
+++ b/web/components/notifications/notification-bell-content.tsx
@@ -272,8 +272,7 @@ function NotificationsHeader({
         {hasUnread ? (
           <Badge
             aria-label={`${unreadCount} unread`}
-            className="bg-primary/10 text-primary"
-            variant="secondary"
+            className="bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
           >
             {unreadCount > 99 ? "99+" : unreadCount} new
           </Badge>

--- a/web/components/notifications/notification-bell-content.tsx
+++ b/web/components/notifications/notification-bell-content.tsx
@@ -534,7 +534,7 @@ function RunGroupNotificationRow({
                 <li key={run.id}>
                   <Link
                     className={cn(
-                      "flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 font-mono text-xs hover:bg-muted/80 focus-visible:bg-muted/80 focus-visible:outline-none",
+                      "flex min-h-4 cursor-pointer items-center gap-2 rounded px-1 py-1 font-mono text-xs hover:bg-muted/80 focus-visible:bg-muted/80 focus-visible:outline-none",
                       run.readAt === null
                         ? "text-foreground"
                         : "text-muted-foreground"

--- a/web/components/notifications/notification-bell-content.tsx
+++ b/web/components/notifications/notification-bell-content.tsx
@@ -19,10 +19,9 @@ import {
   type NotificationItem,
   useNotifications,
 } from "@/components/notifications/notifications-provider";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { avatarColor } from "@/lib/avatar-color";
+import { UnknownUserAvatar, UserAvatar } from "@/components/user-avatar";
 import type { InstrumentType } from "@/lib/db/schema";
 import { cn, formatRelativeTime } from "@/lib/utils";
 
@@ -379,18 +378,17 @@ function CommentNotificationRow({
         onClick={onActivate}
       >
         {n.actor ? (
-          <Avatar size="sm">
-            {n.actor.avatarUrl ? (
-              <AvatarImage alt={n.actor.displayName} src={n.actor.avatarUrl} />
-            ) : null}
-            <AvatarFallback className={avatarColor(n.actor.id)}>
-              {n.actor.initials}
-            </AvatarFallback>
-          </Avatar>
+          <UserAvatar
+            size="sm"
+            user={{
+              userId: n.actor.id,
+              displayName: n.actor.displayName,
+              initials: n.actor.initials,
+              avatarUrl: n.actor.avatarUrl,
+            }}
+          />
         ) : (
-          <Avatar size="sm">
-            <AvatarFallback>?</AvatarFallback>
-          </Avatar>
+          <UnknownUserAvatar size="sm" />
         )}
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <p className="text-sm leading-snug">

--- a/web/components/notifications/slack-connection-card.tsx
+++ b/web/components/notifications/slack-connection-card.tsx
@@ -55,7 +55,7 @@ function SectionHeader({
           revoked ? (
             <Badge variant="destructive">Reconnect required</Badge>
           ) : (
-            <Badge variant="outline">
+            <Badge className="bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-300">
               Connected{slackTeamName ? ` · ${slackTeamName}` : ""}
             </Badge>
           )

--- a/web/components/runs/delete-run-dialog.tsx
+++ b/web/components/runs/delete-run-dialog.tsx
@@ -64,11 +64,11 @@ export function DeleteRunDialog({
     <AlertDialog onOpenChange={setOpen} open={open}>
       <AlertDialogTrigger asChild>
         <Button
-          className="h-7 gap-1 text-destructive text-xs hover:text-destructive"
+          className="gap-1.5 border-destructive/30 bg-background text-destructive text-sm hover:bg-destructive/5 hover:text-destructive"
           size="sm"
-          variant="ghost"
+          variant="outline"
         >
-          <Trash2 className="size-3" />
+          <Trash2 className="size-4" />
           Delete
         </Button>
       </AlertDialogTrigger>

--- a/web/components/runs/file-status-badge.tsx
+++ b/web/components/runs/file-status-badge.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
 
 type FileStatus =
   | "detected"
@@ -13,13 +14,19 @@ const statusConfig: Record<
   {
     label: string;
     variant: "default" | "outline" | "secondary" | "destructive";
+    className?: string;
   }
 > = {
   detected: { label: "Detected", variant: "outline" },
   upload_requested: { label: "Upload Requested", variant: "secondary" },
   uploaded: { label: "Uploaded", variant: "secondary" },
   processing: { label: "Processing", variant: "default" },
-  completed: { label: "Completed", variant: "default" },
+  completed: {
+    label: "Completed",
+    variant: "default",
+    className:
+      "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-300",
+  },
   failed: { label: "Failed", variant: "destructive" },
 };
 
@@ -30,7 +37,10 @@ export function FileStatusBadge({ status }: { status: string }) {
   };
 
   return (
-    <Badge className="text-[10px]" variant={config.variant}>
+    <Badge
+      className={cn("text-[10px]", config.className)}
+      variant={config.variant}
+    >
       {config.label}
     </Badge>
   );

--- a/web/components/runs/image-carousel-report.tsx
+++ b/web/components/runs/image-carousel-report.tsx
@@ -2,6 +2,7 @@
 
 import { ExternalLink } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import { RunSectionHeading } from "@/components/runs/run-section-heading";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -70,7 +71,7 @@ export function ImageCarouselReport({ files }: { files: RunFile[] }) {
   if (images.length === 0) {
     return (
       <div className="flex flex-col gap-2">
-        <h2 className="font-semibold text-sm">Report Data</h2>
+        <RunSectionHeading title="Report Data" />
         <Card size="sm">
           <CardContent>
             <p className="text-muted-foreground text-sm">
@@ -87,12 +88,7 @@ export function ImageCarouselReport({ files }: { files: RunFile[] }) {
 
   return (
     <div className="flex flex-col gap-2">
-      <h2 className="font-semibold text-sm">
-        Report Data{" "}
-        <span className="ml-1 font-mono font-normal text-muted-foreground text-xs">
-          {images.length} image(s)
-        </span>
-      </h2>
+      <RunSectionHeading countLabel={images.length} title="Report Data" />
       <Card size="sm">
         <CardContent className="flex flex-col gap-3">
           <div className="flex items-center justify-between gap-2">

--- a/web/components/runs/metadata-badges.tsx
+++ b/web/components/runs/metadata-badges.tsx
@@ -96,11 +96,7 @@ export function MetadataFieldBadge({
   if (!value) {
     return <span className="text-muted-foreground">&mdash;</span>;
   }
-  return (
-    <Badge className={cn("font-mono", colorClass)} variant="outline">
-      {value}
-    </Badge>
-  );
+  return <Badge className={cn("font-mono", colorClass)}>{value}</Badge>;
 }
 
 function BadgeRow({
@@ -115,11 +111,7 @@ function BadgeRow({
   return (
     <div className={cn("flex flex-wrap gap-1", className)}>
       {values.map((v) => (
-        <Badge
-          className={cn("font-mono", colorMap?.[v])}
-          key={v}
-          variant="outline"
-        >
+        <Badge className={cn("font-mono", colorMap?.[v])} key={v}>
           {v}
         </Badge>
       ))}
@@ -171,11 +163,7 @@ export function TruncatedBadges({
       <TooltipTrigger asChild>
         <div className="flex flex-wrap gap-1">
           {visible.map((v) => (
-            <Badge
-              className={cn("font-mono", colorMap?.[v])}
-              key={v}
-              variant="outline"
-            >
+            <Badge className={cn("font-mono", colorMap?.[v])} key={v}>
               {v}
             </Badge>
           ))}

--- a/web/components/runs/raman-report-section.tsx
+++ b/web/components/runs/raman-report-section.tsx
@@ -1,4 +1,5 @@
 import { RamanSpectrumViewer } from "@/components/runs/raman-spectrum-viewer";
+import { RunSectionHeading } from "@/components/runs/run-section-heading";
 import { Card, CardContent } from "@/components/ui/card";
 
 export interface RamanSpectrumFileRef {
@@ -14,7 +15,7 @@ export function RamanReportSection({
   if (spectra.length === 0) {
     return (
       <div className="flex flex-col gap-2">
-        <h2 className="font-semibold text-sm">Report Data</h2>
+        <RunSectionHeading title="Report Data" />
         <Card size="sm">
           <CardContent>
             <p className="text-muted-foreground text-sm">
@@ -28,12 +29,7 @@ export function RamanReportSection({
 
   return (
     <div className="flex flex-col gap-2">
-      <h2 className="font-semibold text-sm">
-        Report Data{" "}
-        <span className="ml-1 font-mono font-normal text-muted-foreground text-xs">
-          {spectra.length} {spectra.length === 1 ? "spectrum" : "spectra"}
-        </span>
-      </h2>
+      <RunSectionHeading countLabel={spectra.length} title="Report Data" />
       <Card size="sm">
         <CardContent>
           <RamanSpectrumViewer spectra={spectra} />

--- a/web/components/runs/run-attributions-section.tsx
+++ b/web/components/runs/run-attributions-section.tsx
@@ -1,9 +1,8 @@
 import { RanByCell } from "@/components/instruments/runs-table/ran-by-cell";
 import type { RunAttribution } from "@/lib/api/instrument-runs";
 
-// Used inline in the run header's metadata row (alongside Created/Updated
-// timestamps) to show and mutate attributions. Reuses RanByCell so the
-// claim/remove UX matches the list.
+// Used in the run summary card's "Ran by" field to show and mutate
+// attributions. Reuses RanByCell so the claim/remove UX matches the list.
 export function RunAttributionsSection({
   instrumentId,
   runId,
@@ -14,13 +13,12 @@ export function RunAttributionsSection({
   attributions: RunAttribution[];
 }) {
   return (
-    <div className="flex items-center gap-2">
-      <span>Ran By</span>
-      <RanByCell
-        attributions={attributions}
-        instrumentId={instrumentId}
-        runId={runId}
-      />
-    </div>
+    <RanByCell
+      attributions={attributions}
+      compact
+      instrumentId={instrumentId}
+      runId={runId}
+      showName
+    />
   );
 }

--- a/web/components/runs/run-comments-section.tsx
+++ b/web/components/runs/run-comments-section.tsx
@@ -1,4 +1,5 @@
 import { RunCommentsList } from "@/components/runs/run-comments-list";
+import { RunSectionHeading } from "@/components/runs/run-section-heading";
 import type { RunCommentDto } from "@/lib/api/run-comments";
 
 // Server component. The page fetches `initialComments` in parallel with
@@ -6,7 +7,8 @@ import type { RunCommentDto } from "@/lib/api/run-comments";
 // hands them in here, so this component itself is pure presentation.
 //
 // Layout matches the other run-detail sections (Report Data, Files): the
-// heading sits outside the card stack with an inline comment count.
+// heading sits outside the card stack with an inline count in the form
+// "Comments (N)".
 // Each comment and the new-comment form get their own card inside
 // `RunCommentsList` to match the conversational stacked-cards design.
 // The whole stack is capped to half the container width so prose
@@ -22,14 +24,7 @@ export function RunCommentsSection({
 }) {
   return (
     <div className="flex flex-col gap-2">
-      <h2 className="font-semibold text-sm">
-        Comments
-        {comments.length > 0 && (
-          <span className="ml-1 font-mono font-normal text-muted-foreground text-xs">
-            {comments.length}
-          </span>
-        )}
-      </h2>
+      <RunSectionHeading countLabel={comments.length} title="Comments" />
       <div>
         <RunCommentsList
           initialComments={comments}

--- a/web/components/runs/run-detail.ts
+++ b/web/components/runs/run-detail.ts
@@ -22,7 +22,7 @@ export const RunDetail = {
 };
 
 export interface RunDetailProps {
-  // Rendered below the header on every variant. Parent composes the
+  // Rendered in the summary card's "Ran by" field. Parent composes the
   // attribution UI so server-only user/session wiring stays at the page.
   attributionsSlot: React.ReactNode;
   // Aggregate per-run file counts (footer summary, variant counts).

--- a/web/components/runs/run-detail.ts
+++ b/web/components/runs/run-detail.ts
@@ -29,6 +29,7 @@ export interface RunDetailProps {
   fileStats: RunFileStats;
   // Current page of the server-paginated files table.
   files: RunFile[];
+  filesDownloadableCount: RunFilesPage["downloadableCount"];
   filesPagination: RunFilesPage["pagination"];
   instrumentId: string;
   // Processed + PDF files for the report sections and well-data parsing.

--- a/web/components/runs/run-detail.ts
+++ b/web/components/runs/run-detail.ts
@@ -38,5 +38,8 @@ export interface RunDetailProps {
   reportImages: RunFile[];
   run: RunDetailType;
   runId: string;
+  // Previous/next run navigation for the header. Parent composes it so the
+  // server-side neighbor lookup stays at the page, like `attributionsSlot`.
+  runNavSlot: React.ReactNode;
   wellData: RawWellRow[];
 }

--- a/web/components/runs/run-files-section.tsx
+++ b/web/components/runs/run-files-section.tsx
@@ -6,6 +6,7 @@ import { debounce, useQueryStates } from "nuqs";
 import { useEffect, useTransition } from "react";
 import { toast } from "sonner";
 import { PaginationNav } from "@/components/pagination-nav";
+import { RunSectionHeading } from "@/components/runs/run-section-heading";
 import {
   TablePendingBoundary,
   TablePendingProvider,
@@ -44,9 +45,42 @@ import {
 // the URL and refetching the page.
 const SEARCH_DEBOUNCE_MS = 300;
 
+function formatFilesSectionCount(stats: RunFileStats): string | undefined {
+  const parts: string[] = [];
+  if (stats.rawActive > 0) {
+    parts.push(`${stats.rawActive} raw`);
+  }
+  if (stats.processedActive > 0) {
+    parts.push(`${stats.processedActive} processed`);
+  }
+  return parts.length > 0 ? parts.join(", ") : undefined;
+}
+
+const FILES_STATUS_LABELS: Record<Exclude<FilesStatusFilter, "all">, string> = {
+  raw: "Raw",
+  processed: "Processed",
+  pending: "Pending",
+  uploaded: "Uploaded",
+  processing: "Processing",
+  completed: "Completed",
+  failed: "Failed",
+};
+
+function filesStatusTriggerLabel(
+  status: FilesStatusFilter,
+  activeCount: number
+): string {
+  if (status === "all") {
+    return `All (${activeCount})`;
+  }
+  return FILES_STATUS_LABELS[status];
+}
+
 interface RunFilesSectionProps {
   // Current page of the server-paginated, filtered, sorted file list.
   files: RunFile[];
+  // Downloadable files matching the active table filters (S3-backed).
+  filteredDownloadableCount: number;
   instrumentId: string;
   isDeleted: boolean;
   pagination: RunFilesPage["pagination"];
@@ -93,6 +127,7 @@ export function RunFilesSection(props: RunFilesSectionProps) {
 
 function RunFilesSectionContent({
   files,
+  filteredDownloadableCount,
   pagination,
   stats,
   instrumentId,
@@ -167,7 +202,10 @@ function RunFilesSectionContent({
 
   return (
     <div className="flex flex-col gap-2">
-      <h2 className="font-semibold text-sm">Files</h2>
+      <RunSectionHeading
+        countLabel={formatFilesSectionCount(stats)}
+        title="Files"
+      />
       <div className="rounded-lg border bg-background dark:bg-muted">
         {/* Toolbar: search, filter, sort */}
         <div className="flex items-center gap-2 border-b px-3 py-2">
@@ -199,9 +237,7 @@ function RunFilesSectionContent({
           >
             <SelectTrigger className="h-8 text-sm" size="sm">
               <SelectValue>
-                {filters.files_status === "all"
-                  ? `All (${stats.active})`
-                  : undefined}
+                {filesStatusTriggerLabel(filters.files_status, stats.active)}
               </SelectValue>
             </SelectTrigger>
             <SelectContent>
@@ -294,7 +330,7 @@ function RunFilesSectionContent({
             >
               <Download className="size-3" />
               {isFilterActive
-                ? "Download filtered"
+                ? `Download filtered (${filteredDownloadableCount})`
                 : `Download all (${downloadableCount})`}
             </Button>
           )}

--- a/web/components/runs/run-files-table.tsx
+++ b/web/components/runs/run-files-table.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/components/ui/tooltip";
 import type { RunFile } from "@/lib/api/instrument-runs";
 import { formatDateTime } from "@/lib/date";
-import { formatBytes } from "@/lib/utils";
+import { cn, formatBytes } from "@/lib/utils";
 import {
   FileSelectAllCheckbox,
   FileSelectCheckbox,
@@ -45,6 +45,12 @@ const DOWNLOADABLE_STATUSES = new Set([
 ]);
 
 const REPROCESSABLE_STATUSES = new Set(["completed", "failed"]);
+
+const CATEGORY_BADGE_CLASSES: Record<string, string> = {
+  raw: "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
+  processed:
+    "bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-300",
+};
 
 export function statusLabel(file: RunFile): string {
   if (file.deletedAt !== null) {
@@ -170,7 +176,13 @@ function FileInfoCells({ file }: { file: RunFile }) {
         </span>
       </TableCell>
       <TableCell className="py-2">
-        <Badge className="capitalize" variant="outline">
+        <Badge
+          className={cn(
+            "capitalize",
+            CATEGORY_BADGE_CLASSES[file.category] ??
+              "bg-slate-100 text-slate-700 dark:bg-slate-950 dark:text-slate-300"
+          )}
+        >
           {file.category}
         </Badge>
       </TableCell>

--- a/web/components/runs/run-files-table.tsx
+++ b/web/components/runs/run-files-table.tsx
@@ -74,41 +74,29 @@ function StatusBadge({ file }: { file: RunFile }) {
   switch (label) {
     case "Pending":
       return (
-        <Badge
-          className="border-amber-500/40 bg-amber-500/10 text-amber-400"
-          variant="outline"
-        >
+        <Badge className="bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300">
           {label}
         </Badge>
       );
     case "Uploading":
       return (
-        <Badge
-          className="gap-1 border-sky-500/40 bg-sky-500/10 text-sky-400"
-          variant="outline"
-        >
+        <Badge className="gap-1 bg-sky-100 text-sky-700 dark:bg-sky-950 dark:text-sky-300">
           <Loader2 className="size-3 animate-spin" />
           {label}
         </Badge>
       );
     case "Uploaded":
-      return <Badge variant="outline">{label}</Badge>;
+      return <Badge variant="secondary">{label}</Badge>;
     case "Processing":
       return (
-        <Badge
-          className="gap-1 border-blue-500/40 bg-blue-500/10 text-blue-400"
-          variant="outline"
-        >
+        <Badge className="gap-1 bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300">
           <Loader2 className="size-3 animate-spin" />
           {label}
         </Badge>
       );
     case "Completed":
       return (
-        <Badge
-          className="border-emerald-500/40 bg-emerald-500/10 text-emerald-400"
-          variant="outline"
-        >
+        <Badge className="bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-300">
           {label}
         </Badge>
       );

--- a/web/components/runs/run-header.tsx
+++ b/web/components/runs/run-header.tsx
@@ -4,7 +4,6 @@ import { Trash2 } from "lucide-react";
 import Link from "next/link";
 import { RecordInstrumentVisit } from "@/components/recent-instrument-visit";
 import { RunSwitcher } from "@/components/runs/run-switcher";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -12,8 +11,8 @@ import {
   BreadcrumbList,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import { UserAvatar } from "@/components/user-avatar";
 import type { RunDetail } from "@/lib/api/instrument-runs";
-import { avatarColor } from "@/lib/avatar-color";
 import { formatDateTime } from "@/lib/date";
 
 // Must stay a client component: `formatDateTime` resolves the timezone at
@@ -22,11 +21,9 @@ import { formatDateTime } from "@/lib/date";
 export function RunHeader({
   run,
   children,
-  attributionsSlot,
 }: {
   run: RunDetail;
   children?: React.ReactNode;
-  attributionsSlot?: React.ReactNode;
 }) {
   return (
     <div className="flex flex-col gap-4">
@@ -68,19 +65,7 @@ export function RunHeader({
             {run.deletedByUser && (
               <span className="flex items-center gap-1.5">
                 <span>by</span>
-                <Avatar size="sm">
-                  {run.deletedByUser.avatarUrl ? (
-                    <AvatarImage
-                      alt={run.deletedByUser.displayName}
-                      src={run.deletedByUser.avatarUrl}
-                    />
-                  ) : null}
-                  <AvatarFallback
-                    className={avatarColor(run.deletedByUser.userId)}
-                  >
-                    {run.deletedByUser.initials}
-                  </AvatarFallback>
-                </Avatar>
+                <UserAvatar size="sm" user={run.deletedByUser} />
                 <span className="font-medium">
                   {run.deletedByUser.displayName}
                 </span>
@@ -96,24 +81,6 @@ export function RunHeader({
         </h1>
 
         <div className="flex items-center gap-2">{children}</div>
-      </div>
-
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-muted-foreground text-sm">
-        {run.acquiredAt && (
-          <>
-            <span>Run started {formatDateTime(run.acquiredAt)}</span>
-            <span className="text-muted-foreground/40">&middot;</span>
-          </>
-        )}
-        <span>Reported {formatDateTime(run.createdAt)}</span>
-        <span className="text-muted-foreground/40">&middot;</span>
-        <span>Updated {formatDateTime(run.updatedAt)}</span>
-        {attributionsSlot && (
-          <>
-            <span className="text-muted-foreground/40">&middot;</span>
-            {attributionsSlot}
-          </>
-        )}
       </div>
     </div>
   );

--- a/web/components/runs/run-header.tsx
+++ b/web/components/runs/run-header.tsx
@@ -20,9 +20,12 @@ import { formatDateTime } from "@/lib/date";
 // the viewer's offset (disagreeing with the client-rendered files table).
 export function RunHeader({
   run,
+  runNavSlot,
   children,
 }: {
   run: RunDetail;
+  // Previous/next run navigation, rendered to the left of the action buttons.
+  runNavSlot?: React.ReactNode;
   children?: React.ReactNode;
 }) {
   return (
@@ -80,7 +83,10 @@ export function RunHeader({
           {run.runId}
         </h1>
 
-        <div className="flex items-center gap-2">{children}</div>
+        <div className="flex items-center gap-2">
+          {runNavSlot}
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/web/components/runs/run-metadata-badges.tsx
+++ b/web/components/runs/run-metadata-badges.tsx
@@ -26,8 +26,23 @@ import {
 import { cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
-// Shared row component: label on the left, badge(s) on the right
+// Shared field component: label above value(s)
 // ---------------------------------------------------------------------------
+
+export function MetadataField({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-muted-foreground text-sm">{label}</span>
+      <div className="flex flex-wrap items-center gap-1">{children}</div>
+    </div>
+  );
+}
 
 function MetadataRow({
   label,
@@ -36,12 +51,7 @@ function MetadataRow({
   label: string;
   children: React.ReactNode;
 }) {
-  return (
-    <div className="flex items-center gap-2">
-      <span className="shrink-0 text-muted-foreground text-xs">{label}</span>
-      {children}
-    </div>
-  );
+  return <MetadataField label={label}>{children}</MetadataField>;
 }
 
 function ColorBadge({

--- a/web/components/runs/run-metadata-badges.tsx
+++ b/web/components/runs/run-metadata-badges.tsx
@@ -61,11 +61,7 @@ function ColorBadge({
   value: string;
   colorClass?: string;
 }) {
-  return (
-    <Badge className={cn("font-mono", colorClass)} variant="outline">
-      {value}
-    </Badge>
-  );
+  return <Badge className={cn("font-mono", colorClass)}>{value}</Badge>;
 }
 
 // ---------------------------------------------------------------------------
@@ -347,12 +343,10 @@ function relativeLuminance({
   return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
 }
 
-// Channel colors come straight from instrument metadata. To keep channel
-// badges visually consistent with the other metadata badges, we always use
-// the default outline border and carry the channel's identity on the dot and
-// text color alone. Near-white colors are blended with `--foreground` so the
-// text remains readable on light surfaces while staying vivid on dark ones,
-// and the dot is ringed with `--border` so a white swatch is still visible.
+// Channel colors come straight from instrument metadata. Near-white colors are
+// blended with `--foreground` so the text remains readable on light surfaces
+// while staying vivid on dark ones, and the dot is ringed with `--border` so a
+// white swatch is still visible.
 const NEAR_WHITE_LUMINANCE = 0.85;
 
 export interface ChannelBadgeStyle {
@@ -450,13 +444,13 @@ export function hasHinaMetadata(metadata: Record<string, unknown>) {
   );
 }
 
-// Inline-styled badge using an arbitrary hex color for the border + text.
+// Inline-styled badge using an arbitrary hex color for the label + dot.
 // Used for Hina channels since channel color is run-specific and can't be
 // baked into a static Tailwind palette.
 function ChannelBadge({ name, color }: HinaChannel) {
   const { badge, dot } = getHinaChannelBadgeStyle(color);
   return (
-    <Badge className="font-mono" style={badge} variant="outline">
+    <Badge className="bg-slate-100 font-mono dark:bg-slate-950" style={badge}>
       {color && (
         <span
           aria-hidden="true"
@@ -471,12 +465,12 @@ function ChannelBadge({ name, color }: HinaChannel) {
 
 // Tooltip variant of `ChannelBadge`. The default tooltip surface uses
 // `bg-foreground` + `text-background`, which inverts per theme — so the
-// badge's border and label inherit `currentColor` to stay readable on both
-// the light-mode dark tooltip and the dark-mode light tooltip. The dot keeps
-// the channel hex so the color cue is preserved.
+// badge label inherits `currentColor` to stay readable on both the light-mode
+// dark tooltip and the dark-mode light tooltip. The dot keeps the channel hex
+// so the color cue is preserved.
 function TooltipChannelBadge({ name, color }: HinaChannel) {
   return (
-    <Badge className="border-current font-mono text-current" variant="outline">
+    <Badge className="bg-background/15 font-mono text-current">
       {color && (
         <span
           aria-hidden="true"

--- a/web/components/runs/run-metadata.tsx
+++ b/web/components/runs/run-metadata.tsx
@@ -1,18 +1,26 @@
 import type { ReactNode } from "react";
+import { MetadataField } from "@/components/runs/run-metadata-badges";
+import { RunTimestamps } from "@/components/runs/run-timestamps";
+import { Separator } from "@/components/ui/separator";
+import type { RunDetail } from "@/lib/api/instrument-runs";
 
-export function RunMetadata({ children }: { children?: ReactNode }) {
-  if (!children) {
-    return null;
-  }
-
+export function RunMetadata({
+  run,
+  attributionsSlot,
+  children,
+}: {
+  run: RunDetail;
+  attributionsSlot?: ReactNode;
+  children?: ReactNode;
+}) {
   return (
-    <div className="flex flex-col gap-2">
-      <h2 className="font-semibold text-sm">Metadata</h2>
-      <div className="rounded-lg border bg-background dark:bg-muted">
-        <div className="flex flex-wrap items-center gap-x-5 gap-y-2 px-4 py-3">
-          {children}
-        </div>
+    <div className="rounded-lg border bg-background dark:bg-muted">
+      <div className="flex flex-wrap gap-x-8 gap-y-4 px-4 py-3">
+        {children}
+        <MetadataField label="Ran by">{attributionsSlot}</MetadataField>
       </div>
+      <Separator />
+      <RunTimestamps run={run} />
     </div>
   );
 }

--- a/web/components/runs/run-nav.tsx
+++ b/web/components/runs/run-nav.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+// Previous/next navigation between an instrument's runs, ordered newest-first
+// to match the runs table. `previousHref` is the newer run, `nextHref` the
+// older one; a null href means we're at that end of the list, so the button
+// renders disabled rather than as a link.
+export function RunNav({
+  previousHref,
+  nextHref,
+}: {
+  nextHref: string | null;
+  previousHref: string | null;
+}) {
+  return (
+    <div className="flex items-center gap-1">
+      <RunNavButton
+        href={previousHref}
+        icon={<ChevronLeft />}
+        label="Previous (newer) run"
+      />
+      <RunNavButton
+        href={nextHref}
+        icon={<ChevronRight />}
+        label="Next (older) run"
+      />
+    </div>
+  );
+}
+
+function RunNavButton({
+  href,
+  icon,
+  label,
+}: {
+  href: string | null;
+  icon: React.ReactNode;
+  label: string;
+}) {
+  if (!href) {
+    return (
+      <Button aria-label={label} disabled size="icon-sm" variant="outline">
+        {icon}
+      </Button>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button aria-label={label} asChild size="icon-sm" variant="outline">
+          <Link href={href}>{icon}</Link>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/web/components/runs/run-nav.tsx
+++ b/web/components/runs/run-nav.tsx
@@ -9,55 +9,62 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
+interface AdjacentRun {
+  href: string;
+  runId: string;
+}
+
 // Previous/next navigation between an instrument's runs, ordered newest-first
-// to match the runs table. `previousHref` is the newer run, `nextHref` the
-// older one; a null href means we're at that end of the list, so the button
-// renders disabled rather than as a link.
+// to match the runs table. `previous` is the newer run, `next` the older one;
+// a null neighbor means we're at that end of the list, so the button renders
+// disabled rather than as a link.
 export function RunNav({
-  previousHref,
-  nextHref,
+  previous,
+  next,
 }: {
-  nextHref: string | null;
-  previousHref: string | null;
+  next: AdjacentRun | null;
+  previous: AdjacentRun | null;
 }) {
   return (
     <div className="flex items-center gap-1">
       <RunNavButton
-        href={previousHref}
+        direction="Previous"
         icon={<ChevronLeft />}
-        label="Previous (newer) run"
+        run={previous}
       />
-      <RunNavButton
-        href={nextHref}
-        icon={<ChevronRight />}
-        label="Next (older) run"
-      />
+      <RunNavButton direction="Next" icon={<ChevronRight />} run={next} />
     </div>
   );
 }
 
 function RunNavButton({
-  href,
+  direction,
   icon,
-  label,
+  run,
 }: {
-  href: string | null;
+  direction: "Previous" | "Next";
   icon: React.ReactNode;
-  label: string;
+  run: AdjacentRun | null;
 }) {
-  if (!href) {
+  if (!run) {
     return (
-      <Button aria-label={label} disabled size="icon-sm" variant="outline">
+      <Button
+        aria-label={`${direction} run`}
+        disabled
+        size="icon-sm"
+        variant="outline"
+      >
         {icon}
       </Button>
     );
   }
 
+  const label = `${direction} run: ${run.runId}`;
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <Button aria-label={label} asChild size="icon-sm" variant="outline">
-          <Link href={href}>{icon}</Link>
+          <Link href={run.href}>{icon}</Link>
         </Button>
       </TooltipTrigger>
       <TooltipContent>{label}</TooltipContent>

--- a/web/components/runs/run-report-section.tsx
+++ b/web/components/runs/run-report-section.tsx
@@ -1,5 +1,6 @@
 import { ExternalLink } from "lucide-react";
 import { ColonyDataTable } from "@/components/runs/colony-data-table";
+import { RunSectionHeading } from "@/components/runs/run-section-heading";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import type { RunFile } from "@/lib/api/instrument-runs";
@@ -95,7 +96,7 @@ export function RunReportSection({ files }: { files: RunFile[] }) {
   if (totalCount === 0) {
     return (
       <div className="flex flex-col gap-2">
-        <h2 className="font-semibold text-sm">Report Data</h2>
+        <RunSectionHeading title="Report Data" />
         <Card size="sm">
           <CardContent>
             <p className="text-muted-foreground text-sm">
@@ -109,12 +110,7 @@ export function RunReportSection({ files }: { files: RunFile[] }) {
 
   return (
     <div className="flex flex-col gap-2">
-      <h2 className="font-semibold text-sm">
-        Report Data{" "}
-        <span className="ml-1 font-mono font-normal text-muted-foreground text-xs">
-          {totalCount} file(s)
-        </span>
-      </h2>
+      <RunSectionHeading countLabel={totalCount} title="Report Data" />
       <Card size="sm">
         <CardContent className="flex flex-col gap-6">
           {processedImages.map((file) => (

--- a/web/components/runs/run-section-heading.tsx
+++ b/web/components/runs/run-section-heading.tsx
@@ -1,0 +1,13 @@
+export function RunSectionHeading({
+  title,
+  countLabel,
+}: {
+  title: string;
+  countLabel?: string | number;
+}) {
+  return (
+    <h2 className="font-semibold text-sm">
+      {countLabel == null ? title : `${title} (${countLabel})`}
+    </h2>
+  );
+}

--- a/web/components/runs/run-timestamps.tsx
+++ b/web/components/runs/run-timestamps.tsx
@@ -9,7 +9,7 @@ import { formatDateTimeShort } from "@/lib/date";
 // the viewer's offset.
 export function RunTimestamps({ run }: { run: RunDetail }) {
   return (
-    <div className="flex flex-wrap items-center gap-x-5 gap-y-2 px-4 py-3 text-muted-foreground text-sm">
+    <div className="flex flex-wrap items-center gap-x-5 gap-y-2 px-4 py-3 text-muted-foreground text-xs">
       {run.acquiredAt && (
         <span className="inline-flex items-center gap-1.5">
           <Play aria-hidden="true" className="size-3.5 shrink-0" />

--- a/web/components/runs/run-timestamps.tsx
+++ b/web/components/runs/run-timestamps.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { FileText, Play, RefreshCw } from "lucide-react";
+import type { RunDetail } from "@/lib/api/instrument-runs";
+import { formatDateTimeShort } from "@/lib/date";
+
+// Must stay a client component: `formatDateTimeShort` resolves the timezone at
+// runtime, so rendering on the server uses UTC and shifts every timestamp by
+// the viewer's offset.
+export function RunTimestamps({ run }: { run: RunDetail }) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-5 gap-y-2 px-4 py-3 text-muted-foreground text-sm">
+      {run.acquiredAt && (
+        <span className="inline-flex items-center gap-1.5">
+          <Play aria-hidden="true" className="size-3.5 shrink-0" />
+          Run started {formatDateTimeShort(run.acquiredAt)}
+        </span>
+      )}
+      <span className="inline-flex items-center gap-1.5">
+        <FileText aria-hidden="true" className="size-3.5 shrink-0" />
+        Reported {formatDateTimeShort(run.createdAt)}
+      </span>
+      <span className="inline-flex items-center gap-1.5">
+        <RefreshCw aria-hidden="true" className="size-3.5 shrink-0" />
+        Updated {formatDateTimeShort(run.updatedAt)}
+      </span>
+    </div>
+  );
+}

--- a/web/components/runs/variants/default-run-detail.tsx
+++ b/web/components/runs/variants/default-run-detail.tsx
@@ -10,6 +10,7 @@ import {
 export function DefaultRunDetail({
   run,
   files,
+  filesDownloadableCount,
   filesPagination,
   fileStats,
   reportFiles,
@@ -47,6 +48,7 @@ export function DefaultRunDetail({
         </RunDetail.Metadata>
         <RunDetail.Files
           files={files}
+          filteredDownloadableCount={filesDownloadableCount}
           instrumentId={instrumentId}
           isDeleted={isDeleted}
           pagination={filesPagination}

--- a/web/components/runs/variants/default-run-detail.tsx
+++ b/web/components/runs/variants/default-run-detail.tsx
@@ -17,6 +17,7 @@ export function DefaultRunDetail({
   instrumentId,
   runId,
   attributionsSlot,
+  runNavSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
   const activeFileCount = fileStats.active;
@@ -24,7 +25,7 @@ export function DefaultRunDetail({
 
   return (
     <>
-      <RunDetail.Header run={run}>
+      <RunDetail.Header run={run} runNavSlot={runNavSlot}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}

--- a/web/components/runs/variants/default-run-detail.tsx
+++ b/web/components/runs/variants/default-run-detail.tsx
@@ -23,7 +23,7 @@ export function DefaultRunDetail({
 
   return (
     <>
-      <RunDetail.Header attributionsSlot={attributionsSlot} run={run}>
+      <RunDetail.Header run={run}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}
@@ -38,13 +38,13 @@ export function DefaultRunDetail({
       </RunDetail.Header>
 
       <RunDetail.FilesMetadataLayout>
-        {hasDefaultMetadata(run.metadata as Record<string, unknown>) && (
-          <RunDetail.Metadata>
+        <RunDetail.Metadata attributionsSlot={attributionsSlot} run={run}>
+          {hasDefaultMetadata(run.metadata as Record<string, unknown>) && (
             <DefaultRunBadges
               metadata={run.metadata as Record<string, unknown>}
             />
-          </RunDetail.Metadata>
-        )}
+          )}
+        </RunDetail.Metadata>
         <RunDetail.Files
           files={files}
           instrumentId={instrumentId}

--- a/web/components/runs/variants/epson-scanner-run-detail.tsx
+++ b/web/components/runs/variants/epson-scanner-run-detail.tsx
@@ -10,6 +10,7 @@ import {
 export function EpsonScannerRunDetail({
   run,
   files,
+  filesDownloadableCount,
   filesPagination,
   fileStats,
   reportFiles,
@@ -47,6 +48,7 @@ export function EpsonScannerRunDetail({
         </RunDetail.Metadata>
         <RunDetail.Files
           files={files}
+          filteredDownloadableCount={filesDownloadableCount}
           instrumentId={instrumentId}
           isDeleted={isDeleted}
           pagination={filesPagination}

--- a/web/components/runs/variants/epson-scanner-run-detail.tsx
+++ b/web/components/runs/variants/epson-scanner-run-detail.tsx
@@ -17,6 +17,7 @@ export function EpsonScannerRunDetail({
   instrumentId,
   runId,
   attributionsSlot,
+  runNavSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
   const activeFileCount = fileStats.active;
@@ -24,7 +25,7 @@ export function EpsonScannerRunDetail({
 
   return (
     <>
-      <RunDetail.Header run={run}>
+      <RunDetail.Header run={run} runNavSlot={runNavSlot}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}

--- a/web/components/runs/variants/epson-scanner-run-detail.tsx
+++ b/web/components/runs/variants/epson-scanner-run-detail.tsx
@@ -23,7 +23,7 @@ export function EpsonScannerRunDetail({
 
   return (
     <>
-      <RunDetail.Header attributionsSlot={attributionsSlot} run={run}>
+      <RunDetail.Header run={run}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}
@@ -38,13 +38,13 @@ export function EpsonScannerRunDetail({
       </RunDetail.Header>
 
       <RunDetail.FilesMetadataLayout>
-        {hasEpsonScannerMetadata(run.metadata as Record<string, unknown>) && (
-          <RunDetail.Metadata>
+        <RunDetail.Metadata attributionsSlot={attributionsSlot} run={run}>
+          {hasEpsonScannerMetadata(run.metadata as Record<string, unknown>) && (
             <EpsonScannerRunBadges
               metadata={run.metadata as Record<string, unknown>}
             />
-          </RunDetail.Metadata>
-        )}
+          )}
+        </RunDetail.Metadata>
         <RunDetail.Files
           files={files}
           instrumentId={instrumentId}

--- a/web/components/runs/variants/gel-doc-run-detail.tsx
+++ b/web/components/runs/variants/gel-doc-run-detail.tsx
@@ -17,6 +17,7 @@ export function GelDocRunDetail({
   instrumentId,
   runId,
   attributionsSlot,
+  runNavSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
   const activeFileCount = fileStats.active;
@@ -24,7 +25,7 @@ export function GelDocRunDetail({
 
   return (
     <>
-      <RunDetail.Header run={run}>
+      <RunDetail.Header run={run} runNavSlot={runNavSlot}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}

--- a/web/components/runs/variants/gel-doc-run-detail.tsx
+++ b/web/components/runs/variants/gel-doc-run-detail.tsx
@@ -23,7 +23,7 @@ export function GelDocRunDetail({
 
   return (
     <>
-      <RunDetail.Header attributionsSlot={attributionsSlot} run={run}>
+      <RunDetail.Header run={run}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}
@@ -38,13 +38,13 @@ export function GelDocRunDetail({
       </RunDetail.Header>
 
       <RunDetail.FilesMetadataLayout>
-        {hasGelDocMetadata(run.metadata as Record<string, unknown>) && (
-          <RunDetail.Metadata>
+        <RunDetail.Metadata attributionsSlot={attributionsSlot} run={run}>
+          {hasGelDocMetadata(run.metadata as Record<string, unknown>) && (
             <GelDocRunBadges
               metadata={run.metadata as Record<string, unknown>}
             />
-          </RunDetail.Metadata>
-        )}
+          )}
+        </RunDetail.Metadata>
         <RunDetail.Files
           files={files}
           instrumentId={instrumentId}

--- a/web/components/runs/variants/gel-doc-run-detail.tsx
+++ b/web/components/runs/variants/gel-doc-run-detail.tsx
@@ -10,6 +10,7 @@ import {
 export function GelDocRunDetail({
   run,
   files,
+  filesDownloadableCount,
   filesPagination,
   fileStats,
   reportImages,
@@ -47,6 +48,7 @@ export function GelDocRunDetail({
         </RunDetail.Metadata>
         <RunDetail.Files
           files={files}
+          filteredDownloadableCount={filesDownloadableCount}
           instrumentId={instrumentId}
           isDeleted={isDeleted}
           pagination={filesPagination}

--- a/web/components/runs/variants/hina-microscope-run-detail.tsx
+++ b/web/components/runs/variants/hina-microscope-run-detail.tsx
@@ -10,6 +10,7 @@ import {
 export function HinaMicroscopeRunDetail({
   run,
   files,
+  filesDownloadableCount,
   filesPagination,
   fileStats,
   reportImages,
@@ -45,6 +46,7 @@ export function HinaMicroscopeRunDetail({
         </RunDetail.Metadata>
         <RunDetail.Files
           files={files}
+          filteredDownloadableCount={filesDownloadableCount}
           instrumentId={instrumentId}
           isDeleted={isDeleted}
           pagination={filesPagination}

--- a/web/components/runs/variants/hina-microscope-run-detail.tsx
+++ b/web/components/runs/variants/hina-microscope-run-detail.tsx
@@ -17,6 +17,7 @@ export function HinaMicroscopeRunDetail({
   instrumentId,
   runId,
   attributionsSlot,
+  runNavSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
   const activeFileCount = fileStats.active;
@@ -24,7 +25,7 @@ export function HinaMicroscopeRunDetail({
 
   return (
     <>
-      <RunDetail.Header run={run}>
+      <RunDetail.Header run={run} runNavSlot={runNavSlot}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}

--- a/web/components/runs/variants/hina-microscope-run-detail.tsx
+++ b/web/components/runs/variants/hina-microscope-run-detail.tsx
@@ -23,7 +23,7 @@ export function HinaMicroscopeRunDetail({
 
   return (
     <>
-      <RunDetail.Header attributionsSlot={attributionsSlot} run={run}>
+      <RunDetail.Header run={run}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}
@@ -38,11 +38,11 @@ export function HinaMicroscopeRunDetail({
       </RunDetail.Header>
 
       <RunDetail.FilesMetadataLayout>
-        {hasHinaMetadata(run.metadata as Record<string, unknown>) && (
-          <RunDetail.Metadata>
+        <RunDetail.Metadata attributionsSlot={attributionsSlot} run={run}>
+          {hasHinaMetadata(run.metadata as Record<string, unknown>) && (
             <HinaRunBadges metadata={run.metadata as Record<string, unknown>} />
-          </RunDetail.Metadata>
-        )}
+          )}
+        </RunDetail.Metadata>
         <RunDetail.Files
           files={files}
           instrumentId={instrumentId}

--- a/web/components/runs/variants/instant-raman-run-detail.tsx
+++ b/web/components/runs/variants/instant-raman-run-detail.tsx
@@ -14,6 +14,7 @@ export function InstantRamanRunDetail({
   instrumentId,
   runId,
   attributionsSlot,
+  runNavSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
   const activeFileCount = fileStats.active;
@@ -31,7 +32,7 @@ export function InstantRamanRunDetail({
 
   return (
     <>
-      <RunDetail.Header run={run}>
+      <RunDetail.Header run={run} runNavSlot={runNavSlot}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}

--- a/web/components/runs/variants/instant-raman-run-detail.tsx
+++ b/web/components/runs/variants/instant-raman-run-detail.tsx
@@ -30,7 +30,7 @@ export function InstantRamanRunDetail({
 
   return (
     <>
-      <RunDetail.Header attributionsSlot={attributionsSlot} run={run}>
+      <RunDetail.Header run={run}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}
@@ -45,6 +45,7 @@ export function InstantRamanRunDetail({
       </RunDetail.Header>
 
       <RunDetail.FilesMetadataLayout>
+        <RunDetail.Metadata attributionsSlot={attributionsSlot} run={run} />
         <RunDetail.Files
           files={files}
           instrumentId={instrumentId}

--- a/web/components/runs/variants/instant-raman-run-detail.tsx
+++ b/web/components/runs/variants/instant-raman-run-detail.tsx
@@ -7,6 +7,7 @@ import { RunDetail } from "@/components/runs/run-detail";
 export function InstantRamanRunDetail({
   run,
   files,
+  filesDownloadableCount,
   filesPagination,
   fileStats,
   reportFiles,
@@ -48,6 +49,7 @@ export function InstantRamanRunDetail({
         <RunDetail.Metadata attributionsSlot={attributionsSlot} run={run} />
         <RunDetail.Files
           files={files}
+          filteredDownloadableCount={filesDownloadableCount}
           instrumentId={instrumentId}
           isDeleted={isDeleted}
           pagination={filesPagination}

--- a/web/components/runs/variants/plate-reader-run-detail.tsx
+++ b/web/components/runs/variants/plate-reader-run-detail.tsx
@@ -11,6 +11,7 @@ import {
   hasPlateReaderMetadata,
   PlateReaderRunBadges,
 } from "@/components/runs/run-metadata-badges";
+import { RunSectionHeading } from "@/components/runs/run-section-heading";
 import { Card, CardContent } from "@/components/ui/card";
 import type { RawWellRow } from "@/lib/api/instrument-runs";
 
@@ -237,12 +238,7 @@ function PlateMapSection({
 
   return (
     <div className="flex flex-col gap-2">
-      <h2 className="font-semibold text-sm">
-        Plate Maps{" "}
-        <span className="ml-1 font-mono font-normal text-muted-foreground text-xs">
-          {groups.length} map(s)
-        </span>
-      </h2>
+      <RunSectionHeading countLabel={groups.length} title="Plate Maps" />
       <Card size="sm">
         <CardContent className="flex flex-col gap-6">
           <div className="flex flex-col gap-10">
@@ -276,6 +272,7 @@ function PlateMapSection({
 export function PlateReaderRunDetail({
   run,
   files,
+  filesDownloadableCount,
   filesPagination,
   fileStats,
   wellData,
@@ -325,6 +322,7 @@ export function PlateReaderRunDetail({
         </RunDetail.Metadata>
         <RunDetail.Files
           files={files}
+          filteredDownloadableCount={filesDownloadableCount}
           instrumentId={instrumentId}
           isDeleted={isDeleted}
           pagination={filesPagination}

--- a/web/components/runs/variants/plate-reader-run-detail.tsx
+++ b/web/components/runs/variants/plate-reader-run-detail.tsx
@@ -301,7 +301,7 @@ export function PlateReaderRunDetail({
 
   return (
     <>
-      <RunDetail.Header attributionsSlot={attributionsSlot} run={run}>
+      <RunDetail.Header run={run}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}
@@ -316,13 +316,13 @@ export function PlateReaderRunDetail({
       </RunDetail.Header>
 
       <RunDetail.FilesMetadataLayout>
-        {hasPlateReaderMetadata(run.metadata as Record<string, unknown>) && (
-          <RunDetail.Metadata>
+        <RunDetail.Metadata attributionsSlot={attributionsSlot} run={run}>
+          {hasPlateReaderMetadata(run.metadata as Record<string, unknown>) && (
             <PlateReaderRunBadges
               metadata={run.metadata as Record<string, unknown>}
             />
-          </RunDetail.Metadata>
-        )}
+          )}
+        </RunDetail.Metadata>
         <RunDetail.Files
           files={files}
           instrumentId={instrumentId}

--- a/web/components/runs/variants/plate-reader-run-detail.tsx
+++ b/web/components/runs/variants/plate-reader-run-detail.tsx
@@ -279,6 +279,7 @@ export function PlateReaderRunDetail({
   instrumentId,
   runId,
   attributionsSlot,
+  runNavSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
   const activeFileCount = fileStats.active;
@@ -298,7 +299,7 @@ export function PlateReaderRunDetail({
 
   return (
     <>
-      <RunDetail.Header run={run}>
+      <RunDetail.Header run={run} runNavSlot={runNavSlot}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}

--- a/web/components/runs/variants/qpcr-run-detail.tsx
+++ b/web/components/runs/variants/qpcr-run-detail.tsx
@@ -10,6 +10,7 @@ import {
 export function QpcrRunDetail({
   run,
   files,
+  filesDownloadableCount,
   filesPagination,
   fileStats,
   reportFiles,
@@ -45,6 +46,7 @@ export function QpcrRunDetail({
         </RunDetail.Metadata>
         <RunDetail.Files
           files={files}
+          filteredDownloadableCount={filesDownloadableCount}
           instrumentId={instrumentId}
           isDeleted={isDeleted}
           pagination={filesPagination}

--- a/web/components/runs/variants/qpcr-run-detail.tsx
+++ b/web/components/runs/variants/qpcr-run-detail.tsx
@@ -17,6 +17,7 @@ export function QpcrRunDetail({
   instrumentId,
   runId,
   attributionsSlot,
+  runNavSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
   const activeFileCount = fileStats.active;
@@ -24,7 +25,7 @@ export function QpcrRunDetail({
 
   return (
     <>
-      <RunDetail.Header run={run}>
+      <RunDetail.Header run={run} runNavSlot={runNavSlot}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}

--- a/web/components/runs/variants/qpcr-run-detail.tsx
+++ b/web/components/runs/variants/qpcr-run-detail.tsx
@@ -23,7 +23,7 @@ export function QpcrRunDetail({
 
   return (
     <>
-      <RunDetail.Header attributionsSlot={attributionsSlot} run={run}>
+      <RunDetail.Header run={run}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}
@@ -38,11 +38,11 @@ export function QpcrRunDetail({
       </RunDetail.Header>
 
       <RunDetail.FilesMetadataLayout>
-        {hasQpcrMetadata(run.metadata as Record<string, unknown>) && (
-          <RunDetail.Metadata>
+        <RunDetail.Metadata attributionsSlot={attributionsSlot} run={run}>
+          {hasQpcrMetadata(run.metadata as Record<string, unknown>) && (
             <QpcrRunBadges metadata={run.metadata as Record<string, unknown>} />
-          </RunDetail.Metadata>
-        )}
+          )}
+        </RunDetail.Metadata>
         <RunDetail.Files
           files={files}
           instrumentId={instrumentId}

--- a/web/components/runs/variants/tape-station-run-detail.tsx
+++ b/web/components/runs/variants/tape-station-run-detail.tsx
@@ -10,6 +10,7 @@ import {
 export function TapeStationRunDetail({
   run,
   files,
+  filesDownloadableCount,
   filesPagination,
   fileStats,
   reportFiles,
@@ -47,6 +48,7 @@ export function TapeStationRunDetail({
         </RunDetail.Metadata>
         <RunDetail.Files
           files={files}
+          filteredDownloadableCount={filesDownloadableCount}
           instrumentId={instrumentId}
           isDeleted={isDeleted}
           pagination={filesPagination}

--- a/web/components/runs/variants/tape-station-run-detail.tsx
+++ b/web/components/runs/variants/tape-station-run-detail.tsx
@@ -17,6 +17,7 @@ export function TapeStationRunDetail({
   instrumentId,
   runId,
   attributionsSlot,
+  runNavSlot,
 }: RunDetailProps) {
   const isDeleted = run.deletedAt !== null;
   const activeFileCount = fileStats.active;
@@ -24,7 +25,7 @@ export function TapeStationRunDetail({
 
   return (
     <>
-      <RunDetail.Header run={run}>
+      <RunDetail.Header run={run} runNavSlot={runNavSlot}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}

--- a/web/components/runs/variants/tape-station-run-detail.tsx
+++ b/web/components/runs/variants/tape-station-run-detail.tsx
@@ -23,7 +23,7 @@ export function TapeStationRunDetail({
 
   return (
     <>
-      <RunDetail.Header attributionsSlot={attributionsSlot} run={run}>
+      <RunDetail.Header run={run}>
         {!isDeleted && (
           <DeleteRunDialog
             fileCount={activeFileCount}
@@ -38,13 +38,13 @@ export function TapeStationRunDetail({
       </RunDetail.Header>
 
       <RunDetail.FilesMetadataLayout>
-        {hasTapeStationMetadata(run.metadata as Record<string, unknown>) && (
-          <RunDetail.Metadata>
+        <RunDetail.Metadata attributionsSlot={attributionsSlot} run={run}>
+          {hasTapeStationMetadata(run.metadata as Record<string, unknown>) && (
             <TapeStationRunBadges
               metadata={run.metadata as Record<string, unknown>}
             />
-          </RunDetail.Metadata>
-        )}
+          )}
+        </RunDetail.Metadata>
         <RunDetail.Files
           files={files}
           instrumentId={instrumentId}

--- a/web/components/ui/badge.tsx
+++ b/web/components/ui/badge.tsx
@@ -5,17 +5,18 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-4xl border border-transparent px-2 py-0.5 font-medium text-xs transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-4xl px-2 py-0.5 font-medium text-xs transition-all focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default:
+          "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300 [a]:hover:bg-blue-100 dark:[a]:hover:bg-blue-900",
         secondary:
-          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+          "bg-slate-100 text-slate-700 dark:bg-slate-950 dark:text-slate-300 [a]:hover:bg-slate-100 dark:[a]:hover:bg-slate-900",
         destructive:
-          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+          "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-300 [a]:hover:bg-red-100 dark:[a]:hover:bg-red-900",
         outline:
-          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+          "bg-slate-100 text-slate-700 dark:bg-slate-950 dark:text-slate-300 [a]:hover:bg-slate-100 dark:[a]:hover:bg-slate-900",
         ghost:
           "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
         link: "text-primary underline-offset-4 hover:underline",

--- a/web/components/user-avatar.tsx
+++ b/web/components/user-avatar.tsx
@@ -1,0 +1,48 @@
+import type { ComponentProps } from "react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { avatarColor } from "@/lib/avatar-color";
+import { cn } from "@/lib/utils";
+
+export interface UserAvatarUser {
+  avatarUrl: string | null;
+  displayName: string;
+  initials: string;
+  userId: string;
+}
+
+export function UserAvatar({
+  user,
+  size = "sm",
+  className,
+  ...props
+}: {
+  user: UserAvatarUser;
+  size?: "default" | "sm" | "lg";
+  className?: string;
+} & Omit<ComponentProps<typeof Avatar>, "size">) {
+  return (
+    <Avatar className={className} size={size} {...props}>
+      {user.avatarUrl ? (
+        <AvatarImage alt={user.displayName} src={user.avatarUrl} />
+      ) : null}
+      <AvatarFallback className={avatarColor(user.userId)}>
+        {user.initials}
+      </AvatarFallback>
+    </Avatar>
+  );
+}
+
+/** Avatar with no user identity — renders a neutral "?" fallback. */
+export function UnknownUserAvatar({
+  size = "sm",
+  className,
+}: {
+  size?: "default" | "sm" | "lg";
+  className?: string;
+}) {
+  return (
+    <Avatar className={cn(className)} size={size}>
+      <AvatarFallback>?</AvatarFallback>
+    </Avatar>
+  );
+}

--- a/web/components/watchers/watcher-status-badge.tsx
+++ b/web/components/watchers/watcher-status-badge.tsx
@@ -27,15 +27,15 @@ import { cn, formatRelativeTime } from "@/lib/utils";
 export type WatcherBadgeStatus = WatcherOnlineStatus | EffectiveStatus;
 
 const ONLINE_CLASSNAME =
-  "border-transparent bg-green-500/10 text-green-700 dark:bg-green-500/15 dark:text-green-400";
+  "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-300";
 
 const OFFLINE_CLASSNAME =
-  "border-transparent bg-destructive/10 text-destructive dark:bg-destructive/20";
+  "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-300";
 
-const MUTED_FILLED_CLASSNAME =
-  "border-transparent bg-muted text-muted-foreground";
+const MUTED_FILLED_CLASSNAME = "bg-muted text-muted-foreground";
 
-const MUTED_OUTLINED_CLASSNAME = "border-border text-muted-foreground";
+const MUTED_NEUTRAL_CLASSNAME =
+  "bg-slate-100 text-slate-700 dark:bg-slate-950 dark:text-slate-300";
 
 const STATUS_CONFIG: Record<
   WatcherBadgeStatus,
@@ -51,7 +51,7 @@ const STATUS_CONFIG: Record<
   no_watcher: {
     label: "No Watcher",
     Icon: WifiOff,
-    className: MUTED_OUTLINED_CLASSNAME,
+    className: MUTED_NEUTRAL_CLASSNAME,
   },
   // Per-watcher
   watching: { label: "Online", Icon: Radio, className: ONLINE_CLASSNAME },
@@ -67,7 +67,7 @@ const STATUS_CONFIG: Record<
   registered: {
     label: "Registered",
     Icon: Clock,
-    className: MUTED_OUTLINED_CLASSNAME,
+    className: MUTED_NEUTRAL_CLASSNAME,
   },
 };
 

--- a/web/hooks/use-recent-instruments.ts
+++ b/web/hooks/use-recent-instruments.ts
@@ -42,7 +42,11 @@ function readRecentInstruments(): RecentInstrument[] {
 function writeRecentInstruments(instruments: RecentInstrument[]): void {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(instruments));
-    window.dispatchEvent(new Event(UPDATE_EVENT));
+    // Defer so other hook instances (e.g. MainNav) refresh after this
+    // setState commit, not synchronously inside the updater.
+    queueMicrotask(() => {
+      window.dispatchEvent(new Event(UPDATE_EVENT));
+    });
   } catch {
     // Private browsing or quota exceeded — ignore.
   }

--- a/web/hooks/use-recent-watchers.ts
+++ b/web/hooks/use-recent-watchers.ts
@@ -46,7 +46,11 @@ function readRecentWatchers(): RecentWatcher[] {
 function writeRecentWatchers(watchers: RecentWatcher[]): void {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(watchers));
-    window.dispatchEvent(new Event(UPDATE_EVENT));
+    // Defer so other hook instances (e.g. MainNav) refresh after this
+    // setState commit, not synchronously inside the updater.
+    queueMicrotask(() => {
+      window.dispatchEvent(new Event(UPDATE_EVENT));
+    });
   } catch {
     // Private browsing or quota exceeded — ignore.
   }

--- a/web/lib/api/instrument-runs.ts
+++ b/web/lib/api/instrument-runs.ts
@@ -254,6 +254,64 @@ const ALLOWED_SORT_FIELDS: Record<string, SQL | AnyColumn> = {
   updated_at: instrumentRuns.updatedAt,
 };
 
+// ---------------------------------------------------------------------------
+// Adjacent-run navigation for the run detail header.
+// ---------------------------------------------------------------------------
+
+// Resolves the runs immediately newer (`previousRunId`) and older
+// (`nextRunId`) than `current` within the same instrument, matching the runs
+// table's `coalesce(acquired_at, created_at) DESC` ordering. The `id` tiebreak
+// keeps neighbors deterministic when two runs share a timestamp; the list
+// query has no tiebreak, so equal-timestamp ordering is otherwise arbitrary.
+// Deleted runs are excluded to mirror the table's default. Wrapped in `cache()`
+// like `lookupRunByNaturalKey` so a single request reuses the result.
+export const getAdjacentRunIds = cache(
+  async function getAdjacentRunIds(current: {
+    acquiredAt: Date | null;
+    createdAt: Date;
+    id: string;
+    instrumentId: string;
+  }): Promise<{ nextRunId: string | null; previousRunId: string | null }> {
+    const cur = (current.acquiredAt ?? current.createdAt).toISOString();
+    const inSameInstrument = and(
+      eq(instrumentRuns.instrumentId, current.instrumentId),
+      isNull(instrumentRuns.deletedAt)
+    );
+
+    const [previous, next] = await Promise.all([
+      // Newer neighbor: smallest sort value strictly greater than current.
+      db
+        .select({ runId: instrumentRuns.runId })
+        .from(instrumentRuns)
+        .where(
+          and(
+            inSameInstrument,
+            sql`(${acquiredOrCreatedSql} > ${cur}::timestamptz or (${acquiredOrCreatedSql} = ${cur}::timestamptz and ${instrumentRuns.id} > ${current.id}))`
+          )
+        )
+        .orderBy(asc(acquiredOrCreatedSql), asc(instrumentRuns.id))
+        .limit(1),
+      // Older neighbor: greatest sort value strictly less than current.
+      db
+        .select({ runId: instrumentRuns.runId })
+        .from(instrumentRuns)
+        .where(
+          and(
+            inSameInstrument,
+            sql`(${acquiredOrCreatedSql} < ${cur}::timestamptz or (${acquiredOrCreatedSql} = ${cur}::timestamptz and ${instrumentRuns.id} < ${current.id}))`
+          )
+        )
+        .orderBy(desc(acquiredOrCreatedSql), desc(instrumentRuns.id))
+        .limit(1),
+    ]);
+
+    return {
+      previousRunId: previous[0]?.runId ?? null,
+      nextRunId: next[0]?.runId ?? null,
+    };
+  }
+);
+
 export async function buildRunListQuery(filters: RunListFilters) {
   const perPage = Math.min(Math.max(filters.perPage, 1), MAX_PER_PAGE);
   const conditions: SQL[] = [];

--- a/web/lib/api/instrument-runs.ts
+++ b/web/lib/api/instrument-runs.ts
@@ -655,6 +655,9 @@ function runFilesOrderBy(sort: FilesSortField): SQL[] {
 
 export interface RunFilesPage {
   data: RunFile[];
+  // Files in the current filter that have S3 keys and can be zipped by the
+  // archive route (matches `loadDownloadableFiles` after id resolution).
+  downloadableCount: number;
   pagination: {
     page: number;
     per_page: number;
@@ -673,8 +676,11 @@ export async function buildRunFilesQuery(
 
   const where = and(...runFilesWhere(runInternalId, filters));
 
-  const [{ total }] = await db
-    .select({ total: sql<number>`cast(count(*) as int)` })
+  const [{ total, downloadableCount }] = await db
+    .select({
+      total: sql<number>`cast(count(*) as int)`,
+      downloadableCount: sql<number>`cast(count(*) filter (where ${files.s3Bucket} is not null and ${files.s3Key} is not null and ${files.deletedAt} is null) as int)`,
+    })
     .from(files)
     .where(where);
 
@@ -688,6 +694,7 @@ export async function buildRunFilesQuery(
 
   return {
     data,
+    downloadableCount,
     pagination: {
       page: safePage,
       per_page: safePerPage,
@@ -703,7 +710,10 @@ export async function buildRunFilesQuery(
 // run detail page's `generateMetadata`.
 export interface RunFileStats {
   active: number;
+  // Files awaiting an upload request (status = detected).
+  detected: number;
   dismissed: number;
+  failed: number;
   pending: number;
   processedActive: number;
   processing: number;
@@ -725,6 +735,8 @@ export async function getRunFileStats(
       dismissed: sql<number>`cast(count(*) filter (where ${files.deletedAt} is not null) as int)`,
       rawActive: sql<number>`cast(count(*) filter (where ${files.category} = 'raw' and ${activeNotDeleted}) as int)`,
       processedActive: sql<number>`cast(count(*) filter (where ${files.category} = 'processed' and ${activeNotDeleted}) as int)`,
+      detected: sql<number>`cast(count(*) filter (where ${files.status} = 'detected' and ${activeNotDeleted}) as int)`,
+      failed: sql<number>`cast(count(*) filter (where ${files.status} = 'failed' and ${activeNotDeleted}) as int)`,
       pending: sql<number>`cast(count(*) filter (where ${files.status} in ('detected', 'upload_requested') and ${activeNotDeleted}) as int)`,
       uploaded: sql<number>`cast(count(*) filter (where ${files.status} not in ('detected', 'upload_requested', 'processing') and ${activeNotDeleted}) as int)`,
       processing: sql<number>`cast(count(*) filter (where ${files.status} = 'processing' and ${activeNotDeleted}) as int)`,

--- a/web/lib/date.ts
+++ b/web/lib/date.ts
@@ -20,6 +20,11 @@ export function formatDateTime(date: Date): string {
   return formatInTimeZone(date, getTimeZone(), "MMM d, yyyy h:mm a");
 }
 
+/** Formats a date as `"MMM d, h:mm a"`, e.g. `"Jun 26, 9:13 AM"`. */
+export function formatDateTimeShort(date: Date): string {
+  return formatInTimeZone(date, getTimeZone(), "MMM d, h:mm a");
+}
+
 /** Returns the date as a `"yyyy-MM-dd"` string for HTML date inputs. */
 export function toDateInputValue(date: Date): string {
   return formatInTimeZone(date, getTimeZone(), "yyyy-MM-dd");

--- a/web/lib/instrument-colors.ts
+++ b/web/lib/instrument-colors.ts
@@ -1,57 +1,53 @@
 // ---------- Gel doc ----------
 
 export const CAPTURE_TYPE_COLORS: Record<string, string> = {
-  Gel: "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300",
-  Blot: "border-purple-200 bg-purple-50 text-purple-700 dark:border-purple-800 dark:bg-purple-950 dark:text-purple-300",
-  Plate:
-    "border-teal-200 bg-teal-50 text-teal-700 dark:border-teal-800 dark:bg-teal-950 dark:text-teal-300",
+  Gel: "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
+  Blot: "bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-300",
+  Plate: "bg-teal-100 text-teal-700 dark:bg-teal-950 dark:text-teal-300",
   Colony:
-    "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-800 dark:bg-orange-950 dark:text-orange-300",
+    "bg-orange-100 text-orange-700 dark:bg-orange-950 dark:text-orange-300",
 };
 
 export const IMAGING_MODE_COLORS: Record<string, string> = {
   Fluorescence:
-    "border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-300",
+    "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-300",
   Chemiluminescence:
-    "border-violet-200 bg-violet-50 text-violet-700 dark:border-violet-800 dark:bg-violet-950 dark:text-violet-300",
+    "bg-violet-100 text-violet-700 dark:bg-violet-950 dark:text-violet-300",
   Colorimetric:
-    "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300",
+    "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300",
   "UV Transillumination":
-    "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-800 dark:bg-rose-950 dark:text-rose-300",
+    "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300",
   "White Epi":
-    "border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-300",
+    "bg-slate-100 text-slate-700 dark:bg-slate-950 dark:text-slate-300",
 };
 
 export const CHANNEL_COLOR_STYLES: Record<string, string> = {
-  Red: "border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300",
-  Green:
-    "border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-300",
-  Blue: "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300",
-  Cyan: "border-cyan-200 bg-cyan-50 text-cyan-700 dark:border-cyan-800 dark:bg-cyan-950 dark:text-cyan-300",
+  Red: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-300",
+  Green: "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-300",
+  Blue: "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
+  Cyan: "bg-cyan-100 text-cyan-700 dark:bg-cyan-950 dark:text-cyan-300",
   Magenta:
-    "border-fuchsia-200 bg-fuchsia-50 text-fuchsia-700 dark:border-fuchsia-800 dark:bg-fuchsia-950 dark:text-fuchsia-300",
+    "bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-950 dark:text-fuchsia-300",
   Yellow:
-    "border-yellow-200 bg-yellow-50 text-yellow-700 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-300",
+    "bg-yellow-100 text-yellow-700 dark:bg-yellow-950 dark:text-yellow-300",
   Orange:
-    "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-800 dark:bg-orange-950 dark:text-orange-300",
-  "Far Red":
-    "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-800 dark:bg-rose-950 dark:text-rose-300",
+    "bg-orange-100 text-orange-700 dark:bg-orange-950 dark:text-orange-300",
+  "Far Red": "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300",
 };
 
 // ---------- Epson V700 Scanner ----------
 
 export const DPI_COLORS: Record<string, string> = {
-  "300":
-    "border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-800 dark:bg-sky-950 dark:text-sky-300",
+  "300": "bg-sky-100 text-sky-700 dark:bg-sky-950 dark:text-sky-300",
   "600":
-    "border-indigo-200 bg-indigo-50 text-indigo-700 dark:border-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
+    "bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300",
 };
 
 // Stored values are the canonical strings written by the Lambda
 // (`"rgb"` / `"bw"`); the human label is computed at the call site.
 export const COLOR_MODE_COLORS: Record<string, string> = {
-  rgb: "border-fuchsia-200 bg-fuchsia-50 text-fuchsia-700 dark:border-fuchsia-800 dark:bg-fuchsia-950 dark:text-fuchsia-300",
-  bw: "border-stone-200 bg-stone-50 text-stone-700 dark:border-stone-800 dark:bg-stone-950 dark:text-stone-300",
+  rgb: "bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-950 dark:text-fuchsia-300",
+  bw: "bg-stone-100 text-stone-700 dark:bg-stone-950 dark:text-stone-300",
 };
 
 export const COLOR_MODE_LABELS: Record<string, string> = {
@@ -71,19 +67,17 @@ export function formatColorMode(value: string): string {
 // ---------- Plate reader ----------
 
 export const MEASUREMENT_TYPE_COLORS: Record<string, string> = {
-  Kinetic:
-    "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300",
-  Endpoint:
-    "border-teal-200 bg-teal-50 text-teal-600 dark:border-teal-700 dark:bg-teal-900 dark:text-teal-400",
+  Kinetic: "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
+  Endpoint: "bg-teal-100 text-teal-600 dark:bg-teal-900 dark:text-teal-400",
   "Well Scan":
-    "border-purple-200 bg-purple-50 text-purple-700 dark:border-purple-800 dark:bg-purple-950 dark:text-purple-300",
+    "bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-300",
 };
 
 export const MEASUREMENT_MODE_COLORS: Record<string, string> = {
   Absorbance:
-    "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-800 dark:bg-orange-950 dark:text-orange-300",
+    "bg-orange-100 text-orange-700 dark:bg-orange-950 dark:text-orange-300",
   Fluorescence:
-    "border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-300",
+    "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-300",
 };
 
 // ---------- qPCR ----------
@@ -92,25 +86,24 @@ export const MEASUREMENT_MODE_COLORS: Record<string, string> = {
 // below so the same label always maps to the same color across the table and
 // the run-detail metadata section.
 export const DYE_CHANNEL_COLORS: Record<string, string> = {
-  HEX: "border-stone-200 bg-stone-50 text-stone-700 dark:border-stone-800 dark:bg-stone-950 dark:text-stone-300",
-  TAMRA:
-    "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300",
-  ROX: "border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-300",
+  HEX: "bg-stone-100 text-stone-700 dark:bg-stone-950 dark:text-stone-300",
+  TAMRA: "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
+  ROX: "bg-slate-100 text-slate-700 dark:bg-slate-950 dark:text-slate-300",
   "ORANGE 560":
-    "border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300",
+    "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
 };
 
 // ---------- Shared wavelength cycle ----------
 
 export const WAVELENGTH_COLOR_CYCLE = [
-  "border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-800 dark:bg-sky-950 dark:text-sky-300",
-  "border-teal-200 bg-teal-50 text-teal-700 dark:border-teal-800 dark:bg-teal-950 dark:text-teal-300",
-  "border-indigo-200 bg-indigo-50 text-indigo-700 dark:border-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
-  "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-800 dark:bg-rose-950 dark:text-rose-300",
-  "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300",
-  "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
-  "border-fuchsia-200 bg-fuchsia-50 text-fuchsia-700 dark:border-fuchsia-800 dark:bg-fuchsia-950 dark:text-fuchsia-300",
-  "border-cyan-200 bg-cyan-50 text-cyan-700 dark:border-cyan-800 dark:bg-cyan-950 dark:text-cyan-300",
+  "bg-sky-100 text-sky-700 dark:bg-sky-950 dark:text-sky-300",
+  "bg-teal-100 text-teal-700 dark:bg-teal-950 dark:text-teal-300",
+  "bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300",
+  "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300",
+  "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300",
+  "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+  "bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-950 dark:text-fuchsia-300",
+  "bg-cyan-100 text-cyan-700 dark:bg-cyan-950 dark:text-cyan-300",
 ] as const;
 
 /** Assign a stable color from `WAVELENGTH_COLOR_CYCLE` to each wavelength string. */


### PR DESCRIPTION
## Summary

A batch of UI/UX polish across the web app, centered on the run detail page, badges, and avatars.

### Badges
- Reworked the base `Badge` variants to use filled, theme-aware colors (`bg-*-100 / text-*-700` with dark-mode counterparts) and dropped borders (`web/components/ui/badge.tsx`).
- Propagated the filled treatment everywhere: file status + category badges, watcher status, run metadata badges, instrument color tokens (`web/lib/instrument-colors.ts`), members "Admin", Slack "Connected", and the notification unread count.
- Raw vs. Processed file category badges are now color-coded (blue / purple).

### Shared avatar component
- Added `UserAvatar` / `UnknownUserAvatar` (`web/components/user-avatar.tsx`) and replaced the duplicated `Avatar` + `avatarColor` + `toInitials` wiring in the tokens page, members table, notifications, run header, and `RanByCell`.

### Run detail redesign
- Restructured the summary card: metadata fields now sit above a separated `RunTimestamps` row (new client component), with a dedicated "Ran by" field instead of inline header timestamps.
- New `RunSectionHeading` component unifies section headers with an inline `(N)` count (Files, Report Data, Comments, Plate Maps).
- `MetadataField` renders label-above-value; `RanByCell` gained `showName` / `compact` modes and an extracted `AttributionAvatars`.

### Files section
- Surfaced a filtered downloadable count (`Download filtered (N)`) via a new `downloadableCount` aggregate in `buildRunFilesQuery`, plus `detected` / `failed` file stats and clearer status-filter trigger labels.

### Previous/next run navigation
- Added `getAdjacentRunIds` (`web/lib/api/instrument-runs.ts`): a cached neighbor lookup ordered by `coalesce(acquired_at, created_at)` with an `id` tiebreak, matching the runs table and excluding deleted runs.
- New `RunNav` component renders Previous (newer) / Next (older) buttons to the left of Delete, threaded into the header via a `runNavSlot` (mirroring `attributionsSlot`). Tooltips and aria-labels read `Previous run: <name>` / `Next run: <name>`; ends of the list render disabled.

### Misc
- `suppressHydrationWarning` on `<body>` to absorb browser-extension DOM tweaks.
- Deferred the recent-visit `localStorage` update event via `queueMicrotask` so other hook instances refresh after commit (`use-recent-instruments`, `use-recent-watchers`).
- Added `formatDateTimeShort` date helper.

## Test plan

- [x] Run detail page: header shows Previous/Next buttons left of Delete; they navigate in the same date-desc order as the runs table, disable at the first/last run, and tooltips show the target run name.
- [x] Summary card renders metadata, "Ran by" (with names), and the timestamps row correctly across instrument variants (plate reader, gel doc, qPCR, tape station, hina, epson, raman, default).
- [x] Badges render with correct filled colors in both light and dark mode.
- [x] Files section shows `Download filtered (N)` when filters are active and `Download all (N)` otherwise.
- [x] Avatars (with image and fallback initials) render consistently in tokens, members, notifications, run header, and run table.
- [x] `make check-all` passes.

Made with [Cursor](https://cursor.com)