### PR TITLE
Add workflow to apply DB migrations on merges to staging/production

### DIFF
--- a/.github/workflows/apply-migrations.yml
+++ b/.github/workflows/apply-migrations.yml
@@ -1,0 +1,39 @@
+name: Apply database migrations
+
+on:
+  push:
+    branches:
+      - staging
+      - production
+    paths:
+      - .github/workflows/apply-migrations.yml
+      - web/drizzle/**
+
+# Serialize migration runs per environment so two merges can't apply
+# migrations against the same Render database concurrently.
+concurrency:
+  group: apply-migrations-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  apply-migrations:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name }}
+
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install packages
+        run: npm ci
+        working-directory: web
+
+      - name: Apply Drizzle migrations
+        run: npm run db:migrate
+        working-directory: web

--- a/developer-docs/ops/ci-and-deployment.md
+++ b/developer-docs/ops/ci-and-deployment.md
@@ -2,7 +2,7 @@
 
 ## GitHub Actions
 
-Four workflows run on pushes to `staging`/`production` and on pull requests targeting those branches. A fifth (`publish-watcher.yml`) runs only on `watcher-v*` tag pushes and manual dispatch.
+Four workflows run on pushes to `staging`/`production` and on pull requests targeting those branches. A fifth (`apply-migrations.yml`) runs on merges to `staging`/`production` that touch migration files, and a sixth (`publish-watcher.yml`) runs only on `watcher-v*` tag pushes and manual dispatch.
 
 ### Python lint and typecheck (`python-lint.yml`)
 
@@ -27,6 +27,12 @@ Four workflows run on pushes to `staging`/`production` and on pull requests targ
 - Starts a Postgres 17 service container and Node.js 24.
 - `make fe-test-mcp` — runs in-memory MCP protocol tests (mocked data layer, no database).
 - `make fe-test-integration` — runs Vitest integration tests that test the API routes and MCP server over HTTP against a real database.
+
+### Apply database migrations (`apply-migrations.yml`)
+
+Triggered on pushes to `staging`/`production` (i.e. PR merges) that change files under `web/drizzle/`. The single job sets `environment: ${{ github.ref_name }}` so GitHub selects that environment's secrets and protection rules, then runs `npm run db:migrate` (Drizzle) against the environment's Render database using the environment's `DATABASE_URL` secret. A per-branch `concurrency` group prevents overlapping migration runs.
+
+Production is gated by a required-reviewer protection rule on the `production` GitHub environment, so production migrations pause for manual approval before applying. Each environment needs a `DATABASE_URL` secret pointing at its Render connection string, and the Render database must accept connections from GitHub-hosted runners.
 
 ### Publish watcher (`publish-watcher.yml`)
 
@@ -64,7 +70,7 @@ vercel env pull
 
 Staging and production each have a dedicated PostgreSQL instance hosted on [Render](https://dashboard.render.com/project/prj-d75d0jma2pns738r4110).
 
-Schema changes are applied with Drizzle:
+Merges to `staging`/`production` that change files under `web/drizzle/` automatically apply migrations via the [`apply-migrations.yml`](#apply-database-migrations-apply-migrationsyml) workflow (production is gated on manual approval). The commands below are for local runs or manual application:
 
 ```sh
 cd web


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/apply-migrations.yml`, which runs `npm run db:migrate` (Drizzle) against the environment's Render database when a PR merges into `staging` or `production` and touches `web/drizzle/`.
- Uses `environment: ${{ github.ref_name }}` so GitHub selects the matching per-environment `DATABASE_URL` secret and protection rules. A per-branch `concurrency` group prevents overlapping migration runs.
- Production is gated on a required-reviewer environment protection rule, so production migrations pause for manual approval.
- Documents the workflow in `developer-docs/ops/ci-and-deployment.md`.

## Operator prerequisites (repo settings, not code)

- Add a `DATABASE_URL` secret to both the `staging` and `production` GitHub Environments (each pointing at that environment's Render connection string).
- Add a required-reviewer protection rule to the `production` environment to enforce the manual approval gate.
- Confirm the Render databases accept connections from GitHub-hosted runners (add runner IPs if an allowlist is enabled).

## Test plan

- [ ] Merge a PR touching `web/drizzle/` into `staging` and confirm the workflow runs and applies migrations.
- [ ] Confirm a production run pauses for approval before applying.

Made with [Cursor](https://cursor.com)