### PR TITLE
Restrict S3 bucket writes to approved principals

### DIFF
--- a/.github/workflows/infra-validate.yml
+++ b/.github/workflows/infra-validate.yml
@@ -1,0 +1,35 @@
+name: Infra template validation
+
+on:
+  push:
+    branches:
+      - staging
+      - production
+    paths:
+      - .github/workflows/infra-validate.yml
+      - infra/**
+      - Makefile
+  pull_request:
+    branches:
+      - staging
+      - production
+    paths:
+      - .github/workflows/infra-validate.yml
+      - infra/**
+      - Makefile
+
+jobs:
+  infra-validate:
+    runs-on: ubuntu-latest
+    # `sam validate --lint` runs cfn-lint offline (no AWS credentials needed),
+    # but the SAM CLI still wants a region to be resolvable.
+    env:
+      AWS_DEFAULT_REGION: us-west-1
+    steps:
+      - uses: actions/checkout@v6
+      - uses: aws-actions/setup-sam@v3
+        with:
+          use-installer: true
+
+      - name: Validate CloudFormation templates
+        run: make sam-validate

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,14 @@ endif
 	@echo "Pushed $(ECR_REGISTRY)/data-hub:$(IMAGE_TAG)"
 
 # SAM infrastructure.
+# Lint both CloudFormation templates with cfn-lint (via `sam validate --lint`).
+# Offline and credential-free, so it's safe to run anywhere; kept out of
+# `check-all` because it needs the SAM CLI, which only deployers install.
+.PHONY: sam-validate
+sam-validate:
+	cd infra && sam validate --lint --region us-west-1 --template template.yaml
+	cd infra && sam validate --lint --region us-west-1 --template bootstrap.yaml
+
 .PHONY: sam-bootstrap
 sam-bootstrap:
 	aws cloudformation deploy \

--- a/developer-docs/ops/ci-and-deployment.md
+++ b/developer-docs/ops/ci-and-deployment.md
@@ -195,6 +195,8 @@ On pushes to `staging` or `production`, the **Deploy Lambda** workflow:
 Secrets (`DATA_HUB_API_KEY`, etc.) are stored in GitHub environment secrets scoped to each environment.
 
 > **Note:** The CI deploy role has intentionally narrow permissions — enough to push a new container image, update the existing CloudFormation stack, and modify the data buckets' S3 event notifications (so new instrument triggers roll out via CI), but _not_ enough to create the stack from scratch or to add/remove S3 buckets or Lambda functions. Initial stack creation and structural infrastructure changes must be performed by an admin with broader AWS permissions. Once the stack exists, routine image-update deploys and new-trigger rollouts through CI work without issue.
+>
+> The bucket policies that deny object writes from unapproved principals (`RawDataBucketPolicy`, `ProcessedDataBucketPolicy`, `ArchivesBucketPolicy`) are managed the same way: adding or changing them requires `s3:PutBucketPolicy`, which the CI role does **not** hold (by design — a routine CI role that could rewrite these policies could also disable the write protection). Apply changes to the deny lists via an admin `make sam-deploy`, not CI.
 
 #### Local deployment
 

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -228,6 +228,84 @@ Resources:
         - Key: project
           Value: arcadia-data-hub
 
+  # ---- S3 bucket policies: deny object writes from unapproved principals ----
+  # The account grants all users full S3 access, so the identity policies above
+  # can't actually stop writes — only an explicit Deny (which beats every Allow)
+  # can. Each bucket exempts just its legitimate writer, plus root as break-glass.
+  # `s3:PutBucketPolicy` is intentionally not denied, to avoid self-lockout.
+
+  RawDataBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref RawDataBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: DenyObjectWritesExceptWebApp
+            Effect: Deny
+            Principal: "*"
+            Action:
+              - s3:PutObject
+              - s3:PutObjectAcl
+              - s3:DeleteObject
+              - s3:DeleteObjectVersion
+              - s3:RestoreObject
+              - s3:AbortMultipartUpload
+            Resource: !Sub "arn:aws:s3:::arcadia-data-hub-raw-${Environment}/*"
+            Condition:
+              ArnNotLike:
+                aws:PrincipalArn:
+                  - !GetAtt WebAppS3Role.Arn
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:root"
+
+  ProcessedDataBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ProcessedDataBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: DenyObjectWritesExceptLambda
+            Effect: Deny
+            Principal: "*"
+            Action:
+              - s3:PutObject
+              - s3:PutObjectAcl
+              - s3:DeleteObject
+              - s3:DeleteObjectVersion
+              - s3:RestoreObject
+              - s3:AbortMultipartUpload
+            Resource: !Sub "arn:aws:s3:::arcadia-data-hub-processed-${Environment}/*"
+            Condition:
+              ArnNotLike:
+                aws:PrincipalArn:
+                  - !GetAtt LambdaExecutionRole.Arn
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:root"
+
+  ArchivesBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ArchivesBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: DenyObjectWritesExceptLambda
+            Effect: Deny
+            Principal: "*"
+            Action:
+              - s3:PutObject
+              - s3:PutObjectAcl
+              - s3:DeleteObject
+              - s3:DeleteObjectVersion
+              - s3:RestoreObject
+              - s3:AbortMultipartUpload
+            Resource: !Sub "arn:aws:s3:::arcadia-data-hub-archives-${Environment}/*"
+            Condition:
+              ArnNotLike:
+                aws:PrincipalArn:
+                  - !GetAtt LambdaExecutionRole.Arn
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:root"
+
   # ---- Lambda function ----
 
   DataHubFunction:

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -61,6 +61,14 @@ Resources:
       BucketName: !Sub "arcadia-data-hub-raw-${Environment}"
       VersioningConfiguration:
         Status: Enabled
+      # Pin Block Public Access on so it's guaranteed by IaC rather than the
+      # S3 account default. All access is via presigned URLs; nothing here is
+      # ever public.
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       # Allow the web app to fetch raw files from the browser via the
       # `/api/v1/files/:id/download` 302-redirect to a presigned S3 URL.
       # Image/PDF previews bypass CORS via `<img>`/`<iframe>`, but client-side
@@ -178,6 +186,12 @@ Resources:
       BucketName: !Sub "arcadia-data-hub-processed-${Environment}"
       VersioningConfiguration:
         Status: Enabled
+      # See RawDataBucket — pinned on rather than relying on the S3 default.
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       # See RawDataBucket for the CORS rationale — both buckets back the same
       # `/api/v1/files/:id/download` endpoint so they need parity.
       CorsConfiguration:


### PR DESCRIPTION
## Summary

Arcadia's AWS account grants all IAM users full `s3:*`, so the scoped Lambda/web-app identity policies can't actually prevent an in-account user from writing to the data buckets. This PR adds a resource-policy backstop and pins public-access protections, plus CI/tooling to lint the templates.

- **Explicit-Deny bucket policies** on the raw, processed, and archives buckets (`RawDataBucketPolicy`, `ProcessedDataBucketPolicy`, `ArchivesBucketPolicy`). Each denies object-mutating actions for `Principal: "*"` and exempts only that bucket's legitimate writer role (via `aws:PrincipalArn` + `ArnNotLike`) plus the account root as break-glass. An explicit Deny overrides every Allow, so this neutralizes the account-wide grant for these buckets. `s3:PutBucketPolicy` is intentionally left un-denied to avoid self-lockout.
- **Pin Block Public Access** on the raw and processed buckets (archives already had it) so the protection is guaranteed by IaC rather than the S3 account default. The live buckets already have these settings, so this only makes CloudFormation own the config.
- **`make sam-validate`** target that lints both templates offline via `sam validate --lint` (no AWS creds). Kept out of `check-all` since it needs the SAM CLI, which only deployers install.
- **`infra-validate.yml`** workflow that runs `make sam-validate` on PRs/pushes touching `infra/**`, so template changes are caught before an admin deploy.

## Deploy notes

- These are structural changes: the CI deploy role intentionally lacks `s3:PutBucketPolicy` / `s3:PutBucketPublicAccessBlock`, so apply via an admin `make sam-deploy ENV=...`, not CI. Documented in `developer-docs/ops/ci-and-deployment.md`.
- Deploy and verify on **staging first**, especially the raw-bucket upload path (watcher upload via the web app's presigned URL) — that's the one flow where a mistake in the raw exemption would surface as a failed upload. Then promote to production.

## Test plan

- [x] `make sam-validate` passes for both templates.
- [x] Verified live buckets already have full Block Public Access enabled (no public write exposure today).
- [x] Admin `sam deploy` to staging; confirm watcher upload, Lambda processing (processed bucket), and archive build (archives bucket) all still succeed.
- [x] Confirm a non-exempt IAM user is denied `PutObject` on each bucket.
- [x] Promote to production.

Made with [Cursor](https://cursor.com)