### PR TITLE
Add staging run cleanup script and preview deployment banner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,7 +201,7 @@ cython_debug/
 #   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #   and can be added to the global gitignore or merged into this file. However, if you prefer, 
 #   you could uncomment the following to ignore the entire vscode folder
-# .vscode/
+.vscode/
 
 # Ruff stuff:
 .ruff_cache/

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -149,3 +149,16 @@ html.dark .shiki span {
     @apply font-sans;
   }
 }
+
+/* Preview banner offsets; height matches `PREVIEW_BANNER_HEIGHT` / banner `h-8`. */
+html[data-preview-deployment] {
+  --banner-height: 2rem;
+}
+
+html[data-preview-deployment] body {
+  padding-top: var(--banner-height);
+}
+
+html[data-preview-deployment] [data-slot="sidebar-container"] {
+  top: var(--banner-height);
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -8,6 +8,7 @@ import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { AppSidebar } from "@/components/app-sidebar";
 import { NotificationBell } from "@/components/notifications/notification-bell";
 import { NotificationsProvider } from "@/components/notifications/notifications-provider";
+import { PreviewDeploymentBanner } from "@/components/preview-deployment-banner";
 import { ArchiveDownloadProvider } from "@/components/runs/archive-download-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import {
@@ -110,6 +111,11 @@ export default async function RootLayout({
   const sidebarCookie = (await cookies()).get(SIDEBAR_COOKIE_NAME)?.value;
   const sidebarDefaultOpen = sidebarCookie !== "false";
 
+  // `--banner-height` is the single knob that offsets the body, the
+  // viewport-fixed sidebar, and the full-height auth screen for the preview
+  // banner. Left unset off preview, so each `var(..., 0px)` consumer is a no-op.
+  const isPreview = process.env.VERCEL_ENV === "preview";
+
   return (
     <html
       className={cn(
@@ -118,6 +124,7 @@ export default async function RootLayout({
         "font-sans",
         fontSans.variable
       )}
+      data-preview-deployment={isPreview ? "" : undefined}
       lang="en"
       suppressHydrationWarning
     >
@@ -126,6 +133,7 @@ export default async function RootLayout({
           <ThemeProvider>
             <NuqsAdapter>
               <TooltipProvider>
+                <PreviewDeploymentBanner />
                 {session ? (
                   <NotificationsProvider
                     initialUnreadCount={initialUnreadCount}

--- a/web/components/auth/auth-screen.tsx
+++ b/web/components/auth/auth-screen.tsx
@@ -66,7 +66,7 @@ export function AuthScreen({
   children,
 }: AuthScreenProps) {
   return (
-    <div className="grid min-h-svh w-full lg:grid-cols-2">
+    <div className="grid min-h-[calc(100svh_-_var(--banner-height,0px))] w-full lg:grid-cols-2">
       <div className="flex flex-col bg-background">
         <div className="flex flex-1 flex-col justify-center px-8 py-12 sm:px-12 lg:px-16">
           <div className="mx-auto w-full max-w-md">

--- a/web/components/preview-deployment-banner.tsx
+++ b/web/components/preview-deployment-banner.tsx
@@ -1,0 +1,37 @@
+import { TriangleAlert } from "lucide-react";
+
+/** Kept in sync with the banner's `h-8` class; layout/sidebar subtract this. */
+export const PREVIEW_BANNER_HEIGHT = "2rem";
+
+// `fixed` rather than in-flow so it paints above the viewport-fixed sidebar
+// (`z-10`); `RootLayout` reserves space via `--banner-height` so nothing hides
+// under it. `VERCEL_*` are unset off Vercel, so this only renders on previews.
+export function PreviewDeploymentBanner() {
+  if (process.env.VERCEL_ENV !== "preview") {
+    return null;
+  }
+
+  const branch = process.env.VERCEL_GIT_COMMIT_REF;
+  const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL;
+
+  return (
+    <div
+      className="fixed inset-x-0 top-0 z-50 flex h-8 items-center justify-center gap-2 overflow-hidden bg-amber-500 px-4 text-center font-medium text-amber-950 text-sm dark:bg-amber-400"
+      role="alert"
+    >
+      <TriangleAlert className="size-4 shrink-0" />
+      <span className="truncate">
+        This is a preview deployment
+        {branch ? ` for the ${branch} branch` : ""}.
+      </span>
+      {productionUrl ? (
+        <a
+          className="shrink-0 underline underline-offset-2 hover:no-underline"
+          href={`https://${productionUrl}`}
+        >
+          Go to production
+        </a>
+      ) : null}
+    </div>
+  );
+}

--- a/web/components/ui/sidebar.tsx
+++ b/web/components/ui/sidebar.tsx
@@ -133,7 +133,7 @@ function SidebarProvider({
     <SidebarContext.Provider value={contextValue}>
       <div
         className={cn(
-          "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+          "group/sidebar-wrapper flex min-h-[calc(100svh_-_var(--banner-height,0px))] w-full has-data-[variant=inset]:bg-sidebar",
           className
         )}
         data-slot="sidebar-wrapper"
@@ -231,7 +231,7 @@ function Sidebar({
       />
       <div
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=right]:right-0 data-[side=left]:left-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] md:flex",
+          "fixed top-[var(--banner-height,0px)] bottom-0 z-10 hidden w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=right]:right-0 data-[side=left]:left-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] md:flex",
           // Adjust the padding for floating and inset variants.
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "db:seed": "tsx scripts/seed-database.ts",
     "db:reseed": "npm run db:reset && npm run db:push && npm run db:seed",
     "db:process-fixtures": "tsx scripts/process-seeded-fixtures.ts",
+    "db:clear-runs": "tsx scripts/clear-run-file-records.ts",
     "test:mcp": "vitest run --config vitest.config.ts",
     "test:mcp:watch": "vitest --config vitest.config.ts",
     "test:integration": "vitest run --config vitest.integration.config.ts",

--- a/web/scripts/README.md
+++ b/web/scripts/README.md
@@ -16,6 +16,11 @@ This guard lives in `assert-local-db.ts` and protects `db:reseed` as well
 against a different database, update the expected URL in
 `assert-local-db.ts` rather than removing the check.
 
+`clear-run-file-records.ts` is the deliberate exception: it targets a
+**remote** database on purpose, so it does not use the local-only gate. Its
+guardrails are different (dry-run by default + explicit `--confirm`) — see
+its section below.
+
 ## `reset-database.ts`
 
 Drops and recreates the `public` schema, wiping all tables and data. Used as the first step in a full database rebuild.
@@ -31,3 +36,74 @@ After running, you'll need to recreate the schema.
 ```sh
 npm run db:push
 ```
+
+## `seed-database.ts`
+
+Populates the database with a believable steady state: a workspace admin user
+(`dev@local`) + PAT, one instrument per type, watchers with heartbeats/events,
+runs with files, comments, attributions, and archive jobs in each lifecycle
+state. Clears existing rows first, then prints a sign-in email and a fresh PAT
+for API calls.
+
+### Usage
+
+```sh
+# Seed on top of the current schema
+npm run db:seed
+
+# Reset → push → seed (the usual loop)
+npm run db:reseed
+```
+
+The seed's final step drives the lambda over each fixture-bearing run so the
+dashboard shows real processed artifacts. That step is **skipped** unless the
+dev server is already running (see `process-seeded-fixtures.ts` below); the
+seed prints a hint when it skips.
+
+## `process-seeded-fixtures.ts`
+
+Post-hoc fixture processing for when the seed skipped it (typically because
+`npm run dev` wasn't up during `npm run db:reseed`). Mints a fresh PAT for the
+dev user and drives the lambda's `data-hub-process` handler over the seeded
+fixtures.
+
+### Usage
+
+```sh
+# one terminal
+npm run dev
+
+# another terminal, once the dev server is reachable
+npm run db:process-fixtures
+```
+
+## `clear-run-file-records.ts`
+
+Hard-deletes run and file records (and everything that FK-references them:
+`notifications`, `run_comments`, `run_attributions`, `archive_jobs`, `files`, `instrument_runs`) while **preserving `instruments` and `watchers`**, so lab instrument PCs stay registered and can be re-pointed between environments. 
+
+Used to reset the long-lived "staging-as-prod" database before production cutover. It does **not** touch S3 — object deletion is a separate, manual step.
+
+Unlike the scripts above, this one intentionally targets a remote database,
+so it skips the local-only gate. Instead it is dry-run by default (prints row counts of both cleared and preserved tables), requires `--confirm` to delete, echoes the redacted target host, and refuses to run against the local dev database. All deletes run in a single transaction.
+
+### Usage
+
+```sh
+# Dry run — verify target + counts, no changes
+DATABASE_URL='<remote-url>' npm run db:clear-runs
+
+# Commit the wipe
+DATABASE_URL='<remote-url>' npm run db:clear-runs -- --confirm
+
+# Also drop watcher heartbeats/events (kept by default)
+DATABASE_URL='<remote-url>' npm run db:clear-runs -- --confirm --clear-watcher-activity
+```
+
+## Helper modules (not run directly)
+
+- `assert-local-db.ts` — the local-only safety gate imported by
+  `reset-database.ts`, `seed-database.ts`, and `process-seeded-fixtures.ts`
+  (see [Local-only safety gate](#local-only-safety-gate)).
+- `process-fixtures.ts` — shared lambda probe/spawn logic imported by
+  `seed-database.ts` and `process-seeded-fixtures.ts`.

--- a/web/scripts/clear-run-file-records.ts
+++ b/web/scripts/clear-run-file-records.ts
@@ -1,0 +1,137 @@
+// Clear run and file records from a Data Hub database while preserving
+// instruments and watchers, so lab instrument PCs can be re-pointed between
+// environments without losing their identity/registration.
+//
+// This is the tool used to reset the long-lived "staging-as-prod" database
+// before real production cutover. It does NOT touch S3 — object deletion is a
+// separate, manual step.
+//
+// Unlike scripts/reset-database.ts and scripts/seed-database.ts, this script
+// intentionally targets a REMOTE database, so it deliberately does NOT use
+// assertLocalDatabaseUrl. Guardrails instead: dry-run by default, an explicit
+// --confirm flag to mutate, and it echoes the (redacted) target host.
+//
+// Usage:
+//   DATABASE_URL=postgres://…  tsx scripts/clear-run-file-records.ts            # dry run: counts only
+//   DATABASE_URL=postgres://…  tsx scripts/clear-run-file-records.ts --confirm  # actually delete
+//   …--confirm --clear-watcher-activity   # also drop watcher heartbeats/events
+
+import "dotenv/config";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+
+const args = new Set(process.argv.slice(2));
+const confirm = args.has("--confirm");
+const clearWatcherActivity = args.has("--clear-watcher-activity");
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  console.error("clear-run-file-records: DATABASE_URL is not set.");
+  process.exit(1);
+}
+
+// Local dev has its own reset/reseed tooling; this destructive-on-remote
+// script should never be the thing pointed at the dev DB by mistake.
+const LOCAL_DATABASE_URL =
+  "postgres://postgres:postgres@127.0.0.1:5432/data-hub-local";
+if (databaseUrl === LOCAL_DATABASE_URL) {
+  console.error(
+    "clear-run-file-records: DATABASE_URL points at the local dev database."
+  );
+  console.error("  Use `npm run db:reseed` for local resets instead.");
+  process.exit(1);
+}
+
+function redact(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.password) {
+      parsed.password = "***";
+    }
+    return parsed.toString();
+  } catch {
+    return "<unparseable DATABASE_URL>";
+  }
+}
+
+// Mirror lib/db/index.ts: managed Postgres (Render) needs TLS over the public
+// endpoint; only 127.0.0.1/localhost speak plaintext.
+function requiresSsl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return hostname !== "localhost" && hostname !== "127.0.0.1";
+  } catch {
+    return false;
+  }
+}
+
+// Child-first: everything that FK-references instrument_runs (and, for
+// `files`, has onDelete: no action) must go before the runs themselves.
+const RUN_FILE_TABLES = [
+  "notifications",
+  "run_comments",
+  "run_attributions",
+  "archive_jobs",
+  "files",
+  "instrument_runs",
+] as const;
+
+const WATCHER_ACTIVITY_TABLES = [
+  "watcher_events",
+  "watcher_heartbeats",
+] as const;
+
+const tablesToClear = clearWatcherActivity
+  ? [...WATCHER_ACTIVITY_TABLES, ...RUN_FILE_TABLES]
+  : RUN_FILE_TABLES;
+
+const pool = new Pool({
+  connectionString: databaseUrl,
+  ssl: requiresSsl(databaseUrl) ? { rejectUnauthorized: false } : false,
+});
+const db = drizzle(pool);
+
+console.log(`Target database: ${redact(databaseUrl)}`);
+console.log(
+  `Mode: ${confirm ? "DELETE (irreversible)" : "dry run (no changes)"}`
+);
+console.log("");
+
+async function countRows(table: string): Promise<number> {
+  const result = await db.execute<{ count: number }>(
+    sql.raw(`SELECT count(*)::int AS count FROM "${table}"`)
+  );
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+try {
+  console.log("Row counts:");
+  for (const table of tablesToClear) {
+    console.log(`  ${table}: ${await countRows(table)}`);
+  }
+
+  console.log("");
+  console.log("Preserved (not touched):");
+  for (const table of ["instruments", "watchers"]) {
+    console.log(`  ${table}: ${await countRows(table)}`);
+  }
+  console.log("");
+
+  if (confirm) {
+    await db.transaction(async (tx) => {
+      for (const table of tablesToClear) {
+        const result = await tx.execute(sql.raw(`DELETE FROM "${table}"`));
+        console.log(`Deleted ${result.rowCount ?? 0} rows from ${table}.`);
+      }
+    });
+
+    console.log("");
+    console.log("Done. Instruments and watchers were preserved.");
+    console.log("Reminder: S3 objects were NOT deleted — do that separately.");
+  } else {
+    console.log("Dry run only. Re-run with --confirm to delete the above.");
+  }
+} finally {
+  await pool.end();
+}


### PR DESCRIPTION
## Summary

- Adds `web/scripts/clear-run-file-records.ts` (`npm run db:clear-runs`) to wipe run and file records from a remote database ahead of production cutover, while **preserving `instruments` and `watchers`** so lab instrument PCs stay registered and can be re-pointed between environments.
- Hard-deletes, child-first in a single transaction: `notifications` → `run_comments` → `run_attributions` → `archive_jobs` → `files` → `instrument_runs` (`files` must precede `instrument_runs` because its FK is `onDelete: no action`).
- Guardrails suited to a remote target: **dry-run by default** (prints counts of cleared + preserved tables), requires `--confirm` to delete, echoes the redacted host, opts into TLS for remote hosts, and refuses to run against the local dev DB. Optional `--clear-watcher-activity` also drops `watcher_heartbeats` / `watcher_events` (kept by default).
- Does **not** touch S3 — object deletion is a separate, manual step.
- Documents every runnable script and internal helper in `web/scripts/README.md` (previously only `reset-database.ts` was covered).
- Adds a full-width **preview deployment banner** on Vercel preview builds (`VERCEL_ENV === "preview"`), shown on authenticated pages and login/auth screens. Displays the source branch (`VERCEL_GIT_COMMIT_REF`) and links to production via `VERCEL_PROJECT_PRODUCTION_URL`. Layout offsets (`--banner-height`) push the fixed sidebar and main content below the banner so nothing is covered.

## Test plan

- [x] `make check-all` passes (format, lint, typecheck, tests, build).
- [x] Dry run against staging prints expected counts and the redacted host, makes no changes.
- [x] `--confirm` run deletes run/file rows and leaves `instruments` / `watchers` intact.
- [x] Script exits early when pointed at the local dev database.
- [x] On a Vercel preview deployment, the orange banner spans the full page width (including over the sidebar).
- [x] Banner shows branch name and "Go to production" link; link opens the production URL.
- [x] Sidebar and main content start below the banner (no overlap).
- [x] Banner also appears on `/login` and other unauthenticated auth screens.
- [x] Banner does not appear on production or local `next dev`.