### PR TITLE
Add global search over runs, files, and instruments

### DIFF
--- a/web/app/api/v1/search/route.ts
+++ b/web/app/api/v1/search/route.ts
@@ -1,0 +1,42 @@
+import type { NextRequest } from "next/server";
+import { authorize } from "@/lib/api/auth";
+import { globalSearch, type SearchScope } from "@/lib/api/search";
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/search?q=…&scope=all|runs|files|instruments
+//
+// Cross-entity global search powering the ⌘K palette. Returns grouped,
+// relevance-ordered matches over runs, files, and instruments. There is no
+// row-level scoping in Data Hub, so any caller with `runs:read` sees the same
+// set the rest of the app exposes.
+// ---------------------------------------------------------------------------
+
+const VALID_SCOPES: ReadonlySet<SearchScope> = new Set([
+  "all",
+  "runs",
+  "files",
+  "instruments",
+]);
+
+function parseScope(raw: string | null): SearchScope {
+  return raw && VALID_SCOPES.has(raw as SearchScope)
+    ? (raw as SearchScope)
+    : "all";
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await authorize(request, "runs:read");
+  if (authResult instanceof Response) {
+    return authResult;
+  }
+
+  const { searchParams } = request.nextUrl;
+  const query = searchParams.get("q") ?? "";
+  const scope = parseScope(searchParams.get("scope"));
+
+  // The builder itself returns an empty result below the minimum length, so
+  // the guard here just avoids the DB round-trip for 0–1 char queries.
+  const result = await globalSearch({ query, scope });
+
+  return Response.json(result);
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -146,9 +146,11 @@ export default async function RootLayout({
                           }}
                         />
                         <SidebarInset className="pb-12">
-                          <header className="flex h-12 shrink-0 items-center justify-between gap-2 px-4">
-                            <SidebarTrigger />
-                            <div className="flex items-center gap-2">
+                          <header className="flex h-14 shrink-0 items-center justify-between gap-2 px-4">
+                            <div className="flex h-8 items-center">
+                              <SidebarTrigger />
+                            </div>
+                            <div className="flex h-8 items-center gap-2">
                               <SearchTrigger />
                               <NotificationBell />
                             </div>

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -10,6 +10,7 @@ import { NotificationBell } from "@/components/notifications/notification-bell";
 import { NotificationsProvider } from "@/components/notifications/notifications-provider";
 import { PreviewDeploymentBanner } from "@/components/preview-deployment-banner";
 import { ArchiveDownloadProvider } from "@/components/runs/archive-download-provider";
+import { SearchTrigger } from "@/components/search/search-trigger";
 import { ThemeProvider } from "@/components/theme-provider";
 import {
   SIDEBAR_COOKIE_NAME,
@@ -147,7 +148,10 @@ export default async function RootLayout({
                         <SidebarInset className="pb-12">
                           <header className="flex h-12 shrink-0 items-center justify-between gap-2 px-4">
                             <SidebarTrigger />
-                            <NotificationBell />
+                            <div className="flex items-center gap-2">
+                              <SearchTrigger />
+                              <NotificationBell />
+                            </div>
                           </header>
                           {children}
                         </SidebarInset>

--- a/web/components/search/global-search.tsx
+++ b/web/components/search/global-search.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { Command as CommandPrimitive } from "cmdk";
+import { Clock, SearchIcon, SearchX } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import {
+  SearchFileRow,
+  SearchInstrumentRow,
+  SearchRunRow,
+} from "@/components/search/search-result-item";
+import { useRecentSearches } from "@/components/search/use-recent-searches";
+import {
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type {
+  GlobalSearchResult,
+  SearchFileResult,
+  SearchInstrumentResult,
+  SearchRunResult,
+  SearchScope,
+} from "@/lib/api/search";
+import { MIN_QUERY_LENGTH } from "@/lib/search-constants";
+import { cn } from "@/lib/utils";
+
+const DEBOUNCE_MS = 200;
+
+const SCOPE_TABS: { id: SearchScope; label: string }[] = [
+  { id: "all", label: "All" },
+  { id: "runs", label: "Runs" },
+  { id: "files", label: "Files" },
+  { id: "instruments", label: "Instruments" },
+];
+
+const EMPTY_RESULT: GlobalSearchResult = {
+  runs: [],
+  files: [],
+  instruments: [],
+  counts: { runs: 0, files: 0, instruments: 0, total: 0 },
+};
+
+function runHref(run: SearchRunResult): string {
+  return `/instruments/${run.instrumentId}/runs/${encodeURIComponent(run.runId)}`;
+}
+
+// Files have no standalone page, so deep-link to the parent run and pre-fill
+// the run-detail files search (which already filters + highlights that table).
+function fileHref(file: SearchFileResult): string {
+  return `/instruments/${file.instrumentId}/runs/${encodeURIComponent(
+    file.runId
+  )}?files_search=${encodeURIComponent(file.filename)}`;
+}
+
+function instrumentHref(instrument: SearchInstrumentResult): string {
+  return `/instruments/${instrument.id}`;
+}
+
+function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+      {children}
+    </kbd>
+  );
+}
+
+export function GlobalSearch({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const router = useRouter();
+  const { recent, add: addRecent } = useRecentSearches();
+  const [query, setQuery] = useState("");
+  const [scope, setScope] = useState<SearchScope>("all");
+  const [result, setResult] = useState<GlobalSearchResult>(EMPTY_RESULT);
+  const [loading, setLoading] = useState(false);
+
+  const trimmed = query.trim();
+  const isSearchable = trimmed.length >= MIN_QUERY_LENGTH;
+
+  // Reset transient state whenever the modal closes so the next open starts
+  // clean (empty query, "All" tab, recent-searches view).
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setScope("all");
+      setResult(EMPTY_RESULT);
+      setLoading(false);
+    }
+  }, [open]);
+
+  // Debounced, race-safe fetch. An AbortController cancels the in-flight
+  // request when the query/scope changes so stale responses can't overwrite
+  // fresher ones.
+  useEffect(() => {
+    if (!(open && isSearchable)) {
+      setResult(EMPTY_RESULT);
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+    const timer = setTimeout(async () => {
+      try {
+        const params = new URLSearchParams({ q: trimmed, scope });
+        const res = await fetch(`/api/v1/search?${params}`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`Search failed: ${res.status}`);
+        }
+        const data = (await res.json()) as GlobalSearchResult;
+        setResult(data);
+      } catch (err) {
+        if (!(err instanceof DOMException && err.name === "AbortError")) {
+          setResult(EMPTY_RESULT);
+        }
+      } finally {
+        // Only the latest (non-aborted) request clears the spinner.
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      controller.abort();
+      clearTimeout(timer);
+    };
+  }, [open, trimmed, isSearchable, scope]);
+
+  const navigate = useCallback(
+    (href: string) => {
+      addRecent(trimmed);
+      onOpenChange(false);
+      router.push(href);
+    },
+    [addRecent, trimmed, onOpenChange, router]
+  );
+
+  const showRecent = !isSearchable;
+  const hasResults = result.counts.total > 0;
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent
+        className="top-[12%] w-full max-w-[720px] translate-y-0 gap-0 overflow-hidden p-0"
+        showCloseButton={false}
+      >
+        <DialogTitle className="sr-only">Search Data Hub</DialogTitle>
+        <DialogDescription className="sr-only">
+          Search across runs, files, and instruments.
+        </DialogDescription>
+
+        <CommandPrimitive
+          className="flex w-full flex-col"
+          label="Search runs, files, or instruments"
+          loop
+          shouldFilter={false}
+        >
+          <div className="flex items-center gap-2 border-b px-4">
+            <SearchIcon className="size-5 shrink-0 text-muted-foreground" />
+            {/* Radix Dialog moves focus to the first focusable element (this
+                input) on open, so no explicit autoFocus is needed. */}
+            <CommandPrimitive.Input
+              className="flex h-12 w-full bg-transparent text-base outline-none placeholder:text-muted-foreground"
+              onValueChange={setQuery}
+              placeholder="Search runs, files, or instruments"
+              value={query}
+            />
+            <Kbd>esc</Kbd>
+          </div>
+
+          <div className="flex items-center gap-1 border-b px-2 py-2">
+            {SCOPE_TABS.map((tab) => (
+              <button
+                className={cn(
+                  "rounded-md px-3 py-1 font-medium text-sm transition-colors",
+                  scope === tab.id
+                    ? "bg-primary/10 text-primary"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                )}
+                key={tab.id}
+                onClick={() => setScope(tab.id)}
+                type="button"
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          {isSearchable ? (
+            <div
+              aria-live="polite"
+              className="px-4 pt-3 pb-1 text-muted-foreground text-xs"
+            >
+              {loading
+                ? "Searching…"
+                : `${result.counts.total} ${
+                    result.counts.total === 1 ? "result" : "results"
+                  } for "${trimmed}"`}
+            </div>
+          ) : null}
+
+          <CommandList className="max-h-[420px] px-2 pb-2">
+            {showRecent ? (
+              <RecentSearches
+                onSelect={(value) => setQuery(value)}
+                recent={recent}
+              />
+            ) : null}
+
+            {isSearchable && !loading && !hasResults ? (
+              <NoResults query={trimmed} />
+            ) : null}
+
+            {isSearchable && hasResults ? (
+              <>
+                {result.runs.length > 0 ? (
+                  <CommandGroup heading="Runs">
+                    {result.runs.map((run) => (
+                      <CommandItem
+                        key={run.id}
+                        onSelect={() => navigate(runHref(run))}
+                        value={`run:${run.id}`}
+                      >
+                        <SearchRunRow query={trimmed} result={run} />
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                ) : null}
+
+                {result.files.length > 0 ? (
+                  <CommandGroup heading="Files">
+                    {result.files.map((file) => (
+                      <CommandItem
+                        key={file.id}
+                        onSelect={() => navigate(fileHref(file))}
+                        value={`file:${file.id}`}
+                      >
+                        <SearchFileRow query={trimmed} result={file} />
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                ) : null}
+
+                {result.instruments.length > 0 ? (
+                  <CommandGroup heading="Instruments">
+                    {result.instruments.map((instrument) => (
+                      <CommandItem
+                        key={instrument.id}
+                        onSelect={() => navigate(instrumentHref(instrument))}
+                        value={`instrument:${instrument.id}`}
+                      >
+                        <SearchInstrumentRow
+                          query={trimmed}
+                          result={instrument}
+                        />
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                ) : null}
+              </>
+            ) : null}
+          </CommandList>
+
+          <div className="flex items-center justify-between border-t px-4 py-2.5 text-muted-foreground text-xs">
+            <div className="flex items-center gap-3">
+              <span className="flex items-center gap-1">
+                <Kbd>↑↓</Kbd> navigate
+              </span>
+              <span className="flex items-center gap-1">
+                <Kbd>↵</Kbd> open
+              </span>
+            </div>
+            <span className="flex items-center gap-1">
+              <Kbd>⌘K</Kbd> to open from anywhere
+            </span>
+          </div>
+        </CommandPrimitive>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RecentSearches({
+  recent,
+  onSelect,
+}: {
+  recent: string[];
+  onSelect: (value: string) => void;
+}) {
+  if (recent.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 py-12 text-center">
+        <SearchIcon className="size-7 text-muted-foreground" />
+        <p className="text-muted-foreground text-sm">
+          Search runs, files, or instruments
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <CommandGroup heading="Recent searches">
+      {recent.map((value) => (
+        <CommandItem
+          key={value}
+          onSelect={() => onSelect(value)}
+          // Prefix keeps recent-search values from colliding with result ids.
+          value={`recent:${value}`}
+        >
+          <Clock className="size-4 shrink-0 text-muted-foreground" />
+          <span className="truncate">{value}</span>
+        </CommandItem>
+      ))}
+    </CommandGroup>
+  );
+}
+
+function NoResults({ query }: { query: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 py-12 text-center">
+      <SearchX className="size-7 text-muted-foreground" />
+      <p className="text-muted-foreground text-sm">No results for "{query}"</p>
+    </div>
+  );
+}

--- a/web/components/search/global-search.tsx
+++ b/web/components/search/global-search.tsx
@@ -155,7 +155,7 @@ export function GlobalSearch({
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent
-        className="top-[12%] w-full max-w-[720px] translate-y-0 gap-0 overflow-hidden p-0"
+        className="top-[12%] w-full translate-y-0 gap-0 overflow-hidden p-0 sm:max-w-[600px]"
         showCloseButton={false}
       >
         <DialogTitle className="sr-only">Search Data Hub</DialogTitle>

--- a/web/components/search/highlight.tsx
+++ b/web/components/search/highlight.tsx
@@ -1,0 +1,60 @@
+import { Fragment } from "react";
+
+// Escapes regex metacharacters so the query is matched literally — a filename
+// query like `.*jpg` must highlight those characters, not act as a wildcard.
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Renders `text` with every case-insensitive occurrence of `query` wrapped in
+ * an accent-colored highlight. This is the primary signal for *why* a result
+ * matched, so it's applied to every field where the query can appear (title,
+ * secondary line, and match-reason line).
+ */
+export function Highlight({
+  text,
+  query,
+  className,
+}: {
+  text: string;
+  query: string;
+  className?: string;
+}) {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return <>{text}</>;
+  }
+
+  const lowerQuery = trimmed.toLowerCase();
+  const markClassName =
+    className ??
+    "rounded-[3px] bg-primary/15 px-0.5 text-primary dark:bg-primary/25";
+
+  // Split into segments and drop the empty strings the regex emits between
+  // adjacent matches. A cumulative character offset gives every segment a
+  // stable, unique key without relying on the array index.
+  let offset = 0;
+  const segments = text
+    .split(new RegExp(`(${escapeRegExp(trimmed)})`, "gi"))
+    .map((value) => {
+      const start = offset;
+      offset += value.length;
+      return { value, start };
+    })
+    .filter((segment) => segment.value !== "");
+
+  return (
+    <>
+      {segments.map((segment) =>
+        segment.value.toLowerCase() === lowerQuery ? (
+          <mark className={markClassName} key={segment.start}>
+            {segment.value}
+          </mark>
+        ) : (
+          <Fragment key={segment.start}>{segment.value}</Fragment>
+        )
+      )}
+    </>
+  );
+}

--- a/web/components/search/search-result-item.tsx
+++ b/web/components/search/search-result-item.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import {
+  Activity,
+  Cpu,
+  File as FileIcon,
+  FileSpreadsheet,
+  FileText,
+  Image as ImageIcon,
+  type LucideIcon,
+} from "lucide-react";
+import { Highlight } from "@/components/search/highlight";
+import { WatcherStatusBadge } from "@/components/watchers/watcher-status-badge";
+import type {
+  SearchFileResult,
+  SearchInstrumentResult,
+  SearchRunResult,
+} from "@/lib/api/search";
+import { cn, formatBytes, formatRelativeTime } from "@/lib/utils";
+
+const IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "tif",
+  "tiff",
+  "bmp",
+  "nd2",
+]);
+const SPREADSHEET_EXTENSIONS = new Set(["csv", "tsv", "xls", "xlsx"]);
+const TEXT_EXTENSIONS = new Set([
+  "txt",
+  "md",
+  "json",
+  "xml",
+  "log",
+  "yaml",
+  "yml",
+]);
+
+// Maps a filename to a type-appropriate glyph, falling back to a generic file
+// icon for unmapped extensions.
+function iconForFilename(filename: string): LucideIcon {
+  const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+  if (IMAGE_EXTENSIONS.has(ext)) {
+    return ImageIcon;
+  }
+  if (SPREADSHEET_EXTENSIONS.has(ext)) {
+    return FileSpreadsheet;
+  }
+  if (TEXT_EXTENSIONS.has(ext)) {
+    return FileText;
+  }
+  return FileIcon;
+}
+
+// Shared row scaffold: leading icon, a flexible text column, and a right stat.
+function ResultRowShell({
+  icon: Icon,
+  children,
+  stat,
+}: {
+  icon: LucideIcon;
+  children: React.ReactNode;
+  stat: React.ReactNode;
+}) {
+  return (
+    <>
+      <Icon className="size-4 shrink-0 text-muted-foreground" />
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">{children}</div>
+      <div className="ml-auto shrink-0 whitespace-nowrap pl-2 text-muted-foreground text-xs">
+        {stat}
+      </div>
+    </>
+  );
+}
+
+function pluralRuns(count: number): string {
+  return `${count} total ${count === 1 ? "run" : "runs"}`;
+}
+
+export function SearchRunRow({
+  result,
+  query,
+}: {
+  result: SearchRunResult;
+  query: string;
+}) {
+  const when = result.acquiredAt ?? result.createdAt;
+  return (
+    <ResultRowShell
+      icon={Activity}
+      stat={`${result.fileCount} ${result.fileCount === 1 ? "file" : "files"} · ${formatBytes(result.totalSizeBytes)}`}
+    >
+      <span className="truncate font-medium font-mono text-sm">
+        <Highlight query={query} text={result.runId} />
+      </span>
+      <span className="truncate text-muted-foreground text-xs">
+        <Highlight query={query} text={result.instrumentName} /> ·{" "}
+        {formatRelativeTime(when)}
+      </span>
+      {result.matchReason === "file" && result.matchedFilename ? (
+        <span className="truncate text-muted-foreground text-xs">
+          Contains{" "}
+          <span className="font-mono">
+            <Highlight query={query} text={result.matchedFilename} />
+          </span>
+        </span>
+      ) : null}
+    </ResultRowShell>
+  );
+}
+
+export function SearchFileRow({
+  result,
+  query,
+}: {
+  result: SearchFileResult;
+  query: string;
+}) {
+  return (
+    <ResultRowShell
+      icon={iconForFilename(result.filename)}
+      stat={formatBytes(result.sizeBytes)}
+    >
+      <span className="truncate font-medium font-mono text-sm">
+        <Highlight query={query} text={result.filename} />
+      </span>
+      <span className="flex min-w-0 items-center gap-1 truncate text-muted-foreground text-xs">
+        <span className="truncate">{result.instrumentName}</span>
+        <span aria-hidden="true">›</span>
+        <span className="truncate font-mono">{result.runId}</span>
+      </span>
+    </ResultRowShell>
+  );
+}
+
+export function SearchInstrumentRow({
+  result,
+  query,
+}: {
+  result: SearchInstrumentResult;
+  query: string;
+}) {
+  return (
+    <ResultRowShell
+      icon={Cpu}
+      stat={
+        <WatcherStatusBadge
+          lastOnlineAt={
+            result.lastWatcherHeartbeatAt
+              ? new Date(result.lastWatcherHeartbeatAt)
+              : null
+          }
+          status={result.watcherStatus}
+        />
+      }
+    >
+      <span className={cn("truncate font-medium text-sm")}>
+        <Highlight query={query} text={result.displayName} />
+      </span>
+      <span className="truncate text-muted-foreground text-xs">
+        {result.matchReason === "pattern" && result.matchedPattern ? (
+          <>
+            Matches pattern{" "}
+            <span className="font-mono">
+              <Highlight query={query} text={result.matchedPattern} />
+            </span>{" "}
+            · {pluralRuns(result.runCount)}
+          </>
+        ) : (
+          pluralRuns(result.runCount)
+        )}
+      </span>
+    </ResultRowShell>
+  );
+}

--- a/web/components/search/search-trigger.tsx
+++ b/web/components/search/search-trigger.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { SearchIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { GlobalSearch } from "@/components/search/global-search";
+
+// Returns true when the keydown originated from an editable field, so a
+// global ⌘K/Ctrl+K doesn't hijack a shortcut a text field might own.
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tag = target.tagName;
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    target.isContentEditable
+  );
+}
+
+export function SearchTrigger() {
+  const [open, setOpen] = useState(false);
+  // Platform detection runs post-mount so the SSR'd markup (no hint) matches
+  // the first client render, avoiding a hydration mismatch.
+  const [shortcutHint, setShortcutHint] = useState("");
+
+  useEffect(() => {
+    const isMac = /mac|iphone|ipad|ipod/i.test(navigator.userAgent);
+    setShortcutHint(isMac ? "⌘K" : "Ctrl K");
+  }, []);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (
+        event.key.toLowerCase() !== "k" ||
+        !(event.metaKey || event.ctrlKey)
+      ) {
+        return;
+      }
+      // When the palette is already open its own input handles keys; don't
+      // treat that as an editable-field bail-out.
+      if (!open && isEditableTarget(event.target)) {
+        return;
+      }
+      event.preventDefault();
+      setOpen((prev) => !prev);
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  return (
+    <>
+      <button
+        aria-label="Search runs, files, or instruments"
+        className="flex h-8 items-center gap-2 rounded-md border bg-background px-2.5 text-muted-foreground text-sm transition-colors hover:bg-muted hover:text-foreground sm:w-64 dark:bg-muted/40"
+        onClick={() => setOpen(true)}
+        type="button"
+      >
+        <SearchIcon className="size-4 shrink-0" />
+        <span className="hidden truncate sm:inline">Search…</span>
+        {shortcutHint ? (
+          <kbd className="ml-auto hidden rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px] sm:inline">
+            {shortcutHint}
+          </kbd>
+        ) : null}
+      </button>
+      <GlobalSearch onOpenChange={setOpen} open={open} />
+    </>
+  );
+}

--- a/web/components/search/search-trigger.tsx
+++ b/web/components/search/search-trigger.tsx
@@ -3,6 +3,7 @@
 import { SearchIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { GlobalSearch } from "@/components/search/global-search";
+import { Button } from "@/components/ui/button";
 
 // Returns true when the keydown originated from an editable field, so a
 // global ⌘K/Ctrl+K doesn't hijack a shortcut a text field might own.
@@ -53,20 +54,22 @@ export function SearchTrigger() {
 
   return (
     <>
-      <button
+      <Button
         aria-label="Search runs, files, or instruments"
-        className="flex h-8 items-center gap-2 rounded-md border bg-background px-2.5 text-muted-foreground text-sm transition-colors hover:bg-muted hover:text-foreground sm:w-64 dark:bg-muted/40"
+        className="justify-start gap-2 font-normal text-muted-foreground sm:w-64 dark:bg-muted/40"
         onClick={() => setOpen(true)}
+        size="sm"
         type="button"
+        variant="outline"
       >
-        <SearchIcon className="size-4 shrink-0" />
+        <SearchIcon />
         <span className="hidden truncate sm:inline">Search…</span>
         {shortcutHint ? (
           <kbd className="ml-auto hidden rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px] sm:inline">
             {shortcutHint}
           </kbd>
         ) : null}
-      </button>
+      </Button>
       <GlobalSearch onOpenChange={setOpen} open={open} />
     </>
   );

--- a/web/components/search/search-trigger.tsx
+++ b/web/components/search/search-trigger.tsx
@@ -1,9 +1,24 @@
 "use client";
 
 import { SearchIcon } from "lucide-react";
+import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
-import { GlobalSearch } from "@/components/search/global-search";
 import { Button } from "@/components/ui/button";
+
+// `GlobalSearch` pulls in cmdk plus the result-row/highlight components, none
+// of which are needed until the palette is actually opened. This trigger is
+// mounted on every authenticated page (root layout header), so keeping it out
+// of the initial bundle matters more than it would for a one-off dialog.
+const GlobalSearch = dynamic(
+  () => import("@/components/search/global-search").then((m) => m.GlobalSearch),
+  { ssr: false }
+);
+
+// Warms the module cache so opening the palette (click or ⌘K) feels instant
+// once the user has shown intent by hovering/focusing the trigger.
+function preloadGlobalSearch() {
+  import("@/components/search/global-search");
+}
 
 // Returns true when the keydown originated from an editable field, so a
 // global ⌘K/Ctrl+K doesn't hijack a shortcut a text field might own.
@@ -58,6 +73,8 @@ export function SearchTrigger() {
         aria-label="Search runs, files, or instruments"
         className="justify-start gap-2 font-normal text-muted-foreground sm:w-64 dark:bg-muted/40"
         onClick={() => setOpen(true)}
+        onFocus={preloadGlobalSearch}
+        onMouseEnter={preloadGlobalSearch}
         size="sm"
         type="button"
         variant="outline"

--- a/web/components/search/use-recent-searches.ts
+++ b/web/components/search/use-recent-searches.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "data-hub:recent-searches";
+const MAX_RECENT = 8;
+
+function read(): string[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((v): v is string => typeof v === "string")
+      : [];
+  } catch {
+    // Corrupt or unavailable storage — treat as no history.
+    return [];
+  }
+}
+
+/**
+ * Session-persisted recent search queries backed by `localStorage`. Kept
+ * client-only and per-browser by design (v1 has no server-side history).
+ * Returns the list plus `add`/`clear` mutators; the list is capped at
+ * MAX_RECENT with most-recent-first ordering and case-insensitive dedup.
+ */
+export function useRecentSearches() {
+  const [recent, setRecent] = useState<string[]>([]);
+
+  // Hydrate after mount to avoid a server/client mismatch on the SSR'd shell.
+  useEffect(() => {
+    setRecent(read());
+  }, []);
+
+  const persist = useCallback((next: string[]) => {
+    setRecent(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      // Storage full or blocked — the in-memory list still works this session.
+    }
+  }, []);
+
+  const add = useCallback(
+    (query: string) => {
+      const trimmed = query.trim();
+      if (!trimmed) {
+        return;
+      }
+      setRecent((current) => {
+        const deduped = current.filter(
+          (q) => q.toLowerCase() !== trimmed.toLowerCase()
+        );
+        const next = [trimmed, ...deduped].slice(0, MAX_RECENT);
+        try {
+          window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        } catch {
+          // ignore — see persist()
+        }
+        return next;
+      });
+    },
+    // persist intentionally unused here; add() writes inline to avoid a stale
+    // closure over `recent`.
+    []
+  );
+
+  const clear = useCallback(() => {
+    persist([]);
+  }, [persist]);
+
+  return { recent, add, clear };
+}

--- a/web/drizzle/0029_add_search_trgm_indexes.sql
+++ b/web/drizzle/0029_add_search_trgm_indexes.sql
@@ -1,0 +1,8 @@
+-- Trigram matching support for global search. `gin_trgm_ops` below is only
+-- available once this extension exists. Drizzle does not manage extensions, so
+-- it is created here (and, for the `drizzle-kit push` paths used by local
+-- reseed and integration tests, in reset-database.ts / the test global-setup).
+CREATE EXTENSION IF NOT EXISTS pg_trgm;--> statement-breakpoint
+CREATE INDEX "idx_files_filename_trgm" ON "files" USING gin ("filename" gin_trgm_ops) WHERE "files"."deleted_at" is null;--> statement-breakpoint
+CREATE INDEX "idx_instrument_runs_run_id_trgm" ON "instrument_runs" USING gin ("run_id" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "idx_instruments_display_name_trgm" ON "instruments" USING gin ("display_name" gin_trgm_ops);

--- a/web/drizzle/meta/0029_snapshot.json
+++ b/web/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,2188 @@
+{
+  "id": "90447fa8-1d75-4bfa-a7b4-ae83c4f14121",
+  "prevId": "617a8c5b-dff4-4a2c-8e1a-fea5ecbace3b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": ["provider", "providerAccountId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archive_jobs": {
+      "name": "archive_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archive_bucket": {
+          "name": "archive_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_key": {
+          "name": "archive_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "archive_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_archive_jobs_inflight": {
+          "name": "uq_archive_jobs_inflight",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"archive_jobs\".\"status\" in ('pending', 'building')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_archive_jobs_run_fingerprint_status": {
+          "name": "idx_archive_jobs_run_fingerprint_status",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "archive_jobs_instrument_run_id_instrument_runs_id_fk": {
+          "name": "archive_jobs_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["instrument_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "archive_jobs_created_by_user_id_fk": {
+          "name": "archive_jobs_created_by_user_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "file_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raw'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_requested_at": {
+          "name": "upload_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_files_instrument_run_id_relative_path": {
+          "name": "uq_files_instrument_run_id_relative_path",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"relative_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_active_instrument_run_id_filename": {
+          "name": "uq_files_active_instrument_run_id_filename",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_s3_key": {
+          "name": "uq_files_s3_key",
+          "columns": [
+            {
+              "expression": "s3_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"s3_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_instrument_run_id": {
+          "name": "idx_files_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_status_instrument_run_id": {
+          "name": "idx_files_status_instrument_run_id",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_upload_queue": {
+          "name": "idx_files_upload_queue",
+          "columns": [
+            {
+              "expression": "upload_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"upload_requested_at\" is not null and \"files\".\"uploaded_at\" is null and \"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_metadata_gin": {
+          "name": "idx_files_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_files_filename_trgm": {
+          "name": "idx_files_filename_trgm",
+          "columns": [
+            {
+              "expression": "\"filename\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_instrument_run_id_instrument_runs_id_fk": {
+          "name": "files_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["instrument_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_notification_subscriptions": {
+      "name": "instrument_notification_subscriptions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_instrument_notification_subscriptions_user_id": {
+          "name": "idx_instrument_notification_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_notification_subscriptions_user_id_user_id_fk": {
+          "name": "instrument_notification_subscriptions_user_id_user_id_fk",
+          "tableFrom": "instrument_notification_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "instrument_notification_subscriptions_instrument_id_instruments_id_fk": {
+          "name": "instrument_notification_subscriptions_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_notification_subscriptions",
+          "tableTo": "instruments",
+          "columnsFrom": ["instrument_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "instrument_notification_subscriptions_user_id_instrument_id_pk": {
+          "name": "instrument_notification_subscriptions_user_id_instrument_id_pk",
+          "columns": ["user_id", "instrument_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_runs": {
+      "name": "instrument_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "instrument_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lambda'"
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instrument_runs_instrument_id_created_at": {
+          "name": "idx_instrument_runs_instrument_id_created_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active": {
+          "name": "idx_instrument_runs_active",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active_acquired_at": {
+          "name": "idx_instrument_runs_active_acquired_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"acquired_at\", \"created_at\") desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_metadata_gin": {
+          "name": "idx_instrument_runs_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_instrument_runs_run_id_trgm": {
+          "name": "idx_instrument_runs_run_id_trgm",
+          "columns": [
+            {
+              "expression": "\"run_id\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_runs_instrument_id_instruments_id_fk": {
+          "name": "instrument_runs_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "instruments",
+          "columnsFrom": ["instrument_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_watcher_id_watchers_id_fk": {
+          "name": "instrument_runs_watcher_id_watchers_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "watchers",
+          "columnsFrom": ["watcher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_deleted_by_user_id_fk": {
+          "name": "instrument_runs_deleted_by_user_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "user",
+          "columnsFrom": ["deleted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_instrument_runs_instrument_id_run_id": {
+          "name": "uq_instrument_runs_instrument_id_run_id",
+          "nullsNotDistinct": false,
+          "columns": ["instrument_id", "run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instruments": {
+      "name": "instruments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instrument_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instrument_type": {
+          "name": "instrument_type",
+          "type": "instrument_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_instruments_display_name_trgm": {
+          "name": "idx_instruments_display_name_trgm",
+          "columns": [
+            {
+              "expression": "\"display_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runs_all_muted": {
+          "name": "runs_all_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "comments_attributed_enabled": {
+          "name": "comments_attributed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "comments_participated_enabled": {
+          "name": "comments_participated_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "slack_runs_enabled": {
+          "name": "slack_runs_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slack_comments_attributed_enabled": {
+          "name": "slack_comments_attributed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slack_comments_participated_enabled": {
+          "name": "slack_comments_participated_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_user_id_fk": {
+          "name": "notification_preferences_user_id_user_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id_created_at": {
+          "name": "idx_notifications_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_id_unread": {
+          "name": "idx_notifications_user_id_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_run_id_instrument_runs_id_fk": {
+          "name": "notifications_run_id_instrument_runs_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_comment_id_run_comments_id_fk": {
+          "name": "notifications_comment_id_run_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "run_comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_user_id_user_id_fk": {
+          "name": "notifications_actor_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['*']::text[]"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_personal_access_tokens_user_id": {
+          "name": "idx_personal_access_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_user_id_fk": {
+          "name": "personal_access_tokens_user_id_user_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_attributions": {
+      "name": "run_attributions",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_attributions_run_id": {
+          "name": "idx_run_attributions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_attributions_user_id": {
+          "name": "idx_run_attributions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_attributions_run_id_instrument_runs_id_fk": {
+          "name": "run_attributions_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_attributions_user_id_user_id_fk": {
+          "name": "run_attributions_user_id_user_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_attributions_run_id_user_id_pk": {
+          "name": "run_attributions_run_id_user_id_pk",
+          "columns": ["run_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_comments": {
+      "name": "run_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_run_comments_run_id_created_at": {
+          "name": "idx_run_comments_run_id_created_at",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_comments_user_id": {
+          "name": "idx_run_comments_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_comments_run_id_instrument_runs_id_fk": {
+          "name": "run_comments_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_comments_user_id_user_id_fk": {
+          "name": "run_comments_user_id_user_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_channel_config": {
+      "name": "slack_channel_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_channel_config_updated_by_user_id_fk": {
+          "name": "slack_channel_config_updated_by_user_id_fk",
+          "tableFrom": "slack_channel_config",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "slack_channel_config_singleton": {
+          "name": "slack_channel_config_singleton",
+          "value": "\"slack_channel_config\".\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_connections": {
+      "name": "slack_connections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_name": {
+          "name": "slack_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_connections_user_id_user_id_fk": {
+          "name": "slack_connections_user_id_user_id_fk",
+          "tableFrom": "slack_connections",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_events": {
+      "name": "watcher_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "watcher_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_events_watcher_id_timestamp": {
+          "name": "idx_watcher_events_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_watcher_events_watcher_id_event_type": {
+          "name": "idx_watcher_events_watcher_id_event_type",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_events_watcher_id_watchers_id_fk": {
+          "name": "watcher_events_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_events",
+          "tableTo": "watchers",
+          "columnsFrom": ["watcher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_heartbeats": {
+      "name": "watcher_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_mode": {
+          "name": "upload_mode",
+          "type": "upload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_uploaded_since_last": {
+          "name": "files_uploaded_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "runs_reported_since_last": {
+          "name": "runs_reported_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_since_last": {
+          "name": "errors_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_heartbeats_watcher_id_timestamp": {
+          "name": "idx_watcher_heartbeats_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_heartbeats_watcher_id_watchers_id_fk": {
+          "name": "watcher_heartbeats_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_heartbeats",
+          "tableTo": "watchers",
+          "columnsFrom": ["watcher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_release_config": {
+      "name": "watcher_release_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_supported_version": {
+          "name": "min_supported_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stable'"
+        },
+        "mandatory": {
+          "name": "mandatory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watcher_release_config_updated_by_user_id_fk": {
+          "name": "watcher_release_config_updated_by_user_id_fk",
+          "tableFrom": "watcher_release_config",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "watcher_release_config_singleton": {
+          "name": "watcher_release_config_singleton",
+          "value": "\"watcher_release_config\".\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.watchers": {
+      "name": "watchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_info": {
+          "name": "os_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watcher_version": {
+          "name": "watcher_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_checksum": {
+          "name": "config_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_yaml": {
+          "name": "config_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "watcher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_watchers_active_instrument_id": {
+          "name": "uq_watchers_active_instrument_id",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"watchers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchers_instrument_id_instruments_id_fk": {
+          "name": "watchers_instrument_id_instruments_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "instruments",
+          "columnsFrom": ["instrument_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.archive_job_status": {
+      "name": "archive_job_status",
+      "schema": "public",
+      "values": ["pending", "building", "ready", "failed"]
+    },
+    "public.file_category": {
+      "name": "file_category",
+      "schema": "public",
+      "values": ["raw", "processed"]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "detected",
+        "upload_requested",
+        "uploaded",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.instrument_run_source": {
+      "name": "instrument_run_source",
+      "schema": "public",
+      "values": ["lambda", "watcher"]
+    },
+    "public.instrument_status": {
+      "name": "instrument_status",
+      "schema": "public",
+      "values": ["pending", "active", "inactive"]
+    },
+    "public.instrument_type": {
+      "name": "instrument_type",
+      "schema": "public",
+      "values": [
+        "generic",
+        "plate_reader",
+        "gel_doc",
+        "qpcr",
+        "tape_station",
+        "hina_microscope",
+        "epson_v700_scanner",
+        "instant_raman"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": ["run_created", "comment_attributed", "comment_participated"]
+    },
+    "public.upload_mode": {
+      "name": "upload_mode",
+      "schema": "public",
+      "values": ["auto", "manual"]
+    },
+    "public.watcher_event_type": {
+      "name": "watcher_event_type",
+      "schema": "public",
+      "values": [
+        "watcher_started",
+        "watcher_stopped",
+        "file_uploaded",
+        "upload_failed",
+        "run_reported",
+        "config_synced",
+        "error",
+        "update_started",
+        "update_succeeded",
+        "update_failed"
+      ]
+    },
+    "public.watcher_status": {
+      "name": "watcher_status",
+      "schema": "public",
+      "values": ["registered", "watching", "stopped"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1782935691822,
       "tag": "0028_add_slack_channel_config",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1783365397666,
+      "tag": "0029_add_search_trgm_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/web/lib/api/search.ts
+++ b/web/lib/api/search.ts
@@ -1,0 +1,330 @@
+import { and, desc, eq, ilike, isNull, or, type SQL, sql } from "drizzle-orm";
+import {
+  getWatcherOnlineStatus,
+  type WatcherOnlineStatus,
+} from "@/components/watchers/watcher-online-status";
+import { getInstrumentListWithCounts } from "@/lib/api/instruments";
+import { db } from "@/lib/db";
+import {
+  files,
+  instrumentRuns,
+  instruments,
+  runAttributions,
+  users,
+} from "@/lib/db/schema";
+import { MIN_QUERY_LENGTH } from "@/lib/search-constants";
+
+// Global search across the three top-level entities. Backed by the pg_trgm
+// GIN indexes added in migration 0029 so the `ilike '%…%'` scans stay fast as
+// the run/file tables grow (one instrument alone already carries 600+ runs).
+
+export type SearchScope = "all" | "runs" | "files" | "instruments";
+
+// Per-group cap when searching everything at once ("All" tab). Matches the
+// mockups. A scoped search (single tab) uses SCOPED_LIMIT so "Show all"
+// surfaces a longer list without a dedicated results page.
+const ALL_TAB_PER_GROUP = 5;
+const SCOPED_LIMIT = 25;
+
+// Why a run surfaced. `run_id` is the run's own title (highest relevance);
+// `file` means a contained filename matched (drives the "Contains …" line);
+// `instrument`/`ran_by` are secondary metadata matches.
+export type RunMatchReason = "run_id" | "file" | "instrument" | "ran_by";
+
+export interface SearchRunResult {
+  acquiredAt: string | null;
+  createdAt: string;
+  fileCount: number;
+  id: string;
+  instrumentId: string;
+  instrumentName: string;
+  // Set only when `matchReason` is "file" — an example matching filename.
+  matchedFilename: string | null;
+  matchReason: RunMatchReason;
+  runId: string;
+  totalSizeBytes: number;
+  type: "run";
+}
+
+export interface SearchFileResult {
+  filename: string;
+  id: number;
+  instrumentId: string;
+  instrumentName: string;
+  runId: string;
+  sizeBytes: number | null;
+  type: "file";
+}
+
+export type InstrumentMatchReason = "name" | "pattern";
+
+export interface SearchInstrumentResult {
+  displayName: string;
+  id: string;
+  lastWatcherHeartbeatAt: string | null;
+  // Set only when `matchReason` is "pattern" — the configured pattern that
+  // matched (e.g. "*.nd2"), so the client can highlight it.
+  matchedPattern: string | null;
+  matchReason: InstrumentMatchReason;
+  runCount: number;
+  status: "pending" | "active" | "inactive";
+  type: "instrument";
+  watcherStatus: WatcherOnlineStatus;
+}
+
+export interface GlobalSearchResult {
+  counts: {
+    runs: number;
+    files: number;
+    instruments: number;
+    // Sum of the *visible* (capped) results — this is the "N results for …"
+    // figure the header shows, matching what the user actually sees.
+    total: number;
+  };
+  files: SearchFileResult[];
+  instruments: SearchInstrumentResult[];
+  runs: SearchRunResult[];
+}
+
+// Escapes LIKE wildcards so user input matches literally. A filename like
+// `.*jpg` or a pattern query must be treated as text, never as a LIKE/regex
+// pattern. Mirrors the escaping already used in `buildRunListQuery`.
+function escapeLike(query: string): string {
+  return query.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+}
+
+const acquiredOrCreated = sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt})`;
+
+async function searchRuns(
+  query: string,
+  limit: number
+): Promise<SearchRunResult[]> {
+  const escaped = escapeLike(query);
+  const substring = `%${escaped}%`;
+  const prefix = `${escaped}%`;
+
+  // A run matches on its own id, its instrument's name, a contained (active)
+  // filename, or an attributed user's name/email.
+  const fileMatch = sql<boolean>`exists (select 1 from ${files} f where f.instrument_run_id = ${instrumentRuns.id} and f.deleted_at is null and f.filename ilike ${substring})`;
+  const ranByMatch = sql<boolean>`exists (select 1 from ${runAttributions} ra join ${users} u on u.id = ra.user_id where ra.run_id = ${instrumentRuns.id} and (u.name ilike ${substring} or u.email ilike ${substring}))`;
+
+  const matchCondition = or(
+    ilike(instrumentRuns.runId, substring),
+    ilike(instruments.displayName, substring),
+    fileMatch,
+    ranByMatch
+  ) as SQL;
+
+  const where = and(isNull(instrumentRuns.deletedAt), matchCondition);
+
+  // Relevance: a prefix hit on the run id (the title) outranks any substring
+  // hit, which outranks a metadata-only match; recency breaks ties.
+  const relevance = sql<number>`case when ${instrumentRuns.runId} ilike ${prefix} then 2 when ${instrumentRuns.runId} ilike ${substring} then 1 else 0 end`;
+
+  const rows = await db
+    .select({
+      id: instrumentRuns.id,
+      runId: instrumentRuns.runId,
+      instrumentId: instrumentRuns.instrumentId,
+      instrumentName: instruments.displayName,
+      acquiredAt: instrumentRuns.acquiredAt,
+      createdAt: instrumentRuns.createdAt,
+      // Raw-file aggregates mirror the run list rows shown elsewhere.
+      fileCount: sql<number>`cast(count(${files.id}) filter (where ${files.deletedAt} is null) as int)`,
+      totalSizeBytes: sql<number>`cast(coalesce(sum(${files.sizeBytes}) filter (where ${files.deletedAt} is null), 0) as bigint)`,
+      matchedRunId: sql<boolean>`bool_or(${instrumentRuns.runId} ilike ${substring})`,
+      matchedInstrument: sql<boolean>`bool_or(${instruments.displayName} ilike ${substring})`,
+      matchedFile: sql<boolean>`bool_or(${fileMatch})`,
+      matchedFilename: sql<
+        string | null
+      >`(select f.filename from ${files} f where f.instrument_run_id = ${instrumentRuns.id} and f.deleted_at is null and f.filename ilike ${substring} order by f.filename limit 1)`,
+    })
+    .from(instrumentRuns)
+    .innerJoin(instruments, eq(instrumentRuns.instrumentId, instruments.id))
+    .leftJoin(
+      files,
+      and(
+        eq(files.instrumentRunId, instrumentRuns.id),
+        eq(files.category, "raw")
+      )
+    )
+    .where(where)
+    .groupBy(instrumentRuns.id, instruments.displayName)
+    .orderBy(desc(relevance), desc(acquiredOrCreated))
+    .limit(limit);
+
+  return rows.map((row) => {
+    // Precedence: title match first, then a nested-file match (worth its own
+    // "Contains …" line), then instrument, then attribution.
+    let matchReason: RunMatchReason;
+    if (row.matchedRunId) {
+      matchReason = "run_id";
+    } else if (row.matchedFile) {
+      matchReason = "file";
+    } else if (row.matchedInstrument) {
+      matchReason = "instrument";
+    } else {
+      matchReason = "ran_by";
+    }
+    return {
+      type: "run" as const,
+      id: row.id,
+      runId: row.runId,
+      instrumentId: row.instrumentId,
+      instrumentName: row.instrumentName,
+      acquiredAt: row.acquiredAt ? row.acquiredAt.toISOString() : null,
+      createdAt: row.createdAt.toISOString(),
+      fileCount: row.fileCount,
+      totalSizeBytes: Number(row.totalSizeBytes),
+      matchReason,
+      matchedFilename: matchReason === "file" ? row.matchedFilename : null,
+    };
+  });
+}
+
+async function searchFiles(
+  query: string,
+  limit: number
+): Promise<SearchFileResult[]> {
+  const escaped = escapeLike(query);
+  const substring = `%${escaped}%`;
+  const prefix = `${escaped}%`;
+
+  const relevance = sql<number>`case when ${files.filename} ilike ${prefix} then 1 else 0 end`;
+
+  const rows = await db
+    .select({
+      id: files.id,
+      filename: files.filename,
+      sizeBytes: files.sizeBytes,
+      runId: instrumentRuns.runId,
+      instrumentId: instrumentRuns.instrumentId,
+      instrumentName: instruments.displayName,
+    })
+    .from(files)
+    .innerJoin(instrumentRuns, eq(files.instrumentRunId, instrumentRuns.id))
+    .innerJoin(instruments, eq(instrumentRuns.instrumentId, instruments.id))
+    .where(
+      and(
+        isNull(files.deletedAt),
+        isNull(instrumentRuns.deletedAt),
+        ilike(files.filename, substring)
+      )
+    )
+    .orderBy(desc(relevance), desc(files.createdAt))
+    .limit(limit);
+
+  return rows.map((row) => ({
+    type: "file" as const,
+    id: row.id,
+    filename: row.filename,
+    sizeBytes: row.sizeBytes,
+    runId: row.runId,
+    instrumentId: row.instrumentId,
+    instrumentName: row.instrumentName,
+  }));
+}
+
+// Instruments are few (fleet-scale), and their file patterns live in watcher
+// config YAML rather than a column, so matching happens in JS over the same
+// pre-aggregated list the instruments page uses. A query matches an
+// instrument by display name, id, or any configured file pattern.
+async function searchInstruments(
+  query: string,
+  limit: number
+): Promise<SearchInstrumentResult[]> {
+  const needle = query.toLowerCase();
+  const all = await getInstrumentListWithCounts();
+
+  const matched = all
+    .map((row) => {
+      const nameHit =
+        row.displayName.toLowerCase().includes(needle) ||
+        row.id.toLowerCase().includes(needle);
+      const matchedPattern = row.filePatterns.find((p) =>
+        p.toLowerCase().includes(needle)
+      );
+      if (!(nameHit || matchedPattern)) {
+        return null;
+      }
+      // Name/id is the instrument's identity — rank it above a pattern-only
+      // match. A prefix hit on the name ranks highest.
+      const prefixHit = row.displayName.toLowerCase().startsWith(needle);
+      const relevance = nameHit ? (prefixHit ? 2 : 1) : 0;
+      return {
+        result: {
+          type: "instrument" as const,
+          id: row.id,
+          displayName: row.displayName,
+          status: row.status,
+          watcherStatus: getWatcherOnlineStatus(row),
+          lastWatcherHeartbeatAt: row.lastWatcherHeartbeatAt
+            ? row.lastWatcherHeartbeatAt.toISOString()
+            : null,
+          runCount: row.runCount,
+          matchReason: nameHit ? ("name" as const) : ("pattern" as const),
+          matchedPattern: nameHit ? null : (matchedPattern ?? null),
+        },
+        relevance,
+        lastRunAt: row.lastRunAt?.getTime() ?? 0,
+      };
+    })
+    .filter((m): m is NonNullable<typeof m> => m !== null)
+    .sort((a, b) => b.relevance - a.relevance || b.lastRunAt - a.lastRunAt)
+    .slice(0, limit)
+    .map((m) => m.result);
+
+  return matched;
+}
+
+export async function globalSearch({
+  query,
+  scope = "all",
+}: {
+  query: string;
+  scope?: SearchScope;
+}): Promise<GlobalSearchResult> {
+  const trimmed = query.trim();
+
+  const empty: GlobalSearchResult = {
+    runs: [],
+    files: [],
+    instruments: [],
+    counts: { runs: 0, files: 0, instruments: 0, total: 0 },
+  };
+
+  if (trimmed.length < MIN_QUERY_LENGTH) {
+    return empty;
+  }
+
+  const runLimit =
+    scope === "all" ? ALL_TAB_PER_GROUP : scope === "runs" ? SCOPED_LIMIT : 0;
+  const fileLimit =
+    scope === "all" ? ALL_TAB_PER_GROUP : scope === "files" ? SCOPED_LIMIT : 0;
+  const instrumentLimit =
+    scope === "all"
+      ? ALL_TAB_PER_GROUP
+      : scope === "instruments"
+        ? SCOPED_LIMIT
+        : 0;
+
+  const [runs, filesResult, instrumentsResult] = await Promise.all([
+    runLimit > 0 ? searchRuns(trimmed, runLimit) : Promise.resolve([]),
+    fileLimit > 0 ? searchFiles(trimmed, fileLimit) : Promise.resolve([]),
+    instrumentLimit > 0
+      ? searchInstruments(trimmed, instrumentLimit)
+      : Promise.resolve([]),
+  ]);
+
+  return {
+    runs,
+    files: filesResult,
+    instruments: instrumentsResult,
+    counts: {
+      runs: runs.length,
+      files: filesResult.length,
+      instruments: instrumentsResult.length,
+      total: runs.length + filesResult.length + instrumentsResult.length,
+    },
+  };
+}

--- a/web/lib/db/schema.ts
+++ b/web/lib/db/schema.ts
@@ -274,34 +274,46 @@ export const personalAccessTokens = pgTable(
   (token) => [index("idx_personal_access_tokens_user_id").on(token.userId)]
 );
 
-export const instruments = pgTable("instruments", {
-  // Kebab-case identifier (e.g., `spectramax-id3-plate-reader`). Also used as
-  // the first segment of the S3 key (`{instrument_id}/{run_id}/{filename}`).
-  id: text("id").primaryKey(),
-  // Human-readable name (e.g., "SpectraMax iD3 Plate Reader").
-  displayName: text("display_name").notNull(),
-  // New instruments registered via the watcher CLI start as `pending` until
-  // confirmed by an admin.
-  status: instrumentStatusEnum("status").notNull().default("active"),
-  // Categorises the instrument for variant-specific UI (e.g., plate reader
-  // runs display a plate map grid). Defaults to "generic" for existing rows.
-  instrumentType: instrumentTypeEnum("instrument_type")
-    .notNull()
-    .default("generic"),
-  createdAt: timestamp("created_at", {
-    withTimezone: true,
-    mode: "date",
-  })
-    .notNull()
-    .defaultNow(),
-  updatedAt: timestamp("updated_at", {
-    withTimezone: true,
-    mode: "date",
-  })
-    .notNull()
-    .defaultNow()
-    .$onUpdate(() => new Date()),
-});
+export const instruments = pgTable(
+  "instruments",
+  {
+    // Kebab-case identifier (e.g., `spectramax-id3-plate-reader`). Also used as
+    // the first segment of the S3 key (`{instrument_id}/{run_id}/{filename}`).
+    id: text("id").primaryKey(),
+    // Human-readable name (e.g., "SpectraMax iD3 Plate Reader").
+    displayName: text("display_name").notNull(),
+    // New instruments registered via the watcher CLI start as `pending` until
+    // confirmed by an admin.
+    status: instrumentStatusEnum("status").notNull().default("active"),
+    // Categorises the instrument for variant-specific UI (e.g., plate reader
+    // runs display a plate map grid). Defaults to "generic" for existing rows.
+    instrumentType: instrumentTypeEnum("instrument_type")
+      .notNull()
+      .default("generic"),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "date",
+    })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", {
+      withTimezone: true,
+      mode: "date",
+    })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (instrument) => [
+    // Trigram GIN index backing the case-insensitive `ilike '%…%'` display-name
+    // match in global search. Requires the `pg_trgm` extension (created in
+    // migration 0029).
+    index("idx_instruments_display_name_trgm").using(
+      "gin",
+      sql`${instrument.displayName} gin_trgm_ops`
+    ),
+  ]
+);
 
 export const watchers = pgTable(
   "watchers",
@@ -516,6 +528,14 @@ export const instrumentRuns = pgTable(
       )
       .where(sql`${run.deletedAt} is null`),
     index("idx_instrument_runs_metadata_gin").using("gin", run.metadata),
+    // Trigram GIN index backing the case-insensitive `ilike '%…%'` run-id
+    // match in global search (and the dashboard run search). Requires the
+    // `pg_trgm` extension (created in migration 0029). Without it these
+    // substring scans are sequential.
+    index("idx_instrument_runs_run_id_trgm").using(
+      "gin",
+      sql`${run.runId} gin_trgm_ops`
+    ),
   ]
 );
 
@@ -625,6 +645,13 @@ export const files = pgTable(
         sql`${file.uploadRequestedAt} is not null and ${file.uploadedAt} is null and ${file.deletedAt} is null`
       ),
     index("idx_files_metadata_gin").using("gin", file.metadata),
+    // Trigram GIN index backing the case-insensitive `ilike '%…%'` filename
+    // match used by global search and the per-run files table. Scoped to
+    // active rows since both callers filter out soft-deleted files. Requires
+    // the `pg_trgm` extension (created in migration 0029).
+    index("idx_files_filename_trgm")
+      .using("gin", sql`${file.filename} gin_trgm_ops`)
+      .where(sql`${file.deletedAt} is null`),
   ]
 );
 

--- a/web/lib/search-constants.ts
+++ b/web/lib/search-constants.ts
@@ -1,0 +1,7 @@
+// Client-safe constants shared between the search UI and the server-only
+// `lib/api/search` module. Kept in its own file so client components can
+// import the value without pulling the DB layer into the browser bundle.
+
+// Below this length a query is too broad to be useful, so neither the client
+// nor the backend runs a search.
+export const MIN_QUERY_LENGTH = 2;

--- a/web/scripts/reset-database.ts
+++ b/web/scripts/reset-database.ts
@@ -12,6 +12,11 @@ const db = drizzle(pool);
 console.log("Dropping public schema…");
 await db.execute(sql`DROP SCHEMA public CASCADE`);
 await db.execute(sql`CREATE SCHEMA public`);
+// Recreate the pg_trgm extension dropped with the public schema. The trigram
+// GIN indexes in schema.ts reference `gin_trgm_ops`, so the extension must
+// exist before the subsequent `db:push`. Migration 0029 handles this for the
+// `db:migrate` path; push does not run migrations, hence this line.
+await db.execute(sql`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
 console.log("Database reset. Run `npm run db:push` to re-create tables.");
 
 await pool.end();

--- a/web/tests/integration/global-setup.ts
+++ b/web/tests/integration/global-setup.ts
@@ -79,6 +79,17 @@ export async function setup() {
 
   const databaseUrl = `${PG_URL}/${TEST_DB}`;
 
+  // The trigram GIN indexes in schema.ts reference `gin_trgm_ops`, which only
+  // exists once the pg_trgm extension is installed. `drizzle-kit push` (below)
+  // does not create extensions, so ensure it exists on the fresh test DB first.
+  const trgmClient = new Client({ connectionString: databaseUrl });
+  await trgmClient.connect();
+  try {
+    await trgmClient.query("CREATE EXTENSION IF NOT EXISTS pg_trgm");
+  } finally {
+    await trgmClient.end();
+  }
+
   // Stand up an in-process HTTP capture server so tests can assert on
   // outgoing Slack webhook calls and Slack Web API DMs without depending on
   // the real Slack API.

--- a/web/tests/integration/search.test.ts
+++ b/web/tests/integration/search.test.ts
@@ -1,0 +1,178 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { GlobalSearchResult } from "@/lib/api/search";
+import { files, instrumentRuns, instruments, watchers } from "@/lib/db/schema";
+import {
+  api,
+  closeTestDb,
+  getTestDb,
+  resetDb,
+  seedTestUser,
+} from "@/tests/integration/helpers";
+
+// Seeds a run with the given files and returns the run's UUID.
+async function seedRun(
+  instrumentId: string,
+  runId: string,
+  filenames: string[]
+): Promise<string> {
+  const db = getTestDb();
+  const [run] = await db
+    .insert(instrumentRuns)
+    .values({ instrumentId, runId })
+    .returning({ id: instrumentRuns.id });
+  if (filenames.length > 0) {
+    await db.insert(files).values(
+      filenames.map((filename, i) => ({
+        instrumentRunId: run.id,
+        filename,
+        relativePath: filename,
+        sizeBytes: (i + 1) * 1000,
+      }))
+    );
+  }
+  return run.id;
+}
+
+async function search(
+  token: string,
+  query: string,
+  scope?: string
+): Promise<GlobalSearchResult> {
+  const params = new URLSearchParams({ q: query });
+  if (scope) {
+    params.set("scope", scope);
+  }
+  const res = await api(`/api/v1/search?${params}`, { token });
+  expect(res.status).toBe(200);
+  return (await res.json()) as GlobalSearchResult;
+}
+
+describe("Global search API", () => {
+  let token: string;
+
+  beforeAll(async () => {
+    await resetDb();
+    ({ token } = await seedTestUser());
+
+    const db = getTestDb();
+    await db.insert(instruments).values([
+      {
+        id: "hina-microscope",
+        displayName: "Hina Microscope",
+        status: "active",
+      },
+      { id: "plate-reader-x", displayName: "Plate Reader X", status: "active" },
+    ]);
+
+    // The Hina microscope watches for *.nd2; Plate Reader X watches for *.csv
+    // but has no runs (exercises the zero-run pattern-match case).
+    await db.insert(watchers).values([
+      {
+        instrumentId: "hina-microscope",
+        hostname: "hina-pc",
+        status: "watching",
+        lastHeartbeatAt: new Date(),
+        configYaml: 'instrument:\n  file_patterns:\n    - "*.nd2"\n',
+      },
+      {
+        instrumentId: "plate-reader-x",
+        hostname: "plate-pc",
+        status: "watching",
+        lastHeartbeatAt: new Date(),
+        configYaml: 'instrument:\n  file_patterns:\n    - "*.csv"\n',
+      },
+    ]);
+
+    await seedRun("hina-microscope", "20260706_112803_385", ["sample_012.nd2"]);
+    await seedRun("hina-microscope", "20260630_101502_204", ["scan_009.nd2"]);
+    // Literal special characters: `photo.*jpg` must match a `.*jpg` query while
+    // `photoXjpg` must not (the query is never treated as a regex/glob).
+    await seedRun("hina-microscope", "special-run", [
+      "photo.*jpg",
+      "photoXjpg",
+    ]);
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  it("requires authentication", async () => {
+    const res = await api("/api/v1/search?q=nd2");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns an empty result below the minimum query length", async () => {
+    const result = await search(token, "n");
+    expect(result.counts.total).toBe(0);
+    expect(result.runs).toHaveLength(0);
+    expect(result.files).toHaveLength(0);
+    expect(result.instruments).toHaveLength(0);
+  });
+
+  it("matches a run by its run id", async () => {
+    const result = await search(token, "20260706");
+    const run = result.runs.find((r) => r.runId === "20260706_112803_385");
+    expect(run).toBeDefined();
+    expect(run?.matchReason).toBe("run_id");
+    expect(run?.matchedFilename).toBeNull();
+  });
+
+  it("surfaces runs, files, and the instrument together for a nested filename match", async () => {
+    const result = await search(token, "nd2");
+
+    // Both nd2-bearing runs surface, attributed to the contained file.
+    const runIds = result.runs.map((r) => r.runId);
+    expect(runIds).toContain("20260706_112803_385");
+    expect(runIds).toContain("20260630_101502_204");
+    const run = result.runs.find((r) => r.runId === "20260706_112803_385");
+    expect(run?.matchReason).toBe("file");
+    expect(run?.matchedFilename).toBe("sample_012.nd2");
+
+    // The individual files surface in the Files group.
+    const filenames = result.files.map((f) => f.filename);
+    expect(filenames).toContain("sample_012.nd2");
+    expect(filenames).toContain("scan_009.nd2");
+
+    // The instrument surfaces via its configured *.nd2 pattern.
+    const instrument = result.instruments.find(
+      (i) => i.id === "hina-microscope"
+    );
+    expect(instrument).toBeDefined();
+    expect(instrument?.matchReason).toBe("pattern");
+    expect(instrument?.matchedPattern).toBe("*.nd2");
+  });
+
+  it("matches an instrument by display name", async () => {
+    const result = await search(token, "Hina");
+    const instrument = result.instruments.find(
+      (i) => i.id === "hina-microscope"
+    );
+    expect(instrument).toBeDefined();
+    expect(instrument?.matchReason).toBe("name");
+  });
+
+  it("scopes results to a single type when requested", async () => {
+    const result = await search(token, "nd2", "runs");
+    expect(result.runs.length).toBeGreaterThan(0);
+    expect(result.files).toHaveLength(0);
+    expect(result.instruments).toHaveLength(0);
+  });
+
+  it("treats special characters in the query literally, not as a pattern", async () => {
+    const result = await search(token, ".*jpg", "files");
+    const filenames = result.files.map((f) => f.filename);
+    expect(filenames).toContain("photo.*jpg");
+    expect(filenames).not.toContain("photoXjpg");
+  });
+
+  it("returns a pattern-matched instrument even when it has zero runs", async () => {
+    const result = await search(token, "csv", "instruments");
+    const instrument = result.instruments.find(
+      (i) => i.id === "plate-reader-x"
+    );
+    expect(instrument).toBeDefined();
+    expect(instrument?.matchReason).toBe("pattern");
+    expect(instrument?.runCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a keyboard-accessible global search (persistent header field + `Cmd/Ctrl+K`) reachable from every authenticated page.
- New `GET /api/v1/search` endpoint (`lib/api/search.ts`) returns grouped, relevance-ranked matches across runs, files, and instruments in parallel, with per-result match-reason tracking and literal wildcard escaping (so `.*jpg` is matched as text).
- cmdk-based modal with scope tabs (All/Runs/Files/Instruments), debounced + abortable fetch, accent match-highlighting, recent searches (localStorage), and distinct empty / no-results states. Files deep-link to their parent run via `?files_search=`; instruments reuse the existing Online/Offline watcher pill.
- Adds `pg_trgm` GIN indexes on `instrument_runs.run_id`, `files.filename`, and `instruments.display_name` (migration `0029`), with extension creation wired into the `drizzle-kit push` paths (reset script + integration global-setup) since push does not manage extensions.

## Notes
- Data Hub has no row-level access model — any authenticated user reads all runs/files/instruments — so search is gated on `runs:read` and returns the same set the rest of the app exposes.
- Recent searches are per-browser (localStorage) only, per the agreed v1 scope.

## Test plan
- [x] `make check-all` (Python + frontend format/lint/typecheck) passes.
- [x] `web/tests/integration/search.test.ts` — 8 tests passing: auth required, min-length guard, run-id match, nested-filename match surfacing runs + files + pattern-matched instrument together, display-name match, scoped search, literal special characters (`.*jpg`), and a pattern-matched instrument with zero runs.
- [x] Manual: `Cmd/Ctrl+K` from multiple pages; the "nd2" example surfaces a run, its files, and the instrument together with highlighting; tab switching; keyboard-only navigation (`↑↓`, `↵`, `Esc`).

Made with [Cursor](https://cursor.com)