### PR TITLE
Fix dashboard date filter RSC crash

### DIFF
--- a/web/components/dashboard/runs-table.tsx
+++ b/web/components/dashboard/runs-table.tsx
@@ -27,7 +27,6 @@ import {
 } from "@/components/ui/table";
 import type { RunListRow } from "@/lib/api/instrument-runs";
 import { runRowToRef } from "@/lib/runs/row-actions";
-import { dashboardSearchParams } from "@/lib/search-params";
 import { cn, formatBytes } from "@/lib/utils";
 
 export function RunsTable({
@@ -48,8 +47,8 @@ export function RunsTable({
   unattributedCount: number;
   ranByYouCount: number;
   // When provided, the "Ran By" column becomes a filterable dropdown bound to
-  // `dashboardSearchParams.ran_by`. Omitted on a member's runs page, where every
-  // row is the same user, so a plain header is rendered instead.
+  // the dashboard `ran_by` search param. Omitted on a member's runs page, where
+  // every row is the same user, so a plain header is rendered instead.
   ranByOptions?: RanByOption[];
   // Footer suffix for the ran-by count; third-person on another member's page.
   ranByLabel?: string;
@@ -95,7 +94,7 @@ export function RunsTable({
                   label="Ran By"
                   options={ranByOptions}
                   paramKey="ran_by"
-                  searchParams={dashboardSearchParams}
+                  paramsSource="dashboard"
                 />
               ) : (
                 "Ran By"

--- a/web/components/instruments/runs-table/filterable-column-header.tsx
+++ b/web/components/instruments/runs-table/filterable-column-header.tsx
@@ -17,14 +17,21 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { instrumentDetailSearchParams } from "@/lib/search-params";
+import {
+  dashboardSearchParams,
+  instrumentDetailSearchParams,
+} from "@/lib/search-params";
 import { cn } from "@/lib/utils";
 
-// The header drives a single nullable-string radio filter and resets the page,
-// so it works with any nuqs parser map exposing the target column key plus a
-// `page` key. Defaults to the per-instrument params; the dashboard tables pass
-// `dashboardSearchParams` instead.
-type ColumnFilterKeyMap = UseQueryStatesKeysMap & { page: unknown };
+// Resolved inside this client module so Server Components can pick a source by
+// string without shipping parser objects (and their `eq`/`parse` functions)
+// across the RSC boundary.
+const PARAMS_BY_SOURCE = {
+  instrument: instrumentDetailSearchParams,
+  dashboard: dashboardSearchParams,
+} as const;
+
+type ParamsSource = keyof typeof PARAMS_BY_SOURCE;
 
 // Column-filter keys are the nullable-string entries in the parser map
 // (`parseAsString` without a default). Keys whose parser carries a default —
@@ -53,18 +60,21 @@ function normalizeOption(option: FilterOption): {
 }
 
 export function FilterableColumnHeader<
-  KeyMap extends ColumnFilterKeyMap = typeof instrumentDetailSearchParams,
+  Source extends ParamsSource = "instrument",
 >({
   label,
   paramKey,
   options,
-  searchParams = instrumentDetailSearchParams as unknown as KeyMap,
+  paramsSource = "instrument" as Source,
 }: {
   label: string;
-  paramKey: FilterParamKey<KeyMap>;
+  paramKey: FilterParamKey<(typeof PARAMS_BY_SOURCE)[Source]>;
   options: FilterOption[];
-  searchParams?: KeyMap;
+  // Which shared nuqs map to bind. Keep this a string — never pass the parser
+  // object itself from a Server Component.
+  paramsSource?: Source;
 }) {
+  const searchParams = PARAMS_BY_SOURCE[paramsSource];
   const { startTransition } = useTablePending();
   const [filters, setFilters] = useQueryStates(searchParams, {
     shallow: false,
@@ -99,7 +109,7 @@ export function FilterableColumnHeader<
             setFilters({
               [paramKey]: value || null,
               page: 1,
-            } as Partial<Nullable<Values<KeyMap>>>)
+            } as Partial<Nullable<Values<(typeof PARAMS_BY_SOURCE)[Source]>>>)
           }
           value={currentValue ?? ""}
         >


### PR DESCRIPTION
## Summary
- Home-page recent runs crashed when changing the date filter because the server `RunsTable` passed the full nuqs `dashboardSearchParams` map (with `eq`/`parse` functions) into the client `FilterableColumnHeader`.
- Resolve the parser map inside the client component via a `paramsSource` string (`"dashboard"` | `"instrument"`) so nothing non-serializable crosses the RSC boundary.

## Test plan
- [ ] On the home page, open Recent runs → Date range → Last 3 days; page should reload without the “Functions cannot be passed directly to Client Components” error
- [ ] Confirm other presets and Clear still work
- [ ] Confirm the Ran By column filter still updates `ran_by` in the URL
- [ ] Spot-check an instrument runs page column filter still works (default `paramsSource`)


Made with [Cursor](https://cursor.com)