### PR TITLE
Add MIT license across repo for open sourcing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Arcadia Science
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -82,3 +82,11 @@ make py-test-integration
 # Run API integration tests (requires Postgres).
 make fe-test-integration
 ```
+
+## License
+
+Data Hub is released under the [MIT License](LICENSE). Copyright (c) 2026 Arcadia Science.
+
+"Data Hub" and "Arcadia Science", along with related names and logos, are marks of
+Arcadia Science. The MIT License covers the source code only and does not grant any
+right to use these names or logos.

--- a/lambda/LICENSE
+++ b/lambda/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Arcadia Science
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lambda/pyproject.toml
+++ b/lambda/pyproject.toml
@@ -2,6 +2,11 @@
 name = "data-hub-lambda"
 version = "0.2.0"
 requires-python = ">=3.12"
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [
+    { name = "Arcadia Science", email = "swe@arcadiascience.com" },
+]
 dependencies = [
     "data-hub-shared",
     "arcadia-microscopy-tools>=0.4.1",
@@ -19,7 +24,7 @@ dependencies = [
 data-hub-process = "data_hub_lambda.cli:cli"
 
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.uv.sources]

--- a/packages/shared/LICENSE
+++ b/packages/shared/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Arcadia Science
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/shared/pyproject.toml
+++ b/packages/shared/pyproject.toml
@@ -2,13 +2,18 @@
 name = "data-hub-shared"
 version = "0.1.0"
 requires-python = ">=3.12"
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [
+    { name = "Arcadia Science", email = "swe@arcadiascience.com" },
+]
 dependencies = [
     "boto3>=1.35",
     "requests>=2.31",
 ]
 
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "type": "module",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",


### PR DESCRIPTION
## Summary

Prepares Data Hub for open sourcing under a single, consistent MIT license.

- Add a root `LICENSE` and per-package `LICENSE` files (`lambda/`, `packages/shared/`) — `Copyright (c) 2026 Arcadia Science`, matching the existing `watcher/LICENSE`.
- Declare MIT license metadata (`license`, `license-files`, author) for the `lambda` and `shared` packages, which previously had none. Bumped their `setuptools` build requirement to `>=77` as PEP 639's SPDX `license` string + `license-files` require (the watcher already pins this).
- Set `"license": "MIT"` in `web/package.json` (stays `private`).
- Add a **License** section plus a trademark note to the README (MIT covers source code only, not the "Data Hub"/"Arcadia Science" names and logos).

## Audit (no code changes needed)

- **Dependency licenses:** all permissive (MIT/BSD/Apache/ISC). First-party `arcadia-microscopy-tools` is MIT.
- **Secrets / git history:** clean — no `.env` ever committed; no real AWS keys, private keys, Slack tokens, or PATs in the tree or across history. All matches were local-dev placeholders, test fixtures, or `.env.example` templates.

## Test plan

- [x] `make check-all` passes (ruff, pyright, ultracite/biome, tsc).
- [x] `uv build` succeeds for `data-hub-lambda` and `data-hub-shared`; `LICENSE` is bundled into wheel `dist-info/licenses/`.
- [x] Eyeball `infra/template.yaml` / `infra/bootstrap.yaml` for account IDs, ARNs, or bucket names before making the repo public.

Made with [Cursor](https://cursor.com)