### PR TITLE
Bind admin-minted PATs to a chosen workspace member

### DIFF
--- a/web/app/api/v1/mcp/route.ts
+++ b/web/app/api/v1/mcp/route.ts
@@ -30,6 +30,11 @@ const handler = createMcpHandler(
 // MCP-specific scope vocabulary and no connect-time gate beyond a valid
 // token. The `*` wildcard from legacy/backfilled tokens is honored by
 // `hasScope`, so deployed watchers and the Lambda keep working.
+//
+// TODO: Replace admin-minted PATs with an OAuth authorization-code flow so
+// members can authorize their own MCP client. Binding a PAT to a user fixes
+// write attribution (claim_run, etc.), but sharing a long-lived secret is a
+// stopgap until each user can grant access without an admin minting a token.
 const verifyToken = async (
   req: Request,
   bearerToken?: string

--- a/web/app/api/v1/tokens/route.ts
+++ b/web/app/api/v1/tokens/route.ts
@@ -3,8 +3,9 @@ import type { NextRequest } from "next/server";
 import { requireAdmin, requireSession } from "@/lib/api/auth";
 import { apiError, UNAUTHORIZED, VALIDATION_ERROR } from "@/lib/api/errors";
 import { validateRequestedScopes } from "@/lib/api/scopes";
+import { resolveTokenOwnerUserId } from "@/lib/api/token-owner";
 import { db } from "@/lib/db";
-import { personalAccessTokens } from "@/lib/db/schema";
+import { personalAccessTokens, users } from "@/lib/db/schema";
 import { generateToken, getTokenPrefix, hashToken } from "@/lib/tokens";
 
 export async function GET() {
@@ -44,7 +45,12 @@ export async function POST(request: NextRequest) {
     return authResult;
   }
 
-  let body: { name?: string; expires_at?: string; scopes?: unknown };
+  let body: {
+    name?: string;
+    expires_at?: string;
+    scopes?: unknown;
+    user_id?: unknown;
+  };
   try {
     body = await request.json();
   } catch {
@@ -65,6 +71,22 @@ export async function POST(request: NextRequest) {
     return apiError(400, VALIDATION_ERROR, validation.error);
   }
   const scopes = validation.scopes;
+
+  const owner = await resolveTokenOwnerUserId(
+    body.user_id,
+    authResult.userId,
+    async (id) => {
+      const [row] = await db
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.id, id))
+        .limit(1);
+      return Boolean(row);
+    }
+  );
+  if (!owner.ok) {
+    return apiError(400, VALIDATION_ERROR, owner.error);
+  }
 
   let expiresAt: Date | null = null;
   if (body.expires_at) {
@@ -94,7 +116,7 @@ export async function POST(request: NextRequest) {
   const [inserted] = await db
     .insert(personalAccessTokens)
     .values({
-      userId: authResult.userId,
+      userId: owner.userId,
       name,
       tokenHash,
       tokenPrefix,

--- a/web/app/settings/tokens/page.tsx
+++ b/web/app/settings/tokens/page.tsx
@@ -173,7 +173,11 @@ export default async function TokensPage() {
               : "View personal access tokens for API authentication."}
           </p>
         </div>
-        {isAdmin ? <CreateTokenDialog /> : <CreateTokenDisabledButton />}
+        {isAdmin ? (
+          <CreateTokenDialog currentUserId={session.user.id} />
+        ) : (
+          <CreateTokenDisabledButton />
+        )}
       </div>
 
       <div className="mt-6">

--- a/web/app/settings/tokens/page.tsx
+++ b/web/app/settings/tokens/page.tsx
@@ -6,6 +6,7 @@ import { SignInRequired } from "@/components/auth/sign-in-required";
 import { CreateTokenDialog } from "@/components/tokens/create-token-dialog";
 import { CreateTokenDisabledButton } from "@/components/tokens/create-token-disabled-button";
 import { DeleteTokenDialog } from "@/components/tokens/delete-token-dialog";
+import { TokenScopeBadges } from "@/components/tokens/token-scope-badges";
 import { TokensTableSkeleton } from "@/components/tokens/tokens-table-skeleton";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -22,7 +23,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { UserAvatar } from "@/components/user-avatar";
-import { LEGACY_SCOPE_EXPANSIONS } from "@/lib/api/scopes";
 import { auth } from "@/lib/auth";
 import { toInitials } from "@/lib/avatar-color";
 import { db } from "@/lib/db";
@@ -37,105 +37,6 @@ export const metadata: Metadata = {
   openGraph: { title: "Access Tokens", description },
   twitter: { title: "Access Tokens", description },
 };
-
-// Render a token's scopes as a compact column. Four branches:
-//
-//   1. `[]` → "No scopes" pill. The DB column is non-null with a default
-//      of `['*']` and the create-token form rejects empty arrays, so this
-//      shouldn't appear in practice — but rendering an explicit empty
-//      state here is much clearer than a silently-empty cell if it ever
-//      does happen (e.g. a manual SQL update).
-//   2. `["*"]` (backfill wildcard) → single "Full access (legacy)" pill so
-//      pre-scope tokens stand out and read as rotation candidates.
-//   3. Single explicit scope → that scope as a badge, no tooltip needed
-//      because everything is already visible.
-//   4. Multiple explicit scopes → first scope (sorted) plus a "+N"
-//      counter badge. Hovering the cell reveals the full list in a
-//      tooltip so the table stays scannable on tokens with many scopes.
-//
-// Deprecated coarse `:write` scopes (superseded by fine-grained actions but
-// still honored on old tokens) render with an amber tint wherever they
-// appear, flagging them for re-issue.
-const LEGACY_COARSE_SCOPES = new Set(Object.keys(LEGACY_SCOPE_EXPANSIONS));
-
-function ScopeBadge({ scope }: { scope: string }) {
-  const isLegacy = LEGACY_COARSE_SCOPES.has(scope);
-  return (
-    <Badge
-      className={
-        isLegacy
-          ? "font-mono text-amber-600 text-xs dark:text-amber-500"
-          : "font-mono text-xs"
-      }
-      variant="secondary"
-    >
-      {scope}
-    </Badge>
-  );
-}
-
-function TokenScopeBadges({ scopes }: { scopes: string[] }) {
-  if (scopes.length === 0) {
-    return (
-      <Badge
-        className="text-muted-foreground text-xs italic"
-        variant="secondary"
-      >
-        No scopes
-      </Badge>
-    );
-  }
-
-  if (scopes.length === 1 && scopes[0] === "*") {
-    return (
-      <Badge
-        className="text-amber-600 text-xs dark:text-amber-500"
-        variant="secondary"
-      >
-        Full access (legacy)
-      </Badge>
-    );
-  }
-
-  // Stable sort grouped by resource: scopes within the same resource share
-  // a prefix, so a plain lexicographic sort already groups them. The first
-  // entry in the sorted list is the one shown in the collapsed cell.
-  const sorted = [...scopes].sort();
-
-  if (sorted.length === 1) {
-    return <ScopeBadge scope={sorted[0]} />;
-  }
-
-  const [first, ...rest] = sorted;
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div className="flex w-fit flex-wrap items-center gap-1">
-          <ScopeBadge scope={first} />
-          <Badge className="text-xs" variant="secondary">
-            +{rest.length}
-          </Badge>
-        </div>
-      </TooltipTrigger>
-      <TooltipContent>
-        <div className="flex flex-col gap-0.5 font-mono text-xs">
-          {sorted.map((scope) => (
-            <span
-              className={
-                LEGACY_COARSE_SCOPES.has(scope)
-                  ? "text-amber-600 dark:text-amber-500"
-                  : undefined
-              }
-              key={scope}
-            >
-              {scope}
-            </span>
-          ))}
-        </div>
-      </TooltipContent>
-    </Tooltip>
-  );
-}
 
 export default async function TokensPage() {
   // Page-level auth gate so we never run the workspace-wide PAT query for

--- a/web/components/dashboard/dashboard-stats.tsx
+++ b/web/components/dashboard/dashboard-stats.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { UserAvatar } from "@/components/user-avatar";
+import { UserAvatarLink } from "@/components/user-avatar";
 import type {
   DashboardStats,
   MyRunsStats,
@@ -161,12 +161,15 @@ export function DashboardStatsCards({
         }
         value={
           topAttributor ? (
-            <span className="flex items-center gap-2">
-              <UserAvatar size="sm" user={topAttributor.user} />
+            <UserAvatarLink
+              className="gap-2"
+              size="sm"
+              user={topAttributor.user}
+            >
               <span className="truncate">
                 {firstName(topAttributor.user.displayName)}
               </span>
-            </span>
+            </UserAvatarLink>
           ) : (
             "—"
           )

--- a/web/components/tokens/create-token-dialog.tsx
+++ b/web/components/tokens/create-token-dialog.tsx
@@ -279,11 +279,13 @@ function CreateTokenForm({
     });
   }, []);
 
+  // A failed roster fetch falls back to a self-mint rather than blocking;
+  // only an in-flight load (no error yet) gates submit.
   const canSubmit =
     Boolean(name.trim()) &&
     selected.size > 0 &&
     Boolean(ownerId) &&
-    users !== null &&
+    (users !== null || usersError) &&
     !isPending;
 
   const handleCreate = () => {
@@ -336,8 +338,9 @@ function CreateTokenForm({
         <div className="grid gap-2">
           <Label htmlFor="token-owner">User</Label>
           {usersError ? (
-            <p className="text-destructive text-sm">
-              Failed to load workspace members. Close and try again.
+            <p className="text-muted-foreground text-sm">
+              Couldn't load workspace members. This token will be created for
+              you — reopen the dialog to choose a different owner.
             </p>
           ) : (
             <Select

--- a/web/components/tokens/create-token-dialog.tsx
+++ b/web/components/tokens/create-token-dialog.tsx
@@ -547,20 +547,20 @@ function ScopeRow({
         id={`scope-${scope}`}
         onCheckedChange={() => onToggle(scope)}
       />
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="flex flex-1 items-center justify-between gap-2">
+      <span className="flex flex-1 items-center justify-between gap-2">
+        <Tooltip>
+          <TooltipTrigger asChild>
             <span className="flex items-center gap-1.5">
               {meta.label}
               {meta.destructive ? (
                 <TriangleAlert className="size-3 text-amber-600 dark:text-amber-500" />
               ) : null}
             </span>
-            <code className="text-muted-foreground text-xs">{scope}</code>
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>{meta.description}</TooltipContent>
-      </Tooltip>
+          </TooltipTrigger>
+          <TooltipContent side="right">{meta.description}</TooltipContent>
+        </Tooltip>
+        <code className="text-muted-foreground text-xs">{scope}</code>
+      </span>
     </label>
   );
 }

--- a/web/components/tokens/create-token-dialog.tsx
+++ b/web/components/tokens/create-token-dialog.tsx
@@ -2,7 +2,13 @@
 
 import { ChevronsUpDown, Loader2, Plus, TriangleAlert } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useMemo, useState, useTransition } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
 import { toast } from "sonner";
 import { CopyButton } from "@/components/copy-button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -64,6 +70,12 @@ interface ResourceGroup {
   scopes: Scope[];
 }
 
+interface WorkspaceUser {
+  email: string | null;
+  id: string;
+  name: string | null;
+}
+
 // Group scopes by resource, preserving ALL_SCOPES order so the grid layout is
 // deterministic and adding a scope surfaces automatically.
 function groupScopesByResource(): ResourceGroup[] {
@@ -90,7 +102,18 @@ function computeExpiresAt(days: string): string | undefined {
   return d.toISOString();
 }
 
-export function CreateTokenDialog() {
+function userLabel(user: WorkspaceUser): string {
+  if (user.name && user.email) {
+    return `${user.name} (${user.email})`;
+  }
+  return user.name ?? user.email ?? user.id;
+}
+
+export function CreateTokenDialog({
+  currentUserId,
+}: {
+  currentUserId: string;
+}) {
   const [open, setOpen] = useState(false);
   const [view, setView] = useState<View>({ kind: "form" });
 
@@ -130,6 +153,7 @@ export function CreateTokenDialog() {
       >
         {view.kind === "form" ? (
           <CreateTokenForm
+            currentUserId={currentUserId}
             onCreated={(plaintext) => setView({ kind: "success", plaintext })}
           />
         ) : (
@@ -147,15 +171,46 @@ export function CreateTokenDialog() {
 }
 
 function CreateTokenForm({
+  currentUserId,
   onCreated,
 }: {
+  currentUserId: string;
   onCreated: (plaintext: string) => void;
 }) {
   const [name, setName] = useState("");
+  const [ownerId, setOwnerId] = useState(currentUserId);
+  const [users, setUsers] = useState<WorkspaceUser[] | null>(null);
+  const [usersError, setUsersError] = useState(false);
   const [expiry, setExpiry] = useState("90");
   const [selected, setSelected] = useState<Set<Scope>>(() => new Set());
   const [customOpen, setCustomOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
+
+  // Lazy-load the roster when the form mounts (dialog opened), not on the
+  // tokens page itself — most visits are audits, not mints.
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/v1/users")
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error("Failed to load users");
+        }
+        return res.json() as Promise<WorkspaceUser[]>;
+      })
+      .then((rows) => {
+        if (!cancelled) {
+          setUsers(rows);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setUsersError(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const groups = useMemo(groupScopesByResource, []);
 
@@ -224,7 +279,12 @@ function CreateTokenForm({
     });
   }, []);
 
-  const canSubmit = Boolean(name.trim()) && selected.size > 0 && !isPending;
+  const canSubmit =
+    Boolean(name.trim()) &&
+    selected.size > 0 &&
+    Boolean(ownerId) &&
+    users !== null &&
+    !isPending;
 
   const handleCreate = () => {
     startTransition(async () => {
@@ -236,6 +296,7 @@ function CreateTokenForm({
           name: name.trim(),
           expires_at: expiresAt,
           scopes: Array.from(selected),
+          user_id: ownerId,
         }),
       });
 
@@ -256,6 +317,8 @@ function CreateTokenForm({
         <DialogTitle>Create access token</DialogTitle>
         <DialogDescription>
           Tokens are used to authenticate API requests from external tools.
+          Write actions (like claiming a run) are attributed to the selected
+          user.
         </DialogDescription>
       </DialogHeader>
       <div className="grid gap-4 py-2">
@@ -269,6 +332,35 @@ function CreateTokenForm({
             placeholder="e.g. Plate Reader PC"
             value={name}
           />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="token-owner">User</Label>
+          {usersError ? (
+            <p className="text-destructive text-sm">
+              Failed to load workspace members. Close and try again.
+            </p>
+          ) : (
+            <Select
+              disabled={users === null}
+              onValueChange={setOwnerId}
+              value={ownerId}
+            >
+              <SelectTrigger id="token-owner">
+                <SelectValue
+                  placeholder={
+                    users === null ? "Loading members…" : "Select user"
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {(users ?? []).map((user) => (
+                  <SelectItem key={user.id} value={user.id}>
+                    {userLabel(user)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
         </div>
         <div className="grid gap-2">
           <Label htmlFor="token-expiry">Expiration</Label>

--- a/web/components/tokens/token-scope-badges.tsx
+++ b/web/components/tokens/token-scope-badges.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { LEGACY_SCOPE_EXPANSIONS } from "@/lib/api/scopes";
+
+// Client module so TooltipTrigger `asChild` hydrates correctly. Rendering
+// that composition from an RSC intermittently drops the trigger children on
+// soft navigation (radix-ui/primitives#3883); a full reload masked it.
+
+// Compact scopes column. Four branches:
+//
+//   1. `[]` → "No scopes" pill. The DB column is non-null with a default of
+//      `['*']` and the create-token form rejects empty arrays, so this
+//      shouldn't appear in practice — but an explicit empty state is clearer
+//      than a blank cell if it ever does (e.g. a manual SQL update).
+//   2. `["*"]` (backfill wildcard) → single "Full access (legacy)" pill so
+//      pre-scope tokens stand out and read as rotation candidates.
+//   3. Single explicit scope → that scope as a badge, no tooltip needed
+//      because everything is already visible.
+//   4. Multiple explicit scopes → first scope (sorted) plus a "+N" counter
+//      badge. Hovering the cell reveals the full list in a tooltip so the
+//      table stays scannable on tokens with many scopes.
+//
+// Deprecated coarse `:write` scopes (superseded by fine-grained actions but
+// still honored on old tokens) render with an amber tint wherever they
+// appear, flagging them for re-issue.
+const LEGACY_COARSE_SCOPES = new Set(Object.keys(LEGACY_SCOPE_EXPANSIONS));
+
+function ScopeBadge({ scope }: { scope: string }) {
+  const isLegacy = LEGACY_COARSE_SCOPES.has(scope);
+  return (
+    <Badge
+      className={
+        isLegacy
+          ? "font-mono text-amber-600 text-xs dark:text-amber-500"
+          : "font-mono text-xs"
+      }
+      variant="secondary"
+    >
+      {scope}
+    </Badge>
+  );
+}
+
+export function TokenScopeBadges({ scopes }: { scopes: string[] }) {
+  if (scopes.length === 0) {
+    return (
+      <Badge
+        className="text-muted-foreground text-xs italic"
+        variant="secondary"
+      >
+        No scopes
+      </Badge>
+    );
+  }
+
+  if (scopes.length === 1 && scopes[0] === "*") {
+    return (
+      <Badge
+        className="text-amber-600 text-xs dark:text-amber-500"
+        variant="secondary"
+      >
+        Full access (legacy)
+      </Badge>
+    );
+  }
+
+  // Stable sort grouped by resource: scopes within the same resource share
+  // a prefix, so a plain lexicographic sort already groups them. The first
+  // entry in the sorted list is the one shown in the collapsed cell.
+  const sorted = [...scopes].sort();
+
+  if (sorted.length === 1) {
+    return <ScopeBadge scope={sorted[0]} />;
+  }
+
+  const [first, ...rest] = sorted;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="flex w-fit flex-wrap items-center gap-1">
+          <ScopeBadge scope={first} />
+          <Badge className="text-xs" variant="secondary">
+            +{rest.length}
+          </Badge>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="flex flex-col gap-0.5 font-mono text-xs">
+          {sorted.map((scope) => (
+            <span
+              className={
+                LEGACY_COARSE_SCOPES.has(scope)
+                  ? "text-amber-600 dark:text-amber-500"
+                  : undefined
+              }
+              key={scope}
+            >
+              {scope}
+            </span>
+          ))}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/web/lib/api/token-owner.ts
+++ b/web/lib/api/token-owner.ts
@@ -24,7 +24,9 @@ export async function resolveTokenOwnerUserId(
   }
 
   const userId = requestedUserId.trim();
-  if (!(await userExists(userId))) {
+  // The caller is authenticated, so it exists — skip the DB round-trip for
+  // self-mints (the UI always sends `user_id`, even for the minting admin).
+  if (userId !== callerUserId && !(await userExists(userId))) {
     return { ok: false, error: "user_id does not match a known user" };
   }
 

--- a/web/lib/api/token-owner.ts
+++ b/web/lib/api/token-owner.ts
@@ -1,0 +1,32 @@
+// Resolves which user owns a newly minted PAT.
+//
+// Admins mint tokens for other members (MCP clients, watchers). The owner is
+// the identity Bearer auth and write attribution (claim_run, comments, etc.)
+// use — not necessarily the admin who clicked Create. Omitting `user_id`
+// keeps the previous default: the minting admin owns the token (service
+// accounts, watcher/Lambda keys).
+
+export type ResolveTokenOwnerResult =
+  | { ok: true; userId: string }
+  | { ok: false; error: string };
+
+export async function resolveTokenOwnerUserId(
+  requestedUserId: unknown,
+  callerUserId: string,
+  userExists: (id: string) => Promise<boolean>
+): Promise<ResolveTokenOwnerResult> {
+  if (requestedUserId === undefined || requestedUserId === null) {
+    return { ok: true, userId: callerUserId };
+  }
+
+  if (typeof requestedUserId !== "string" || !requestedUserId.trim()) {
+    return { ok: false, error: "user_id must be a non-empty string" };
+  }
+
+  const userId = requestedUserId.trim();
+  if (!(await userExists(userId))) {
+    return { ok: false, error: "user_id does not match a known user" };
+  }
+
+  return { ok: true, userId };
+}

--- a/web/lib/db/schema.ts
+++ b/web/lib/db/schema.ts
@@ -236,7 +236,8 @@ export const personalAccessTokens = pgTable(
   "personal_access_tokens",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    // The user who created this token.
+    // Token owner / acting identity for Bearer auth and write attribution.
+    // An admin may mint a token bound to another user (e.g. an MCP client).
     userId: text("user_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3445,15 +3445,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
-      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
+      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
-      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
       "cpu": [
         "arm64"
       ],
@@ -3467,9 +3467,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
-      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
       "cpu": [
         "x64"
       ],
@@ -3483,11 +3483,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
-      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3499,11 +3502,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
-      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3515,11 +3521,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
-      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3531,11 +3540,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
-      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3547,9 +3559,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
-      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
       "cpu": [
         "arm64"
       ],
@@ -3563,9 +3575,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
-      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
       "cpu": [
         "x64"
       ],
@@ -11912,12 +11924,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
-      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
+      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.9",
+        "@next/env": "16.2.10",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -11931,14 +11943,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.9",
-        "@next/swc-darwin-x64": "16.2.9",
-        "@next/swc-linux-arm64-gnu": "16.2.9",
-        "@next/swc-linux-arm64-musl": "16.2.9",
-        "@next/swc-linux-x64-gnu": "16.2.9",
-        "@next/swc-linux-x64-musl": "16.2.9",
-        "@next/swc-win32-arm64-msvc": "16.2.9",
-        "@next/swc-win32-x64-msvc": "16.2.9",
+        "@next/swc-darwin-arm64": "16.2.10",
+        "@next/swc-darwin-x64": "16.2.10",
+        "@next/swc-linux-arm64-gnu": "16.2.10",
+        "@next/swc-linux-arm64-musl": "16.2.10",
+        "@next/swc-linux-x64-gnu": "16.2.10",
+        "@next/swc-linux-x64-musl": "16.2.10",
+        "@next/swc-win32-arm64-msvc": "16.2.10",
+        "@next/swc-win32-x64-msvc": "16.2.10",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/web/tests/unit/token-owner.test.ts
+++ b/web/tests/unit/token-owner.test.ts
@@ -34,6 +34,17 @@ describe("resolveTokenOwnerUserId", () => {
     expect(userExists).toHaveBeenCalledWith(bobId);
   });
 
+  it("skips the existence check when minting for the caller", async () => {
+    const userExists = vi.fn();
+    const result = await resolveTokenOwnerUserId(
+      callerId,
+      callerId,
+      userExists
+    );
+    expect(result).toEqual({ ok: true, userId: callerId });
+    expect(userExists).not.toHaveBeenCalled();
+  });
+
   it("trims whitespace around user_id", async () => {
     const bobId = "bob-user-id";
     const userExists = vi.fn(async (id: string) => id === bobId);

--- a/web/tests/unit/token-owner.test.ts
+++ b/web/tests/unit/token-owner.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveTokenOwnerUserId } from "@/lib/api/token-owner";
+
+// Owner resolution for `POST /api/v1/tokens`. Pure aside from the injected
+// `userExists` check — unit-tested here because the integration harness has
+// no session cookies and cannot hit the admin-only mint path over HTTP.
+
+describe("resolveTokenOwnerUserId", () => {
+  const callerId = "admin-user-id";
+
+  it("defaults to the caller when user_id is omitted", async () => {
+    const userExists = vi.fn();
+    const result = await resolveTokenOwnerUserId(
+      undefined,
+      callerId,
+      userExists
+    );
+    expect(result).toEqual({ ok: true, userId: callerId });
+    expect(userExists).not.toHaveBeenCalled();
+  });
+
+  it("defaults to the caller when user_id is null", async () => {
+    const userExists = vi.fn();
+    const result = await resolveTokenOwnerUserId(null, callerId, userExists);
+    expect(result).toEqual({ ok: true, userId: callerId });
+    expect(userExists).not.toHaveBeenCalled();
+  });
+
+  it("returns a known user_id as the owner", async () => {
+    const bobId = "bob-user-id";
+    const userExists = vi.fn(async (id: string) => id === bobId);
+    const result = await resolveTokenOwnerUserId(bobId, callerId, userExists);
+    expect(result).toEqual({ ok: true, userId: bobId });
+    expect(userExists).toHaveBeenCalledWith(bobId);
+  });
+
+  it("trims whitespace around user_id", async () => {
+    const bobId = "bob-user-id";
+    const userExists = vi.fn(async (id: string) => id === bobId);
+    const result = await resolveTokenOwnerUserId(
+      `  ${bobId}  `,
+      callerId,
+      userExists
+    );
+    expect(result).toEqual({ ok: true, userId: bobId });
+  });
+
+  it("rejects an unknown user_id", async () => {
+    const userExists = vi.fn(async () => false);
+    const result = await resolveTokenOwnerUserId(
+      "missing-user",
+      callerId,
+      userExists
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/known user/);
+    }
+  });
+
+  it("rejects a non-string user_id", async () => {
+    const userExists = vi.fn();
+    const result = await resolveTokenOwnerUserId(42, callerId, userExists);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/non-empty string/);
+    }
+    expect(userExists).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty or whitespace-only user_id", async () => {
+    const userExists = vi.fn();
+    for (const value of ["", "   "]) {
+      const result = await resolveTokenOwnerUserId(value, callerId, userExists);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatch(/non-empty string/);
+      }
+    }
+    expect(userExists).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Admins can select which workspace member owns a newly minted personal access token, so Bearer write actions (e.g. `claim_run`) attribute to that user instead of the minting admin.
- Create-token dialog adds a User picker (defaults to the current admin); omitting `user_id` on the API keeps the previous admin-as-owner default for watcher/Lambda keys.
- If the workspace roster (`/api/v1/users`) fails to load, the dialog gracefully falls back to a self-mint instead of blocking token creation entirely.
- Owner resolution short-circuits the DB existence check when minting for the authenticated caller, avoiding a needless round-trip.
- Leaves an MCP OAuth TODO noting PAT minting as a stopgap until members can authorize their own clients.

## Test plan

- [x] As admin, create a token for another member; confirm Settings → Access Tokens User column shows that member
- [x] Use that token to `claim_run` (MCP or REST); confirm attribution is the selected member, not the admin
- [x] Create a token without changing User (self); confirm behavior matches prior admin-owned tokens


Made with [Cursor](https://cursor.com)