### PR TITLE
Split access token scopes into fine-grained actions

### DIFF
--- a/web/app/api/v1/files/[fileId]/reprocess/route.ts
+++ b/web/app/api/v1/files/[fileId]/reprocess/route.ts
@@ -17,7 +17,7 @@ interface RouteContext {
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "files:write");
+  const authResult = await authorize(request, "files:reprocess");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/files/[fileId]/route.ts
+++ b/web/app/api/v1/files/[fileId]/route.ts
@@ -42,7 +42,7 @@ const VALID_TRANSITIONS: Record<string, string[]> = {
 // ---------------------------------------------------------------------------
 
 export async function PATCH(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "files:write");
+  const authResult = await authorize(request, "files:update");
   if (authResult instanceof Response) {
     return authResult;
   }
@@ -198,7 +198,7 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
 // ---------------------------------------------------------------------------
 
 export async function DELETE(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "files:write");
+  const authResult = await authorize(request, "files:delete");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/attributions/me/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/attributions/me/route.ts
@@ -23,7 +23,7 @@ interface RouteContext {
 // ---------------------------------------------------------------------------
 
 export async function PUT(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "runs:write");
+  const authResult = await authorize(request, "runs:attribute");
   if (authResult instanceof Response) {
     return authResult;
   }
@@ -59,7 +59,7 @@ export async function PUT(request: NextRequest, { params }: RouteContext) {
 // ---------------------------------------------------------------------------
 
 export async function DELETE(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "runs:write");
+  const authResult = await authorize(request, "runs:attribute");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/comments/[commentId]/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/comments/[commentId]/route.ts
@@ -38,7 +38,7 @@ async function preflight(
   // Both PATCH and DELETE on this route mutate comment state, so both
   // require runs:write. Bake the check into the shared preflight so a
   // future verb added here can't accidentally skip it.
-  const authResult = await authorize(request, "runs:write");
+  const authResult = await authorize(request, "runs:comment");
   if (authResult instanceof Response) {
     return { kind: "error", response: authResult };
   }

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/comments/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/comments/route.ts
@@ -58,7 +58,7 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "runs:write");
+  const authResult = await authorize(request, "runs:comment");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/files/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/files/route.ts
@@ -32,7 +32,7 @@ interface RouteContext {
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "files:write");
+  const authResult = await authorize(request, "files:create");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/reprocess/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/reprocess/route.ts
@@ -24,7 +24,7 @@ const REPROCESSABLE_STATUSES = ["completed", "failed"] as const;
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "runs:write");
+  const authResult = await authorize(request, "runs:reprocess");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload-all/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload-all/route.ts
@@ -26,7 +26,7 @@ interface RouteContext {
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "runs:write");
+  const authResult = await authorize(request, "runs:upload");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload-url/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload-url/route.ts
@@ -36,7 +36,7 @@ const UPLOADED_OR_LATER_STATUSES = new Set([
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "runs:write");
+  const authResult = await authorize(request, "runs:upload");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload/route.ts
@@ -28,7 +28,7 @@ interface RouteContext {
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "runs:write");
+  const authResult = await authorize(request, "runs:upload");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/restore/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/restore/route.ts
@@ -19,7 +19,7 @@ interface RouteContext {
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "runs:write");
+  const authResult = await authorize(request, "runs:delete");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/route.ts
@@ -104,7 +104,7 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
 // ---------------------------------------------------------------------------
 
 export async function PATCH(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "runs:write");
+  const authResult = await authorize(request, "runs:update");
   if (authResult instanceof Response) {
     return authResult;
   }
@@ -227,7 +227,7 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
 // ---------------------------------------------------------------------------
 
 export async function DELETE(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "runs:write");
+  const authResult = await authorize(request, "runs:delete");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/instruments/[instrumentId]/runs/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/route.ts
@@ -25,7 +25,7 @@ interface RouteContext {
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "runs:write");
+  const authResult = await authorize(request, "runs:create");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/watchers/[watcherId]/config/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/config/route.ts
@@ -15,7 +15,7 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ watcherId: string }> }
 ) {
-  const authResult = await authorize(request, "watchers:write");
+  const authResult = await authorize(request, "watchers:report");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/watchers/[watcherId]/events/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/events/route.ts
@@ -21,7 +21,7 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ watcherId: string }> }
 ) {
-  const authResult = await authorize(request, "watchers:write");
+  const authResult = await authorize(request, "watchers:report");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
@@ -24,7 +24,7 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ watcherId: string }> }
 ) {
-  const authResult = await authorize(request, "watchers:write");
+  const authResult = await authorize(request, "watchers:report");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/watchers/[watcherId]/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/route.ts
@@ -60,7 +60,7 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ watcherId: string }> }
 ) {
-  const authResult = await authorize(request, "watchers:write");
+  const authResult = await authorize(request, "watchers:admin");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/watchers/register/route.ts
+++ b/web/app/api/v1/watchers/register/route.ts
@@ -11,7 +11,7 @@ import { db } from "@/lib/db";
 import { instruments, watchers } from "@/lib/db/schema";
 
 export async function POST(request: NextRequest) {
-  const authResult = await authorize(request, "watchers:write");
+  const authResult = await authorize(request, "watchers:report");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/settings/tokens/page.tsx
+++ b/web/app/settings/tokens/page.tsx
@@ -22,6 +22,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { UserAvatar } from "@/components/user-avatar";
+import { LEGACY_SCOPE_EXPANSIONS } from "@/lib/api/scopes";
 import { auth } from "@/lib/auth";
 import { toInitials } from "@/lib/avatar-color";
 import { db } from "@/lib/db";
@@ -44,13 +45,35 @@ export const metadata: Metadata = {
 //      shouldn't appear in practice — but rendering an explicit empty
 //      state here is much clearer than a silently-empty cell if it ever
 //      does happen (e.g. a manual SQL update).
-//   2. `["*"]` (backfill wildcard) → single "Full access" pill so legacy
-//      tokens stand out at a glance.
+//   2. `["*"]` (backfill wildcard) → single "Full access (legacy)" pill so
+//      pre-scope tokens stand out and read as rotation candidates.
 //   3. Single explicit scope → that scope as a badge, no tooltip needed
 //      because everything is already visible.
 //   4. Multiple explicit scopes → first scope (sorted) plus a "+N"
 //      counter badge. Hovering the cell reveals the full list in a
 //      tooltip so the table stays scannable on tokens with many scopes.
+//
+// Deprecated coarse `:write` scopes (superseded by fine-grained actions but
+// still honored on old tokens) render with an amber tint wherever they
+// appear, flagging them for re-issue.
+const LEGACY_COARSE_SCOPES = new Set(Object.keys(LEGACY_SCOPE_EXPANSIONS));
+
+function ScopeBadge({ scope }: { scope: string }) {
+  const isLegacy = LEGACY_COARSE_SCOPES.has(scope);
+  return (
+    <Badge
+      className={
+        isLegacy
+          ? "font-mono text-amber-600 text-xs dark:text-amber-500"
+          : "font-mono text-xs"
+      }
+      variant="secondary"
+    >
+      {scope}
+    </Badge>
+  );
+}
+
 function TokenScopeBadges({ scopes }: { scopes: string[] }) {
   if (scopes.length === 0) {
     return (
@@ -65,8 +88,11 @@ function TokenScopeBadges({ scopes }: { scopes: string[] }) {
 
   if (scopes.length === 1 && scopes[0] === "*") {
     return (
-      <Badge className="text-xs" variant="secondary">
-        Full access
+      <Badge
+        className="text-amber-600 text-xs dark:text-amber-500"
+        variant="secondary"
+      >
+        Full access (legacy)
       </Badge>
     );
   }
@@ -77,11 +103,7 @@ function TokenScopeBadges({ scopes }: { scopes: string[] }) {
   const sorted = [...scopes].sort();
 
   if (sorted.length === 1) {
-    return (
-      <Badge className="font-mono text-xs" variant="secondary">
-        {sorted[0]}
-      </Badge>
-    );
+    return <ScopeBadge scope={sorted[0]} />;
   }
 
   const [first, ...rest] = sorted;
@@ -89,9 +111,7 @@ function TokenScopeBadges({ scopes }: { scopes: string[] }) {
     <Tooltip>
       <TooltipTrigger asChild>
         <div className="flex w-fit flex-wrap items-center gap-1">
-          <Badge className="font-mono text-xs" variant="secondary">
-            {first}
-          </Badge>
+          <ScopeBadge scope={first} />
           <Badge className="text-xs" variant="secondary">
             +{rest.length}
           </Badge>
@@ -100,7 +120,16 @@ function TokenScopeBadges({ scopes }: { scopes: string[] }) {
       <TooltipContent>
         <div className="flex flex-col gap-0.5 font-mono text-xs">
           {sorted.map((scope) => (
-            <span key={scope}>{scope}</span>
+            <span
+              className={
+                LEGACY_COARSE_SCOPES.has(scope)
+                  ? "text-amber-600 dark:text-amber-500"
+                  : undefined
+              }
+              key={scope}
+            >
+              {scope}
+            </span>
           ))}
         </div>
       </TooltipContent>

--- a/web/components/tokens/create-token-dialog.tsx
+++ b/web/components/tokens/create-token-dialog.tsx
@@ -168,7 +168,9 @@ function CreateTokenForm({
 
   // Resources that have a write-type scope selected but not their `:read`.
   // Scopes stay atomic (write never implies read), so this is a common
-  // footgun for interactive tooling — surface it as a soft warning.
+  // footgun for interactive tooling — surface it as a soft warning. It is
+  // suppressed for exact preset matches below: machine presets (Watcher,
+  // Lambda) legitimately write resources they never GET.
   const missingReadResources = useMemo(() => {
     const missing = new Set<string>();
     for (const scope of selected) {
@@ -314,7 +316,7 @@ function CreateTokenForm({
             </CollapsibleContent>
           </Collapsible>
           <CapabilitySummary scopes={selectedList} />
-          {missingReadResources.length > 0 ? (
+          {activePresetId === null && missingReadResources.length > 0 ? (
             <Alert variant="destructive">
               <TriangleAlert />
               <AlertDescription>
@@ -452,11 +454,13 @@ function ScopeRow({
       />
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="flex items-center gap-1.5">
-            {meta.label}
-            {meta.destructive ? (
-              <TriangleAlert className="size-3 text-amber-600 dark:text-amber-500" />
-            ) : null}
+          <span className="flex flex-1 items-center justify-between gap-2">
+            <span className="flex items-center gap-1.5">
+              {meta.label}
+              {meta.destructive ? (
+                <TriangleAlert className="size-3 text-amber-600 dark:text-amber-500" />
+              ) : null}
+            </span>
             <code className="text-muted-foreground text-xs">{scope}</code>
           </span>
         </TooltipTrigger>

--- a/web/components/tokens/create-token-dialog.tsx
+++ b/web/components/tokens/create-token-dialog.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { Loader2, Plus } from "lucide-react";
+import { ChevronsUpDown, Loader2, Plus, TriangleAlert } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { CopyButton } from "@/components/copy-button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import {
   Dialog,
   DialogContent,
@@ -25,6 +31,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { SCOPE_METADATA, SCOPE_PRESETS } from "@/lib/api/scope-catalog";
 import { ALL_SCOPES, type Scope } from "@/lib/api/scopes";
 
 // Lifted dialog state: the form and success bodies are sibling components
@@ -42,6 +55,32 @@ const EXPIRY_PRESETS = [
   { label: "No expiry", value: "none" },
 ] as const;
 
+// Scopes are `resource:action`; `:read` is the sole read action per resource.
+const READ_SCOPES = ALL_SCOPES.filter((s) => s.endsWith(":read"));
+const WRITE_SCOPES = ALL_SCOPES.filter((s) => !s.endsWith(":read"));
+
+interface ResourceGroup {
+  resource: string;
+  scopes: Scope[];
+}
+
+// Group scopes by resource, preserving ALL_SCOPES order so the grid layout is
+// deterministic and adding a scope surfaces automatically.
+function groupScopesByResource(): ResourceGroup[] {
+  const byResource = new Map<string, Scope[]>();
+  for (const scope of ALL_SCOPES) {
+    const [resource] = scope.split(":") as [string];
+    const list = byResource.get(resource) ?? [];
+    list.push(scope);
+    byResource.set(resource, list);
+  }
+  return Array.from(byResource, ([resource, scopes]) => ({ resource, scopes }));
+}
+
+function setsEqual(a: Set<Scope>, b: readonly Scope[]): boolean {
+  return a.size === b.length && b.every((s) => a.has(s));
+}
+
 function computeExpiresAt(days: string): string | undefined {
   if (days === "none") {
     return;
@@ -51,34 +90,10 @@ function computeExpiresAt(days: string): string | undefined {
   return d.toISOString();
 }
 
-// Resource → [read, write] grid order. Derived from ALL_SCOPES so adding a
-// new scope automatically surfaces in the picker. Tokens API rejects "*"
-// from callers, so it's intentionally absent here.
-interface ResourceRow {
-  read?: Scope;
-  resource: string;
-  write?: Scope;
-}
-
-function buildResourceRows(): ResourceRow[] {
-  const byResource = new Map<string, ResourceRow>();
-  for (const scope of ALL_SCOPES) {
-    const [resource, action] = scope.split(":") as [string, "read" | "write"];
-    const row = byResource.get(resource) ?? { resource };
-    row[action] = scope;
-    byResource.set(resource, row);
-  }
-  return Array.from(byResource.values());
-}
-
 export function CreateTokenDialog() {
   const [open, setOpen] = useState(false);
   const [view, setView] = useState<View>({ kind: "form" });
 
-  // Discriminated `view` controls the body: `"form"` while creating, then
-  // flipping to `{ kind: "success", plaintext }` once the API responds.
-  // No `step` boolean, no shared plaintext state — `plaintext` exists only
-  // in the success branch.
   return (
     <Dialog
       onOpenChange={(value) => {
@@ -101,6 +116,7 @@ export function CreateTokenDialog() {
         </Button>
       </DialogTrigger>
       <DialogContent
+        className="max-h-[90vh] overflow-y-auto sm:max-w-lg"
         onEscapeKeyDown={(e) => {
           if (view.kind === "success") {
             e.preventDefault();
@@ -138,14 +154,41 @@ function CreateTokenForm({
   const [name, setName] = useState("");
   const [expiry, setExpiry] = useState("90");
   const [selected, setSelected] = useState<Set<Scope>>(() => new Set());
+  const [customOpen, setCustomOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
 
-  // ALL_SCOPES is module-level constant, so the grid is stable across
-  // renders — memoising the build avoids re-grouping on every keystroke.
-  const resourceRows = useMemo(() => buildResourceRows(), []);
+  const groups = useMemo(groupScopesByResource, []);
 
-  // Functional setState so the handler identity stays stable across
-  // renders; the Checkbox subtree can rely on Object.is to skip re-render.
+  // Which preset (if any) the current selection matches. Derived during
+  // render so preset highlighting can't drift out of sync with the boxes.
+  const activePresetId = useMemo(() => {
+    const match = SCOPE_PRESETS.find((p) => setsEqual(selected, p.scopes));
+    return match?.id ?? null;
+  }, [selected]);
+
+  // Resources that have a write-type scope selected but not their `:read`.
+  // Scopes stay atomic (write never implies read), so this is a common
+  // footgun for interactive tooling — surface it as a soft warning.
+  const missingReadResources = useMemo(() => {
+    const missing = new Set<string>();
+    for (const scope of selected) {
+      if (scope.endsWith(":read")) {
+        continue;
+      }
+      const [resource] = scope.split(":") as [string];
+      if (!selected.has(`${resource}:read` as Scope)) {
+        missing.add(resource);
+      }
+    }
+    return Array.from(missing);
+  }, [selected]);
+
+  const selectedList = useMemo(
+    () => ALL_SCOPES.filter((s) => selected.has(s)),
+    [selected]
+  );
+
+  // Functional setState so handler identities stay stable across renders.
   const toggle = useCallback((s: Scope) => {
     setSelected((prev) => {
       const next = new Set(prev);
@@ -158,8 +201,27 @@ function CreateTokenForm({
     });
   }, []);
 
-  // Disabled state is derived inline from the inputs — no extra `useState`
-  // mirror, no effect to keep them in sync.
+  const applyPreset = useCallback((scopes: readonly Scope[]) => {
+    setSelected(new Set(scopes));
+  }, []);
+
+  // Toggle a whole column: clear the group if it's already fully selected,
+  // otherwise add every scope in it.
+  const toggleColumn = useCallback((scopes: readonly Scope[]) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      const allSelected = scopes.every((s) => next.has(s));
+      for (const s of scopes) {
+        if (allSelected) {
+          next.delete(s);
+        } else {
+          next.add(s);
+        }
+      }
+      return next;
+    });
+  }, []);
+
   const canSubmit = Boolean(name.trim()) && selected.size > 0 && !isPending;
 
   const handleCreate = () => {
@@ -220,28 +282,47 @@ function CreateTokenForm({
               ))}
             </SelectContent>
           </Select>
+          {expiry === "none" ? (
+            <p className="flex items-center gap-1.5 text-amber-600 text-xs dark:text-amber-500">
+              <TriangleAlert className="size-3.5 shrink-0" />
+              This token never expires. Prefer a fixed expiry and rotate it.
+            </p>
+          ) : null}
         </div>
         <div className="grid gap-2">
           <Label>Scopes</Label>
-          <div className="grid grid-cols-[1fr_auto_auto] items-center gap-x-4 gap-y-2 rounded-md border bg-background px-3 py-2 dark:bg-muted">
-            <div className="font-medium text-muted-foreground text-xs">
-              Resource
-            </div>
-            <div className="w-14 text-center font-medium text-muted-foreground text-xs">
-              Read
-            </div>
-            <div className="w-14 text-center font-medium text-muted-foreground text-xs">
-              Write
-            </div>
-            {resourceRows.map((row) => (
-              <ScopeRow
-                key={row.resource}
+          <PresetPicker activePresetId={activePresetId} onApply={applyPreset} />
+          <Collapsible onOpenChange={setCustomOpen} open={customOpen}>
+            <CollapsibleTrigger asChild>
+              <Button
+                className="w-full justify-between text-muted-foreground"
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                Customize scopes
+                <ChevronsUpDown className="size-4" />
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="pt-2">
+              <ScopeGrid
+                groups={groups}
                 onToggle={toggle}
-                row={row}
+                onToggleColumn={toggleColumn}
                 selected={selected}
               />
-            ))}
-          </div>
+            </CollapsibleContent>
+          </Collapsible>
+          <CapabilitySummary scopes={selectedList} />
+          {missingReadResources.length > 0 ? (
+            <Alert variant="destructive">
+              <TriangleAlert />
+              <AlertDescription>
+                No read access for {missingReadResources.join(", ")}. Add the
+                matching read scope if the tool needs to fetch these resources.
+              </AlertDescription>
+            </Alert>
+          ) : null}
           <p className="text-muted-foreground text-xs">
             Pick the minimum scopes this token needs. You can&apos;t change them
             after creation — revoke and re-issue instead.
@@ -260,43 +341,161 @@ function CreateTokenForm({
   );
 }
 
+function PresetPicker({
+  activePresetId,
+  onApply,
+}: {
+  activePresetId: string | null;
+  onApply: (scopes: readonly Scope[]) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {SCOPE_PRESETS.map((preset) => (
+        <Tooltip key={preset.id}>
+          <TooltipTrigger asChild>
+            <Button
+              onClick={() => onApply(preset.scopes)}
+              size="sm"
+              type="button"
+              variant={activePresetId === preset.id ? "default" : "outline"}
+            >
+              {preset.label}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{preset.description}</TooltipContent>
+        </Tooltip>
+      ))}
+    </div>
+  );
+}
+
+function ScopeGrid({
+  groups,
+  selected,
+  onToggle,
+  onToggleColumn,
+}: {
+  groups: ResourceGroup[];
+  selected: Set<Scope>;
+  onToggle: (s: Scope) => void;
+  onToggleColumn: (scopes: readonly Scope[]) => void;
+}) {
+  return (
+    <TooltipProvider>
+      <div className="rounded-md border bg-background dark:bg-muted">
+        <div className="flex items-center justify-between gap-2 border-b px-3 py-2">
+          <span className="font-medium text-muted-foreground text-xs">
+            Resource
+          </span>
+          <div className="flex gap-1">
+            <Button
+              onClick={() => onToggleColumn(READ_SCOPES)}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              All read
+            </Button>
+            <Button
+              onClick={() => onToggleColumn(WRITE_SCOPES)}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              All write
+            </Button>
+          </div>
+        </div>
+        <div className="max-h-64 overflow-y-auto px-3 py-2">
+          {groups.map((group) => (
+            <div className="py-1.5" key={group.resource}>
+              <div className="font-medium text-xs capitalize">
+                {group.resource.replace("-", " ")}
+              </div>
+              <div className="mt-1 grid gap-1.5">
+                {group.scopes.map((scope) => (
+                  <ScopeRow
+                    key={scope}
+                    onToggle={onToggle}
+                    scope={scope}
+                    selected={selected.has(scope)}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}
+
 function ScopeRow({
-  row,
+  scope,
   selected,
   onToggle,
 }: {
-  row: ResourceRow;
-  selected: Set<Scope>;
+  scope: Scope;
+  selected: boolean;
   onToggle: (s: Scope) => void;
 }) {
+  const meta = SCOPE_METADATA[scope];
   return (
-    <>
-      <div className="text-sm">{row.resource}</div>
-      <div className="flex w-14 justify-center">
-        {row.read ? (
-          <Checkbox
-            aria-label={row.read}
-            checked={selected.has(row.read)}
-            id={`scope-${row.read}`}
-            onCheckedChange={() => onToggle(row.read as Scope)}
-          />
-        ) : (
-          <span className="text-muted-foreground/40 text-xs">—</span>
-        )}
-      </div>
-      <div className="flex w-14 justify-center">
-        {row.write ? (
-          <Checkbox
-            aria-label={row.write}
-            checked={selected.has(row.write)}
-            id={`scope-${row.write}`}
-            onCheckedChange={() => onToggle(row.write as Scope)}
-          />
-        ) : (
-          <span className="text-muted-foreground/40 text-xs">—</span>
-        )}
-      </div>
-    </>
+    <label
+      className="flex cursor-pointer items-center gap-2 text-sm"
+      htmlFor={`scope-${scope}`}
+    >
+      <Checkbox
+        checked={selected}
+        id={`scope-${scope}`}
+        onCheckedChange={() => onToggle(scope)}
+      />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="flex items-center gap-1.5">
+            {meta.label}
+            {meta.destructive ? (
+              <TriangleAlert className="size-3 text-amber-600 dark:text-amber-500" />
+            ) : null}
+            <code className="text-muted-foreground text-xs">{scope}</code>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{meta.description}</TooltipContent>
+      </Tooltip>
+    </label>
+  );
+}
+
+function CapabilitySummary({ scopes }: { scopes: Scope[] }) {
+  if (scopes.length === 0) {
+    return (
+      <p className="text-muted-foreground text-xs italic">
+        No scopes selected yet.
+      </p>
+    );
+  }
+  return (
+    <div className="rounded-md border bg-muted/40 px-3 py-2">
+      <p className="mb-1 font-medium text-xs">This token will be able to:</p>
+      <ul className="grid gap-0.5">
+        {scopes.map((scope) => {
+          const meta = SCOPE_METADATA[scope];
+          return (
+            <li
+              className={`flex items-center gap-1.5 text-xs ${meta.destructive ? "text-amber-600 dark:text-amber-500" : "text-muted-foreground"}`}
+              key={scope}
+            >
+              {meta.destructive ? (
+                <TriangleAlert className="size-3 shrink-0" />
+              ) : (
+                <span className="size-1 shrink-0 rounded-full bg-current opacity-60" />
+              )}
+              {meta.description}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
   );
 }
 

--- a/web/lib/api/scope-catalog.ts
+++ b/web/lib/api/scope-catalog.ts
@@ -1,0 +1,182 @@
+import type { Scope } from "@/lib/api/scopes";
+
+// Human-facing copy for each scope, consumed by the token modal's per-scope
+// tooltips and the live "this token can…" summary. `destructive` drives the
+// warning styling so admins can spot delete/reset grants at a glance.
+export interface ScopeMeta {
+  description: string;
+  destructive: boolean;
+  label: string;
+}
+
+export const SCOPE_METADATA: Record<Scope, ScopeMeta> = {
+  "instruments:read": {
+    label: "View instruments",
+    description: "Read instruments, dashboard status, and file patterns.",
+    destructive: false,
+  },
+  "instruments:write": {
+    label: "Manage instruments",
+    description: "Create instruments and edit their configuration.",
+    destructive: false,
+  },
+  "runs:read": {
+    label: "View runs",
+    description:
+      "Read and search runs, their files, comments, and attributions.",
+    destructive: false,
+  },
+  "runs:create": {
+    label: "Create runs",
+    description: "Create run records.",
+    destructive: false,
+  },
+  "runs:update": {
+    label: "Edit runs",
+    description: "Update run metadata.",
+    destructive: false,
+  },
+  "runs:delete": {
+    label: "Delete runs",
+    description: "Soft-delete and restore runs.",
+    destructive: true,
+  },
+  "runs:reprocess": {
+    label: "Reprocess runs",
+    description: "Re-run the processing workflow for a run.",
+    destructive: true,
+  },
+  "runs:upload": {
+    label: "Upload to runs",
+    description: "Request presigned S3 URLs to upload files to a run.",
+    destructive: false,
+  },
+  "runs:attribute": {
+    label: "Claim runs",
+    description: "Claim or unclaim runs on your own behalf.",
+    destructive: false,
+  },
+  "runs:comment": {
+    label: "Comment on runs",
+    description: "Add, edit, and delete run comments.",
+    destructive: false,
+  },
+  "files:read": {
+    label: "View files",
+    description: "Read file metadata and download files and run archives.",
+    destructive: false,
+  },
+  "files:create": {
+    label: "Create files",
+    description: "Register file records against a run.",
+    destructive: false,
+  },
+  "files:update": {
+    label: "Edit files",
+    description: "Update file metadata and upload state.",
+    destructive: false,
+  },
+  "files:delete": {
+    label: "Delete files",
+    description: "Delete files.",
+    destructive: true,
+  },
+  "files:reprocess": {
+    label: "Reprocess files",
+    description: "Re-run the processing workflow for a file.",
+    destructive: true,
+  },
+  "watchers:read": {
+    label: "View watchers",
+    description: "Read watcher status, heartbeats, and upload queues.",
+    destructive: false,
+  },
+  "watchers:report": {
+    label: "Report as watcher",
+    description: "Register, heartbeat, send events, and push watcher config.",
+    destructive: false,
+  },
+  "watchers:admin": {
+    label: "Administer watchers",
+    description: "Delete watchers.",
+    destructive: true,
+  },
+  "archive-jobs:read": {
+    label: "View archive jobs",
+    description: "Read run-archive job status.",
+    destructive: false,
+  },
+  "archive-jobs:write": {
+    label: "Update archive jobs",
+    description: "Update run-archive job status (Lambda callback).",
+    destructive: false,
+  },
+};
+
+export interface ScopePreset {
+  description: string;
+  id: string;
+  label: string;
+  scopes: Scope[];
+}
+
+// Curated starting points offered above the granular grid. Machine presets
+// (Watcher, Lambda) mirror the exact endpoints those agents call so a token
+// minted from them is already least-privilege; MCP mirrors the scopes the
+// MCP tools check, giving a member an MCP-client surface analogous to the
+// web UI. Custom (no preset) leaves the grid untouched for fine-tuning.
+export const SCOPE_PRESETS: ScopePreset[] = [
+  {
+    id: "read-only",
+    label: "Read-only",
+    description: "View everything, change nothing.",
+    scopes: [
+      "instruments:read",
+      "runs:read",
+      "files:read",
+      "watchers:read",
+      "archive-jobs:read",
+    ],
+  },
+  {
+    id: "mcp",
+    label: "MCP",
+    description:
+      "For an MCP client — browse, download, reprocess files, and claim runs, like the web UI.",
+    scopes: [
+      "instruments:read",
+      "runs:read",
+      "runs:attribute",
+      "files:read",
+      "files:reprocess",
+      "watchers:read",
+    ],
+  },
+  {
+    id: "watcher",
+    label: "Watcher",
+    description: "For a watcher agent reporting runs and uploads.",
+    scopes: [
+      "instruments:read",
+      "instruments:write",
+      "watchers:read",
+      "watchers:report",
+      "runs:create",
+      "runs:update",
+      "runs:upload",
+      "files:update",
+    ],
+  },
+  {
+    id: "lambda",
+    label: "Lambda",
+    description: "For the processing Lambda writing runs and file results.",
+    scopes: [
+      "runs:create",
+      "runs:update",
+      "files:create",
+      "files:update",
+      "archive-jobs:write",
+    ],
+  },
+];

--- a/web/lib/api/scopes.ts
+++ b/web/lib/api/scopes.ts
@@ -1,17 +1,27 @@
-// Canonical scope vocabulary. Each entry is `resource:action` and is added
+// Canonical scope vocabulary. Each entry is `resource:action` and is granted
 // or revoked atomically — there are no implicit hierarchies (e.g. `:write`
-// does not imply `:read`). The `*` wildcard is reserved for the migration
-// backfill and for the watcher/Lambda PATs until they are rotated to
-// least-privilege; `POST /api/v1/tokens` rejects it from API callers.
+// does not imply `:read`, and `runs:reprocess` does not imply `runs:delete`).
+// Actions are split finely so a token can carry the minimum a caller needs:
+// reprocessing a run never drags along the ability to delete one.
 export const ALL_SCOPES = [
   "instruments:read",
   "instruments:write",
   "runs:read",
-  "runs:write",
+  "runs:create",
+  "runs:update",
+  "runs:delete",
+  "runs:reprocess",
+  "runs:upload",
+  "runs:attribute",
+  "runs:comment",
   "files:read",
-  "files:write",
+  "files:create",
+  "files:update",
+  "files:delete",
+  "files:reprocess",
   "watchers:read",
-  "watchers:write",
+  "watchers:report",
+  "watchers:admin",
   "archive-jobs:read",
   "archive-jobs:write",
 ] as const;
@@ -22,6 +32,30 @@ export type Scope = (typeof ALL_SCOPES)[number];
 // (`POST /api/v1/tokens`). Avoids re-scanning ALL_SCOPES on every request.
 export const SCOPE_SET: Set<Scope> = new Set<Scope>(ALL_SCOPES);
 
+// Coarse scopes minted before the fine-grained split, plus `*`. These are no
+// longer offered when creating a token, but tokens already carrying them
+// (deployed watchers, the Lambda, migration-backfilled PATs) must keep
+// authorizing. `hasScope` expands them to the fine scopes they used to imply
+// so nothing breaks before those tokens are rotated to least-privilege.
+export const LEGACY_SCOPE_EXPANSIONS: Record<string, readonly Scope[]> = {
+  "runs:write": [
+    "runs:create",
+    "runs:update",
+    "runs:delete",
+    "runs:reprocess",
+    "runs:upload",
+    "runs:attribute",
+    "runs:comment",
+  ],
+  "files:write": [
+    "files:create",
+    "files:update",
+    "files:delete",
+    "files:reprocess",
+  ],
+  "watchers:write": ["watchers:report", "watchers:admin"],
+};
+
 // Shape required by `hasScope`. We intentionally avoid importing the full
 // `AuthResult` from `@/lib/api/auth` to break a circular dependency —
 // scopes.ts is imported by auth.ts callers.
@@ -30,22 +64,24 @@ interface AuthLike {
 }
 
 export function hasScope(auth: AuthLike, required: Scope): boolean {
-  return auth.scopes.includes("*") || auth.scopes.includes(required);
+  if (auth.scopes.includes("*") || auth.scopes.includes(required)) {
+    return true;
+  }
+  // A held legacy `:write` covers the fine scope it used to imply.
+  return auth.scopes.some((held) =>
+    LEGACY_SCOPE_EXPANSIONS[held]?.includes(required)
+  );
 }
 
 // Validates the `scopes` field on a `POST /api/v1/tokens` request body.
 // Returns the typed scope array on success, or an error message ready for
-// the 400 response. Extracted from the route handler so the rules
-// ("non-empty", "no wildcard", "valid vocabulary") can be unit-tested
-// without spinning up the Next.js server, NextAuth, or the database.
+// the 400 response. Extracted from the route handler so the rules can be
+// unit-tested without spinning up the Next.js server, NextAuth, or the DB.
 //
-// Rules enforced here:
-//   - `scopes` must be an array with at least one entry.
-//   - The wildcard `*` is rejected — it's reserved for the migration
-//     backfill and the watcher/Lambda PATs; API callers must enumerate.
-//   - Every entry must be a string in `SCOPE_SET`. Unknown / non-string
-//     entries are reported in the error message verbatim so callers can
-//     spot typos quickly.
+// New tokens must enumerate fine scopes: the wildcard `*` and the legacy
+// coarse `:write` scopes are rejected so freshly minted credentials are
+// always least-privilege, even though `hasScope` still honors them on
+// existing tokens.
 export type ScopeValidationResult =
   | { ok: true; scopes: Scope[] }
   | { ok: false; error: string };
@@ -58,6 +94,15 @@ export function validateRequestedScopes(input: unknown): ScopeValidationResult {
     return {
       ok: false,
       error: "scopes must not include the wildcard '*' — list explicit scopes",
+    };
+  }
+  const legacy = input.filter(
+    (s): s is string => typeof s === "string" && s in LEGACY_SCOPE_EXPANSIONS
+  );
+  if (legacy.length > 0) {
+    return {
+      ok: false,
+      error: `Deprecated coarse scopes are not allowed on new tokens: ${legacy.join(", ")}. Use the fine-grained scopes instead.`,
     };
   }
   const invalid = input.filter(

--- a/web/lib/mcp/tools.ts
+++ b/web/lib/mcp/tools.ts
@@ -547,7 +547,7 @@ export function registerTools(server: McpServer) {
       annotations: { readOnlyHint: false, destructiveHint: true },
     },
     async ({ fileId }, { authInfo }) => {
-      const scopeError = requireMcpScope(authInfo, "files:write");
+      const scopeError = requireMcpScope(authInfo, "files:reprocess");
       if (scopeError) {
         return scopeError;
       }
@@ -616,7 +616,7 @@ export function registerTools(server: McpServer) {
       },
     },
     async ({ instrumentId, runId }, { authInfo }) => {
-      const scopeError = requireMcpScope(authInfo, "runs:write");
+      const scopeError = requireMcpScope(authInfo, "runs:attribute");
       if (scopeError) {
         return scopeError;
       }
@@ -662,7 +662,7 @@ export function registerTools(server: McpServer) {
       },
     },
     async ({ instrumentId, runId }, { authInfo }) => {
-      const scopeError = requireMcpScope(authInfo, "runs:write");
+      const scopeError = requireMcpScope(authInfo, "runs:attribute");
       if (scopeError) {
         return scopeError;
       }

--- a/web/tests/integration/mcp.test.ts
+++ b/web/tests/integration/mcp.test.ts
@@ -326,7 +326,9 @@ describe("MCP Server (HTTP)", () => {
       scopedToken
     );
     expect(claim.isError).toBe(true);
-    expect(claim.content[0].text).toMatch(/missing required scope: runs:write/);
+    expect(claim.content[0].text).toMatch(
+      /missing required scope: runs:attribute/
+    );
   });
 
   it("['files:read'] can call get_file but not reprocess_file", async () => {
@@ -348,7 +350,7 @@ describe("MCP Server (HTTP)", () => {
     );
     expect(reprocess.isError).toBe(true);
     expect(reprocess.content[0].text).toMatch(
-      /missing required scope: files:write/
+      /missing required scope: files:reprocess/
     );
   });
 

--- a/web/tests/integration/scopes.test.ts
+++ b/web/tests/integration/scopes.test.ts
@@ -56,16 +56,17 @@ describe("PAT scopes", () => {
     expect(postRes.status).toBe(403);
     const body = await postRes.json();
     expect(body.error.code).toBe("FORBIDDEN");
-    expect(body.error.message).toMatch(/missing required scope: runs:write/);
+    expect(body.error.message).toMatch(/missing required scope: runs:create/);
   });
 
   // -------------------------------------------------------------------------
-  // runs:write — allowed to POST. (We don't assert GET-denied here because
-  // some callers grant both `:read` and `:write` for the same noun, and the
-  // route enforcement is the same one tested in the read-only case above.)
+  // Legacy 'runs:write' — a coarse scope minted before the fine-grained
+  // split. `hasScope` expands it, so it still satisfies the fine `runs:create`
+  // the POST route now requires. Guards the backward-compat path for deployed
+  // watcher/Lambda tokens.
   // -------------------------------------------------------------------------
 
-  it("['runs:write'] can POST runs", async () => {
+  it("legacy ['runs:write'] still satisfies runs:create on POST", async () => {
     const { token } = await seedTestUser({ scopes: ["runs:write"] });
 
     const postRes = await api(`/api/v1/instruments/${instrumentId}/runs`, {
@@ -172,7 +173,7 @@ describe("PAT scopes", () => {
     const getRes = await api("/api/v1/watchers", { token });
     expect(getRes.status).toBe(200);
 
-    // POST /watchers/register requires `watchers:write`. We send a
+    // POST /watchers/register requires `watchers:report`. We send a
     // well-formed body referencing a non-existent instrument; the scope
     // guard runs before the lookup, so 403 = scope-fail and any other
     // 4xx = scope-pass.
@@ -184,7 +185,7 @@ describe("PAT scopes", () => {
     expect(postRes.status).toBe(403);
     const body = await postRes.json();
     expect(body.error.message).toMatch(
-      /missing required scope: watchers:write/
+      /missing required scope: watchers:report/
     );
   });
 
@@ -224,9 +225,9 @@ describe("PAT scopes", () => {
   // implicit hierarchy to `hasScope`.
   // -------------------------------------------------------------------------
 
-  it("['runs:read', 'files:write'] grants exactly those scopes and nothing else", async () => {
+  it("['runs:read', 'files:update'] grants exactly those scopes and nothing else", async () => {
     const { token } = await seedTestUser({
-      scopes: ["runs:read", "files:write"],
+      scopes: ["runs:read", "files:update"],
     });
 
     // runs:read → GET succeeds
@@ -235,7 +236,7 @@ describe("PAT scopes", () => {
     });
     expect(runsGet.status).toBe(200);
 
-    // runs:write → POST denied (no implicit `:write` from `:read`)
+    // runs:create → POST denied (reading runs never implies creating them)
     const runsPost = await api(`/api/v1/instruments/${instrumentId}/runs`, {
       method: "POST",
       token,
@@ -243,10 +244,10 @@ describe("PAT scopes", () => {
     });
     expect(runsPost.status).toBe(403);
     expect((await runsPost.json()).error.message).toMatch(
-      /missing required scope: runs:write/
+      /missing required scope: runs:create/
     );
 
-    // files:write → PATCH passes the scope guard. The file doesn't exist
+    // files:update → PATCH passes the scope guard. The file doesn't exist
     // so we get a 404 from the not-found branch, not 403 from the guard.
     const filesPatch = await api("/api/v1/files/99999", {
       method: "PATCH",

--- a/web/tests/unit/scope-validation.test.ts
+++ b/web/tests/unit/scope-validation.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { ALL_SCOPES, validateRequestedScopes } from "@/lib/api/scopes";
+import {
+  ALL_SCOPES,
+  hasScope,
+  validateRequestedScopes,
+} from "@/lib/api/scopes";
 
 // Validates the scope-list parsing rules used by `POST /api/v1/tokens`.
 // These tests run with no DB / no Next.js server — `validateRequestedScopes`
@@ -55,7 +59,16 @@ describe("validateRequestedScopes", () => {
       expect(result.error).toMatch(/Invalid scopes: bogus:read/);
       // The full vocabulary is enumerated so callers can spot typos.
       expect(result.error).toContain("runs:read");
-      expect(result.error).toContain("files:write");
+      expect(result.error).toContain("files:reprocess");
+    }
+  });
+
+  it("rejects deprecated coarse '*:write' scopes on new tokens", () => {
+    const result = validateRequestedScopes(["runs:write"]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/Deprecated coarse scopes/);
+      expect(result.error).toContain("runs:write");
     }
   });
 
@@ -76,7 +89,7 @@ describe("validateRequestedScopes", () => {
   });
 
   it("accepts a mix of read and write scopes across resources", () => {
-    const requested = ["runs:read", "files:write", "watchers:read"];
+    const requested = ["runs:read", "files:reprocess", "watchers:read"];
     const result = validateRequestedScopes(requested);
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -90,5 +103,55 @@ describe("validateRequestedScopes", () => {
     if (result.ok) {
       expect(result.scopes).toHaveLength(ALL_SCOPES.length);
     }
+  });
+});
+
+// `hasScope` is the runtime gate every route calls. Beyond exact matches it
+// honors the wildcard and expands legacy coarse `:write` scopes so tokens
+// minted before the fine-grained split keep working.
+describe("hasScope", () => {
+  it("matches an exactly-granted fine scope", () => {
+    expect(hasScope({ scopes: ["runs:reprocess"] }, "runs:reprocess")).toBe(
+      true
+    );
+  });
+
+  it("does not imply other actions on the same resource", () => {
+    expect(hasScope({ scopes: ["runs:reprocess"] }, "runs:delete")).toBe(false);
+    expect(hasScope({ scopes: ["files:read"] }, "files:delete")).toBe(false);
+  });
+
+  it("wildcard grants everything", () => {
+    for (const scope of ALL_SCOPES) {
+      expect(hasScope({ scopes: ["*"] }, scope)).toBe(true);
+    }
+  });
+
+  it("expands a legacy 'runs:write' to its fine actions", () => {
+    for (const scope of [
+      "runs:create",
+      "runs:update",
+      "runs:delete",
+      "runs:reprocess",
+      "runs:upload",
+      "runs:attribute",
+      "runs:comment",
+    ] as const) {
+      expect(hasScope({ scopes: ["runs:write"] }, scope)).toBe(true);
+    }
+    // Expansion is scoped to the same resource — it never leaks reads or
+    // other resources.
+    expect(hasScope({ scopes: ["runs:write"] }, "runs:read")).toBe(false);
+    expect(hasScope({ scopes: ["runs:write"] }, "files:create")).toBe(false);
+  });
+
+  it("expands legacy 'files:write' and 'watchers:write'", () => {
+    expect(hasScope({ scopes: ["files:write"] }, "files:delete")).toBe(true);
+    expect(hasScope({ scopes: ["watchers:write"] }, "watchers:admin")).toBe(
+      true
+    );
+    expect(hasScope({ scopes: ["watchers:write"] }, "watchers:report")).toBe(
+      true
+    );
   });
 });


### PR DESCRIPTION
## Summary

Access token (PAT) scopes were too coarse: a single `runs:write` or `files:write` bundled create, update, delete, reprocess, upload, attribute, and comment together, so granting one narrow capability (e.g. reprocess) also handed over destructive ones (e.g. delete). This splits the vocabulary into per-action scopes and reworks the token creation UX around curated presets.

- **Fine-grained scope vocabulary** (`web/lib/api/scopes.ts`): `runs:{read,create,update,delete,reprocess,upload,attribute,comment}`, `files:{read,create,update,delete,reprocess}`, `watchers:{read,report,admin}`; `instruments` and `archive-jobs` unchanged.
- **No migration / backward compatible**: `hasScope` expands the legacy coarse `*:write` scopes and `*` so deployed watcher/Lambda tokens keep authorizing. New tokens must enumerate fine scopes (`validateRequestedScopes` rejects `*` and the legacy coarse scopes).
- **Re-tagged enforcement**: every `authorize()` call site across `web/app/api/v1/**` and the `requireMcpScope` calls in `web/lib/mcp/tools.ts` now require the specific action scope (e.g. reprocess no longer implies delete; a watcher token can't delete watchers).
- **Reworked create-token modal** (`web/components/tokens/create-token-dialog.tsx`, `web/lib/api/scope-catalog.ts`): role presets (Read-only, MCP, Watcher, Lambda) as the primary path, a collapsible per-resource grid, per-scope tooltips, a live "this token will be able to…" summary with destructive actions flagged, "All read"/"All write" column toggles, and a no-expiry warning. The write-without-read warning is suppressed for exact preset matches (machine presets legitimately write resources they never read).
- **Tokens table** (`web/app/settings/tokens/page.tsx`): flags legacy `*` as "Full access (legacy)" and tints deprecated coarse scopes for rotation.

Presets are derived from the actual endpoints the Lambda and watcher clients call, so tokens minted from them are least-privilege.

<img width="589" height="677" alt="Screenshot 2026-07-10 at 12 35 26 PM" src="https://github.com/user-attachments/assets/dc12cf1e-121c-4802-a0a7-b87f84b2f9cd" />

## Test plan

- [x] `make check-all` (Python + frontend format, lint, typecheck) passes
- [x] Unit tests pass (`web/tests/unit/scope-validation.test.ts`), including new `hasScope` legacy-expansion coverage
- [x] Integration suites (`web/tests/integration/scopes.test.ts`, `mcp.test.ts`) — updated for the new scope strings and a legacy-compat case
- [x] Manual: create tokens via each preset and confirm the capability summary, warnings, and grid behave as expected

Made with [Cursor](https://cursor.com)