### PR TITLE
Surface pending instrument status and seed a realistic pending watcher

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,3 +1,7 @@
+# Public docs site base URL. Defaults to https://arcadia-data-hub-docs.vercel.app
+# when unset.
+# DOCS_BASE_URL=
+
 # Database.
 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/data-hub-local
 

--- a/web/app/instruments/page.tsx
+++ b/web/app/instruments/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next/types";
 import { SignInRequired } from "@/components/auth/sign-in-required";
+import { AddInstrumentDialog } from "@/components/instruments/add-instrument-dialog";
 import {
   InstrumentRowManagementActions,
   InstrumentsTable,
@@ -10,6 +11,7 @@ import {
   listInstrumentSubscriptions,
 } from "@/lib/api/notifications";
 import { auth } from "@/lib/auth";
+import { ADD_INSTRUMENT_DOCS_URL, MANAGING_TOKENS_DOCS_URL } from "@/lib/docs";
 
 const description = "Instruments connected to Data Hub.";
 
@@ -56,6 +58,10 @@ export default async function InstrumentsPage() {
     <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-6 2xl:w-7xl">
       <div className="flex items-center justify-between">
         <h1 className="font-semibold text-2xl tracking-tight">Instruments</h1>
+        <AddInstrumentDialog
+          getTokenUrl={MANAGING_TOKENS_DOCS_URL}
+          setupGuideUrl={ADD_INSTRUMENT_DOCS_URL}
+        />
       </div>
       <InstrumentsTable
         data={instruments}

--- a/web/components/instruments/add-instrument-dialog.tsx
+++ b/web/components/instruments/add-instrument-dialog.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { ExternalLink, Plus } from "lucide-react";
+import { InstrumentStatusBadge } from "@/components/instruments/instrument-status-badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+const STEPS = [
+  {
+    title: "Install the watcher on the instrument PC",
+    description:
+      "A lab operator runs the watcher and registers the instrument. You'll need a personal access token.",
+  },
+  {
+    title: "Activate it here",
+    description: (
+      <>
+        It appears with a <InstrumentStatusBadge status="pending" /> badge. An
+        admin clicks Confirm.
+      </>
+    ),
+  },
+  {
+    title: "Start watching",
+    description: "Runs and files appear in the dashboard as they upload.",
+  },
+] as const;
+
+export function AddInstrumentDialog({
+  setupGuideUrl,
+  getTokenUrl,
+}: {
+  setupGuideUrl: string;
+  getTokenUrl: string;
+}) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button size="sm">
+          <Plus data-icon="inline-start" />
+          Add instrument
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add an instrument</DialogTitle>
+          <DialogDescription>
+            Instruments are registered from the instrument PC, then activated
+            here.
+          </DialogDescription>
+        </DialogHeader>
+        <ol className="grid gap-4">
+          {STEPS.map((step, index) => (
+            <li className="flex gap-3" key={step.title}>
+              <span
+                aria-hidden
+                className="flex size-6 shrink-0 items-center justify-center rounded-full bg-sky-100 font-medium text-sky-700 text-xs dark:bg-sky-950 dark:text-sky-300"
+              >
+                {index + 1}
+              </span>
+              <div className="grid gap-1 pt-0.5">
+                <p className="font-medium leading-none">{step.title}</p>
+                <p className="text-muted-foreground text-sm leading-snug">
+                  {step.description}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <DialogFooter className="sm:justify-between">
+          <Button asChild size="sm">
+            <a href={setupGuideUrl} rel="noopener noreferrer" target="_blank">
+              Open setup guide
+              <ExternalLink className="size-3" />
+            </a>
+          </Button>
+          <Button asChild size="sm" variant="ghost">
+            <a href={getTokenUrl} rel="noopener noreferrer" target="_blank">
+              Get a token
+            </a>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/components/instruments/instrument-header.tsx
+++ b/web/components/instruments/instrument-header.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { InstrumentStatusBadge } from "@/components/instruments/instrument-status-badge";
 import { InstrumentNotificationSwitch } from "@/components/notifications/instrument-notification-switch";
 import { RecordInstrumentVisit } from "@/components/recent-instrument-visit";
 import {
@@ -9,9 +10,47 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
-import { getWatcherOnlineStatus } from "@/components/watchers/watcher-online-status";
+import {
+  getWatcherOnlineStatus,
+  type WatcherOnlineStatus,
+} from "@/components/watchers/watcher-online-status";
 import { WatcherStatusBadge } from "@/components/watchers/watcher-status-badge";
 import type { InstrumentDetail } from "@/lib/api/instruments";
+
+// While an instrument is `pending` its lifecycle state (awaiting admin Confirm)
+// is the relevant signal, so it pre-empts the watcher connectivity badge. Once
+// active, the watcher badge — linked to the canonical watcher when present —
+// takes over.
+function renderStatusBadge(
+  instrument: InstrumentDetail,
+  watcherStatus: WatcherOnlineStatus
+) {
+  if (instrument.status === "pending") {
+    return <InstrumentStatusBadge className="px-2 py-3" status="pending" />;
+  }
+
+  const badge = (
+    <WatcherStatusBadge
+      className="px-2 py-3"
+      lastOnlineAt={instrument.lastWatcherHeartbeatAt}
+      status={watcherStatus}
+      verbose
+    />
+  );
+
+  if (instrument.activeWatcherId) {
+    return (
+      <Link
+        className="transition-colors hover:opacity-80"
+        href={`/watchers/${instrument.activeWatcherId}`}
+      >
+        {badge}
+      </Link>
+    );
+  }
+
+  return badge;
+}
 
 export function InstrumentHeader({
   instrument,
@@ -70,23 +109,7 @@ export function InstrumentHeader({
               masterMuted={notifications.masterMuted}
             />
           ) : null}
-          {instrument.activeWatcherId ? (
-            <Link href={`/watchers/${instrument.activeWatcherId}`}>
-              <WatcherStatusBadge
-                className="px-2 py-3 transition-colors hover:opacity-80"
-                lastOnlineAt={instrument.lastWatcherHeartbeatAt}
-                status={watcherStatus}
-                verbose
-              />
-            </Link>
-          ) : (
-            <WatcherStatusBadge
-              className="px-2 py-3"
-              lastOnlineAt={instrument.lastWatcherHeartbeatAt}
-              status={watcherStatus}
-              verbose
-            />
-          )}
+          {renderStatusBadge(instrument, watcherStatus)}
         </div>
       </div>
 

--- a/web/components/instruments/instrument-status-badge.tsx
+++ b/web/components/instruments/instrument-status-badge.tsx
@@ -1,0 +1,51 @@
+import { CheckCircle2, Clock, Power } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { InstrumentListItem } from "@/lib/api/instruments";
+import { cn } from "@/lib/utils";
+
+/**
+ * Instrument lifecycle status, distinct from the watcher connectivity shown by
+ * `WatcherStatusBadge`. Surfaced in the instruments table only while an
+ * instrument is `pending` (awaiting admin Confirm); active rows fall back to
+ * their watcher status, which is the more useful signal once activated.
+ */
+export type InstrumentLifecycleStatus = InstrumentListItem["status"];
+
+const STATUS_CONFIG: Record<
+  InstrumentLifecycleStatus,
+  { label: string; Icon: typeof Clock; className: string }
+> = {
+  pending: {
+    label: "Pending",
+    Icon: Clock,
+    className:
+      "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300",
+  },
+  active: {
+    label: "Active",
+    Icon: CheckCircle2,
+    className:
+      "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-300",
+  },
+  inactive: {
+    label: "Inactive",
+    Icon: Power,
+    className: "bg-muted text-muted-foreground",
+  },
+};
+
+export function InstrumentStatusBadge({
+  status,
+  className,
+}: {
+  status: InstrumentLifecycleStatus;
+  className?: string;
+}) {
+  const { label, Icon, className: variantClassName } = STATUS_CONFIG[status];
+  return (
+    <Badge className={cn(variantClassName, className)}>
+      <Icon />
+      {label}
+    </Badge>
+  );
+}

--- a/web/components/instruments/instruments-table.tsx
+++ b/web/components/instruments/instruments-table.tsx
@@ -2,6 +2,7 @@ import { SearchX } from "lucide-react";
 import type { ReactNode } from "react";
 import { RelativeTime } from "@/components/dashboard/relative-time";
 import { EditInstrumentDialog } from "@/components/instruments/edit-instrument-dialog";
+import { InstrumentStatusBadge } from "@/components/instruments/instrument-status-badge";
 import { RowActionsCell } from "@/components/instruments/row-actions-cell";
 import { ClickableRow } from "@/components/instruments/runs-table/clickable-row";
 import { StatusActions } from "@/components/instruments/status-actions";
@@ -111,10 +112,14 @@ export function InstrumentsTable({
                   </span>
                 </TableCell>
                 <TableCell>
-                  <WatcherStatusBadge
-                    lastOnlineAt={row.lastWatcherHeartbeatAt}
-                    status={watcherStatus}
-                  />
+                  {row.status === "pending" ? (
+                    <InstrumentStatusBadge status="pending" />
+                  ) : (
+                    <WatcherStatusBadge
+                      lastOnlineAt={row.lastWatcherHeartbeatAt}
+                      status={watcherStatus}
+                    />
+                  )}
                 </TableCell>
                 <TableCell>
                   {row.filePatterns.length > 0 ? (

--- a/web/lib/db/seed.ts
+++ b/web/lib/db/seed.ts
@@ -203,18 +203,31 @@ const WATCHER_STATUSES = ["watching", "registered", "stopped"] as const;
 
 export async function seedWatchers(
   db: Db,
-  instrumentIds: string[]
+  instruments: Pick<SeededInstrument, "id" | "status">[]
 ): Promise<SeededWatcher[]> {
-  if (instrumentIds.length === 0) {
+  // Mirror the register endpoint: only active and pending instruments accept a
+  // watcher. A pending instrument is seeded with a `registered` watcher (no
+  // heartbeats) to model the realistic "watcher registered, awaiting admin
+  // activation" state — instruments only ever exist because a watcher
+  // registered against them, so a pending instrument with no watcher is a
+  // state the real system can't produce.
+  const eligible = instruments.filter(
+    (i) => i.status === "active" || i.status === "pending"
+  );
+  if (eligible.length === 0) {
     return [];
   }
 
   const now = new Date();
-  const watcherValues = instrumentIds.map((instrumentId, idx) => {
-    const status = WATCHER_STATUSES[idx % WATCHER_STATUSES.length];
+  let activeIdx = 0;
+  const watcherValues = eligible.map((instrument, idx) => {
+    const status =
+      instrument.status === "pending"
+        ? ("registered" as const)
+        : WATCHER_STATUSES[activeIdx++ % WATCHER_STATUSES.length];
     return {
       id: crypto.randomUUID(),
-      instrumentId,
+      instrumentId: instrument.id,
       hostname: `seed-host-${idx + 1}`,
       osInfo: "Windows 11 23H2",
       watcherVersion: "9.9.9",

--- a/web/lib/docs.ts
+++ b/web/lib/docs.ts
@@ -1,0 +1,5 @@
+export const DOCS_BASE_URL =
+  process.env.DOCS_BASE_URL ?? "https://arcadia-data-hub-docs.vercel.app";
+
+export const ADD_INSTRUMENT_DOCS_URL = `${DOCS_BASE_URL}/docs/adding-an-instrument`;
+export const MANAGING_TOKENS_DOCS_URL = `${DOCS_BASE_URL}/docs/managing-tokens`;

--- a/web/scripts/seed-database.ts
+++ b/web/scripts/seed-database.ts
@@ -57,10 +57,7 @@ console.log("Seeding instruments…");
 const instruments = await seedInstruments(db);
 
 console.log("Seeding watchers + heartbeats + events…");
-await seedWatchers(
-  db,
-  instruments.filter((i) => i.status === "active").map((i) => i.id)
-);
+await seedWatchers(db, instruments);
 
 console.log("Seeding runs + files…");
 const activeInstruments = instruments.filter((i) => i.status === "active");


### PR DESCRIPTION
## Summary
- Seed a `registered` watcher (no heartbeats) for the pending instrument so the seed models the real "watcher registered, awaiting admin activation" flow instead of the impossible "pending instrument with no watcher" state.
- Add an `InstrumentStatusBadge` and show a "Pending" badge in the instruments table and the instrument detail header while an instrument awaits Confirm, matching (and now sharing) the badge used in the Add-instrument dialog copy.
- Includes the Add-instrument dialog wiring on the instruments page and the `lib/docs.ts` docs-URL helpers.

## Test plan
- [x] `make db-reseed`, then confirm the Generic Lab Instrument row shows a **Pending** badge (not "No Watcher") with the Confirm button.
- [x] Open the pending instrument's detail page and confirm the header shows the **Pending** badge.
- [x] Confirm the instrument, then verify both surfaces fall back to the watcher connectivity badge.
- [x] `make check-all` passes.

Made with [Cursor](https://cursor.com)