### PR TITLE
Add per-user runs page and home runs enhancements

### DIFF
--- a/web/app/my-runs/page.tsx
+++ b/web/app/my-runs/page.tsx
@@ -123,6 +123,7 @@ async function MyRunsSection({
           <TablePendingBoundary>
             <RunsTable
               data={runResult.data}
+              emptyLabel="No runs attributed to you yet."
               hasFilters={hasFilters}
               pendingUploadCount={pendingUploadCount}
               ranByYouCount={ranByYouCount}

--- a/web/app/my-runs/page.tsx
+++ b/web/app/my-runs/page.tsx
@@ -1,0 +1,142 @@
+import type { Metadata } from "next/types";
+import { Suspense } from "react";
+import { SignInRequired } from "@/components/auth/sign-in-required";
+import {
+  MyRunsStatsCards,
+  MyRunsStatsCardsSkeleton,
+} from "@/components/dashboard/dashboard-stats";
+import {
+  DashboardRunsSkeleton,
+  RunsTable,
+} from "@/components/dashboard/runs-table";
+import { RunsToolbar } from "@/components/dashboard/runs-toolbar";
+import { RunBulkActionBar } from "@/components/instruments/runs-table/run-bulk-action-bar";
+import { RunSelectionProvider } from "@/components/instruments/runs-table/run-selection-provider";
+import { PaginationNav } from "@/components/pagination-nav";
+import {
+  TablePendingBoundary,
+  TablePendingProvider,
+} from "@/components/table-pending";
+import { getInstruments, getMyRunsStats } from "@/lib/api/dashboard";
+import { buildRunListQuery } from "@/lib/api/instrument-runs";
+import { auth } from "@/lib/auth";
+import { dashboardParamsCache, hasActiveFilters } from "@/lib/search-params";
+
+type DashboardParams = Awaited<ReturnType<typeof dashboardParamsCache.parse>>;
+
+const description = "Runs you're attributed to across the lab's instruments.";
+
+export const metadata: Metadata = {
+  title: "My runs",
+  description,
+  openGraph: { title: "My runs", description },
+  twitter: { title: "My runs", description },
+};
+
+export default async function MyRunsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const session = await auth();
+  if (!session) {
+    return (
+      <SignInRequired callbackUrl="/my-runs">
+        Sign in to view your runs.
+      </SignInRequired>
+    );
+  }
+
+  const params = dashboardParamsCache.parse(await searchParams);
+  const userId = session.user.id;
+
+  // Each section fetches its own data behind a Suspense boundary so the static
+  // shell paints immediately and the stats + runs stream in independently.
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 p-6 2xl:w-7xl">
+      <section className="flex flex-col gap-3">
+        <h1 className="font-medium text-lg tracking-tight">My runs</h1>
+        <Suspense fallback={<MyRunsStatsCardsSkeleton />}>
+          <MyRunsStatsSection userId={userId} />
+        </Suspense>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <Suspense fallback={<DashboardRunsSkeleton />}>
+          <MyRunsSection params={params} userId={userId} />
+        </Suspense>
+      </section>
+    </div>
+  );
+}
+
+async function MyRunsStatsSection({ userId }: { userId: string }) {
+  const stats = await getMyRunsStats(userId);
+  return <MyRunsStatsCards stats={stats} />;
+}
+
+async function MyRunsSection({
+  params,
+  userId,
+}: {
+  params: DashboardParams;
+  userId: string;
+}) {
+  const instrumentIds =
+    params.instrument_id.length > 0 ? params.instrument_id : undefined;
+
+  // The toolbar instrument list and the filtered run page are independent.
+  // Runs are scoped to the viewer via `ranBy`, so the URL `ran_by` param (which
+  // the dashboard toolbar never sets here) is intentionally ignored.
+  const [instruments, runResult] = await Promise.all([
+    getInstruments(true),
+    buildRunListQuery({
+      ranBy: userId,
+      instrumentId: instrumentIds,
+      search: params.search || undefined,
+      dateFrom: params.date_from ?? undefined,
+      dateTo: params.date_to ?? undefined,
+      page: params.page,
+      perPage: params.per_page,
+      includeDeleted: params.include_deleted,
+      statuses: params.status.length > 0 ? params.status : undefined,
+    }),
+  ]);
+
+  const hasFilters = hasActiveFilters(params);
+  const pendingUploadCount = runResult.data.filter(
+    (row) => row.files_pending_upload > 0
+  ).length;
+  const unattributedCount = runResult.data.filter(
+    (row) => row.attributions.length === 0
+  ).length;
+  // Every row is attributed to the viewer here, so "ran by you" equals the
+  // shown count; the footer still reports it for consistency with other tables.
+  const ranByYouCount = runResult.data.length;
+
+  return (
+    <RunSelectionProvider>
+      <TablePendingProvider>
+        <div className="flex flex-col gap-3">
+          <RunsToolbar instruments={instruments} />
+          <RunBulkActionBar />
+          <TablePendingBoundary>
+            <RunsTable
+              data={runResult.data}
+              hasFilters={hasFilters}
+              pendingUploadCount={pendingUploadCount}
+              ranByYouCount={ranByYouCount}
+              totalCount={runResult.pagination.total}
+              unattributedCount={unattributedCount}
+            />
+          </TablePendingBoundary>
+          <PaginationNav
+            page={runResult.pagination.page}
+            pageParam="page"
+            totalPages={runResult.pagination.total_pages}
+          />
+        </div>
+      </TablePendingProvider>
+    </RunSelectionProvider>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -23,8 +23,15 @@ import {
   TablePendingBoundary,
   TablePendingProvider,
 } from "@/components/table-pending";
-import { getDashboardStats, getInstruments } from "@/lib/api/dashboard";
-import { buildRunListQuery } from "@/lib/api/instrument-runs";
+import {
+  getDashboardStats,
+  getInstruments,
+  getTopAttributorThisWeek,
+} from "@/lib/api/dashboard";
+import {
+  buildRunListQuery,
+  getRanByFilterOptions,
+} from "@/lib/api/instrument-runs";
 import { getRecentActiveInstrumentsForDashboard } from "@/lib/api/instruments";
 import { auth } from "@/lib/auth";
 import { dashboardParamsCache, hasActiveFilters } from "@/lib/search-params";
@@ -107,8 +114,12 @@ async function DashboardStatsSection({
 }: {
   currentUserId: string | null;
 }) {
-  const stats = await getDashboardStats(currentUserId);
-  return <DashboardStatsCards stats={stats} />;
+  // The fleet stats and the leaderboard card are independent aggregates.
+  const [stats, topAttributor] = await Promise.all([
+    getDashboardStats(currentUserId),
+    getTopAttributorThisWeek(),
+  ]);
+  return <DashboardStatsCards stats={stats} topAttributor={topAttributor} />;
 }
 
 async function DashboardInstrumentsSection() {
@@ -152,10 +163,12 @@ async function DashboardRunsSection({
   // RunsDateFilter and keeps the initial payload bounded.
   const defaultDateFrom = last24hISOString();
 
-  // The toolbar instrument list and the filtered run page are independent.
-  // Only active instruments are useful filter targets on the dashboard.
-  const [instruments, runResult] = await Promise.all([
+  // The toolbar instrument list, the fleet-wide attributor options, and the
+  // filtered run page are all independent. Only active instruments are useful
+  // filter targets on the dashboard.
+  const [instruments, ranByUsers, runResult] = await Promise.all([
     getInstruments(true),
+    getRanByFilterOptions(),
     buildRunListQuery({
       instrumentId: instrumentIds,
       search: params.search || undefined,
@@ -164,9 +177,24 @@ async function DashboardRunsSection({
       page: params.page,
       perPage: params.per_page,
       includeDeleted: params.include_deleted,
+      ranBy: params.ran_by ?? undefined,
       statuses: params.status.length > 0 ? params.status : undefined,
     }),
   ]);
+
+  // Current user pinned as "You" at the top (if they've attributed anything),
+  // then other attributors by display name, then the "Unattributed" sentinel —
+  // matching the per-instrument page's dropdown.
+  const meOption = currentUserId
+    ? ranByUsers.find((u) => u.userId === currentUserId)
+    : undefined;
+  const ranByOptions = [
+    ...(meOption ? [{ value: meOption.userId, label: "You" }] : []),
+    ...ranByUsers
+      .filter((u) => u.userId !== currentUserId)
+      .map((u) => ({ value: u.userId, label: u.displayName })),
+    { value: "unattributed", label: "Unattributed" },
+  ];
 
   const hasFilters = hasActiveFilters(params);
   const pendingUploadCount = runResult.data.filter(
@@ -192,6 +220,7 @@ async function DashboardRunsSection({
               data={runResult.data}
               hasFilters={hasFilters}
               pendingUploadCount={pendingUploadCount}
+              ranByOptions={ranByOptions}
               ranByYouCount={ranByYouCount}
               totalCount={runResult.pagination.total}
               unattributedCount={unattributedCount}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -80,7 +80,7 @@ export default async function DashboardPage({
   return (
     <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 p-6 2xl:w-7xl">
       <Suspense fallback={<StatCardsSkeleton />}>
-        <DashboardStatsSection currentUserId={currentUserId} />
+        <DashboardStatsSection />
       </Suspense>
 
       <section className="flex flex-col gap-3">
@@ -109,14 +109,10 @@ export default async function DashboardPage({
   );
 }
 
-async function DashboardStatsSection({
-  currentUserId,
-}: {
-  currentUserId: string | null;
-}) {
+async function DashboardStatsSection() {
   // The fleet stats and the leaderboard card are independent aggregates.
   const [stats, topAttributor] = await Promise.all([
-    getDashboardStats(currentUserId),
+    getDashboardStats(),
     getTopAttributorThisWeek(),
   ]);
   return <DashboardStatsCards stats={stats} topAttributor={topAttributor} />;

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -213,7 +213,7 @@ async function DashboardRunsSection({
     <RunSelectionProvider>
       <TablePendingProvider>
         <div className="flex flex-col gap-3">
-          <RunsToolbar instruments={instruments} />
+          <RunsToolbar dateDefaultPreset="24h" instruments={instruments} />
           <RunBulkActionBar />
           <TablePendingBoundary>
             <RunsTable

--- a/web/app/users/[userId]/page.tsx
+++ b/web/app/users/[userId]/page.tsx
@@ -1,3 +1,4 @@
+import { notFound } from "next/navigation";
 import type { Metadata } from "next/types";
 import { Suspense } from "react";
 import { SignInRequired } from "@/components/auth/sign-in-required";
@@ -17,81 +18,140 @@ import {
   TablePendingBoundary,
   TablePendingProvider,
 } from "@/components/table-pending";
-import { getInstruments, getMyRunsStats } from "@/lib/api/dashboard";
+import { UserAvatar } from "@/components/user-avatar";
+import {
+  getInstruments,
+  getMyRunsStats,
+  getUserProfile,
+  type UserProfile,
+} from "@/lib/api/dashboard";
 import { buildRunListQuery } from "@/lib/api/instrument-runs";
 import { auth } from "@/lib/auth";
 import { dashboardParamsCache, hasActiveFilters } from "@/lib/search-params";
 
 type DashboardParams = Awaited<ReturnType<typeof dashboardParamsCache.parse>>;
 
-const description = "Runs you're attributed to across the lab's instruments.";
-
-export const metadata: Metadata = {
-  title: "My runs",
-  description,
-  openGraph: { title: "My runs", description },
-  twitter: { title: "My runs", description },
-};
-
-export default async function MyRunsPage({
-  searchParams,
-}: {
+interface Props {
+  params: Promise<{ userId: string }>;
   searchParams: Promise<Record<string, string | string[] | undefined>>;
-}) {
+}
+
+function firstName(displayName: string): string {
+  return displayName.trim().split(/\s+/)[0] || displayName;
+}
+
+// Possessive form for headings/labels, avoiding the awkward "Nadia Ali's" —
+// the given name reads better next to the avatar.
+function possessive(displayName: string): string {
+  const name = firstName(displayName);
+  return name.endsWith("s") ? `${name}'` : `${name}'s`;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { userId } = await params;
   const session = await auth();
+  const profile = await getUserProfile(userId);
+  if (!profile) {
+    return { title: "User not found" };
+  }
+
+  const isSelf = session?.user.id === userId;
+  const title = isSelf ? "My runs" : `${possessive(profile.displayName)} runs`;
+  const description = isSelf
+    ? "Runs you're attributed to across the lab's instruments."
+    : `Runs ${profile.displayName} is attributed to across the lab's instruments.`;
+
+  return {
+    title,
+    description,
+    openGraph: { title, description },
+    twitter: { title, description },
+  };
+}
+
+export default async function UserRunsPage({ params, searchParams }: Props) {
+  const session = await auth();
+  const { userId } = await params;
+
   if (!session) {
     return (
-      <SignInRequired callbackUrl="/my-runs">
-        Sign in to view your runs.
+      <SignInRequired callbackUrl={`/users/${userId}`}>
+        Sign in to view runs.
       </SignInRequired>
     );
   }
 
-  const params = dashboardParamsCache.parse(await searchParams);
-  const userId = session.user.id;
+  const profile = await getUserProfile(userId);
+  if (!profile) {
+    notFound();
+  }
+
+  const dashboardParams = dashboardParamsCache.parse(await searchParams);
+  const isSelf = session.user.id === userId;
+  const heading = isSelf
+    ? "My runs"
+    : `${possessive(profile.displayName)} runs`;
 
   // Each section fetches its own data behind a Suspense boundary so the static
   // shell paints immediately and the stats + runs stream in independently.
   return (
     <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 p-6 2xl:w-7xl">
-      <section className="flex flex-col gap-3">
-        <h1 className="font-medium text-lg tracking-tight">My runs</h1>
+      <section className="flex flex-col gap-6">
+        <div className="flex items-center gap-3">
+          <UserAvatar size="lg" user={profile} />
+          <h1 className="font-medium text-2xl tracking-tight">{heading}</h1>
+        </div>
         <Suspense fallback={<MyRunsStatsCardsSkeleton />}>
-          <MyRunsStatsSection userId={userId} />
+          <UserRunsStatsSection isSelf={isSelf} profile={profile} />
         </Suspense>
       </section>
 
       <section className="flex flex-col gap-3">
         <Suspense fallback={<DashboardRunsSkeleton />}>
-          <MyRunsSection params={params} userId={userId} />
+          <UserRunsSection
+            isSelf={isSelf}
+            params={dashboardParams}
+            profile={profile}
+          />
         </Suspense>
       </section>
     </div>
   );
 }
 
-async function MyRunsStatsSection({ userId }: { userId: string }) {
-  const stats = await getMyRunsStats(userId);
-  return <MyRunsStatsCards stats={stats} />;
+async function UserRunsStatsSection({
+  profile,
+  isSelf,
+}: {
+  profile: UserProfile;
+  isSelf: boolean;
+}) {
+  const stats = await getMyRunsStats(profile.userId);
+  const commentsLabel = isSelf
+    ? undefined
+    : `Comments on ${possessive(profile.displayName)} runs`;
+  return <MyRunsStatsCards commentsLabel={commentsLabel} stats={stats} />;
 }
 
-async function MyRunsSection({
+async function UserRunsSection({
   params,
-  userId,
+  profile,
+  isSelf,
 }: {
   params: DashboardParams;
-  userId: string;
+  profile: UserProfile;
+  isSelf: boolean;
 }) {
   const instrumentIds =
     params.instrument_id.length > 0 ? params.instrument_id : undefined;
 
   // The toolbar instrument list and the filtered run page are independent.
-  // Runs are scoped to the viewer via `ranBy`, so the URL `ran_by` param (which
+  // Runs are scoped to this user via `ranBy`, so the URL `ran_by` param (which
   // the dashboard toolbar never sets here) is intentionally ignored.
   const [instruments, runResult] = await Promise.all([
     getInstruments(true),
     buildRunListQuery({
-      ranBy: userId,
+      ranBy: profile.userId,
       instrumentId: instrumentIds,
       search: params.search || undefined,
       dateFrom: params.date_from ?? undefined,
@@ -110,9 +170,16 @@ async function MyRunsSection({
   const unattributedCount = runResult.data.filter(
     (row) => row.attributions.length === 0
   ).length;
-  // Every row is attributed to the viewer here, so "ran by you" equals the
-  // shown count; the footer still reports it for consistency with other tables.
+  // Every row is attributed to this user, so the ran-by count equals the shown
+  // count; the footer still reports it for consistency with other tables.
   const ranByYouCount = runResult.data.length;
+
+  const emptyLabel = isSelf
+    ? "No runs attributed to you yet."
+    : `No runs attributed to ${profile.displayName} yet.`;
+  const ranByLabel = isSelf
+    ? "ran by you"
+    : `ran by ${firstName(profile.displayName)}`;
 
   return (
     <RunSelectionProvider>
@@ -123,9 +190,10 @@ async function MyRunsSection({
           <TablePendingBoundary>
             <RunsTable
               data={runResult.data}
-              emptyLabel="No runs attributed to you yet."
+              emptyLabel={emptyLabel}
               hasFilters={hasFilters}
               pendingUploadCount={pendingUploadCount}
+              ranByLabel={ranByLabel}
               ranByYouCount={ranByYouCount}
               totalCount={runResult.pagination.total}
               unattributedCount={unattributedCount}

--- a/web/components/app-sidebar/app-sidebar-content.tsx
+++ b/web/components/app-sidebar/app-sidebar-content.tsx
@@ -7,6 +7,7 @@ import { SidebarContent } from "@/components/ui/sidebar";
 import type { SidebarInstrument } from "@/lib/api/sidebar";
 
 interface AppSidebarContentProps {
+  currentUserId: string;
   instruments: SidebarInstrument[];
   isAdmin: boolean;
 }
@@ -16,6 +17,7 @@ interface AppSidebarContentProps {
 // navigates to /settings/* the sidebar swaps in place; navigating away
 // restores the main view automatically.
 export function AppSidebarContent({
+  currentUserId,
   instruments,
   isAdmin,
 }: AppSidebarContentProps) {
@@ -27,7 +29,7 @@ export function AppSidebarContent({
       {isSettings ? (
         <SettingsNav isAdmin={isAdmin} />
       ) : (
-        <MainNav instruments={instruments} />
+        <MainNav currentUserId={currentUserId} instruments={instruments} />
       )}
     </SidebarContent>
   );

--- a/web/components/app-sidebar/index.tsx
+++ b/web/components/app-sidebar/index.tsx
@@ -51,6 +51,7 @@ export function AppSidebar({
         </SidebarMenu>
       </SidebarHeader>
       <AppSidebarContent
+        currentUserId={session.user.id}
         instruments={instruments}
         isAdmin={session.user.isAdmin === true}
       />

--- a/web/components/app-sidebar/main-nav.tsx
+++ b/web/components/app-sidebar/main-nav.tsx
@@ -33,11 +33,13 @@ import type { SidebarInstrument } from "@/lib/api/sidebar";
 const SIDEBAR_RECENT_INSTRUMENTS_LIMIT = 10;
 
 interface MainNavProps {
+  currentUserId: string;
   instruments: SidebarInstrument[];
 }
 
-export function MainNav({ instruments }: MainNavProps) {
+export function MainNav({ currentUserId, instruments }: MainNavProps) {
   const pathname = usePathname();
+  const myRunsHref = `/users/${currentUserId}`;
   const { recent: recentInstruments } = useRecentInstruments();
 
   const recentlyViewedInstruments = useMemo(
@@ -86,10 +88,10 @@ export function MainNav({ instruments }: MainNavProps) {
           <SidebarMenuItem>
             <SidebarMenuButton
               asChild
-              isActive={pathname === "/my-runs"}
+              isActive={pathname === myRunsHref}
               tooltip="My runs"
             >
-              <Link href="/my-runs">
+              <Link href={myRunsHref}>
                 <ListChecks />
                 <span>My runs</span>
               </Link>

--- a/web/components/app-sidebar/main-nav.tsx
+++ b/web/components/app-sidebar/main-nav.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ChevronRight, Cpu, Home, type LucideIcon, Radio } from "lucide-react";
+import {
+  ChevronRight,
+  Cpu,
+  Home,
+  ListChecks,
+  type LucideIcon,
+  Radio,
+} from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useMemo } from "react";
@@ -72,6 +79,19 @@ export function MainNav({ instruments }: MainNavProps) {
               <Link href="/">
                 <Home />
                 <span>Home</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              asChild
+              isActive={pathname === "/my-runs"}
+              tooltip="My runs"
+            >
+              <Link href="/my-runs">
+                <ListChecks />
+                <span>My runs</span>
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/web/components/dashboard/dashboard-stats.tsx
+++ b/web/components/dashboard/dashboard-stats.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { UserAvatar } from "@/components/user-avatar";
 import type {
   DashboardStats,
   MyRunsStats,
@@ -26,6 +27,13 @@ const numberFormatter = new Intl.NumberFormat("en-US");
 
 export function formatNumber(n: number): string {
   return numberFormatter.format(n);
+}
+
+// The leaderboard card shows only the given (first) name to keep the value
+// compact next to the avatar; falls back to the full label when there's no
+// whitespace to split on (e.g. an email-only display name).
+function firstName(displayName: string): string {
+  return displayName.trim().split(/\s+/)[0] || displayName;
 }
 
 export function StatCard({
@@ -151,10 +159,21 @@ export function DashboardStatsCards({
             ? `${formatNumber(topAttributor.runCount)} runs · ${formatBytes(topAttributor.bytesGenerated)} generated`
             : "No attributed runs this week"
         }
-        value={topAttributor ? topAttributor.displayName : "—"}
-        // The leaderboard value is a name, not a number, so drop the numeric
-        // sizing used by the count cards.
-        valueClassName="truncate text-xl"
+        value={
+          topAttributor ? (
+            <span className="flex items-center gap-2">
+              <UserAvatar size="sm" user={topAttributor.user} />
+              <span className="truncate">
+                {firstName(topAttributor.user.displayName)}
+              </span>
+            </span>
+          ) : (
+            "—"
+          )
+        }
+        // The leaderboard value is a name + avatar, not a number, so drop the
+        // numeric sizing used by the count cards.
+        valueClassName="text-xl"
       />
     </div>
   );

--- a/web/components/dashboard/dashboard-stats.tsx
+++ b/web/components/dashboard/dashboard-stats.tsx
@@ -179,7 +179,15 @@ export function DashboardStatsCards({
   );
 }
 
-export function MyRunsStatsCards({ stats }: { stats: MyRunsStats }) {
+export function MyRunsStatsCards({
+  stats,
+  // Only the comments card is possessive; the page passes the third-person form
+  // ("Comments on Nadia's runs") when viewing another member.
+  commentsLabel = MY_RUNS_STAT_LABELS[2],
+}: {
+  stats: MyRunsStats;
+  commentsLabel?: string;
+}) {
   const { runsLast24Hours, runsLast7Days, commentsLast7Days, pendingUploads } =
     stats;
 
@@ -208,7 +216,7 @@ export function MyRunsStatsCards({ stats }: { stats: MyRunsStats }) {
         value={formatNumber(runsLast7Days.total)}
       />
       <StatCard
-        label={MY_RUNS_STAT_LABELS[2]}
+        label={commentsLabel}
         subline={
           commentsLast7Days.count > 0
             ? "in the last 7 days"

--- a/web/components/dashboard/dashboard-stats.tsx
+++ b/web/components/dashboard/dashboard-stats.tsx
@@ -1,23 +1,34 @@
 import type { ReactNode } from "react";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { DashboardStats } from "@/lib/api/dashboard";
+import type {
+  DashboardStats,
+  MyRunsStats,
+  TopAttributor,
+} from "@/lib/api/dashboard";
 import { cn, formatBytes } from "@/lib/utils";
 
 const DASHBOARD_STAT_LABELS = [
   "Runs in the last 24 hours",
   "Runs in the last 7 days",
   "Pending uploads",
-  "My runs this week",
+  "Most runs this week",
+] as const;
+
+const MY_RUNS_STAT_LABELS = [
+  "Runs in the last 24 hours",
+  "Runs in the last 7 days",
+  "Comments in the last 7 days",
+  "Pending uploads",
 ] as const;
 
 const numberFormatter = new Intl.NumberFormat("en-US");
 
-function formatNumber(n: number): string {
+export function formatNumber(n: number): string {
   return numberFormatter.format(n);
 }
 
-function StatCard({
+export function StatCard({
   label,
   value,
   subline,
@@ -46,7 +57,7 @@ function StatCard({
   );
 }
 
-function DataGeneratedSubline({
+export function DataGeneratedSubline({
   bytes,
   emptyLabel,
 }: {
@@ -59,7 +70,11 @@ function DataGeneratedSubline({
   return <span>{formatBytes(bytes)} generated</span>;
 }
 
-export function StatCardsSkeleton() {
+export function StatCardsSkeleton({
+  labels = DASHBOARD_STAT_LABELS,
+}: {
+  labels?: readonly string[];
+} = {}) {
   return (
     <div
       aria-busy="true"
@@ -67,7 +82,7 @@ export function StatCardsSkeleton() {
       className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4"
       role="status"
     >
-      {DASHBOARD_STAT_LABELS.map((label) => (
+      {labels.map((label) => (
         <Card className="gap-2 py-4" key={label} size="sm">
           <div className="px-4">
             <p className="font-medium text-muted-foreground text-xs">{label}</p>
@@ -80,7 +95,17 @@ export function StatCardsSkeleton() {
   );
 }
 
-export function DashboardStatsCards({ stats }: { stats: DashboardStats }) {
+export function MyRunsStatsCardsSkeleton() {
+  return <StatCardsSkeleton labels={MY_RUNS_STAT_LABELS} />;
+}
+
+export function DashboardStatsCards({
+  stats,
+  topAttributor,
+}: {
+  stats: DashboardStats;
+  topAttributor: TopAttributor | null;
+}) {
   const { runsLast24Hours, pendingUploads, runsThisWeek } = stats;
 
   // Highlight pending uploads in red once a backlog forms — a non-zero queue
@@ -122,11 +147,65 @@ export function DashboardStatsCards({ stats }: { stats: DashboardStats }) {
       <StatCard
         label={DASHBOARD_STAT_LABELS[3]}
         subline={
-          runsThisWeek.unattributed > 0
-            ? `${formatNumber(runsThisWeek.unattributed)} unattributed`
-            : "All runs attributed"
+          topAttributor
+            ? `${formatNumber(topAttributor.runCount)} runs · ${formatBytes(topAttributor.bytesGenerated)} generated`
+            : "No attributed runs this week"
         }
-        value={formatNumber(runsThisWeek.mine)}
+        value={topAttributor ? topAttributor.displayName : "—"}
+        // The leaderboard value is a name, not a number, so drop the numeric
+        // sizing used by the count cards.
+        valueClassName="truncate text-xl"
+      />
+    </div>
+  );
+}
+
+export function MyRunsStatsCards({ stats }: { stats: MyRunsStats }) {
+  const { runsLast24Hours, runsLast7Days, commentsLast7Days, pendingUploads } =
+    stats;
+
+  const pendingHasBacklog = pendingUploads.count > 0;
+
+  return (
+    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      <StatCard
+        label={MY_RUNS_STAT_LABELS[0]}
+        subline={
+          <DataGeneratedSubline
+            bytes={runsLast24Hours.bytesGenerated}
+            emptyLabel="No data generated in the last 24 hours"
+          />
+        }
+        value={formatNumber(runsLast24Hours.total)}
+      />
+      <StatCard
+        label={MY_RUNS_STAT_LABELS[1]}
+        subline={
+          <DataGeneratedSubline
+            bytes={runsLast7Days.bytesGenerated}
+            emptyLabel="No data generated in the last 7 days"
+          />
+        }
+        value={formatNumber(runsLast7Days.total)}
+      />
+      <StatCard
+        label={MY_RUNS_STAT_LABELS[2]}
+        subline={
+          commentsLast7Days.count > 0
+            ? "on your runs"
+            : "No comments in the last 7 days"
+        }
+        value={formatNumber(commentsLast7Days.count)}
+      />
+      <StatCard
+        label={MY_RUNS_STAT_LABELS[3]}
+        subline={
+          pendingUploads.count > 0
+            ? `${formatBytes(pendingUploads.totalBytes)} queued`
+            : "Upload queue is clear"
+        }
+        value={formatNumber(pendingUploads.count)}
+        valueClassName={pendingHasBacklog ? "text-destructive" : undefined}
       />
     </div>
   );

--- a/web/components/dashboard/dashboard-stats.tsx
+++ b/web/components/dashboard/dashboard-stats.tsx
@@ -19,13 +19,13 @@ const DASHBOARD_STAT_LABELS = [
 const MY_RUNS_STAT_LABELS = [
   "Runs in the last 24 hours",
   "Runs in the last 7 days",
-  "Comments in the last 7 days",
+  "Comments on your runs",
   "Pending uploads",
 ] as const;
 
 const numberFormatter = new Intl.NumberFormat("en-US");
 
-export function formatNumber(n: number): string {
+function formatNumber(n: number): string {
   return numberFormatter.format(n);
 }
 
@@ -36,7 +36,7 @@ function firstName(displayName: string): string {
   return displayName.trim().split(/\s+/)[0] || displayName;
 }
 
-export function StatCard({
+function StatCard({
   label,
   value,
   subline,
@@ -65,7 +65,7 @@ export function StatCard({
   );
 }
 
-export function DataGeneratedSubline({
+function DataGeneratedSubline({
   bytes,
   emptyLabel,
 }: {
@@ -211,8 +211,8 @@ export function MyRunsStatsCards({ stats }: { stats: MyRunsStats }) {
         label={MY_RUNS_STAT_LABELS[2]}
         subline={
           commentsLast7Days.count > 0
-            ? "on your runs"
-            : "No comments in the last 7 days"
+            ? "in the last 7 days"
+            : "None in the last 7 days"
         }
         value={formatNumber(commentsLast7Days.count)}
       />

--- a/web/components/dashboard/runs-table.tsx
+++ b/web/components/dashboard/runs-table.tsx
@@ -2,6 +2,8 @@ import { SearchX } from "lucide-react";
 import Link from "next/link";
 import { RelativeTime } from "@/components/dashboard/relative-time";
 import { AcquiredColumnHeader } from "@/components/instruments/runs-table/acquired-column-header";
+import { FilterableColumnHeader } from "@/components/instruments/runs-table/filterable-column-header";
+import type { RanByOption } from "@/components/instruments/runs-table/index";
 import { RanByCell } from "@/components/instruments/runs-table/ran-by-cell";
 import { RawFileColumnHeader } from "@/components/instruments/runs-table/raw-file-column-header";
 import { RunIdLabel } from "@/components/instruments/runs-table/run-id-label";
@@ -25,6 +27,7 @@ import {
 } from "@/components/ui/table";
 import type { RunListRow } from "@/lib/api/instrument-runs";
 import { runRowToRef } from "@/lib/runs/row-actions";
+import { dashboardSearchParams } from "@/lib/search-params";
 import { cn, formatBytes } from "@/lib/utils";
 
 export function RunsTable({
@@ -34,6 +37,7 @@ export function RunsTable({
   pendingUploadCount,
   unattributedCount,
   ranByYouCount,
+  ranByOptions,
 }: {
   data: RunListRow[];
   hasFilters: boolean;
@@ -41,6 +45,10 @@ export function RunsTable({
   pendingUploadCount: number;
   unattributedCount: number;
   ranByYouCount: number;
+  // When provided, the "Ran By" column becomes a filterable dropdown bound to
+  // `dashboardSearchParams.ran_by`. Omitted on the "My runs" page, where every
+  // row is the viewer, so a plain header is rendered instead.
+  ranByOptions?: RanByOption[];
 }) {
   if (data.length === 0) {
     return (
@@ -75,7 +83,18 @@ export function RunsTable({
             <TableHead className="text-right">
               <RawFileColumnHeader label="Size" />
             </TableHead>
-            <TableHead>Ran By</TableHead>
+            <TableHead>
+              {ranByOptions ? (
+                <FilterableColumnHeader
+                  label="Ran By"
+                  options={ranByOptions}
+                  paramKey="ran_by"
+                  searchParams={dashboardSearchParams}
+                />
+              ) : (
+                "Ran By"
+              )}
+            </TableHead>
             <TableHead className="text-right">
               <AcquiredColumnHeader />
             </TableHead>

--- a/web/components/dashboard/runs-table.tsx
+++ b/web/components/dashboard/runs-table.tsx
@@ -38,6 +38,7 @@ export function RunsTable({
   unattributedCount,
   ranByYouCount,
   ranByOptions,
+  emptyLabel = "No instrument runs yet.",
 }: {
   data: RunListRow[];
   hasFilters: boolean;
@@ -49,15 +50,17 @@ export function RunsTable({
   // `dashboardSearchParams.ran_by`. Omitted on the "My runs" page, where every
   // row is the viewer, so a plain header is rendered instead.
   ranByOptions?: RanByOption[];
+  // Copy shown when there are no rows and no active filters. Overridden on the
+  // "My runs" page, where "No instrument runs yet." would misdescribe the
+  // viewer-scoped list.
+  emptyLabel?: string;
 }) {
   if (data.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed bg-background py-16 dark:bg-muted">
         <SearchX className="size-8 text-muted-foreground" />
         <p className="text-muted-foreground text-sm">
-          {hasFilters
-            ? "No runs match your filters."
-            : "No instrument runs yet."}
+          {hasFilters ? "No runs match your filters." : emptyLabel}
         </p>
       </div>
     );

--- a/web/components/dashboard/runs-table.tsx
+++ b/web/components/dashboard/runs-table.tsx
@@ -38,6 +38,7 @@ export function RunsTable({
   unattributedCount,
   ranByYouCount,
   ranByOptions,
+  ranByLabel,
   emptyLabel = "No instrument runs yet.",
 }: {
   data: RunListRow[];
@@ -47,12 +48,14 @@ export function RunsTable({
   unattributedCount: number;
   ranByYouCount: number;
   // When provided, the "Ran By" column becomes a filterable dropdown bound to
-  // `dashboardSearchParams.ran_by`. Omitted on the "My runs" page, where every
-  // row is the viewer, so a plain header is rendered instead.
+  // `dashboardSearchParams.ran_by`. Omitted on a member's runs page, where every
+  // row is the same user, so a plain header is rendered instead.
   ranByOptions?: RanByOption[];
-  // Copy shown when there are no rows and no active filters. Overridden on the
-  // "My runs" page, where "No instrument runs yet." would misdescribe the
-  // viewer-scoped list.
+  // Footer suffix for the ran-by count; third-person on another member's page.
+  ranByLabel?: string;
+  // Copy shown when there are no rows and no active filters. Overridden on a
+  // member's runs page, where "No instrument runs yet." would misdescribe the
+  // user-scoped list.
   emptyLabel?: string;
 }) {
   if (data.length === 0) {
@@ -183,6 +186,7 @@ export function RunsTable({
       </Table>
       <RunsTableFooter
         pendingUploadCount={pendingUploadCount}
+        ranByLabel={ranByLabel}
         ranByYouCount={ranByYouCount}
         shownCount={data.length}
         totalCount={totalCount}

--- a/web/components/dashboard/runs-toolbar.tsx
+++ b/web/components/dashboard/runs-toolbar.tsx
@@ -58,6 +58,7 @@ export function RunsToolbar({ instruments }: { instruments: Instrument[] }) {
       date_to: null,
       include_deleted: false,
       status: [],
+      ran_by: null,
       page: 1,
     });
   }

--- a/web/components/dashboard/runs-toolbar.tsx
+++ b/web/components/dashboard/runs-toolbar.tsx
@@ -4,7 +4,10 @@ import { Check, ChevronsUpDown, Search, X } from "lucide-react";
 import { useQueryStates } from "nuqs";
 import { useState } from "react";
 import { RunFiltersCombobox } from "@/components/runs/run-filters-combobox";
-import { RunsDateFilter } from "@/components/runs/runs-date-filter";
+import {
+  type PresetId,
+  RunsDateFilter,
+} from "@/components/runs/runs-date-filter";
 import { useTablePending } from "@/components/table-pending";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -30,7 +33,16 @@ interface Instrument {
   id: string;
 }
 
-export function RunsToolbar({ instruments }: { instruments: Instrument[] }) {
+export function RunsToolbar({
+  instruments,
+  dateDefaultPreset,
+}: {
+  instruments: Instrument[];
+  // The page's server-side default date window, reflected in the date filter's
+  // label/highlight. Omitted on pages that show all runs by default (e.g. "My
+  // runs"), which surfaces an "All time" option instead.
+  dateDefaultPreset?: PresetId;
+}) {
   const { startTransition } = useTablePending();
   const [filters, setFilters] = useQueryStates(dashboardSearchParams, {
     shallow: false,
@@ -147,7 +159,7 @@ export function RunsToolbar({ instruments }: { instruments: Instrument[] }) {
 
           <RunsDateFilter
             align="end"
-            defaultPreset="24h"
+            defaultPreset={dateDefaultPreset}
             onChange={(range) =>
               setFilters({
                 date_from: range.from,

--- a/web/components/instruments/runs-table/filterable-column-header.tsx
+++ b/web/components/instruments/runs-table/filterable-column-header.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import { ChevronsUpDown, ListFilter } from "lucide-react";
-import { useQueryStates } from "nuqs";
-import type { inferParserType } from "nuqs/server";
+import {
+  type Nullable,
+  type UseQueryStatesKeysMap,
+  useQueryStates,
+  type Values,
+} from "nuqs";
 import { useTablePending } from "@/components/table-pending";
 import { Button } from "@/components/ui/button";
 import {
@@ -16,23 +20,25 @@ import {
 import { instrumentDetailSearchParams } from "@/lib/search-params";
 import { cn } from "@/lib/utils";
 
-type InstrumentDetailFilters = inferParserType<
-  typeof instrumentDetailSearchParams
->;
+// The header drives a single nullable-string radio filter and resets the page,
+// so it works with any nuqs parser map exposing the target column key plus a
+// `page` key. Defaults to the per-instrument params; the dashboard tables pass
+// `dashboardSearchParams` instead.
+type ColumnFilterKeyMap = UseQueryStatesKeysMap & { page: unknown };
 
-// Filter-column params are the nullable-string entries in the nuqs map
-// (`parseAsString` without a default). Keys whose parser carries a default
-// — page/per_page/search/include_deleted — aren't column filters and get
-// excluded automatically here. Adding a new `parseAsString` filter to
-// `instrumentDetailSearchParams` makes it a valid `paramKey` with no
-// hand-maintenance needed at this boundary.
-export type FilterParamKey = {
-  [K in keyof InstrumentDetailFilters]: null extends InstrumentDetailFilters[K]
-    ? InstrumentDetailFilters[K] extends string | null
+// Column-filter keys are the nullable-string entries in the parser map
+// (`parseAsString` without a default). Keys whose parser carries a default —
+// page/per_page/search/include_deleted — resolve to non-null values and are
+// excluded automatically, so adding a new `parseAsString` filter to a params
+// map makes it a valid `paramKey` with no hand-maintenance here.
+type FilterParamKey<KeyMap extends UseQueryStatesKeysMap> = {
+  [K in keyof Values<KeyMap>]: null extends Values<KeyMap>[K]
+    ? Values<KeyMap>[K] extends string | null
       ? K
       : never
     : never;
-}[keyof InstrumentDetailFilters];
+}[keyof Values<KeyMap>] &
+  string;
 
 // Options accept either plain strings (value == label) or { value, label }
 // pairs for cases where the URL-stable value and the display label differ
@@ -46,23 +52,27 @@ function normalizeOption(option: FilterOption): {
   return typeof option === "string" ? { value: option, label: option } : option;
 }
 
-export function FilterableColumnHeader({
+export function FilterableColumnHeader<
+  KeyMap extends ColumnFilterKeyMap = typeof instrumentDetailSearchParams,
+>({
   label,
   paramKey,
   options,
+  searchParams = instrumentDetailSearchParams as unknown as KeyMap,
 }: {
   label: string;
-  paramKey: FilterParamKey;
+  paramKey: FilterParamKey<KeyMap>;
   options: FilterOption[];
+  searchParams?: KeyMap;
 }) {
   const { startTransition } = useTablePending();
-  const [filters, setFilters] = useQueryStates(instrumentDetailSearchParams, {
+  const [filters, setFilters] = useQueryStates(searchParams, {
     shallow: false,
     throttleMs: 300,
     startTransition,
   });
 
-  const currentValue = filters[paramKey];
+  const currentValue = (filters[paramKey] ?? null) as string | null;
 
   return (
     <DropdownMenu>
@@ -86,17 +96,20 @@ export function FilterableColumnHeader({
       <DropdownMenuContent align="start" className="w-48">
         <DropdownMenuRadioGroup
           onValueChange={(value) =>
-            setFilters({ [paramKey]: value || null, page: 1 })
+            setFilters({
+              [paramKey]: value || null,
+              page: 1,
+            } as Partial<Nullable<Values<KeyMap>>>)
           }
           value={currentValue ?? ""}
         >
           <DropdownMenuRadioItem value="">All</DropdownMenuRadioItem>
           <DropdownMenuSeparator />
           {options.map((option) => {
-            const { value, label } = normalizeOption(option);
+            const { value, label: optionLabel } = normalizeOption(option);
             return (
               <DropdownMenuRadioItem key={value} value={value}>
-                {label}
+                {optionLabel}
               </DropdownMenuRadioItem>
             );
           })}

--- a/web/components/instruments/runs-table/ran-by-cell.tsx
+++ b/web/components/instruments/runs-table/ran-by-cell.tsx
@@ -11,7 +11,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { UserAvatar } from "@/components/user-avatar";
+import { UserAvatar, UserAvatarLink } from "@/components/user-avatar";
 import type { RunAttribution } from "@/lib/api/instrument-runs";
 import { toInitials } from "@/lib/avatar-color";
 import { cn } from "@/lib/utils";
@@ -38,12 +38,17 @@ function AttributionAvatars({
   currentUserId,
   showName,
   compact,
+  linkToProfile,
 }: {
   attributions: RunAttribution[];
   currentUserId: string | null;
   showName: boolean;
   compact: boolean;
+  // Links each avatar to the attributed user's runs page. Off in the runs
+  // table (rows already navigate to the run); on in the run detail metadata.
+  linkToProfile: boolean;
 }) {
+  const Avatar = linkToProfile ? UserAvatarLink : UserAvatar;
   const avatarClassName = cn(
     compact
       ? "size-5 ring-1 ring-background [&_[data-slot=avatar-fallback]]:text-[10px]"
@@ -61,7 +66,7 @@ function AttributionAvatars({
     const isSelf = attribution.userId === currentUserId;
     return (
       <span className={rowClassName}>
-        <UserAvatar
+        <Avatar
           className={cn(avatarClassName, isSelf && "ring-primary/30")}
           data-self-attribution={isSelf || undefined}
           size="sm"
@@ -82,7 +87,7 @@ function AttributionAvatars({
             return (
               <Tooltip key={attribution.userId}>
                 <TooltipTrigger asChild>
-                  <UserAvatar
+                  <Avatar
                     className={cn(avatarClassName, isSelf && "ring-primary/30")}
                     data-self-attribution={isSelf || undefined}
                     size="sm"
@@ -109,7 +114,7 @@ function AttributionAvatars({
         return (
           <Tooltip key={attribution.userId}>
             <TooltipTrigger asChild>
-              <UserAvatar
+              <Avatar
                 className={cn(
                   "ring-2 ring-background",
                   isSelf && "ring-primary/30"
@@ -133,12 +138,14 @@ export function RanByCell({
   attributions,
   showName = false,
   compact = false,
+  linkToProfile = false,
 }: {
   instrumentId: string;
   runId: string;
   attributions: RunAttribution[];
   showName?: boolean;
   compact?: boolean;
+  linkToProfile?: boolean;
 }) {
   const { data: session } = useSession();
   const currentUserId = session?.user?.id ?? null;
@@ -251,6 +258,7 @@ export function RanByCell({
         attributions={optimistic}
         compact={compact}
         currentUserId={currentUserId}
+        linkToProfile={linkToProfile}
         showName={showName}
       />
       {isSelfAttributed ? (

--- a/web/components/instruments/runs-table/ran-by-cell.tsx
+++ b/web/components/instruments/runs-table/ran-by-cell.tsx
@@ -45,19 +45,16 @@ function AttributionAvatars({
   currentUserId: string | null;
   showName: boolean;
   compact: boolean;
-  // Links each avatar to the attributed user's runs page. Off in the runs
-  // table (rows already navigate to the run); on in the run detail metadata.
+  // Links each attributor to their runs page. Off in the runs table (rows
+  // already navigate to the run); on in the run detail metadata.
   linkToProfile: boolean;
 }) {
-  const Avatar = linkToProfile ? UserAvatarLink : UserAvatar;
   const avatarClassName = cn(
     compact
       ? "size-5 ring-1 ring-background [&_[data-slot=avatar-fallback]]:text-[10px]"
       : "ring-2 ring-background"
   );
-  const nameClassName = compact
-    ? "font-medium text-foreground text-xs"
-    : "font-medium text-foreground text-sm";
+  const nameClassName = "font-medium text-foreground text-sm";
   const rowClassName = compact
     ? "inline-flex h-5 items-center gap-1.5"
     : "inline-flex items-center gap-2";
@@ -65,11 +62,18 @@ function AttributionAvatars({
   if (showName && attributions.length === 1) {
     const attribution = attributions[0];
     const isSelf = attribution.userId === currentUserId;
+    const avatarProps = {
+      className: cn(avatarClassName, isSelf && "ring-primary/30"),
+      "data-self-attribution": isSelf || undefined,
+      size: "sm" as const,
+      user: attribution,
+    };
     if (linkToProfile) {
       return (
         <UserAvatarLink
-          className={cn(avatarClassName, isSelf && "ring-primary/30")}
-          data-self-attribution={isSelf || undefined}
+          avatarClassName={avatarProps.className}
+          className={rowClassName}
+          data-self-attribution={avatarProps["data-self-attribution"]}
           size="sm"
           user={attribution}
         >
@@ -79,12 +83,7 @@ function AttributionAvatars({
     }
     return (
       <span className={rowClassName}>
-        <UserAvatar
-          className={cn(avatarClassName, isSelf && "ring-primary/30")}
-          data-self-attribution={isSelf || undefined}
-          size="sm"
-          user={attribution}
-        />
+        <UserAvatar {...avatarProps} />
         <span className={nameClassName}>{attribution.displayName}</span>
       </span>
     );
@@ -98,15 +97,25 @@ function AttributionAvatars({
         <span className={cn("flex", compact ? "-space-x-1" : "-space-x-1.5")}>
           {attributions.map((attribution) => {
             const isSelf = attribution.userId === currentUserId;
+            const ringClass = cn(avatarClassName, isSelf && "ring-primary/30");
             return (
               <Tooltip key={attribution.userId}>
                 <TooltipTrigger asChild>
-                  <Avatar
-                    className={cn(avatarClassName, isSelf && "ring-primary/30")}
-                    data-self-attribution={isSelf || undefined}
-                    size="sm"
-                    user={attribution}
-                  />
+                  {linkToProfile ? (
+                    <UserAvatarLink
+                      avatarClassName={ringClass}
+                      data-self-attribution={isSelf || undefined}
+                      size="sm"
+                      user={attribution}
+                    />
+                  ) : (
+                    <UserAvatar
+                      className={ringClass}
+                      data-self-attribution={isSelf || undefined}
+                      size="sm"
+                      user={attribution}
+                    />
+                  )}
                 </TooltipTrigger>
                 <TooltipContent>{attribution.displayName}</TooltipContent>
               </Tooltip>
@@ -114,8 +123,14 @@ function AttributionAvatars({
           })}
         </span>
         {linkToProfile ? (
+          // Name links to the first attributor; stacked avatars above each
+          // link to their own profile (wrapping avatar+name isn't possible
+          // when the first avatar sits in a shared stack).
           <Link
-            className={cn(nameClassName, "hover:underline")}
+            className={cn(
+              nameClassName,
+              "rounded-sm outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-ring"
+            )}
             href={`/users/${first.userId}`}
           >
             {first.displayName}
@@ -135,18 +150,28 @@ function AttributionAvatars({
     <div className="flex -space-x-1.5">
       {attributions.map((attribution) => {
         const isSelf = attribution.userId === currentUserId;
+        const ringClass = cn(
+          "ring-2 ring-background",
+          isSelf && "ring-primary/30"
+        );
         return (
           <Tooltip key={attribution.userId}>
             <TooltipTrigger asChild>
-              <Avatar
-                className={cn(
-                  "ring-2 ring-background",
-                  isSelf && "ring-primary/30"
-                )}
-                data-self-attribution={isSelf || undefined}
-                size="sm"
-                user={attribution}
-              />
+              {linkToProfile ? (
+                <UserAvatarLink
+                  avatarClassName={ringClass}
+                  data-self-attribution={isSelf || undefined}
+                  size="sm"
+                  user={attribution}
+                />
+              ) : (
+                <UserAvatar
+                  className={ringClass}
+                  data-self-attribution={isSelf || undefined}
+                  size="sm"
+                  user={attribution}
+                />
+              )}
             </TooltipTrigger>
             <TooltipContent>{attribution.displayName}</TooltipContent>
           </Tooltip>

--- a/web/components/instruments/runs-table/ran-by-cell.tsx
+++ b/web/components/instruments/runs-table/ran-by-cell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { UserPlus, X } from "lucide-react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { type MouseEvent, useOptimistic, useTransition } from "react";
@@ -64,9 +65,21 @@ function AttributionAvatars({
   if (showName && attributions.length === 1) {
     const attribution = attributions[0];
     const isSelf = attribution.userId === currentUserId;
+    if (linkToProfile) {
+      return (
+        <UserAvatarLink
+          className={cn(avatarClassName, isSelf && "ring-primary/30")}
+          data-self-attribution={isSelf || undefined}
+          size="sm"
+          user={attribution}
+        >
+          <span className={nameClassName}>{attribution.displayName}</span>
+        </UserAvatarLink>
+      );
+    }
     return (
       <span className={rowClassName}>
-        <Avatar
+        <UserAvatar
           className={cn(avatarClassName, isSelf && "ring-primary/30")}
           data-self-attribution={isSelf || undefined}
           size="sm"
@@ -79,6 +92,7 @@ function AttributionAvatars({
 
   if (showName && attributions.length > 1) {
     const hiddenCount = attributions.length - 1;
+    const first = attributions[0];
     return (
       <span className={rowClassName}>
         <span className={cn("flex", compact ? "-space-x-1" : "-space-x-1.5")}>
@@ -99,10 +113,20 @@ function AttributionAvatars({
             );
           })}
         </span>
-        <span className={nameClassName}>
-          {attributions[0].displayName}
-          <span className="text-muted-foreground"> +{hiddenCount}</span>
-        </span>
+        {linkToProfile ? (
+          <Link
+            className={cn(nameClassName, "hover:underline")}
+            href={`/users/${first.userId}`}
+          >
+            {first.displayName}
+            <span className="text-muted-foreground"> +{hiddenCount}</span>
+          </Link>
+        ) : (
+          <span className={nameClassName}>
+            {first.displayName}
+            <span className="text-muted-foreground"> +{hiddenCount}</span>
+          </span>
+        )}
       </span>
     );
   }

--- a/web/components/instruments/runs-table/run-status-icon.tsx
+++ b/web/components/instruments/runs-table/run-status-icon.tsx
@@ -57,7 +57,7 @@ export function RunStatusIcon({
   }
   if (hasUploaded) {
     lines.push(
-      `${filesUploaded} file${filesUploaded > 1 ? "s" : ""} awaiting processing`
+      `${filesUploaded} file${filesUploaded > 1 ? "s" : ""} uploaded`
     );
   }
   if (hasProcessing) {

--- a/web/components/instruments/runs-table/run-status-icon.tsx
+++ b/web/components/instruments/runs-table/run-status-icon.tsx
@@ -56,9 +56,7 @@ export function RunStatusIcon({
     );
   }
   if (hasUploaded) {
-    lines.push(
-      `${filesUploaded} file${filesUploaded > 1 ? "s" : ""} uploaded`
-    );
+    lines.push(`${filesUploaded} file${filesUploaded > 1 ? "s" : ""} uploaded`);
   }
   if (hasProcessing) {
     lines.push(

--- a/web/components/instruments/runs-table/runs-table-footer.tsx
+++ b/web/components/instruments/runs-table/runs-table-footer.tsx
@@ -4,12 +4,16 @@ export function RunsTableFooter({
   pendingUploadCount,
   unattributedCount,
   ranByYouCount,
+  // Trails the ran-by count. Third-person ("ran by Nadia") on another member's
+  // runs page, where "ran by you" would misattribute the viewer.
+  ranByLabel = "ran by you",
 }: {
   shownCount: number;
   totalCount: number;
   pendingUploadCount: number;
   unattributedCount: number;
   ranByYouCount: number;
+  ranByLabel?: string;
 }) {
   return (
     <div className="flex items-center justify-between border-t px-4 py-2.5 text-muted-foreground text-xs">
@@ -20,8 +24,8 @@ export function RunsTableFooter({
       <p>
         <span className="tabular-nums">{pendingUploadCount}</span> pending
         upload · <span className="tabular-nums">{unattributedCount}</span>{" "}
-        unattributed · <span className="tabular-nums">{ranByYouCount}</span> ran
-        by you
+        unattributed · <span className="tabular-nums">{ranByYouCount}</span>{" "}
+        {ranByLabel}
       </p>
     </div>
   );

--- a/web/components/members/members-table.tsx
+++ b/web/components/members/members-table.tsx
@@ -9,7 +9,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { UserAvatar } from "@/components/user-avatar";
+import { UserAvatarLink } from "@/components/user-avatar";
 import { toInitials } from "@/lib/avatar-color";
 
 export interface MemberRow {
@@ -103,27 +103,25 @@ export function MembersTable({ data, currentUserId }: MembersTableProps) {
             return (
               <TableRow key={member.id}>
                 <TableCell>
-                  <div className="flex items-center gap-3">
-                    <UserAvatar
-                      size="sm"
-                      user={{
-                        userId: member.id,
-                        displayName,
-                        initials: toInitials(displayName),
-                        avatarUrl: member.image,
-                      }}
-                    />
-                    <div className="flex flex-col">
-                      <span className="font-medium">
-                        {displayName}
-                        {isSelf ? (
-                          <span className="ml-1.5 text-muted-foreground text-xs">
-                            (you)
-                          </span>
-                        ) : null}
-                      </span>
-                    </div>
-                  </div>
+                  <UserAvatarLink
+                    className="gap-3"
+                    size="sm"
+                    user={{
+                      userId: member.id,
+                      displayName,
+                      initials: toInitials(displayName),
+                      avatarUrl: member.image,
+                    }}
+                  >
+                    <span className="font-medium">
+                      {displayName}
+                      {isSelf ? (
+                        <span className="ml-1.5 text-muted-foreground text-xs">
+                          (you)
+                        </span>
+                      ) : null}
+                    </span>
+                  </UserAvatarLink>
                 </TableCell>
                 <TableCell className="text-muted-foreground">
                   {member.email ?? "—"}

--- a/web/components/runs/run-attributions-section.tsx
+++ b/web/components/runs/run-attributions-section.tsx
@@ -17,6 +17,7 @@ export function RunAttributionsSection({
       attributions={attributions}
       compact
       instrumentId={instrumentId}
+      linkToProfile
       runId={runId}
       showName
     />

--- a/web/components/runs/run-comment-item.tsx
+++ b/web/components/runs/run-comment-item.tsx
@@ -15,7 +15,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -25,6 +24,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Textarea } from "@/components/ui/textarea";
+import { UserAvatarLink } from "@/components/user-avatar";
 import type { RunCommentDto } from "@/lib/api/run-comments";
 
 // Comment timestamps may arrive as Date objects (server-rendered initial
@@ -110,15 +110,16 @@ export function RunCommentItem({
   return (
     <>
       <article className="flex gap-3">
-        <Avatar className="mt-0.5 shrink-0" size="sm">
-          {comment.user.avatarUrl ? (
-            <AvatarImage
-              alt={comment.user.displayName}
-              src={comment.user.avatarUrl}
-            />
-          ) : null}
-          <AvatarFallback>{comment.user.initials}</AvatarFallback>
-        </Avatar>
+        <UserAvatarLink
+          className="mt-0.5 shrink-0"
+          size="sm"
+          user={{
+            userId: comment.user.id,
+            displayName: comment.user.displayName,
+            initials: comment.user.initials,
+            avatarUrl: comment.user.avatarUrl,
+          }}
+        />
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <div className="flex items-start justify-between gap-2">
             <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-muted-foreground text-sm">

--- a/web/components/runs/run-comment-item.tsx
+++ b/web/components/runs/run-comment-item.tsx
@@ -109,112 +109,110 @@ export function RunCommentItem({
 
   return (
     <>
-      <article className="flex gap-3">
-        <UserAvatarLink
-          className="mt-0.5 shrink-0"
-          size="sm"
-          user={{
-            userId: comment.user.id,
-            displayName: comment.user.displayName,
-            initials: comment.user.initials,
-            avatarUrl: comment.user.avatarUrl,
-          }}
-        />
-        <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <div className="flex items-start justify-between gap-2">
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-muted-foreground text-sm">
+      <article className="flex flex-col gap-1">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-muted-foreground text-sm">
+            <UserAvatarLink
+              className="shrink-0"
+              size="sm"
+              user={{
+                userId: comment.user.id,
+                displayName: comment.user.displayName,
+                initials: comment.user.initials,
+                avatarUrl: comment.user.avatarUrl,
+              }}
+            >
               <span className="font-medium text-foreground">
                 {comment.user.displayName}
               </span>
-              <RelativeTime date={toIsoString(comment.created_at)} />
-              {comment.edited_at && (
-                <span>
-                  (edited <RelativeTime date={toIsoString(comment.edited_at)} />
-                  )
-                </span>
-              )}
-            </div>
-            {isAuthor && !isEditing && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    aria-label="Comment actions"
-                    className="-mt-1 -mr-1 size-7 shrink-0 text-muted-foreground/70 hover:text-foreground"
-                    disabled={isDeleting}
-                    size="icon"
-                    type="button"
-                    variant="ghost"
-                  >
-                    <MoreHorizontal className="size-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="min-w-32">
-                  <DropdownMenuItem onSelect={() => setIsEditing(true)}>
-                    <Pencil className="size-3.5" />
-                    Edit
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onSelect={(e) => {
-                      e.preventDefault();
-                      setDeleteOpen(true);
-                    }}
-                    variant="destructive"
-                  >
-                    <Trash2 className="size-3.5" />
-                    Delete
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+            </UserAvatarLink>
+            <RelativeTime date={toIsoString(comment.created_at)} />
+            {comment.edited_at && (
+              <span>
+                (edited <RelativeTime date={toIsoString(comment.edited_at)} />)
+              </span>
             )}
           </div>
-
-          {isEditing ? (
-            <div className="flex flex-col gap-2">
-              <Textarea
-                aria-invalid={tooLong || undefined}
-                aria-label="Edit comment"
-                disabled={isSaving}
-                onChange={(e) => setDraft(e.target.value)}
-                rows={3}
-                value={draft}
-              />
-              <div className="flex items-center justify-between text-muted-foreground text-sm">
-                {tooLong ? (
-                  <span className="text-destructive">
-                    {draft.length}/{MAX_BODY_LENGTH.toLocaleString()} characters
-                  </span>
-                ) : (
-                  <span aria-hidden="true" />
-                )}
-                <div className="flex items-center gap-2">
-                  <Button
-                    disabled={isSaving}
-                    onClick={() => {
-                      setDraft(comment.body);
-                      setIsEditing(false);
-                    }}
-                    size="sm"
-                    type="button"
-                    variant="ghost"
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    disabled={!canSave}
-                    onClick={handleSave}
-                    size="sm"
-                    type="button"
-                  >
-                    {isSaving ? "Saving…" : "Save"}
-                  </Button>
-                </div>
-              </div>
-            </div>
-          ) : (
-            <CommentMarkdown body={comment.body} />
+          {isAuthor && !isEditing && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  aria-label="Comment actions"
+                  className="-mt-1 -mr-1 size-7 shrink-0 text-muted-foreground/70 hover:text-foreground"
+                  disabled={isDeleting}
+                  size="icon"
+                  type="button"
+                  variant="ghost"
+                >
+                  <MoreHorizontal className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-32">
+                <DropdownMenuItem onSelect={() => setIsEditing(true)}>
+                  <Pencil className="size-3.5" />
+                  Edit
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onSelect={(e) => {
+                    e.preventDefault();
+                    setDeleteOpen(true);
+                  }}
+                  variant="destructive"
+                >
+                  <Trash2 className="size-3.5" />
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
         </div>
+
+        {isEditing ? (
+          <div className="flex flex-col gap-2">
+            <Textarea
+              aria-invalid={tooLong || undefined}
+              aria-label="Edit comment"
+              disabled={isSaving}
+              onChange={(e) => setDraft(e.target.value)}
+              rows={3}
+              value={draft}
+            />
+            <div className="flex items-center justify-between text-muted-foreground text-sm">
+              {tooLong ? (
+                <span className="text-destructive">
+                  {draft.length}/{MAX_BODY_LENGTH.toLocaleString()} characters
+                </span>
+              ) : (
+                <span aria-hidden="true" />
+              )}
+              <div className="flex items-center gap-2">
+                <Button
+                  disabled={isSaving}
+                  onClick={() => {
+                    setDraft(comment.body);
+                    setIsEditing(false);
+                  }}
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  disabled={!canSave}
+                  onClick={handleSave}
+                  size="sm"
+                  type="button"
+                >
+                  {isSaving ? "Saving…" : "Save"}
+                </Button>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <CommentMarkdown body={comment.body} />
+        )}
       </article>
 
       <AlertDialog onOpenChange={setDeleteOpen} open={deleteOpen}>

--- a/web/components/runs/run-comment-item.tsx
+++ b/web/components/runs/run-comment-item.tsx
@@ -109,11 +109,10 @@ export function RunCommentItem({
 
   return (
     <>
-      <article className="flex flex-col gap-1">
+      <article className="flex flex-col gap-1.5">
         <div className="flex items-start justify-between gap-2">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-muted-foreground text-sm">
             <UserAvatarLink
-              className="shrink-0"
               size="sm"
               user={{
                 userId: comment.user.id,

--- a/web/components/runs/run-header.tsx
+++ b/web/components/runs/run-header.tsx
@@ -11,7 +11,7 @@ import {
   BreadcrumbList,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
-import { UserAvatar } from "@/components/user-avatar";
+import { UserAvatarLink } from "@/components/user-avatar";
 import type { RunDetail } from "@/lib/api/instrument-runs";
 import { formatDateTime } from "@/lib/date";
 
@@ -68,7 +68,7 @@ export function RunHeader({
             {run.deletedByUser && (
               <span className="flex items-center gap-1.5">
                 <span>by</span>
-                <UserAvatar size="sm" user={run.deletedByUser} />
+                <UserAvatarLink size="sm" user={run.deletedByUser} />
                 <span className="font-medium">
                   {run.deletedByUser.displayName}
                 </span>

--- a/web/components/runs/run-header.tsx
+++ b/web/components/runs/run-header.tsx
@@ -68,10 +68,11 @@ export function RunHeader({
             {run.deletedByUser && (
               <span className="flex items-center gap-1.5">
                 <span>by</span>
-                <UserAvatarLink size="sm" user={run.deletedByUser} />
-                <span className="font-medium">
-                  {run.deletedByUser.displayName}
-                </span>
+                <UserAvatarLink size="sm" user={run.deletedByUser}>
+                  <span className="font-medium">
+                    {run.deletedByUser.displayName}
+                  </span>
+                </UserAvatarLink>
               </span>
             )}
           </span>

--- a/web/components/user-avatar.tsx
+++ b/web/components/user-avatar.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import type { ComponentProps } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { avatarColor } from "@/lib/avatar-color";
@@ -29,6 +30,34 @@ export function UserAvatar({
         {user.initials}
       </AvatarFallback>
     </Avatar>
+  );
+}
+
+// A separate composed component rather than a `clickable` prop on `UserAvatar`,
+// so the plain avatar stays usable where a nested link would be invalid (inside
+// another link or a control that owns the click). Forwards `ref`/props to the
+// `Link` so it can act as a Radix `asChild` trigger (e.g. inside a tooltip).
+export function UserAvatarLink({
+  user,
+  size = "sm",
+  className,
+  ref,
+  ...props
+}: {
+  user: UserAvatarUser;
+  size?: "default" | "sm" | "lg";
+  className?: string;
+} & Omit<ComponentProps<typeof Link>, "href">) {
+  return (
+    <Link
+      aria-label={`View ${user.displayName}'s runs`}
+      className="inline-flex rounded-full outline-none ring-ring ring-offset-2 ring-offset-background transition-opacity hover:opacity-80 focus-visible:ring-2"
+      href={`/users/${user.userId}`}
+      ref={ref}
+      {...props}
+    >
+      <UserAvatar className={className} size={size} user={user} />
+    </Link>
   );
 }
 

--- a/web/components/user-avatar.tsx
+++ b/web/components/user-avatar.tsx
@@ -33,14 +33,15 @@ export function UserAvatar({
   );
 }
 
-// A separate composed component rather than a `clickable` prop on `UserAvatar`,
-// so the plain avatar stays usable where a nested link would be invalid (inside
-// another link or a control that owns the click). Forwards `ref`/props to the
-// `Link` so it can act as a Radix `asChild` trigger (e.g. inside a tooltip).
-// Pass the display name as `children` so avatar + name share one hit target.
+// Composed link rather than a `clickable` prop on `UserAvatar`, so the plain
+// avatar stays usable where a nested link would be invalid. Pass the display
+// name (or other label) as `children` so the hit target covers avatar + text;
+// omit children for avatar-only links (e.g. stacked attribution tooltips).
+// Forwards `ref`/props to the `Link` so it can act as a Radix `asChild` trigger.
 export function UserAvatarLink({
   user,
   size = "sm",
+  avatarClassName,
   className,
   children,
   ref,
@@ -48,21 +49,22 @@ export function UserAvatarLink({
 }: {
   user: UserAvatarUser;
   size?: "default" | "sm" | "lg";
+  avatarClassName?: string;
   className?: string;
   children?: ReactNode;
 } & Omit<ComponentProps<typeof Link>, "href">) {
   return (
     <Link
-      aria-label={children ? undefined : `View ${user.displayName}'s runs`}
+      aria-label={`View ${user.displayName}'s runs`}
       className={cn(
-        "inline-flex items-center outline-none ring-ring ring-offset-2 ring-offset-background transition-opacity hover:opacity-80 focus-visible:ring-2",
-        children ? "gap-1.5 rounded-sm" : "rounded-full"
+        "inline-flex items-center gap-1.5 rounded-sm outline-none ring-ring ring-offset-2 ring-offset-background transition-opacity hover:opacity-80 focus-visible:ring-2",
+        className
       )}
       href={`/users/${user.userId}`}
       ref={ref}
       {...props}
     >
-      <UserAvatar className={className} size={size} user={user} />
+      <UserAvatar className={avatarClassName} size={size} user={user} />
       {children}
     </Link>
   );

--- a/web/components/user-avatar.tsx
+++ b/web/components/user-avatar.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import type { ComponentProps } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { avatarColor } from "@/lib/avatar-color";
 import { cn } from "@/lib/utils";
@@ -37,26 +37,33 @@ export function UserAvatar({
 // so the plain avatar stays usable where a nested link would be invalid (inside
 // another link or a control that owns the click). Forwards `ref`/props to the
 // `Link` so it can act as a Radix `asChild` trigger (e.g. inside a tooltip).
+// Pass the display name as `children` so avatar + name share one hit target.
 export function UserAvatarLink({
   user,
   size = "sm",
   className,
+  children,
   ref,
   ...props
 }: {
   user: UserAvatarUser;
   size?: "default" | "sm" | "lg";
   className?: string;
+  children?: ReactNode;
 } & Omit<ComponentProps<typeof Link>, "href">) {
   return (
     <Link
-      aria-label={`View ${user.displayName}'s runs`}
-      className="inline-flex rounded-full outline-none ring-ring ring-offset-2 ring-offset-background transition-opacity hover:opacity-80 focus-visible:ring-2"
+      aria-label={children ? undefined : `View ${user.displayName}'s runs`}
+      className={cn(
+        "inline-flex items-center outline-none ring-ring ring-offset-2 ring-offset-background transition-opacity hover:opacity-80 focus-visible:ring-2",
+        children ? "gap-1.5 rounded-sm" : "rounded-full"
+      )}
       href={`/users/${user.userId}`}
       ref={ref}
       {...props}
     >
       <UserAvatar className={className} size={size} user={user} />
+      {children}
     </Link>
   );
 }

--- a/web/lib/api/dashboard.ts
+++ b/web/lib/api/dashboard.ts
@@ -1,5 +1,6 @@
 import { and, desc, eq, isNull, type SQL, sql } from "drizzle-orm";
 import { cache } from "react";
+import type { UserAvatarUser } from "@/components/user-avatar";
 import { db } from "@/lib/db";
 import {
   files,
@@ -10,6 +11,7 @@ import {
   users,
   watchers,
 } from "@/lib/db/schema";
+import { toInitials } from "@/lib/utils";
 
 export interface InstrumentSummary {
   displayName: string;
@@ -375,8 +377,8 @@ export const getMyRunsStats = cache(async function getMyRunsStats(
 
 export interface TopAttributor {
   bytesGenerated: number;
-  displayName: string;
   runCount: number;
+  user: UserAvatarUser;
 }
 
 /**
@@ -395,8 +397,10 @@ export const getTopAttributorThisWeek = cache(
     // the byte sum isn't double-counted.
     const [row] = await db
       .select({
+        userId: users.id,
         name: users.name,
         email: users.email,
+        image: users.image,
         runCount: sql<number>`cast(${runCountExpr} as int)`,
         bytesGenerated: sql<string>`${bytesExpr}`,
       })
@@ -418,7 +422,7 @@ export const getTopAttributorThisWeek = cache(
           sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '7 days'`
         )
       )
-      .groupBy(runAttributions.userId, users.name, users.email)
+      .groupBy(users.id, users.name, users.email, users.image)
       .orderBy(desc(runCountExpr), desc(bytesExpr))
       .limit(1);
 
@@ -426,8 +430,14 @@ export const getTopAttributorThisWeek = cache(
       return null;
     }
 
+    const displayName = row.name ?? row.email ?? "Unknown";
     return {
-      displayName: row.name ?? row.email ?? "Unknown",
+      user: {
+        userId: row.userId,
+        displayName,
+        initials: toInitials(displayName),
+        avatarUrl: row.image,
+      },
       runCount: row.runCount,
       bytesGenerated: Number(row.bytesGenerated),
     };

--- a/web/lib/api/dashboard.ts
+++ b/web/lib/api/dashboard.ts
@@ -235,6 +235,40 @@ export const getDashboardStats = cache(
   }
 );
 
+export interface UserProfile extends UserAvatarUser {
+  email: string | null;
+}
+
+// Returns null on an unknown id so the page can `notFound()`. `cache()`-keyed
+// on `userId` so the page header and `generateMetadata` share one lookup.
+export const getUserProfile = cache(async function getUserProfile(
+  userId: string
+): Promise<UserProfile | null> {
+  const [row] = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      image: users.image,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!row) {
+    return null;
+  }
+
+  const displayName = row.name ?? row.email ?? "Unknown user";
+  return {
+    userId: row.id,
+    displayName,
+    initials: toInitials(displayName),
+    avatarUrl: row.image,
+    email: row.email,
+  };
+});
+
 export interface MyRunsStats {
   commentsLast7Days: {
     count: number;

--- a/web/lib/api/dashboard.ts
+++ b/web/lib/api/dashboard.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, desc, eq, isNull, type SQL, sql } from "drizzle-orm";
 import { cache } from "react";
 import { db } from "@/lib/db";
 import {
@@ -6,6 +6,8 @@ import {
   instrumentRuns,
   instruments,
   runAttributions,
+  runComments,
+  users,
   watchers,
 } from "@/lib/db/schema";
 
@@ -241,3 +243,193 @@ export const getDashboardStats = cache(async function getDashboardStats(
     },
   };
 });
+
+export interface MyRunsStats {
+  commentsLast7Days: {
+    count: number;
+  };
+  pendingUploads: {
+    count: number;
+    totalBytes: number;
+  };
+  runsLast7Days: {
+    total: number;
+    bytesGenerated: number;
+  };
+  runsLast24Hours: {
+    total: number;
+    bytesGenerated: number;
+  };
+}
+
+// Correlated EXISTS against `run_attributions`, matching the `ranBy` predicate
+// used by `buildRunListQuery` so the "My runs" cards count the same runs the
+// table below them lists.
+function attributedToUser(userId: string): SQL {
+  return sql`exists (select 1 from ${runAttributions} where ${runAttributions.runId} = ${instrumentRuns.id} and ${runAttributions.userId} = ${userId})`;
+}
+
+/**
+ * Aggregates the four "My runs" summary metrics, all scoped to runs the viewer
+ * is attributed to. Like `getDashboardStats`, each metric is a single
+ * COUNT/SUM issued in parallel to keep the per-query plans simple.
+ *
+ * Unlike the fleet dashboard, this is intentionally not restricted to active
+ * instruments — a user's own runs stay relevant even after an instrument is
+ * retired, and this matches the unrestricted `ranBy` run list on the page.
+ * `cache()` keys on `userId` so parallel requests from different users don't
+ * collide.
+ */
+export const getMyRunsStats = cache(async function getMyRunsStats(
+  userId: string
+): Promise<MyRunsStats> {
+  const attributed = attributedToUser(userId);
+
+  const [[runsRow], [bytesRow], [commentsRow], [pendingRow]] =
+    await Promise.all([
+      // Both run-count windows in one pass — the 24-hour window is a subset of
+      // the weekly window, so a FILTER clause gives us both from one scan.
+      db
+        .select({
+          last24Hours: sql<number>`cast(count(*) filter (where coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '24 hours') as int)`,
+          last7Days: sql<number>`cast(count(*) as int)`,
+        })
+        .from(instrumentRuns)
+        .where(
+          and(
+            isNull(instrumentRuns.deletedAt),
+            sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '7 days'`,
+            attributed
+          )
+        ),
+      // Bytes generated, anchored to each run's acquisition time so the windows
+      // line up with the run-count cards above.
+      db
+        .select({
+          bytesLast24Hours: sql<string>`coalesce(sum(${files.sizeBytes}) filter (where coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '24 hours'), 0)`,
+          bytesLast7Days: sql<string>`coalesce(sum(${files.sizeBytes}), 0)`,
+        })
+        .from(files)
+        .innerJoin(instrumentRuns, eq(files.instrumentRunId, instrumentRuns.id))
+        .where(
+          and(
+            isNull(files.deletedAt),
+            isNull(instrumentRuns.deletedAt),
+            sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '7 days'`,
+            attributed
+          )
+        ),
+      // Comments left in the last 7 days on runs the viewer is attributed to
+      // (including the viewer's own comments).
+      db
+        .select({
+          count: sql<number>`cast(count(*) as int)`,
+        })
+        .from(runComments)
+        .innerJoin(instrumentRuns, eq(instrumentRuns.id, runComments.runId))
+        .where(
+          and(
+            isNull(runComments.deletedAt),
+            isNull(instrumentRuns.deletedAt),
+            sql`${runComments.createdAt} > now() - interval '7 days'`,
+            attributed
+          )
+        ),
+      // Pending uploads across all of the viewer's attributed runs (no time
+      // window — a stuck upload from last month still needs attention).
+      db
+        .select({
+          count: sql<number>`cast(count(*) as int)`,
+          totalBytes: sql<number>`cast(coalesce(sum(${files.sizeBytes}), 0) as bigint)`,
+        })
+        .from(files)
+        .innerJoin(instrumentRuns, eq(files.instrumentRunId, instrumentRuns.id))
+        .where(
+          and(
+            isNull(files.deletedAt),
+            isNull(instrumentRuns.deletedAt),
+            sql`${files.status} in ('detected', 'upload_requested')`,
+            attributed
+          )
+        ),
+    ]);
+
+  return {
+    runsLast24Hours: {
+      total: runsRow?.last24Hours ?? 0,
+      bytesGenerated: Number(bytesRow?.bytesLast24Hours ?? 0),
+    },
+    runsLast7Days: {
+      total: runsRow?.last7Days ?? 0,
+      bytesGenerated: Number(bytesRow?.bytesLast7Days ?? 0),
+    },
+    commentsLast7Days: {
+      count: commentsRow?.count ?? 0,
+    },
+    pendingUploads: {
+      count: pendingRow?.count ?? 0,
+      totalBytes: Number(pendingRow?.totalBytes ?? 0),
+    },
+  };
+});
+
+export interface TopAttributor {
+  bytesGenerated: number;
+  displayName: string;
+  runCount: number;
+}
+
+/**
+ * The user attributed to the most active-instrument runs in the last 7 days,
+ * with the volume of data across those runs. Ties are broken by data
+ * generated. Returns null when no runs were attributed this week. Powers the
+ * "Most runs this week" leaderboard card on the dashboard.
+ */
+export const getTopAttributorThisWeek = cache(
+  async function getTopAttributorThisWeek(): Promise<TopAttributor | null> {
+    const runCountExpr = sql`count(distinct ${instrumentRuns.id})`;
+    const bytesExpr = sql`coalesce(sum(${files.sizeBytes}), 0)`;
+
+    // Each (run, file) pair is one joined row, but counting distinct run ids
+    // keeps the run tally correct, and every file belongs to exactly one run so
+    // the byte sum isn't double-counted.
+    const [row] = await db
+      .select({
+        name: users.name,
+        email: users.email,
+        runCount: sql<number>`cast(${runCountExpr} as int)`,
+        bytesGenerated: sql<string>`${bytesExpr}`,
+      })
+      .from(runAttributions)
+      .innerJoin(instrumentRuns, eq(instrumentRuns.id, runAttributions.runId))
+      .innerJoin(instruments, eq(instruments.id, instrumentRuns.instrumentId))
+      .innerJoin(users, eq(users.id, runAttributions.userId))
+      .leftJoin(
+        files,
+        and(
+          eq(files.instrumentRunId, instrumentRuns.id),
+          isNull(files.deletedAt)
+        )
+      )
+      .where(
+        and(
+          eq(instruments.status, "active"),
+          isNull(instrumentRuns.deletedAt),
+          sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '7 days'`
+        )
+      )
+      .groupBy(runAttributions.userId, users.name, users.email)
+      .orderBy(desc(runCountExpr), desc(bytesExpr))
+      .limit(1);
+
+    if (!row) {
+      return null;
+    }
+
+    return {
+      displayName: row.name ?? row.email ?? "Unknown",
+      runCount: row.runCount,
+      bytesGenerated: Number(row.bytesGenerated),
+    };
+  }
+);

--- a/web/lib/api/dashboard.ts
+++ b/web/lib/api/dashboard.ts
@@ -128,8 +128,6 @@ export interface DashboardStats {
   runsThisWeek: {
     total: number;
     bytesGenerated: number;
-    mine: number;
-    unattributed: number;
   };
 }
 
@@ -140,111 +138,102 @@ export interface DashboardStats {
  * row-multiplication problems we'd hit joining instruments × runs × files ×
  * attributions in a single statement.
  *
- * Wrapped in `cache()` so duplicate calls within the same request (e.g. layout
- * + page) share a result. The cache key includes `currentUserId`, so different
- * users on parallel requests don't collide.
+ * Fleet-wide and viewer-independent, so it's `cache()`-deduped without a key —
+ * duplicate calls within a request (e.g. layout + page) share one result.
  */
-export const getDashboardStats = cache(async function getDashboardStats(
-  currentUserId: string | null
-): Promise<DashboardStats> {
-  const [
-    [runsLast24HoursRow],
-    [bytesGeneratedRow],
-    [pendingRow],
-    [runsThisWeekRow],
-  ] = await Promise.all([
-    db
-      .select({
-        total: sql<number>`cast(count(*) as int)`,
-      })
-      .from(instrumentRuns)
-      .innerJoin(instruments, eq(instruments.id, instrumentRuns.instrumentId))
-      .where(
-        and(
-          eq(instruments.status, "active"),
-          isNull(instrumentRuns.deletedAt),
-          sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '24 hours'`
-        )
-      ),
-    // Span the last 24 hours + the past 7 days in a single pass; the 24-hour
-    // window is a subset of the weekly window, so FILTER clauses give us both
-    // with one index scan. Bytes are attributed to the file's owning run so
-    // the time window matches the corresponding "Runs in the last X" card —
-    // this avoids the null-`processedAt` blind spot for not-yet-processed
-    // files (which still represent data the instrument generated). Windows
-    // are anchored to the run's actual acquisition time when known so
-    // backfilled historical data doesn't pollute the "last 24h"/"this week"
-    // counts.
-    db
-      .select({
-        bytesLast24Hours: sql<string>`coalesce(sum(${files.sizeBytes}) filter (where coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '24 hours'), 0)`,
-        bytesWeek: sql<string>`coalesce(sum(${files.sizeBytes}), 0)`,
-      })
-      .from(files)
-      .innerJoin(instrumentRuns, eq(files.instrumentRunId, instrumentRuns.id))
-      .innerJoin(instruments, eq(instruments.id, instrumentRuns.instrumentId))
-      .where(
-        and(
-          eq(instruments.status, "active"),
-          isNull(files.deletedAt),
-          isNull(instrumentRuns.deletedAt),
-          sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '7 days'`
-        )
-      ),
-    db
-      .select({
-        count: sql<number>`cast(count(*) as int)`,
-        totalBytes: sql<number>`cast(coalesce(sum(${files.sizeBytes}), 0) as bigint)`,
-      })
-      .from(files)
-      .innerJoin(instrumentRuns, eq(files.instrumentRunId, instrumentRuns.id))
-      .innerJoin(instruments, eq(instruments.id, instrumentRuns.instrumentId))
-      .where(
-        and(
-          eq(instruments.status, "active"),
-          isNull(files.deletedAt),
-          sql`${files.status} in ('detected', 'upload_requested')`
-        )
-      ),
-    // "Mine" requires a user; the unattributed count is fleet-wide and
-    // independent of the viewer.
-    db
-      .select({
-        total: sql<number>`cast(count(*) as int)`,
-        mine: currentUserId
-          ? sql<number>`cast(count(*) filter (where exists (select 1 from ${runAttributions} where ${runAttributions.runId} = ${instrumentRuns.id} and ${runAttributions.userId} = ${currentUserId})) as int)`
-          : sql<number>`cast(0 as int)`,
-        unattributed: sql<number>`cast(count(*) filter (where not exists (select 1 from ${runAttributions} where ${runAttributions.runId} = ${instrumentRuns.id})) as int)`,
-      })
-      .from(instrumentRuns)
-      .innerJoin(instruments, eq(instruments.id, instrumentRuns.instrumentId))
-      .where(
-        and(
-          eq(instruments.status, "active"),
-          isNull(instrumentRuns.deletedAt),
-          sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '7 days'`
-        )
-      ),
-  ]);
+export const getDashboardStats = cache(
+  async function getDashboardStats(): Promise<DashboardStats> {
+    const [
+      [runsLast24HoursRow],
+      [bytesGeneratedRow],
+      [pendingRow],
+      [runsThisWeekRow],
+    ] = await Promise.all([
+      db
+        .select({
+          total: sql<number>`cast(count(*) as int)`,
+        })
+        .from(instrumentRuns)
+        .innerJoin(instruments, eq(instruments.id, instrumentRuns.instrumentId))
+        .where(
+          and(
+            eq(instruments.status, "active"),
+            isNull(instrumentRuns.deletedAt),
+            sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '24 hours'`
+          )
+        ),
+      // Span the last 24 hours + the past 7 days in a single pass; the 24-hour
+      // window is a subset of the weekly window, so FILTER clauses give us both
+      // with one index scan. Bytes are attributed to the file's owning run so
+      // the time window matches the corresponding "Runs in the last X" card —
+      // this avoids the null-`processedAt` blind spot for not-yet-processed
+      // files (which still represent data the instrument generated). Windows
+      // are anchored to the run's actual acquisition time when known so
+      // backfilled historical data doesn't pollute the "last 24h"/"this week"
+      // counts.
+      db
+        .select({
+          bytesLast24Hours: sql<string>`coalesce(sum(${files.sizeBytes}) filter (where coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '24 hours'), 0)`,
+          bytesWeek: sql<string>`coalesce(sum(${files.sizeBytes}), 0)`,
+        })
+        .from(files)
+        .innerJoin(instrumentRuns, eq(files.instrumentRunId, instrumentRuns.id))
+        .innerJoin(instruments, eq(instruments.id, instrumentRuns.instrumentId))
+        .where(
+          and(
+            eq(instruments.status, "active"),
+            isNull(files.deletedAt),
+            isNull(instrumentRuns.deletedAt),
+            sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '7 days'`
+          )
+        ),
+      db
+        .select({
+          count: sql<number>`cast(count(*) as int)`,
+          totalBytes: sql<number>`cast(coalesce(sum(${files.sizeBytes}), 0) as bigint)`,
+        })
+        .from(files)
+        .innerJoin(instrumentRuns, eq(files.instrumentRunId, instrumentRuns.id))
+        .innerJoin(instruments, eq(instruments.id, instrumentRuns.instrumentId))
+        .where(
+          and(
+            eq(instruments.status, "active"),
+            isNull(files.deletedAt),
+            sql`${files.status} in ('detected', 'upload_requested')`
+          )
+        ),
+      db
+        .select({
+          total: sql<number>`cast(count(*) as int)`,
+        })
+        .from(instrumentRuns)
+        .innerJoin(instruments, eq(instruments.id, instrumentRuns.instrumentId))
+        .where(
+          and(
+            eq(instruments.status, "active"),
+            isNull(instrumentRuns.deletedAt),
+            sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt}) > now() - interval '7 days'`
+          )
+        ),
+    ]);
 
-  return {
-    runsLast24Hours: {
-      total: runsLast24HoursRow?.total ?? 0,
-      // bigint sums come back as strings from pg; coerce explicitly.
-      bytesGenerated: Number(bytesGeneratedRow?.bytesLast24Hours ?? 0),
-    },
-    pendingUploads: {
-      count: pendingRow?.count ?? 0,
-      totalBytes: Number(pendingRow?.totalBytes ?? 0),
-    },
-    runsThisWeek: {
-      total: runsThisWeekRow?.total ?? 0,
-      bytesGenerated: Number(bytesGeneratedRow?.bytesWeek ?? 0),
-      mine: runsThisWeekRow?.mine ?? 0,
-      unattributed: runsThisWeekRow?.unattributed ?? 0,
-    },
-  };
-});
+    return {
+      runsLast24Hours: {
+        total: runsLast24HoursRow?.total ?? 0,
+        // bigint sums come back as strings from pg; coerce explicitly.
+        bytesGenerated: Number(bytesGeneratedRow?.bytesLast24Hours ?? 0),
+      },
+      pendingUploads: {
+        count: pendingRow?.count ?? 0,
+        totalBytes: Number(pendingRow?.totalBytes ?? 0),
+      },
+      runsThisWeek: {
+        total: runsThisWeekRow?.total ?? 0,
+        bytesGenerated: Number(bytesGeneratedRow?.bytesWeek ?? 0),
+      },
+    };
+  }
+);
 
 export interface MyRunsStats {
   commentsLast7Days: {

--- a/web/lib/api/instrument-runs.ts
+++ b/web/lib/api/instrument-runs.ts
@@ -1343,7 +1343,7 @@ export interface RanByFilterOption {
 }
 
 export async function getRanByFilterOptions(
-  instrumentId: string
+  instrumentId?: string
 ): Promise<RanByFilterOption[]> {
   const rows = await db
     .selectDistinct({
@@ -1356,7 +1356,11 @@ export async function getRanByFilterOptions(
     .innerJoin(instrumentRuns, eq(instrumentRuns.id, runAttributions.runId))
     .where(
       and(
-        eq(instrumentRuns.instrumentId, instrumentId),
+        // Fleet-wide (dashboard) when no instrument is given; otherwise scope
+        // to the one instrument's attributors.
+        instrumentId
+          ? eq(instrumentRuns.instrumentId, instrumentId)
+          : undefined,
         isNull(instrumentRuns.deletedAt)
       )
     )

--- a/web/lib/mcp/tools.ts
+++ b/web/lib/mcp/tools.ts
@@ -249,7 +249,7 @@ export function registerTools(server: McpServer) {
           .array(z.enum(RUN_STATUS_VALUES))
           .optional()
           .describe(
-            "Filter by derived run status (OR'd together). Status is derived from a run's raw file states, priority-exclusive: failed (any file failed), pending (files awaiting upload), uploaded (awaiting processing), processing, completed (all done), empty (no files)."
+            "Filter by derived run status (OR'd together). Status is derived from a run's raw file states, priority-exclusive: failed (any file failed), pending (files awaiting upload), uploaded, processing, completed (all done), empty (no files)."
           ),
       },
       annotations: { readOnlyHint: true },

--- a/web/lib/runs/run-status.ts
+++ b/web/lib/runs/run-status.ts
@@ -43,7 +43,7 @@ export const RUN_STATUS_META: Record<RunStatus, RunStatusMeta> = {
     colorClassName: "text-amber-500",
   },
   uploaded: {
-    label: "Awaiting processing",
+    label: "Uploaded",
     description: "Files are uploaded and waiting in the processing queue",
     Icon: CircleDashed,
     colorClassName: "text-muted-foreground",

--- a/web/lib/search-params.ts
+++ b/web/lib/search-params.ts
@@ -21,6 +21,9 @@ export const dashboardSearchParams = {
   status: parseAsArrayOf(parseAsStringLiteral(RUN_STATUS_VALUES))
     .withDefault([])
     .withOptions({ clearOnDefault: true }),
+  // Attribution filter: either a userId or the reserved sentinel
+  // "unattributed". Mirrors `instrumentDetailSearchParams.ran_by`.
+  ran_by: parseAsString,
   page: parseAsInteger.withDefault(1),
   per_page: parseAsInteger.withDefault(10),
 };
@@ -121,11 +124,13 @@ export function hasActiveFilters(params: {
   instrument_id: string[];
   include_deleted: boolean;
   status: RunStatus[];
+  ran_by: string | null;
 }): boolean {
   return (
     params.search !== "" ||
     params.instrument_id.length > 0 ||
     params.include_deleted ||
-    params.status.length > 0
+    params.status.length > 0 ||
+    params.ran_by !== null
   );
 }


### PR DESCRIPTION
## Summary
- Add a per-user runs page at **`/users/[userId]`** scoped to that member's attributed runs, reusing the dashboard stat cards and runs table. The sidebar **My runs** entry links to `/users/[currentUserId]`; copy, stat labels, empty state, and the table footer adapt for self vs. another member. Its date filter defaults to (and offers) **All time**.
- Make user avatars link to a member's runs page via a new composed **`UserAvatarLink`** — wired into the run detail **metadata header** ("Ran by") and **comments**, without making the shared `UserAvatar` primitive clickable everywhere.
- Add a filterable **Ran By** column to the home page runs table by generalizing `FilterableColumnHeader` over its nuqs parser map (`ran_by` added to `dashboardSearchParams`, fleet-wide attributor options via `getRanByFilterOptions()`).
- Replace the home page's "My runs this week" card with a **Most runs this week** leaderboard card showing the top attributor (`UserAvatar` + first name) and the data they generated.

### Stat cards (user runs)
Runs in the last 24 hours, Runs in the last 7 days, Comments on the user's runs (7d), and Pending uploads — all scoped to `run_attributions` and backed by `getMyRunsStats(userId)`.

### Notable implementation notes
- `getUserProfile(userId)` resolves the target member for the page header/metadata and `notFound()`s on unknown ids; the page is generic and `/my-runs` is removed.
- `UserAvatarLink` forwards `ref`/props so it works as a Radix `asChild` tooltip trigger; `RanByCell` gains an opt-in `linkToProfile` (on in the run detail, off in the runs table so rows stay single-navigation).
- `FilterableColumnHeader` accepts an injected parser map (defaults to `instrumentDetailSearchParams`) so the same dropdown binds to `dashboardSearchParams` on the home table — no change for per-instrument callers.
- New queries (`getMyRunsStats`, `getTopAttributorThisWeek`, `getUserProfile`) run aggregates in parallel and are `cache()`-deduped; page sections stream behind independent Suspense boundaries.

## Test plan
- [x] `/users/[userId]` shows only that member's attributed runs; heading/stat labels/footer read "My runs / you" for self and third-person for others.
- [x] Sidebar "My runs" navigates to the current user's page and is highlighted only there.
- [x] Run detail "Ran by" avatars and comment avatars link to `/users/[userId]`; tooltips still work.
- [x] Home runs table "Ran By" column filters by attributor (You / others / Unattributed) and updates the URL.
- [x] Home "Most runs this week" card shows the top attributor's avatar + first name; neutral state when none.
- [x] `make check-all` passes.

Made with [Cursor](https://cursor.com)
