### PR TITLE
Add run status filter to instrument runs

### DIFF
--- a/web/app/api/v1/instrument-runs/route.ts
+++ b/web/app/api/v1/instrument-runs/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 import { authorize } from "@/lib/api/auth";
 import { buildRunListQuery } from "@/lib/api/instrument-runs";
-import { parseIntParam } from "@/lib/api/validators";
+import { parseIntParam, parseRunStatusParam } from "@/lib/api/validators";
 
 // ---------------------------------------------------------------------------
 // GET /api/v1/instrument-runs
@@ -38,6 +38,7 @@ export async function GET(request: NextRequest) {
     }),
     includeDeleted: searchParams.get("include_deleted") === "true",
     ranBy: searchParams.get("ran_by") ?? undefined,
+    statuses: parseRunStatusParam(searchParams),
   });
 
   return Response.json(result);

--- a/web/app/api/v1/instruments/[instrumentId]/runs/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/route.ts
@@ -4,7 +4,7 @@ import { authorize } from "@/lib/api/auth";
 import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { buildRunListQuery, parseAcquiredAt } from "@/lib/api/instrument-runs";
 import { notifyRunCreated } from "@/lib/api/notifications";
-import { parseIntParam } from "@/lib/api/validators";
+import { parseIntParam, parseRunStatusParam } from "@/lib/api/validators";
 import { db } from "@/lib/db";
 import { files, instrumentRuns, instruments, watchers } from "@/lib/db/schema";
 import { sendSlackMessage } from "@/lib/slack";
@@ -258,6 +258,7 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
     }),
     includeDeleted: searchParams.get("include_deleted") === "true",
     ranBy: searchParams.get("ran_by") ?? undefined,
+    statuses: parseRunStatusParam(searchParams),
   });
 
   return Response.json(result);

--- a/web/app/instruments/[instrumentId]/page.tsx
+++ b/web/app/instruments/[instrumentId]/page.tsx
@@ -264,6 +264,7 @@ async function InstrumentRunsSection({
       dpi: filters.dpi ?? undefined,
       colorMode: filters.color_mode ?? undefined,
       ranBy: filters.ran_by ?? undefined,
+      statuses: filters.run_status.length > 0 ? filters.run_status : undefined,
     }),
     getInstrumentFilterOptions(instrument.instrumentType, instrumentId),
     getRanByFilterOptions(instrumentId),
@@ -287,7 +288,8 @@ async function InstrumentRunsSection({
     filters.hina_size !== null ||
     filters.dpi !== null ||
     filters.color_mode !== null ||
-    filters.ran_by !== null;
+    filters.ran_by !== null ||
+    filters.run_status.length > 0;
 
   const pendingUploadCount = runResult.data.filter(
     (row) => row.files_pending_upload > 0

--- a/web/app/instruments/[instrumentId]/page.tsx
+++ b/web/app/instruments/[instrumentId]/page.tsx
@@ -264,7 +264,7 @@ async function InstrumentRunsSection({
       dpi: filters.dpi ?? undefined,
       colorMode: filters.color_mode ?? undefined,
       ranBy: filters.ran_by ?? undefined,
-      statuses: filters.run_status.length > 0 ? filters.run_status : undefined,
+      statuses: filters.status.length > 0 ? filters.status : undefined,
     }),
     getInstrumentFilterOptions(instrument.instrumentType, instrumentId),
     getRanByFilterOptions(instrumentId),
@@ -289,7 +289,7 @@ async function InstrumentRunsSection({
     filters.dpi !== null ||
     filters.color_mode !== null ||
     filters.ran_by !== null ||
-    filters.run_status.length > 0;
+    filters.status.length > 0;
 
   const pendingUploadCount = runResult.data.filter(
     (row) => row.files_pending_upload > 0

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -164,6 +164,7 @@ async function DashboardRunsSection({
       page: params.page,
       perPage: params.per_page,
       includeDeleted: params.include_deleted,
+      statuses: params.run_status.length > 0 ? params.run_status : undefined,
     }),
   ]);
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -164,7 +164,7 @@ async function DashboardRunsSection({
       page: params.page,
       perPage: params.per_page,
       includeDeleted: params.include_deleted,
-      statuses: params.run_status.length > 0 ? params.run_status : undefined,
+      statuses: params.status.length > 0 ? params.status : undefined,
     }),
   ]);
 

--- a/web/components/dashboard/runs-toolbar.tsx
+++ b/web/components/dashboard/runs-toolbar.tsx
@@ -57,6 +57,7 @@ export function RunsToolbar({ instruments }: { instruments: Instrument[] }) {
       date_from: null,
       date_to: null,
       include_deleted: false,
+      run_status: [],
       page: 1,
     });
   }
@@ -160,6 +161,8 @@ export function RunsToolbar({ instruments }: { instruments: Instrument[] }) {
             onChange={({ includeDeleted }) =>
               setFilters({ include_deleted: includeDeleted, page: 1 })
             }
+            onStatusChange={(next) => setFilters({ run_status: next, page: 1 })}
+            selectedStatuses={filters.run_status}
             values={{ includeDeleted: filters.include_deleted }}
           />
         </div>

--- a/web/components/dashboard/runs-toolbar.tsx
+++ b/web/components/dashboard/runs-toolbar.tsx
@@ -57,7 +57,7 @@ export function RunsToolbar({ instruments }: { instruments: Instrument[] }) {
       date_from: null,
       date_to: null,
       include_deleted: false,
-      run_status: [],
+      status: [],
       page: 1,
     });
   }
