### PR TITLE
Move deployment guides into developer-docs

### DIFF
--- a/.github/workflows/apply-migrations.yml
+++ b/.github/workflows/apply-migrations.yml
@@ -10,7 +10,7 @@ on:
       - web/drizzle/**
 
 # Serialize migration runs per environment so two merges can't apply
-# migrations against the same Render database concurrently.
+# migrations against the same database concurrently.
 concurrency:
   group: apply-migrations-${{ github.ref_name }}
   cancel-in-progress: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Documentation
 
-User-, operator-, and admin-facing documentation — installing a watcher, adding an instrument, managing tokens, deploying the web app and AWS infrastructure, security/permissions — lives on the docs site at https://datahub.arcadiascience.com/docs, **not in this repository**. Search there first for "how do I use/deploy Data Hub" questions; don't rely on training data or guess at UI flows, since the site's `/docs/llms.txt` and `/docs/llms-full.txt` routes (and a `.md` suffix on any page URL) serve clean Markdown that's cheap to fetch.
+User-, operator-, and admin-facing documentation — installing a watcher, adding an instrument, managing tokens, security/permissions — lives on the docs site at https://datahub.arcadiascience.com/docs, **not in this repository**. Search there first for "how do I use Data Hub" questions; don't rely on training data or guess at UI flows, since the site's `/docs/llms.txt` and `/docs/llms-full.txt` routes (and a `.md` suffix on any page URL) serve clean Markdown that's cheap to fetch.
 
-This repo's `developer-docs/` only covers contributing to Data Hub itself: architecture internals, local dev setup (`getting-started.md`, `local-development.md`), conventions, CI/deployment, and per-package references (`lambda.md`, `watcher.md`, `shared-library.md`). See `developer-docs/README.md` for the full index.
+This repo's `developer-docs/` covers contributing to and self-hosting Data Hub itself: architecture internals, local dev setup (`getting-started.md`, `local-development.md`), conventions, CI plus the deployment guide for the web app and AWS infrastructure (`ci-and-deployment.md`), and per-package references (`lambda.md`, `watcher.md`, `shared-library.md`). See `developer-docs/README.md` for the full index.
 
 ## Cursor Cloud specific instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 User-, operator-, and admin-facing documentation — installing a watcher, adding an instrument, managing tokens, security/permissions — lives on the docs site at https://datahub.arcadiascience.com/docs, **not in this repository**. Search there first for "how do I use Data Hub" questions; don't rely on training data or guess at UI flows, since the site's `/docs/llms.txt` and `/docs/llms-full.txt` routes (and a `.md` suffix on any page URL) serve clean Markdown that's cheap to fetch.
 
-This repo's `developer-docs/` covers contributing to and self-hosting Data Hub itself: architecture internals, local dev setup (`getting-started.md`, `local-development.md`), conventions, CI plus the deployment guide for the web app and AWS infrastructure (`ci-and-deployment.md`), and per-package references (`lambda.md`, `watcher.md`, `shared-library.md`). See `developer-docs/README.md` for the full index.
+This repo's `developer-docs/` covers contributing to and self-hosting Data Hub itself: architecture internals, local dev setup (`getting-started.md`, `local-development.md`), conventions, the step-by-step self-hosting guide for the web app and AWS infrastructure (`first-time-deployment.md`) plus CI/ongoing-deploy reference (`ci-and-deployment.md`), and per-package references (`lambda.md`, `watcher.md`, `shared-library.md`). See `developer-docs/README.md` for the full index.
 
 ## Cursor Cloud specific instructions
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ make dev
 
 See the full [Getting started guide](developer-docs/getting-started.md) for prerequisites and details. Don't have AWS/Google credentials? [Local development](developer-docs/local-development.md) covers a zero-credential setup for the web app + API + database alone (no watcher or Lambda needed).
 
-Developer docs live in [developer-docs/](developer-docs/README.md). You can find user documentation (self-hosted deployment, watcher installation, adding an instrument, managing tokens) on the [docs site](https://datahub.arcadiascience.com/docs).
+Developer docs live in [developer-docs/](developer-docs/README.md), including the guide to self-hosting Data Hub (deploying the web app and AWS infrastructure — see [CI and deployment](developer-docs/ci-and-deployment.md)). You can find user documentation (watcher installation, adding an instrument, managing tokens) on the [docs site](https://datahub.arcadiascience.com/docs).
 
 ## Checks and tests
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ make dev
 
 See the full [Getting started guide](developer-docs/getting-started.md) for prerequisites and details. Don't have AWS/Google credentials? [Local development](developer-docs/local-development.md) covers a zero-credential setup for the web app + API + database alone (no watcher or Lambda needed).
 
-Developer docs live in [developer-docs/](developer-docs/README.md), including the guide to self-hosting Data Hub (deploying the web app and AWS infrastructure — see [CI and deployment](developer-docs/ci-and-deployment.md)). You can find user documentation (watcher installation, adding an instrument, managing tokens) on the [docs site](https://datahub.arcadiascience.com/docs).
+Developer docs live in [developer-docs/](developer-docs/README.md), including the step-by-step guide to self-hosting Data Hub (deploying the web app and AWS infrastructure — see [First-time deployment](developer-docs/first-time-deployment.md)). You can find user documentation (watcher installation, adding an instrument, managing tokens) on the [docs site](https://datahub.arcadiascience.com/docs).
 
 ## Checks and tests
 

--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -1,9 +1,11 @@
 # Developer docs
 
-Documentation for developing Data Hub itself. User, operator, and admin
-documentation (installing a watcher, adding an instrument, managing tokens,
-deployment) lives on the [docs site](https://datahub.arcadiascience.com/docs)
-instead — see the root [README](../README.md#getting-started) for that split.
+Documentation for developing and self-hosting Data Hub itself, including
+deploying the web app and AWS infrastructure (see
+[CI and deployment](ci-and-deployment.md)). User, operator, and admin
+documentation (installing a watcher, adding an instrument, managing tokens)
+lives on the [docs site](https://datahub.arcadiascience.com/docs) instead —
+see the root [README](../README.md#getting-started) for that split.
 
 - [Getting started](getting-started.md) — development setup, environment variables, running locally
 - [Local development](local-development.md) — zero-credential dev workflow for the web app + API + database (no watcher / Lambda needed)
@@ -12,6 +14,6 @@ instead — see the root [README](../README.md#getting-started) for that split.
 - [Watcher](watcher.md) — CLI commands, configuration, run detection, upload modes
 - [Lambda](lambda.md) — processing pipeline, supported instruments, adding new instruments
 - [Shared library](shared-library.md) — module reference for `data-hub-shared`
-- [CI and deployment](ci-and-deployment.md) — GitHub Actions, Vercel, Render, Lambda deployment
+- [CI and deployment](ci-and-deployment.md) — GitHub Actions, plus the self-hosted deployment guide (Vercel web app, Render database, AWS Lambda/S3)
 - [Run archives](run-archives.md) — "Download all" flow, cache/dedup model, and on-call runbook
 - [Conventions](conventions.md) — S3 key layout, instrument IDs, code style, environments

--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -2,7 +2,7 @@
 
 Documentation for developing and self-hosting Data Hub itself, including
 deploying the web app and AWS infrastructure (see
-[CI and deployment](ci-and-deployment.md)). User, operator, and admin
+[First-time deployment](first-time-deployment.md)). User, operator, and admin
 documentation (installing a watcher, adding an instrument, managing tokens)
 lives on the [docs site](https://datahub.arcadiascience.com/docs) instead —
 see the root [README](../README.md#getting-started) for that split.
@@ -14,6 +14,7 @@ see the root [README](../README.md#getting-started) for that split.
 - [Watcher](watcher.md) — CLI commands, configuration, run detection, upload modes
 - [Lambda](lambda.md) — processing pipeline, supported instruments, adding new instruments
 - [Shared library](shared-library.md) — module reference for `data-hub-shared`
-- [CI and deployment](ci-and-deployment.md) — GitHub Actions, plus the self-hosted deployment guide (Vercel web app, Render database, AWS Lambda/S3)
+- [First-time deployment](first-time-deployment.md) — step-by-step self-hosting guide: database, Vercel web app, and AWS S3 + Lambda
+- [CI and deployment](ci-and-deployment.md) — GitHub Actions workflows, branch strategy, and how CI redeploys each piece
 - [Run archives](run-archives.md) — "Download all" flow, cache/dedup model, and on-call runbook
 - [Conventions](conventions.md) — S3 key layout, instrument IDs, code style, environments

--- a/developer-docs/ci-and-deployment.md
+++ b/developer-docs/ci-and-deployment.md
@@ -30,9 +30,9 @@ Four workflows run on pushes to `staging`/`production` and on pull requests targ
 
 ### Apply database migrations (`apply-migrations.yml`)
 
-Triggered on pushes to `staging`/`production` (i.e. PR merges) that change files under `web/drizzle/`. The single job sets `environment: ${{ github.ref_name }}` so GitHub selects that environment's secrets and protection rules, then runs `npm run db:migrate` (Drizzle) against the environment's Render database using the environment's `DATABASE_URL` secret. A per-branch `concurrency` group prevents overlapping migration runs.
+Triggered on pushes to `staging`/`production` (i.e. PR merges) that change files under `web/drizzle/`. The single job sets `environment: ${{ github.ref_name }}` so GitHub selects that environment's secrets and protection rules, then runs `npm run db:migrate` (Drizzle) against the environment's PostgreSQL database using the environment's `DATABASE_URL` secret. A per-branch `concurrency` group prevents overlapping migration runs.
 
-Production is gated by a required-reviewer protection rule on the `production` GitHub environment, so production migrations pause for manual approval before applying. Each environment needs a `DATABASE_URL` secret pointing at its Render connection string, and the Render database must accept connections from GitHub-hosted runners.
+Production is gated by a required-reviewer protection rule on the `production` GitHub environment, so production migrations pause for manual approval before applying. Each environment needs a `DATABASE_URL` secret pointing at its PostgreSQL connection string, and that database must accept connections from GitHub-hosted runners.
 
 ### Publish watcher (`publish-watcher.yml`)
 
@@ -59,7 +59,7 @@ Data Hub is self-hosted, running across three backend pieces per environment: a 
 
 ### Web application (Vercel)
 
-The Next.js app is deployed on [Vercel](https://vercel.com/arcadia-science/data-hub). Every branch and commit generates a preview deployment. Merges to `staging` and `production` deploy to their respective environments automatically.
+The Next.js app is deployed on [Vercel](https://vercel.com). Every branch and commit generates a preview deployment. Merges to `staging` and `production` deploy to their respective environments automatically.
 
 Environment variables are managed in the Vercel dashboard and can be pulled locally with:
 
@@ -68,9 +68,9 @@ cd web
 vercel env pull
 ```
 
-### Database (Render)
+### Database (PostgreSQL)
 
-Staging and production each have a dedicated PostgreSQL instance hosted on [Render](https://dashboard.render.com/project/prj-d75d0jma2pns738r4110).
+Give each environment (`staging`, `production`) its own dedicated PostgreSQL instance on any Postgres host.
 
 Merges to `staging`/`production` that change files under `web/drizzle/` automatically apply migrations via the [`apply-migrations.yml`](#apply-database-migrations-apply-migrationsyml) workflow (production is gated on manual approval). The commands below are for local runs or manual application:
 

--- a/developer-docs/ci-and-deployment.md
+++ b/developer-docs/ci-and-deployment.md
@@ -55,6 +55,32 @@ Feature branches target `staging` via pull requests. CI runs on every PR and on 
 
 ## Deployment
 
+Data Hub is self-hosted: before anyone can install a watcher or sign in, your team deploys three pieces of backend infrastructure. Give each environment (`staging`, `production`) its own database and its own AWS stack — they are independent deployments.
+
+| Resource | What it is | Where it runs |
+| --- | --- | --- |
+| **PostgreSQL database** | System of record for instruments, runs, files, watchers, and tokens. | Any PostgreSQL host (e.g. Render, Supabase, Neon). |
+| **Web app + REST API** | The Next.js app that serves the dashboard, REST API, and MCP server. | Vercel. |
+| **AWS infrastructure** | S3 buckets for raw/processed/archive data and the Lambda that preprocesses uploads. | AWS (via SAM). |
+
+The web app and the AWS stack depend on each other's outputs, so the web app goes up first (to mint a URL and an API key), then AWS, then the AWS outputs are fed back into the web app:
+
+```mermaid
+flowchart LR
+    DB[(PostgreSQL)] --> Web[Vercel web app]
+    Web -->|URL + API key| AWS[AWS S3 + Lambda]
+    AWS -->|role ARN + function URL| Web
+    Web --> Ready[Watchers can connect]
+```
+
+1. **Provision a PostgreSQL database** for the environment on any host you like (see [Database (Render)](#database-render)).
+2. **Deploy the web app to Vercel** (see [Web application (Vercel)](#web-application-vercel)). Set `DATABASE_URL` and `ADMIN_EMAILS`, apply the migrations, then sign in as an admin and create a personal access token for the Lambda to use.
+3. **Bootstrap AWS once per account** with `make sam-bootstrap` (see [Lambda (AWS)](#lambda-aws)).
+4. **Deploy the per-environment AWS stack** (see [First-time AWS setup](#first-time-aws-setup)). It needs the web app's URL and the API key from step 2, and it produces the stack outputs you'll need next.
+5. **Finish wiring the web app** by setting `AWS_ROLE_ARN` and `LAMBDA_FUNCTION_URL` in Vercel from the AWS stack outputs, so the app can mint presigned S3 URLs and invoke the Lambda.
+
+The web app deploys successfully before the AWS stack exists; its AWS-dependent features (uploads, reprocessing, run archives) don't work until step 5 wires the outputs back in.
+
 ### Web application (Vercel)
 
 The Next.js app is deployed on [Vercel](https://vercel.com/arcadia-science/data-hub). Every branch and commit generates a preview deployment. Merges to `staging` and `production` deploy to their respective environments automatically.
@@ -227,6 +253,24 @@ make docker-push-lambda ENV=staging
 # Deploy to staging (loads infra/.env.staging automatically).
 make sam-deploy ENV=staging
 ```
+
+#### Adding an S3 trigger for a new instrument
+
+Instruments that support automated preprocessing need an S3 event trigger so the Lambda runs as files land. The processor code lives in `data-hub-lambda` (see [Lambda → Adding a new instrument](lambda.md#adding-a-new-instrument)); this is the infrastructure half. Add a `LambdaConfiguration` entry to the `RawDataBucket` resource's `NotificationConfiguration` in `infra/template.yaml`:
+
+```yaml
+- Event: s3:ObjectCreated:*
+  Filter:
+    S3Key:
+      Rules:
+        - Name: prefix
+          Value: <instrument-id>/
+        - Name: suffix
+          Value: .csv
+  Function: !GetAtt DataHubFunction.Arn
+```
+
+The CI deploy role has permission to roll new triggers out, so the trigger goes live on the next deploy — either the [automated workflow](#automated-deployment-deploy-lambdayml) or a manual `make sam-deploy`. No manual AWS step is needed once the code and trigger are merged.
 
 ### Watcher (PyPI)
 

--- a/developer-docs/ci-and-deployment.md
+++ b/developer-docs/ci-and-deployment.md
@@ -55,31 +55,7 @@ Feature branches target `staging` via pull requests. CI runs on every PR and on 
 
 ## Deployment
 
-Data Hub is self-hosted: before anyone can install a watcher or sign in, your team deploys three pieces of backend infrastructure. Give each environment (`staging`, `production`) its own database and its own AWS stack — they are independent deployments.
-
-| Resource | What it is | Where it runs |
-| --- | --- | --- |
-| **PostgreSQL database** | System of record for instruments, runs, files, watchers, and tokens. | Any PostgreSQL host (e.g. Render, Supabase, Neon). |
-| **Web app + REST API** | The Next.js app that serves the dashboard, REST API, and MCP server. | Vercel. |
-| **AWS infrastructure** | S3 buckets for raw/processed/archive data and the Lambda that preprocesses uploads. | AWS (via SAM). |
-
-The web app and the AWS stack depend on each other's outputs, so the web app goes up first (to mint a URL and an API key), then AWS, then the AWS outputs are fed back into the web app:
-
-```mermaid
-flowchart LR
-    DB[(PostgreSQL)] --> Web[Vercel web app]
-    Web -->|URL + API key| AWS[AWS S3 + Lambda]
-    AWS -->|role ARN + function URL| Web
-    Web --> Ready[Watchers can connect]
-```
-
-1. **Provision a PostgreSQL database** for the environment on any host you like (see [Database (Render)](#database-render)).
-2. **Deploy the web app to Vercel** (see [Web application (Vercel)](#web-application-vercel)). Set `DATABASE_URL` and `ADMIN_EMAILS`, apply the migrations, then sign in as an admin and create a personal access token for the Lambda to use.
-3. **Bootstrap AWS once per account** with `make sam-bootstrap` (see [Lambda (AWS)](#lambda-aws)).
-4. **Deploy the per-environment AWS stack** (see [First-time AWS setup](#first-time-aws-setup)). It needs the web app's URL and the API key from step 2, and it produces the stack outputs you'll need next.
-5. **Finish wiring the web app** by setting `AWS_ROLE_ARN` and `LAMBDA_FUNCTION_URL` in Vercel from the AWS stack outputs, so the app can mint presigned S3 URLs and invoke the Lambda.
-
-The web app deploys successfully before the AWS stack exists; its AWS-dependent features (uploads, reprocessing, run archives) don't work until step 5 wires the outputs back in.
+Data Hub is self-hosted, running across three backend pieces per environment: a PostgreSQL database, the Next.js web app plus REST API on Vercel, and the AWS S3 + Lambda stack. To stand up a new environment from scratch, follow the step-by-step [First-time deployment](first-time-deployment.md) guide. This section is the reference for how each piece is deployed and how CI redeploys it afterward.
 
 ### Web application (Vercel)
 
@@ -120,95 +96,9 @@ The Lambda function is deployed as a Docker container image via [AWS SAM](https:
 - S3 event triggers for each supported instrument
 - IAM roles for Lambda execution, GitHub Actions deployment (OIDC), and Vercel web app S3 access (OIDC)
 
-A separate bootstrap stack (`infra/bootstrap.yaml`) creates shared resources — the ECR repository, the GitHub OIDC identity provider, and the Vercel OIDC identity provider — and only needs to be deployed once:
+A separate bootstrap stack (`infra/bootstrap.yaml`) creates shared per-account resources — the ECR repository, the GitHub OIDC identity provider, and the Vercel OIDC identity provider — and only needs to be deployed once (`make sam-bootstrap`).
 
-```sh
-make sam-bootstrap
-```
-
-#### First-time AWS setup
-
-After deploying the bootstrap stack, follow these steps to bring up the first environment. You need admin-level AWS credentials for the initial deploy (the CI role cannot create stacks from scratch).
-
-**1. Get the bootstrap stack outputs:**
-
-```sh
-aws cloudformation describe-stacks \
-  --stack-name data-hub-bootstrap \
-  --region us-west-1 \
-  --query "Stacks[0].Outputs"
-```
-
-Note the `GitHubOidcProviderArn`, `VercelOidcProviderArn`, and `EcrRepositoryUri` values — you'll need them in steps 3 and 4 below.
-
-> **Note:** If your AWS account already has an OIDC provider for `token.actions.githubusercontent.com` (from another project), the bootstrap stack will fail with an `AWS::EarlyValidation::ResourceExistenceCheck` error. In that case, remove the `GitHubOidcProvider` resource from `bootstrap.yaml` (or skip the bootstrap stack entirely) and use the existing provider's ARN. Check with `aws iam list-open-id-connect-providers`.
-
-**2. Build and push the Docker image to ECR:**
-
-```sh
-make docker-build-lambda
-make docker-push-lambda ENV=staging
-```
-
-This logs in to ECR, tags the image as `staging-<short-sha>`, and pushes it. The ECR registry is derived from your AWS account ID automatically.
-
-**3. Deploy the per-environment stack:**
-
-Create an `infra/.env.staging` file (use `infra/.env.example` as a template) and fill in the values:
-
-```sh
-cp infra/.env.example infra/.env.staging
-```
-
-```
-ECR_IMAGE_URI=<image-uri-from-step-2>
-DATA_HUB_API_URL=https://datahub-staging.example.com/api/v1
-DATA_HUB_API_KEY=<your-api-key>
-GITHUB_OIDC_PROVIDER_ARN=<github-oidc-arn-from-step-1>
-VERCEL_OIDC_PROVIDER_ARN=<vercel-oidc-arn-from-step-1>
-```
-
-Then deploy:
-
-```sh
-make sam-deploy ENV=staging
-```
-
-The Makefile automatically loads `infra/.env.staging` when `ENV=staging` is set. Repeat with an `infra/.env.production` file and `make sam-deploy ENV=production` when ready. These `infra/.env.*` files are gitignored (only `infra/.env.example` is tracked).
-
-**4. Configure GitHub environment secrets:**
-
-After the stack deploys, grab the deploy role ARN:
-
-```sh
-aws cloudformation describe-stacks \
-  --stack-name data-hub-staging \
-  --region us-west-1 \
-  --query "Stacks[0].Outputs[?OutputKey=='DeployRoleArn'].OutputValue" \
-  --output text
-```
-
-In your GitHub repo, go to **Settings → Environments**, create a `staging` environment (and later `production`), and add these secrets:
-
-| Secret | Value |
-| --- | --- |
-| `AWS_DEPLOY_ROLE_ARN` | Deploy role ARN from the stack output |
-| `GH_OIDC_PROVIDER_ARN` | GitHub OIDC provider ARN from the bootstrap stack |
-| `VERCEL_OIDC_PROVIDER_ARN` | Vercel OIDC provider ARN from the bootstrap stack |
-| `SAM_S3_BUCKET` | SAM CLI managed S3 bucket name (see `sam deploy` output, e.g. `aws-sam-cli-managed-default-samclisourcebucket-*`) |
-| `DATA_HUB_API_URL` | Base API URL for the environment |
-| `DATA_HUB_API_KEY` | API key for Lambda → Data Hub authentication (also used by the Lambda's archive-job PATCH callback) |
-
-Slack channel notifications are sent by the **web app** (not the Lambda) when a new run is created. Workspace admins configure the incoming webhook URL in Settings > Notifications > Slack channel (stored in the `slack_channel_config` DB table). After deploying, paste the webhook URL once in that UI before removing any legacy `SLACK_WEBHOOK_URL` env var from Vercel.
-
-You'll also need the `WebAppRoleArn` and `DataHubFunctionUrl` stack outputs to configure the Vercel web app. In the Vercel dashboard (under the appropriate environment), set:
-
-| Vercel env var | Value |
-| --- | --- |
-| `AWS_ROLE_ARN` | `WebAppRoleArn` stack output — lets the web app generate presigned S3 URLs **and** SigV4-sign Lambda Function URL invocations via OIDC federation |
-| `LAMBDA_FUNCTION_URL` | `DataHubFunctionUrl` stack output — the Lambda Function URL for manual reprocessing and archive builds |
-
-Once secrets are set, the CI workflow handles all subsequent deploys automatically.
+Standing up the stack for the first time — the one-time bootstrap, building and pushing the image, the initial `make sam-deploy`, and wiring the GitHub environment secrets and Vercel outputs — is covered step by step in [First-time deployment](first-time-deployment.md). The rest of this section is the reference for deploys after the stack exists.
 
 #### Automated deployment (`deploy-lambda.yml`)
 
@@ -234,7 +124,7 @@ Local deployment requires the following tools in addition to the [general prereq
 - [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) — used by `make sam-deploy` to package and deploy CloudFormation stacks. Install with `brew install aws-sam-cli` on macOS.
 - AWS credentials configured (`aws configure` or environment variables) with permission to deploy the stack.
 
-Create an environment-specific `.env` file if you haven't already (see [first-time setup](#first-time-aws-setup) for details on each variable):
+Create an environment-specific `.env` file if you haven't already (see [First-time deployment → Deploy the AWS infrastructure](first-time-deployment.md#4-deploy-the-aws-infrastructure) for details on each variable):
 
 ```sh
 cp infra/.env.example infra/.env.staging

--- a/developer-docs/first-time-deployment.md
+++ b/developer-docs/first-time-deployment.md
@@ -1,0 +1,183 @@
+# First-time deployment
+
+Data Hub is self-hosted: before anyone can install a watcher or sign in, your team stands up the backend infrastructure. This guide walks through deploying one environment (`staging` shown; repeat the same steps for `production`) from scratch, in order. For the CI workflows and how subsequent deploys happen automatically, see [CI and deployment](ci-and-deployment.md). For how the pieces fit together at runtime, see [Architecture](architecture.md).
+
+## What you'll deploy
+
+| Resource | What it is | Where it runs |
+| --- | --- | --- |
+| **PostgreSQL database** | System of record for instruments, runs, files, watchers, and tokens. | Any PostgreSQL host (e.g. Render, Supabase, Neon). |
+| **Web app + REST API** | The Next.js app that serves the dashboard, REST API, and MCP server. | Vercel. |
+| **AWS infrastructure** | S3 buckets for raw/processed/archive data and the Lambda that preprocesses uploads. | AWS (via SAM). |
+
+Give each environment (`staging`, `production`) its own database and its own AWS stack. They are independent deployments with independent data.
+
+## Order of operations
+
+The web app and the AWS stack depend on each other's outputs, so the web app goes up first (to mint a URL and an API key), then AWS, then the AWS outputs are fed back into the web app.
+
+```mermaid
+flowchart LR
+    DB[(PostgreSQL)] --> Web[Vercel web app]
+    Web -->|URL + API key| AWS[AWS S3 + Lambda]
+    AWS -->|role ARN + function URL| Web
+    Web --> Ready[Watchers can connect]
+```
+
+1. [Provision a PostgreSQL database](#1-provision-a-postgresql-database).
+2. [Deploy the web app to Vercel](#2-deploy-the-web-app-to-vercel).
+3. [Bootstrap AWS](#3-bootstrap-aws-once-per-account) (once per account).
+4. [Deploy the AWS infrastructure](#4-deploy-the-aws-infrastructure) for the environment.
+5. [Finish wiring the web app](#5-finish-wiring-the-web-app) with the AWS stack outputs.
+
+The web app deploys successfully before the AWS stack exists; its AWS-dependent features (uploads, reprocessing, run archives) don't work until step 5 wires the outputs back in.
+
+## Prerequisites
+
+Beyond the [general prerequisites](getting-started.md#prerequisites), you need:
+
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) — bootstrap commands and ECR login.
+- [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) — used by `make sam-deploy` (`brew install aws-sam-cli` on macOS).
+- **Admin-level AWS credentials** (`aws configure` or environment variables) for the initial deploy. The CI deploy role can update an existing stack but cannot create one from scratch.
+- Access to the Vercel project and permission to set its environment variables.
+- A [Google OAuth](https://console.cloud.google.com/apis/credentials) client (ID and secret) for sign-in.
+
+## 1. Provision a PostgreSQL database
+
+Create a PostgreSQL database for the environment on any host you like — [Render](https://render.com), [Supabase](https://supabase.com), [Neon](https://neon.tech), or self-managed. Keep its connection string handy for the next step, and make sure the host accepts connections from Vercel and from GitHub-hosted runners (the [`apply-migrations.yml`](ci-and-deployment.md#apply-database-migrations-apply-migrationsyml) workflow connects from CI).
+
+## 2. Deploy the web app to Vercel
+
+The Next.js app (which also serves the REST API and MCP server) deploys on [Vercel](https://vercel.com). Every branch and commit generates a preview deployment; merges to `staging` and `production` deploy to those environments automatically.
+
+### Set the initial environment variables
+
+In the Vercel dashboard, scoped to the environment, set at least the following. The AWS-related variables come later in [step 5](#5-finish-wiring-the-web-app); the full list lives in [Environment variables](getting-started.md#environment-variables).
+
+| Vercel env var | Purpose |
+| --- | --- |
+| `DATABASE_URL` | Connection string from [step 1](#1-provision-a-postgresql-database). |
+| `AUTH_SECRET` | Session encryption key (generate a 32+ character random string). |
+| `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET` | Google OAuth client credentials for sign-in. |
+| `ADMIN_EMAILS` | Comma-separated emails auto-promoted to admin on sign-in. This bootstraps the first admin, so set it before you sign in. |
+| `CRON_SECRET` | Shared secret for Vercel Cron jobs. The upload-queue sweep (`web/vercel.json`) rejects invocations without it. |
+
+You can pull the current values locally with:
+
+```sh
+cd web
+vercel env pull
+```
+
+### Apply database migrations
+
+Point Drizzle at the environment's database and apply the schema. After the first deploy, merges that touch `web/drizzle/` apply migrations automatically via CI; this initial run is manual:
+
+```sh
+cd web
+
+# Apply committed migrations against DATABASE_URL.
+npm run db:migrate
+```
+
+### Create an API key for the Lambda
+
+Sign in with an account listed in `ADMIN_EMAILS`, then create a personal access token under Settings. The AWS stack and the Lambda use this token as `DATA_HUB_API_KEY` to call the Data Hub API, so create it now and keep it for [step 4](#4-deploy-the-aws-infrastructure). See [Managing tokens](https://datahub.arcadiascience.com/docs/managing-tokens) for the token UI.
+
+## 3. Bootstrap AWS (once per account)
+
+A separate bootstrap stack (`infra/bootstrap.yaml`) creates shared, per-account resources: the ECR repository, the GitHub OIDC identity provider, and the Vercel OIDC identity provider. Deploy it once per AWS account:
+
+```sh
+make sam-bootstrap
+```
+
+> **Note:** If your account already has an OIDC provider for `token.actions.githubusercontent.com` (from another project), the bootstrap stack fails with an `AWS::EarlyValidation::ResourceExistenceCheck` error. Remove the `GitHubOidcProvider` resource from `bootstrap.yaml` (or skip the bootstrap stack) and reuse the existing provider's ARN. Check with `aws iam list-open-id-connect-providers`.
+
+## 4. Deploy the AWS infrastructure
+
+The storage and processing layer — the S3 buckets and the data-processing Lambda — is defined in `infra/template.yaml` and deployed with [AWS SAM](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/). The stack creates the raw/processed S3 buckets, the Lambda function (container image, function URL), the per-instrument S3 event triggers, and the IAM roles for Lambda execution, CI deploys (OIDC), and Vercel web app S3 access (OIDC).
+
+**1. Get the bootstrap stack outputs.**
+
+```sh
+aws cloudformation describe-stacks \
+  --stack-name data-hub-bootstrap \
+  --region us-west-1 \
+  --query "Stacks[0].Outputs"
+```
+
+Note `GitHubOidcProviderArn`, `VercelOidcProviderArn`, and `EcrRepositoryUri` for the steps below.
+
+**2. Build and push the Docker image to ECR.**
+
+```sh
+make docker-build-lambda
+make docker-push-lambda ENV=staging
+```
+
+This logs in to ECR, tags the image `staging-<short-sha>`, and pushes it. The ECR registry is derived from your AWS account ID automatically.
+
+**3. Deploy the per-environment stack.**
+
+Create `infra/.env.staging` from the template and fill it in:
+
+```sh
+cp infra/.env.example infra/.env.staging
+```
+
+```sh
+ECR_IMAGE_URI=<image-uri-from-step-2>
+DATA_HUB_API_URL=https://your-staging-deployment.vercel.app/api/v1
+DATA_HUB_API_KEY=<api-key-from-step-2>
+GITHUB_OIDC_PROVIDER_ARN=<github-oidc-arn-from-step-1>
+VERCEL_OIDC_PROVIDER_ARN=<vercel-oidc-arn-from-step-1>
+```
+
+Then deploy. The Makefile loads `infra/.env.staging` automatically when `ENV=staging` is set:
+
+```sh
+make sam-deploy ENV=staging
+```
+
+These `infra/.env.*` files are gitignored (only `infra/.env.example` is tracked).
+
+**4. Configure GitHub environment secrets.**
+
+These let CI handle every subsequent deploy. Grab the deploy role ARN:
+
+```sh
+aws cloudformation describe-stacks \
+  --stack-name data-hub-staging \
+  --region us-west-1 \
+  --query "Stacks[0].Outputs[?OutputKey=='DeployRoleArn'].OutputValue" \
+  --output text
+```
+
+In the GitHub repo, go to **Settings → Environments**, create a `staging` environment, and add:
+
+| Secret | Value |
+| --- | --- |
+| `AWS_DEPLOY_ROLE_ARN` | Deploy role ARN from the stack output. |
+| `GH_OIDC_PROVIDER_ARN` | GitHub OIDC provider ARN from the bootstrap stack. |
+| `VERCEL_OIDC_PROVIDER_ARN` | Vercel OIDC provider ARN from the bootstrap stack. |
+| `SAM_S3_BUCKET` | SAM CLI managed S3 bucket (see `sam deploy` output). |
+| `DATA_HUB_API_URL` | Base API URL for the environment. |
+| `DATA_HUB_API_KEY` | API key for Lambda → Data Hub auth (also used by the archive-job callback). |
+
+## 5. Finish wiring the web app
+
+The AWS stack you just deployed exposes the outputs the web app needs to reach it. Read `WebAppRoleArn` and `DataHubFunctionUrl` from the stack, then set these in Vercel for the environment:
+
+| Vercel env var | Source | Purpose |
+| --- | --- | --- |
+| `AWS_ROLE_ARN` | `WebAppRoleArn` stack output | Lets the web app generate presigned S3 URLs and SigV4-sign Lambda Function URL invocations via OIDC federation. |
+| `LAMBDA_FUNCTION_URL` | `DataHubFunctionUrl` stack output | The Lambda Function URL for manual reprocessing and archive builds. |
+
+The S3 bucket names default to `arcadia-data-hub-raw-<env>` and `arcadia-data-hub-archives-<env>`; override `S3_RAW_DATA_BUCKET` and `S3_ARCHIVES_BUCKET` in Vercel only if your stack uses different names. Redeploy the web app (or push a commit) so it picks up the new variables.
+
+> **Note:** Slack channel notifications are configured after deploy, not via an environment variable. A workspace admin pastes the incoming webhook URL under Settings > Notifications > Slack channel (stored in the `slack_channel_config` table). Personal Slack DMs use the optional `SLACK_BOT_TOKEN` / `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` variables instead — see [Environment variables](getting-started.md#environment-variables).
+
+## After the backend is up
+
+The environment is ready: lab operators can install watchers and start uploading. Point them at the [Quickstart](https://datahub.arcadiascience.com/docs/quickstart). Every subsequent deploy — web app, migrations, and Lambda — runs through CI; see [CI and deployment](ci-and-deployment.md) for the workflows, the automated Lambda deploy, and manual redeploys.

--- a/developer-docs/lambda.md
+++ b/developer-docs/lambda.md
@@ -72,7 +72,7 @@ Slack channel notifications are sent by the **web app** (`web/lib/slack.ts`), no
 
 4. **Add tests.** Add unit tests in `lambda/tests/` for the new processor.
 
-5. **Configure the S3 trigger and deploy.** See [Deploying AWS infrastructure → Adding a Lambda processor for a new instrument](https://datahub.arcadiascience.com/docs/deploying-aws-infrastructure#adding-a-lambda-processor-for-a-new-instrument) for the `infra/template.yaml` trigger entry and the deploy steps.
+5. **Configure the S3 trigger and deploy.** See [CI and deployment → Adding an S3 trigger for a new instrument](ci-and-deployment.md#adding-an-s3-trigger-for-a-new-instrument) for the `infra/template.yaml` trigger entry and the deploy steps.
 
 ## Local processing CLI
 

--- a/web/README.md
+++ b/web/README.md
@@ -72,7 +72,7 @@ All environment variables can be pulled from the Vercel project using the [Verce
 vercel env pull
 ```
 
-You can also manually copy and paste these from the project's [Environment Variables](https://vercel.com/arcadia-science/data-hub/settings/environment-variables) page.
+You can also manually copy and paste these from your Vercel project's Environment Variables page.
 
 See the table below for a summary of environment variables configured for this application.
 
@@ -95,14 +95,12 @@ Run `npm run precommit` locally before pushing to catch the same issues earlier.
 
 ## Deployment
 
+Data Hub is self-hosted. See the [First-time deployment guide](../developer-docs/first-time-deployment.md) for standing up an environment and [CI and deployment](../developer-docs/ci-and-deployment.md) for how deploys run.
+
 ### Web application
 
 The Data Hub web application is deployed on Vercel. Every branch (as well as every commit) in the repository generates a unique preview deployment.
 
-You can find the Vercel project [here](https://vercel.com/arcadia-science/data-hub).
-
 ### Database
 
-Data Hub has two main environments: staging and production. Each environment uses its own dedicated database instance, both of which are hosted on Render.
-
-You can find the Render project [here](https://dashboard.render.com/project/prj-d75d0jma2pns738r4110).
+Data Hub has two main environments: staging and production. Each environment uses its own dedicated PostgreSQL instance, which you can host on any Postgres service.


### PR DESCRIPTION
## Summary

Moves Data Hub's deployment/self-hosting guides into `developer-docs/` so the public docs site can be strictly user-facing. This is the `data-hub` half; the docs-site half (deleting the pages, rewiring links) is Arcadia-Science/data-hub-docs#7.

- **New [`developer-docs/first-time-deployment.md`](developer-docs/first-time-deployment.md)**: a self-contained, step-by-step guide to standing up one environment from scratch — provision Postgres, deploy the web app to Vercel, bootstrap AWS, deploy the AWS stack, and wire the outputs back.
- **Trimmed [`developer-docs/ci-and-deployment.md`](developer-docs/ci-and-deployment.md)** back to reference (CI workflows, branch strategy, automated/manual redeploys, the S3-trigger snippet, watcher/PyPI) that points at the new guide, instead of mixing setup steps into the CI reference.
- **Corrected stale details** the old docs-site pages carried: Slack channel notifications are configured in the app UI (not a `SLACK_WEBHOOK_URL` env var), and the web-app env step now includes `ADMIN_EMAILS`, `CRON_SECRET`, and the auth vars.
- **Scrubbed Arcadia-internal deployment details**: generalized the database from Render to any Postgres host, dropped the internal Vercel/Render dashboard links (in `ci-and-deployment.md`, `web/README.md`, and a workflow comment).
- Updated `developer-docs/README.md`, root `README.md`, and `AGENTS.md` to feature the guide and stop saying deployment lives on the docs site.

## Not included

`infra/template.yaml` / `infra/bootstrap.yaml` still hardcode the Arcadia Vercel OIDC team (`oidc.vercel.com/arcadia-science`). That's functional CloudFormation config, not docs, and a real self-hosting blocker; parameterizing it is a separate change.

## Test plan

- [x] `make check-all` passes
- [x] Skim [`developer-docs/first-time-deployment.md`](developer-docs/first-time-deployment.md) for accuracy (env vars, stack outputs, ordering)
- [x] Confirm the `lambda.md` and `ci-and-deployment.md` cross-links into the guide resolve