### PR TITLE
Redesign login and auth gate with shared two-panel layout

### DIFF
--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,8 +1,5 @@
-import Image from "next/image";
 import type { Metadata } from "next/types";
-import { DevSignInForm } from "@/components/auth/dev-sign-in-form";
-import { Button } from "@/components/ui/button";
-import { isDevAuthEnabled, signIn } from "@/lib/auth";
+import { AuthScreen } from "@/components/auth/auth-screen";
 
 export const metadata: Metadata = {
   title: "Login",
@@ -10,38 +7,13 @@ export const metadata: Metadata = {
 
 export default function LoginPage() {
   return (
-    <div className="flex h-screen w-full items-center justify-center">
-      <div className="mx-auto flex w-full max-w-md flex-col items-center gap-6">
-        <div className="flex flex-col items-center gap-4 text-center">
-          <Image
-            alt="Data Hub"
-            height={64}
-            priority
-            src="/images/data-hub-logo.svg"
-            width={64}
-          />
-          <h1 className="mt-2 font-semibold text-3xl tracking-tight">
-            Welcome to Data Hub
-          </h1>
-          <p className="text-muted-foreground">
-            Sign in with your Google Workspace account to continue.
-          </p>
-        </div>
-        <form
-          action={async () => {
-            "use server";
-            await signIn("google", { redirectTo: "/" });
-          }}
-          className="w-full"
-        >
-          <Button className="w-full cursor-pointer py-5 text-base" size="lg">
-            Sign in with Google
-          </Button>
-        </form>
-        {isDevAuthEnabled && (
-          <DevSignInForm callbackUrl="/" inputId="login-dev-email" />
-        )}
-      </div>
-    </div>
+    <AuthScreen
+      callbackUrl="/"
+      devInputId="login-dev-email"
+      heading="Welcome to Data Hub"
+    >
+      Lab instrument data, captured and processed automatically — explore your
+      runs from the web, API, or an AI agent.
+    </AuthScreen>
   );
 }

--- a/web/components/auth/auth-screen.tsx
+++ b/web/components/auth/auth-screen.tsx
@@ -1,0 +1,166 @@
+import { CloudUpload, FlaskConical, Lock, Terminal } from "lucide-react";
+import Image from "next/image";
+import { DevSignInForm } from "@/components/auth/dev-sign-in-form";
+import { Button } from "@/components/ui/button";
+import { isDevAuthEnabled, signIn } from "@/lib/auth";
+import { DOCS_BASE_URL, QUICKSTART_DOCS_URL } from "@/lib/docs";
+
+interface AuthScreenProps {
+  callbackUrl: string;
+  children?: React.ReactNode;
+  devInputId: string;
+  heading: string;
+}
+
+const FEATURES = [
+  {
+    icon: CloudUpload,
+    title: "Automatic uploads",
+    description: "A watcher captures every run",
+  },
+  {
+    icon: FlaskConical,
+    title: "Processed instantly",
+    description: "Files ingested as they appear",
+  },
+  {
+    icon: Terminal,
+    title: "Web, API, or AI agent",
+    description: "Analyze runs any way you work",
+  },
+] as const;
+
+function GoogleIcon() {
+  return (
+    <svg
+      aria-hidden
+      className="size-5"
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title>Google</title>
+      <path
+        d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+        fill="#EA4335"
+      />
+      <path
+        d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+        fill="#4285F4"
+      />
+      <path
+        d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+        fill="#34A853"
+      />
+    </svg>
+  );
+}
+
+export function AuthScreen({
+  callbackUrl,
+  heading,
+  devInputId,
+  children,
+}: AuthScreenProps) {
+  return (
+    <div className="grid min-h-svh w-full lg:grid-cols-2">
+      <div className="flex flex-col bg-background">
+        <div className="flex flex-1 flex-col justify-center px-8 py-12 sm:px-12 lg:px-16">
+          <div className="mx-auto w-full max-w-md">
+            <Image
+              alt="Data Hub"
+              className="size-12"
+              height={48}
+              priority
+              src="/images/data-hub-logo.svg"
+              width={48}
+            />
+
+            <h1 className="mt-6 font-semibold text-3xl tracking-tight">
+              {heading}
+            </h1>
+            {children ? (
+              <p className="mt-3 text-muted-foreground leading-relaxed">
+                {children}
+              </p>
+            ) : null}
+
+            <form
+              action={async () => {
+                "use server";
+                await signIn("google", { redirectTo: callbackUrl });
+              }}
+              className="mt-8 w-full"
+            >
+              <Button
+                className="h-11 w-full cursor-pointer gap-3 bg-background text-base shadow-xs"
+                size="lg"
+                type="submit"
+                variant="outline"
+              >
+                <GoogleIcon />
+                Sign in with Google
+              </Button>
+            </form>
+
+            <p className="mt-4 flex items-center gap-2 text-muted-foreground text-sm">
+              <Lock aria-hidden className="size-3.5 shrink-0" />
+              Sign in with your Google Workspace account
+            </p>
+
+            {isDevAuthEnabled ? (
+              <div className="mt-8">
+                <DevSignInForm callbackUrl={callbackUrl} inputId={devInputId} />
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <footer className="px-8 pb-8 sm:px-12 lg:px-16">
+          <div className="mx-auto flex w-full max-w-md gap-6 text-muted-foreground text-sm">
+            <a
+              className="transition-colors hover:text-foreground"
+              href={QUICKSTART_DOCS_URL}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Quickstart
+            </a>
+            <a
+              className="transition-colors hover:text-foreground"
+              href={DOCS_BASE_URL}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Docs
+            </a>
+          </div>
+        </footer>
+      </div>
+
+      <div className="hidden flex-col justify-center bg-blue-50 px-12 py-16 lg:flex dark:bg-blue-950/30">
+        <div className="mx-auto flex w-full max-w-sm flex-col gap-4">
+          {FEATURES.map((feature) => (
+            <div
+              className="flex items-start gap-4 rounded-xl border border-blue-100/80 bg-background p-5 shadow-sm dark:border-blue-900/50"
+              key={feature.title}
+            >
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300">
+                <feature.icon aria-hidden className="size-5" />
+              </div>
+              <div>
+                <p className="font-medium">{feature.title}</p>
+                <p className="mt-0.5 text-muted-foreground text-sm">
+                  {feature.description}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/components/auth/sign-in-required.tsx
+++ b/web/components/auth/sign-in-required.tsx
@@ -1,7 +1,4 @@
-import Image from "next/image";
-import { DevSignInForm } from "@/components/auth/dev-sign-in-form";
-import { Button } from "@/components/ui/button";
-import { isDevAuthEnabled, signIn } from "@/lib/auth";
+import { AuthScreen } from "@/components/auth/auth-screen";
 
 interface SignInRequiredProps {
   /**
@@ -33,41 +30,12 @@ interface SignInRequiredProps {
  */
 export function SignInRequired({ callbackUrl, children }: SignInRequiredProps) {
   return (
-    <div className="flex h-[calc(100svh-3rem)] w-full items-center justify-center">
-      <div className="mx-auto flex w-full max-w-md flex-col items-center gap-6">
-        <div className="flex flex-col items-center gap-4 text-center">
-          <Image
-            alt="Data Hub"
-            height={64}
-            priority
-            src="/images/data-hub-logo.svg"
-            width={64}
-          />
-          <h1 className="mt-2 font-semibold text-3xl tracking-tight">
-            Sign in to Data Hub
-          </h1>
-          {children ? (
-            <p className="text-muted-foreground">{children}</p>
-          ) : null}
-        </div>
-        <form
-          action={async () => {
-            "use server";
-            await signIn("google", { redirectTo: callbackUrl });
-          }}
-          className="w-full"
-        >
-          <Button className="w-full cursor-pointer py-5 text-base" size="lg">
-            Sign in with Google
-          </Button>
-        </form>
-        {isDevAuthEnabled && (
-          <DevSignInForm
-            callbackUrl={callbackUrl}
-            inputId="sign-in-required-dev-email"
-          />
-        )}
-      </div>
-    </div>
+    <AuthScreen
+      callbackUrl={callbackUrl}
+      devInputId="sign-in-required-dev-email"
+      heading="Sign in to Data Hub"
+    >
+      {children ?? "Sign in with your Google Workspace account to continue."}
+    </AuthScreen>
   );
 }

--- a/web/lib/docs.ts
+++ b/web/lib/docs.ts
@@ -1,5 +1,6 @@
 export const DOCS_BASE_URL =
   process.env.DOCS_BASE_URL ?? "https://arcadia-data-hub-docs.vercel.app";
 
+export const QUICKSTART_DOCS_URL = `${DOCS_BASE_URL}/docs/getting-started`;
 export const ADD_INSTRUMENT_DOCS_URL = `${DOCS_BASE_URL}/docs/adding-an-instrument`;
 export const MANAGING_TOKENS_DOCS_URL = `${DOCS_BASE_URL}/docs/managing-tokens`;


### PR DESCRIPTION
## Summary
- Introduces a shared `AuthScreen` component with a two-panel sign-in layout: branding and Google sign-in on the left, feature highlights on a light-blue panel on the right.
- Updates `/login` and in-app `SignInRequired` gates to use the same screen, including the multicolor Google button, docs footer links, and dev sign-in affordance.
- Adds `QUICKSTART_DOCS_URL` for the Quickstart footer link.

## Test plan
- [x] Open `/login` while signed out and confirm the two-panel layout, Google sign-in button, and footer links
- [x] Open an authenticated route (e.g. `/instruments`) while signed out and confirm the gate shows the same layout with its contextual message
- [x] Verify dev sign-in still works locally with `dev@local`
- [x] Check light and dark mode on desktop and mobile (feature panel hidden on small screens)

Made with [Cursor](https://cursor.com)