@@ -161,8 +161,8 @@ export function RunsToolbar({ instruments }: { instruments: Instrument[] }) {
             onChange={({ includeDeleted }) =>
               setFilters({ include_deleted: includeDeleted, page: 1 })
             }
-            onStatusChange={(next) => setFilters({ run_status: next, page: 1 })}
-            selectedStatuses={filters.run_status}
+            onStatusChange={(next) => setFilters({ status: next, page: 1 })}
+            selectedStatuses={filters.status}
             values={{ includeDeleted: filters.include_deleted }}
           />
         </div>

--- a/web/components/instruments/instrument-runs-toolbar.tsx
+++ b/web/components/instruments/instrument-runs-toolbar.tsx
@@ -25,6 +25,7 @@ export function InstrumentRunsToolbar() {
     filters.date_from !== null ||
     filters.date_to !== null ||
     filters.include_deleted ||
+    filters.run_status.length > 0 ||
     filters.wavelength !== null ||
     filters.measurement_mode !== null ||
     filters.measurement_type !== null;
@@ -35,6 +36,7 @@ export function InstrumentRunsToolbar() {
       date_from: null,
       date_to: null,
       include_deleted: false,
+      run_status: [],
       wavelength: null,
       measurement_mode: null,
       measurement_type: null,
@@ -84,6 +86,8 @@ export function InstrumentRunsToolbar() {
             onChange={({ includeDeleted }) =>
               setFilters({ include_deleted: includeDeleted, page: 1 })
             }
+            onStatusChange={(next) => setFilters({ run_status: next, page: 1 })}
+            selectedStatuses={filters.run_status}
             values={{ includeDeleted: filters.include_deleted }}
           />
         </div>

--- a/web/components/instruments/instrument-runs-toolbar.tsx
+++ b/web/components/instruments/instrument-runs-toolbar.tsx
@@ -25,7 +25,7 @@ export function InstrumentRunsToolbar() {
     filters.date_from !== null ||
     filters.date_to !== null ||
     filters.include_deleted ||
-    filters.run_status.length > 0 ||
+    filters.status.length > 0 ||
     filters.wavelength !== null ||
     filters.measurement_mode !== null ||
     filters.measurement_type !== null;
@@ -36,7 +36,7 @@ export function InstrumentRunsToolbar() {
       date_from: null,
       date_to: null,
       include_deleted: false,
-      run_status: [],
+      status: [],
       wavelength: null,
       measurement_mode: null,
       measurement_type: null,
@@ -86,8 +86,8 @@ export function InstrumentRunsToolbar() {
             onChange={({ includeDeleted }) =>
               setFilters({ include_deleted: includeDeleted, page: 1 })
             }
-            onStatusChange={(next) => setFilters({ run_status: next, page: 1 })}
-            selectedStatuses={filters.run_status}
+            onStatusChange={(next) => setFilters({ status: next, page: 1 })}
+            selectedStatuses={filters.status}
             values={{ includeDeleted: filters.include_deleted }}
           />
         </div>

--- a/web/components/instruments/runs-table/run-status-icon.tsx
+++ b/web/components/instruments/runs-table/run-status-icon.tsx
@@ -26,7 +26,6 @@ export function RunStatusIcon({
   errorMessages: string[];
 }) {
   const status = deriveRunStatus({
-    fileCount,
     filesCompleted,
     filesFailed,
     filesPendingUpload,

--- a/web/components/instruments/runs-table/run-status-icon.tsx
+++ b/web/components/instruments/runs-table/run-status-icon.tsx
@@ -1,17 +1,11 @@
 "use client";
 
 import {
-  CircleCheck,
-  CircleDashed,
-  CircleX,
-  Clock,
-  LoaderCircle,
-} from "lucide-react";
-import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { deriveRunStatus, RUN_STATUS_META } from "@/lib/runs/run-status";
 import { cn } from "@/lib/utils";
 
 export function RunStatusIcon({
@@ -31,28 +25,24 @@ export function RunStatusIcon({
   filesProcessing: number;
   errorMessages: string[];
 }) {
+  const status = deriveRunStatus({
+    fileCount,
+    filesCompleted,
+    filesFailed,
+    filesPendingUpload,
+    filesUploaded,
+    filesProcessing,
+  });
+  const { Icon, colorClassName, spin } = RUN_STATUS_META[status];
+
   const hasFailed = filesFailed > 0;
-  const hasProcessing = filesProcessing > 0;
-  const hasUploaded = filesUploaded > 0;
   const hasPending = filesPendingUpload > 0;
+  const hasUploaded = filesUploaded > 0;
+  const hasProcessing = filesProcessing > 0;
   const hasCompleted = filesCompleted > 0;
 
-  // Icon priority: Error > Processing > Completed > Uploaded > Pending upload.
-  // Fallback (no files at all) shows the healthy "completed" icon.
-  const icon = hasFailed ? (
-    <CircleX className="size-4 text-destructive" />
-  ) : hasProcessing ? (
-    <LoaderCircle className="size-4 animate-spin text-sky-500" />
-  ) : hasCompleted ? (
-    <CircleCheck className="size-4 text-green-600 dark:text-green-500" />
-  ) : hasUploaded ? (
-    <CircleDashed className="size-4 text-muted-foreground" />
-  ) : hasPending ? (
-    <Clock className="size-4 text-amber-500" />
-  ) : (
-    <CircleCheck className="size-4 text-green-600 dark:text-green-500" />
-  );
-
+  // Tooltip lists every non-empty bucket in priority order, so a run reveals
+  // its lower-priority states on hover even though the icon shows only the top.
   const lines: string[] = [];
   if (hasFailed) {
     if (errorMessages.length > 0) {
@@ -82,13 +72,17 @@ export function RunStatusIcon({
     );
   }
   if (lines.length === 0) {
-    lines.push("All files processed successfully");
+    lines.push("No files");
   }
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="relative z-10 flex shrink-0">{icon}</span>
+        <span className="relative z-10 flex shrink-0">
+          <Icon
+            className={cn("size-4", colorClassName, spin && "animate-spin")}
+          />
+        </span>
       </TooltipTrigger>
       <TooltipContent
         className={cn(

--- a/web/components/runs/run-filters-combobox.tsx
+++ b/web/components/runs/run-filters-combobox.tsx
@@ -9,12 +9,15 @@ import {
   CommandGroup,
   CommandItem,
   CommandList,
+  CommandSeparator,
 } from "@/components/ui/command";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { RUN_STATUS_OPTIONS, type RunStatus } from "@/lib/runs/run-status";
+import { cn } from "@/lib/utils";
 
 interface FilterValues {
   includeDeleted: boolean;
@@ -33,15 +36,29 @@ const FILTERS: readonly FilterDef[] = [
 export function RunFiltersCombobox({
   values,
   onChange,
+  selectedStatuses,
+  onStatusChange,
 }: {
   values: FilterValues;
   onChange: (next: FilterValues) => void;
+  // When both are provided, a multi-select STATUS group is rendered.
+  selectedStatuses?: RunStatus[];
+  onStatusChange?: (next: RunStatus[]) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const activeCount = FILTERS.reduce(
-    (count, f) => (values[f.key] ? count + 1 : count),
-    0
-  );
+  const showStatus =
+    selectedStatuses !== undefined && onStatusChange !== undefined;
+  const activeCount =
+    FILTERS.reduce((count, f) => (values[f.key] ? count + 1 : count), 0) +
+    (selectedStatuses?.length ?? 0);
+
+  function toggleStatus(status: RunStatus) {
+    const current = selectedStatuses ?? [];
+    const next = current.includes(status)
+      ? current.filter((s) => s !== status)
+      : [...current, status];
+    onStatusChange?.(next);
+  }
 
   return (
     <Popover onOpenChange={setOpen} open={open}>
@@ -84,6 +101,33 @@ export function RunFiltersCombobox({
                 );
               })}
             </CommandGroup>
+            {showStatus && (
+              <>
+                <CommandSeparator />
+                <CommandGroup heading="Status">
+                  {RUN_STATUS_OPTIONS.map((status) => {
+                    const Icon = status.Icon;
+                    const active = selectedStatuses?.includes(status.value);
+                    return (
+                      <CommandItem
+                        data-checked={active}
+                        key={status.value}
+                        onSelect={() => toggleStatus(status.value)}
+                        value={status.label}
+                      >
+                        <Icon
+                          className={cn(
+                            status.colorClassName,
+                            status.spin && "animate-spin"
+                          )}
+                        />
+                        {status.label}
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              </>
+            )}
           </CommandList>
         </Command>
       </PopoverContent>

--- a/web/lib/api/instrument-runs.ts
+++ b/web/lib/api/instrument-runs.ts
@@ -1,6 +1,16 @@
 import { parse } from "csv-parse/sync";
 import type { AnyColumn, SQL } from "drizzle-orm";
-import { and, asc, desc, eq, ilike, inArray, isNull, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  ilike,
+  inArray,
+  isNull,
+  or,
+  sql,
+} from "drizzle-orm";
 import { cache } from "react";
 import { formatHinaSizes } from "@/components/runs/run-metadata-badges";
 import { db } from "@/lib/db";
@@ -12,6 +22,7 @@ import {
   runAttributions,
   users,
 } from "@/lib/db/schema";
+import type { RunStatus } from "@/lib/runs/run-status";
 import { getS3ObjectStream } from "@/lib/s3";
 
 // ---------------------------------------------------------------------------
@@ -235,6 +246,8 @@ interface RunListFilters {
   search?: string;
   sort?: string;
   source?: string;
+  // Derived run statuses to match (OR'd together). Undefined/empty = no filter.
+  statuses?: RunStatus[];
   wavelength?: string;
 }
 
@@ -253,6 +266,43 @@ const ALLOWED_SORT_FIELDS: Record<string, SQL | AnyColumn> = {
   created_at: instrumentRuns.createdAt,
   updated_at: instrumentRuns.updatedAt,
 };
+
+// Mirrors the aggregate LEFT JOIN's scope so the filter matches the shown icon.
+const rawFileScopeSql = sql`${files.instrumentRunId} = ${instrumentRuns.id} and ${files.category} = 'raw' and ${files.deletedAt} is null`;
+
+function existsRawFileWithStatus(statusSql: SQL): SQL {
+  return sql`exists (select 1 from ${files} where ${rawFileScopeSql} and ${statusSql})`;
+}
+
+// Priority-exclusive (NOT) EXISTS predicate per derived status, mirroring
+// `deriveRunStatus`. Correlated subqueries (not a HAVING over the aggregate)
+// keep the pagination COUNT off a `files` join and on the status/run indexes.
+function runStatusCondition(status: RunStatus): SQL {
+  const failed = existsRawFileWithStatus(sql`${files.status} = 'failed'`);
+  const pending = existsRawFileWithStatus(
+    sql`${files.status} in ('detected', 'upload_requested')`
+  );
+  const uploaded = existsRawFileWithStatus(sql`${files.status} = 'uploaded'`);
+  const processing = existsRawFileWithStatus(
+    sql`${files.status} = 'processing'`
+  );
+  const completed = existsRawFileWithStatus(sql`${files.status} = 'completed'`);
+
+  switch (status) {
+    case "failed":
+      return failed;
+    case "pending":
+      return sql`(not ${failed} and ${pending})`;
+    case "uploaded":
+      return sql`(not ${failed} and not ${pending} and ${uploaded})`;
+    case "processing":
+      return sql`(not ${failed} and not ${pending} and not ${uploaded} and ${processing})`;
+    case "completed":
+      return sql`(not ${failed} and not ${pending} and not ${uploaded} and not ${processing} and ${completed})`;
+    default:
+      return sql`not exists (select 1 from ${files} where ${rawFileScopeSql})`;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Adjacent-run navigation for the run detail header.
@@ -456,6 +506,13 @@ export async function buildRunListQuery(filters: RunListFilters) {
     conditions.push(
       sql`exists (select 1 from ${runAttributions} where ${runAttributions.runId} = ${instrumentRuns.id} and ${runAttributions.userId} = ${filters.ranBy})`
     );
+  }
+
+  if (filters.statuses && filters.statuses.length > 0) {
+    const statusOr = or(...filters.statuses.map(runStatusCondition));
+    if (statusOr) {
+      conditions.push(statusOr);
+    }
   }
 
   const where = conditions.length > 0 ? and(...conditions) : undefined;

--- a/web/lib/api/validators.ts
+++ b/web/lib/api/validators.ts
@@ -1,6 +1,10 @@
+import { RUN_STATUS_VALUES, type RunStatus } from "@/lib/runs/run-status";
+
 const KEBAB_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const RUN_STATUS_SET = new Set<string>(RUN_STATUS_VALUES);
 
 export function isValidKebabCase(id: string): boolean {
   return KEBAB_RE.test(id);
@@ -37,4 +41,22 @@ export function parseDateParam(value: string | null): Date | null {
   }
   const d = new Date(value);
   return Number.isNaN(d.getTime()) ? null : d;
+}
+
+// Accepts repeated (`?status=a&status=b`) or comma-separated (`?status=a,b`)
+// values, silently dropping unknown ones. Returns undefined when nothing valid
+// remains so the query treats it as "no status filter".
+export function parseRunStatusParam(
+  searchParams: URLSearchParams
+): RunStatus[] | undefined {
+  const seen = new Set<RunStatus>();
+  for (const raw of searchParams.getAll("status")) {
+    for (const part of raw.split(",")) {
+      const value = part.trim();
+      if (RUN_STATUS_SET.has(value)) {
+        seen.add(value as RunStatus);
+      }
+    }
+  }
+  return seen.size > 0 ? [...seen] : undefined;
 }

--- a/web/lib/mcp/tools.ts
+++ b/web/lib/mcp/tools.ts
@@ -22,6 +22,7 @@ import { hasScope, type Scope } from "@/lib/api/scopes";
 import { getWatcherHeartbeats, getWatcherList } from "@/lib/api/watchers";
 import { db } from "@/lib/db";
 import { runAttributions } from "@/lib/db/schema";
+import { RUN_STATUS_VALUES } from "@/lib/runs/run-status";
 import {
   getPresignedDownloadUrl,
   PRESIGNED_DOWNLOAD_URL_EXPIRY_SECONDS,
@@ -177,7 +178,7 @@ export function registerTools(server: McpServer) {
     {
       title: "Search Runs",
       description:
-        "Search instrument runs with filtering, pagination, and sorting. Supports plate reader metadata filters (wavelength, measurement mode/type).",
+        "Search instrument runs with filtering, pagination, and sorting. Supports run status filters and plate reader metadata filters (wavelength, measurement mode/type).",
       inputSchema: {
         instrumentId: z
           .union([z.string(), z.array(z.string())])
@@ -244,6 +245,12 @@ export function registerTools(server: McpServer) {
           .describe(
             'Filter by attributor. Pass a user id to match runs attributed to that user, or the literal "unattributed" to match runs with no attributions. Use list_run_attributors to discover valid user ids.'
           ),
+        status: z
+          .array(z.enum(RUN_STATUS_VALUES))
+          .optional()
+          .describe(
+            "Filter by derived run status (OR'd together). Status is derived from a run's raw file states, priority-exclusive: failed (any file failed), pending (files awaiting upload), uploaded (awaiting processing), processing, completed (all done), empty (no files)."
+          ),
       },
       annotations: { readOnlyHint: true },
     },
@@ -267,6 +274,7 @@ export function registerTools(server: McpServer) {
         measurementMode: args.measurementMode,
         measurementType: args.measurementType,
         ranBy: args.ranBy,
+        statuses: args.status,
       });
       return textResult(result);
     }

--- a/web/lib/runs/run-status.ts
+++ b/web/lib/runs/run-status.ts
@@ -75,7 +75,6 @@ export const RUN_STATUS_OPTIONS = RUN_STATUS_VALUES.map((value) => ({
 }));
 
 export interface RunStatusCounts {
-  fileCount: number;
   filesCompleted: number;
   filesFailed: number;
   filesPendingUpload: number;
@@ -83,8 +82,9 @@ export interface RunStatusCounts {
   filesUploaded: number;
 }
 
-// Collapse per-run file aggregates into one status. Mirrors the SQL predicates:
-// a run with files always hits a bucket, so `empty` only fires at zero files.
+// Keep the priority order in sync with the SQL predicates in
+// `buildRunListQuery`. Every non-deleted raw file falls into one bucket (the
+// `file_status` enum has no other values), so `empty` needs no `fileCount`.
 export function deriveRunStatus(counts: RunStatusCounts): RunStatus {
   if (counts.filesFailed > 0) {
     return "failed";

--- a/web/lib/runs/run-status.ts
+++ b/web/lib/runs/run-status.ts
@@ -1,0 +1,105 @@
+import {
+  Circle,
+  CircleCheck,
+  CircleDashed,
+  CircleX,
+  Clock,
+  LoaderCircle,
+  type LucideIcon,
+} from "lucide-react";
+
+// Order is the single source of truth for status priority, shared by the icon
+// and the exclusive SQL predicates in `buildRunListQuery`. Highest first.
+export const RUN_STATUS_VALUES = [
+  "failed",
+  "pending",
+  "uploaded",
+  "processing",
+  "completed",
+  "empty",
+] as const;
+
+export type RunStatus = (typeof RUN_STATUS_VALUES)[number];
+
+export interface RunStatusMeta {
+  colorClassName: string;
+  description: string;
+  Icon: LucideIcon;
+  label: string;
+  spin?: boolean;
+}
+
+export const RUN_STATUS_META: Record<RunStatus, RunStatusMeta> = {
+  failed: {
+    label: "Failed",
+    description: "One or more files failed processing",
+    Icon: CircleX,
+    colorClassName: "text-destructive",
+  },
+  pending: {
+    label: "Pending upload",
+    description: "Files are waiting on the instrument PC to be uploaded",
+    Icon: Clock,
+    colorClassName: "text-amber-500",
+  },
+  uploaded: {
+    label: "Awaiting processing",
+    description: "Files are uploaded and waiting in the processing queue",
+    Icon: CircleDashed,
+    colorClassName: "text-muted-foreground",
+  },
+  processing: {
+    label: "Processing",
+    description: "Files are actively being processed",
+    Icon: LoaderCircle,
+    colorClassName: "text-sky-500",
+    spin: true,
+  },
+  completed: {
+    label: "Completed",
+    description: "All files processed successfully",
+    Icon: CircleCheck,
+    colorClassName: "text-green-600 dark:text-green-500",
+  },
+  empty: {
+    label: "Empty",
+    description: "Run has no files",
+    Icon: Circle,
+    colorClassName: "text-muted-foreground",
+  },
+};
+
+export const RUN_STATUS_OPTIONS = RUN_STATUS_VALUES.map((value) => ({
+  value,
+  ...RUN_STATUS_META[value],
+}));
+
+export interface RunStatusCounts {
+  fileCount: number;
+  filesCompleted: number;
+  filesFailed: number;
+  filesPendingUpload: number;
+  filesProcessing: number;
+  filesUploaded: number;
+}
+
+// Collapse per-run file aggregates into one status. Mirrors the SQL predicates:
+// a run with files always hits a bucket, so `empty` only fires at zero files.
+export function deriveRunStatus(counts: RunStatusCounts): RunStatus {
+  if (counts.filesFailed > 0) {
+    return "failed";
+  }
+  if (counts.filesPendingUpload > 0) {
+    return "pending";
+  }
+  if (counts.filesUploaded > 0) {
+    return "uploaded";
+  }
+  if (counts.filesProcessing > 0) {
+    return "processing";
+  }
+  if (counts.filesCompleted > 0) {
+    return "completed";
+  }
+  return "empty";
+}

--- a/web/lib/search-params.ts
+++ b/web/lib/search-params.ts
@@ -18,7 +18,7 @@ export const dashboardSearchParams = {
   date_to: parseAsString.withOptions({ clearOnDefault: true }),
   include_deleted: parseAsBoolean.withDefault(false),
   // Derived run status, multi-select. Empty array = no filter (show all).
-  run_status: parseAsArrayOf(parseAsStringLiteral(RUN_STATUS_VALUES))
+  status: parseAsArrayOf(parseAsStringLiteral(RUN_STATUS_VALUES))
     .withDefault([])
     .withOptions({ clearOnDefault: true }),
   page: parseAsInteger.withDefault(1),
@@ -62,7 +62,7 @@ export const instrumentDetailSearchParams = {
   // Attribution filter: either a userId or the reserved sentinel "unattributed".
   ran_by: parseAsString,
   // Derived run status, multi-select. Empty array = no filter (show all).
-  run_status: parseAsArrayOf(parseAsStringLiteral(RUN_STATUS_VALUES))
+  status: parseAsArrayOf(parseAsStringLiteral(RUN_STATUS_VALUES))
     .withDefault([])
     .withOptions({ clearOnDefault: true }),
 };
@@ -120,12 +120,12 @@ export function hasActiveFilters(params: {
   search: string;
   instrument_id: string[];
   include_deleted: boolean;
-  run_status: RunStatus[];
+  status: RunStatus[];
 }): boolean {
   return (
     params.search !== "" ||
     params.instrument_id.length > 0 ||
     params.include_deleted ||
-    params.run_status.length > 0
+    params.status.length > 0
   );
 }

--- a/web/lib/search-params.ts
+++ b/web/lib/search-params.ts
@@ -6,6 +6,7 @@ import {
   parseAsString,
   parseAsStringLiteral,
 } from "nuqs/server";
+import { RUN_STATUS_VALUES, type RunStatus } from "@/lib/runs/run-status";
 
 // All dashboard filter/pagination state lives in the URL via nuqs. This makes
 // filter combinations shareable via link and keeps the server component in
@@ -16,6 +17,10 @@ export const dashboardSearchParams = {
   date_from: parseAsString.withOptions({ clearOnDefault: true }),
   date_to: parseAsString.withOptions({ clearOnDefault: true }),
   include_deleted: parseAsBoolean.withDefault(false),
+  // Derived run status, multi-select. Empty array = no filter (show all).
+  run_status: parseAsArrayOf(parseAsStringLiteral(RUN_STATUS_VALUES))
+    .withDefault([])
+    .withOptions({ clearOnDefault: true }),
   page: parseAsInteger.withDefault(1),
   per_page: parseAsInteger.withDefault(10),
 };
@@ -56,6 +61,10 @@ export const instrumentDetailSearchParams = {
   color_mode: parseAsString,
   // Attribution filter: either a userId or the reserved sentinel "unattributed".
   ran_by: parseAsString,
+  // Derived run status, multi-select. Empty array = no filter (show all).
+  run_status: parseAsArrayOf(parseAsStringLiteral(RUN_STATUS_VALUES))
+    .withDefault([])
+    .withOptions({ clearOnDefault: true }),
 };
 
 export const instrumentDetailParamsCache = createSearchParamsCache(
@@ -111,10 +120,12 @@ export function hasActiveFilters(params: {
   search: string;
   instrument_id: string[];
   include_deleted: boolean;
+  run_status: RunStatus[];
 }): boolean {
   return (
     params.search !== "" ||
     params.instrument_id.length > 0 ||
-    params.include_deleted
+    params.include_deleted ||
+    params.run_status.length > 0
   );
 }

--- a/web/tests/integration/run-status-filter.test.ts
+++ b/web/tests/integration/run-status-filter.test.ts
@@ -1,0 +1,134 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { files, instrumentRuns, instruments } from "@/lib/db/schema";
+import {
+  api,
+  closeTestDb,
+  getTestDb,
+  resetDb,
+  seedTestUser,
+} from "@/tests/integration/helpers";
+
+// Run status is derived (never stored) from a run's raw-file states. These
+// tests seed files directly and assert the `?status=` filter and its
+// `pagination.total` honor the same priority-exclusive ordering as
+// `deriveRunStatus`. Every request is scoped by instrument_id so totals stay
+// deterministic regardless of other seeded data.
+
+type FileStatus =
+  | "detected"
+  | "upload_requested"
+  | "uploaded"
+  | "processing"
+  | "completed"
+  | "failed";
+
+describe("Run status filter", () => {
+  let token: string;
+  const instrumentId = "run-status-filter-instrument";
+
+  async function seedRun(runId: string, fileStatuses: FileStatus[]) {
+    const db = getTestDb();
+    const [run] = await db
+      .insert(instrumentRuns)
+      .values({ instrumentId, runId, source: "watcher" })
+      .returning({ id: instrumentRuns.id });
+    if (fileStatuses.length > 0) {
+      await db.insert(files).values(
+        fileStatuses.map((status, i) => ({
+          instrumentRunId: run.id,
+          filename: `${runId}-${i}.csv`,
+          category: "raw" as const,
+          status,
+        }))
+      );
+    }
+  }
+
+  async function fetchRuns(query: string) {
+    const res = await api(
+      `/api/v1/instrument-runs?instrument_id=${instrumentId}&per_page=100&${query}`,
+      { token }
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    return {
+      ids: body.data.map((r: { run_id: string }) => r.run_id) as string[],
+      total: body.pagination.total as number,
+    };
+  }
+
+  beforeAll(async () => {
+    await resetDb();
+    ({ token } = await seedTestUser());
+
+    const db = getTestDb();
+    await db.insert(instruments).values({
+      id: instrumentId,
+      displayName: "Run Status Filter Instrument",
+      status: "active",
+    });
+
+    // One run per terminal bucket. The mixed runs each pair a higher-priority
+    // file with a completed file, proving priority-exclusivity: they must be
+    // hidden from the lower-priority `completed` filter.
+    await seedRun("rs-empty", []);
+    await seedRun("rs-completed", ["completed", "completed"]);
+    await seedRun("rs-failed", ["failed", "completed"]);
+    await seedRun("rs-pending", ["detected", "completed"]);
+    await seedRun("rs-uploaded", ["uploaded", "completed"]);
+    await seedRun("rs-processing", ["processing", "completed"]);
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  it("filters to a single status and reports a matching total", async () => {
+    const { ids, total } = await fetchRuns("status=failed");
+    expect(ids).toEqual(["rs-failed"]);
+    expect(total).toBe(1);
+  });
+
+  // The core parity guarantee: `completed` must exclude runs that merely
+  // contain a completed file but rank higher (failed/pending/uploaded/processing).
+  it("'completed' matches only all-completed runs", async () => {
+    const { ids, total } = await fetchRuns("status=completed");
+    expect(ids).toEqual(["rs-completed"]);
+    expect(total).toBe(1);
+  });
+
+  it("'empty' matches only runs with no files", async () => {
+    const { ids, total } = await fetchRuns("status=empty");
+    expect(ids).toEqual(["rs-empty"]);
+    expect(total).toBe(1);
+  });
+
+  it("OR's repeated status params together", async () => {
+    const { ids, total } = await fetchRuns("status=failed&status=empty");
+    expect(new Set(ids)).toEqual(new Set(["rs-failed", "rs-empty"]));
+    expect(total).toBe(2);
+  });
+
+  it("accepts the comma-separated form", async () => {
+    const { ids, total } = await fetchRuns("status=failed,empty");
+    expect(new Set(ids)).toEqual(new Set(["rs-failed", "rs-empty"]));
+    expect(total).toBe(2);
+  });
+
+  it("ignores unknown status values instead of erroring or over-filtering", async () => {
+    const { total } = await fetchRuns("status=bogus");
+    expect(total).toBe(6);
+  });
+
+  it("applies the same filter on the instrument-scoped endpoint", async () => {
+    const res = await api(
+      `/api/v1/instruments/${instrumentId}/runs?status=pending&per_page=100`,
+      { token }
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const ids = body.data.map((r: { run_id: string }) => r.run_id);
+    expect(ids).toEqual(["rs-pending"]);
+    expect(body.pagination.total).toBe(1);
+  });
+});

--- a/web/tests/unit/run-status.test.ts
+++ b/web/tests/unit/run-status.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { parseRunStatusParam } from "@/lib/api/validators";
+import {
+  deriveRunStatus,
+  RUN_STATUS_VALUES,
+  type RunStatusCounts,
+} from "@/lib/runs/run-status";
+
+// Pure-function coverage for the two halves of the derived-status contract:
+// `deriveRunStatus` (used by the icon) and `parseRunStatusParam` (used by both
+// REST GET routes and the MCP tool). The SQL predicates that mirror this
+// priority live in `buildRunListQuery` and are exercised by the integration
+// suite (`tests/integration/run-status-filter.test.ts`).
+
+const ZERO: RunStatusCounts = {
+  filesCompleted: 0,
+  filesFailed: 0,
+  filesPendingUpload: 0,
+  filesProcessing: 0,
+  filesUploaded: 0,
+};
+
+function counts(overrides: Partial<RunStatusCounts>): RunStatusCounts {
+  return { ...ZERO, ...overrides };
+}
+
+describe("deriveRunStatus", () => {
+  it("returns 'empty' when every bucket is zero", () => {
+    expect(deriveRunStatus(ZERO)).toBe("empty");
+  });
+
+  it("maps each bucket to its status in isolation", () => {
+    expect(deriveRunStatus(counts({ filesFailed: 1 }))).toBe("failed");
+    expect(deriveRunStatus(counts({ filesPendingUpload: 1 }))).toBe("pending");
+    expect(deriveRunStatus(counts({ filesUploaded: 1 }))).toBe("uploaded");
+    expect(deriveRunStatus(counts({ filesProcessing: 1 }))).toBe("processing");
+    expect(deriveRunStatus(counts({ filesCompleted: 1 }))).toBe("completed");
+  });
+
+  it("prefers 'failed' over every lower-priority bucket", () => {
+    expect(
+      deriveRunStatus(
+        counts({
+          filesFailed: 1,
+          filesPendingUpload: 1,
+          filesUploaded: 1,
+          filesProcessing: 1,
+          filesCompleted: 1,
+        })
+      )
+    ).toBe("failed");
+  });
+
+  // The intentional behavior change: pending outranks completed, so a run with
+  // both still-pending and already-completed files reads as "pending".
+  it("prefers 'pending' over 'completed'", () => {
+    expect(
+      deriveRunStatus(counts({ filesPendingUpload: 1, filesCompleted: 5 }))
+    ).toBe("pending");
+  });
+
+  it("prefers 'uploaded' over 'processing' and 'completed'", () => {
+    expect(
+      deriveRunStatus(
+        counts({ filesUploaded: 1, filesProcessing: 1, filesCompleted: 1 })
+      )
+    ).toBe("uploaded");
+  });
+
+  it("prefers 'processing' over 'completed'", () => {
+    expect(
+      deriveRunStatus(counts({ filesProcessing: 1, filesCompleted: 1 }))
+    ).toBe("processing");
+  });
+});
+
+describe("parseRunStatusParam", () => {
+  it("returns undefined when the param is absent", () => {
+    expect(parseRunStatusParam(new URLSearchParams())).toBeUndefined();
+  });
+
+  it("parses a single value", () => {
+    expect(parseRunStatusParam(new URLSearchParams("status=failed"))).toEqual([
+      "failed",
+    ]);
+  });
+
+  it("parses repeated params", () => {
+    expect(
+      parseRunStatusParam(new URLSearchParams("status=failed&status=empty"))
+    ).toEqual(["failed", "empty"]);
+  });
+
+  it("parses a comma-separated list", () => {
+    expect(
+      parseRunStatusParam(new URLSearchParams("status=failed,empty"))
+    ).toEqual(["failed", "empty"]);
+  });
+
+  it("trims whitespace around comma-separated values", () => {
+    expect(
+      parseRunStatusParam(new URLSearchParams("status=failed , empty"))
+    ).toEqual(["failed", "empty"]);
+  });
+
+  it("drops unknown values but keeps the valid ones", () => {
+    expect(
+      parseRunStatusParam(new URLSearchParams("status=failed,bogus,empty"))
+    ).toEqual(["failed", "empty"]);
+  });
+
+  it("returns undefined when every value is unknown", () => {
+    expect(
+      parseRunStatusParam(new URLSearchParams("status=bogus&status=nope"))
+    ).toBeUndefined();
+  });
+
+  it("de-duplicates repeated values", () => {
+    expect(
+      parseRunStatusParam(
+        new URLSearchParams("status=failed&status=failed,failed")
+      )
+    ).toEqual(["failed"]);
+  });
+
+  it("accepts every documented status value", () => {
+    const query = RUN_STATUS_VALUES.join(",");
+    expect(parseRunStatusParam(new URLSearchParams(`status=${query}`))).toEqual(
+      [...RUN_STATUS_VALUES]
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a multi-select run-status filter across the instrument runs surfaces. Run status is derived from a run's raw-file aggregates (never stored), and this exposes it as a filter on the instrument detail page, the dashboard, both REST run-list endpoints, and the MCP `search_runs` tool.

- **Shared source of truth** — new `web/lib/runs/run-status.ts` defines the ordered `RUN_STATUS_VALUES` (`failed > pending > uploaded > processing > completed > empty`), `RUN_STATUS_META` (label/icon/color), and `deriveRunStatus()`. This single ordering drives the icon priority, the SQL predicates, the nuqs parsers, and the REST validator so they cannot drift.
- **Index-friendly query** — `buildRunListQuery` gains an optional `statuses?` filter built from priority-exclusive correlated `EXISTS`/`NOT EXISTS` predicates pushed into the shared `conditions[]`. The pagination COUNT query stays join-free and index-backed (`idx_files_status_instrument_run_id`, and `idx_files_instrument_run_id` for `empty`) — no `GROUP BY`/`HAVING`, no schema migration.
- **Filter UI** — `RunFiltersCombobox` gains an optional multi-select STATUS group, wired into both the instrument and dashboard toolbars (including `clearFilters` and `hasFilters`).
- **Icon reorder + Empty** — `RunStatusIcon` now derives its icon/color from the shared table using the new priority; no-file runs render a dedicated hollow `Circle` ("No files") instead of the green check.
- **REST + MCP** — `parseRunStatusParam` (repeated or comma-separated `status`, unknown values dropped) feeds both v1 GET routes; `search_runs` gains a `status` array arg.
- **Consistent param name** — the dashboard/instrument URL query key, the REST `?status=` param, and the MCP `status` arg are all named `status`, so a shared dashboard link matches the API surface.

## Behavior change to note

Because `pending`/`uploaded` now outrank `processing`/`completed`, a run with both completed and still-pending files shows the amber "Pending upload" icon instead of the green check. This is intended but visible fleet-wide.

## Test plan

- [x] `make check-all` (ruff, pyright, ultracite, `tsc --noEmit`) passes clean.
- [x] Instrument page + dashboard: toggle each status and combinations; confirm rows match their icons under the new priority, `empty` shows only zero-file runs, pagination total updates, Clear resets, and the URL reflects `?status=...`.
- [x] REST: `curl` both endpoints with `?status=failed&status=empty` (and comma-separated form); confirm filtering, `pagination.total`, and that unknown status values are ignored rather than erroring.
- [x] MCP: call `search_runs` with `status: ["failed"]` and confirm results match; verify the schema advertises the new arg.

Made with [Cursor](https://cursor.com)