### PR TITLE
Align dashboard stat card value rows to a shared height

### DIFF
--- a/web/components/dashboard/dashboard-stats.tsx
+++ b/web/components/dashboard/dashboard-stats.tsx
@@ -53,7 +53,9 @@ function StatCard({
         <p className="font-medium text-muted-foreground text-xs">{label}</p>
         <p
           className={cn(
-            "mt-1.5 font-heading font-semibold text-2xl tabular-nums leading-none tracking-tight",
+            // `h-7` matches the leaderboard avatar (`size-sm`) so every value
+            // row shares one height and the sublines stay aligned.
+            "mt-1.5 flex h-7 items-center font-heading font-semibold text-2xl tabular-nums leading-none tracking-tight",
             valueClassName
           )}
         >
@@ -94,7 +96,7 @@ export function StatCardsSkeleton({
         <Card className="gap-2 py-4" key={label} size="sm">
           <div className="px-4">
             <p className="font-medium text-muted-foreground text-xs">{label}</p>
-            <Skeleton className="mt-1.5 h-6 w-10" />
+            <Skeleton className="mt-1.5 h-7 w-10" />
             <Skeleton className="mt-1.5 h-4 w-full" />
           </div>
         </Card>
@@ -174,9 +176,7 @@ export function DashboardStatsCards({
             "—"
           )
         }
-        // The leaderboard value is a name + avatar, not a number, so drop the
-        // numeric sizing and tighten the label gap so the row sits closer.
-        valueClassName="mt-0.5 text-xl"
+        valueClassName="text-xl"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Give every dashboard `StatCard` value row a shared `h-7` flex height so numeric values and the “Most runs this week” avatar + name line up.
- Drop the leaderboard card’s tighter top margin so its label/value/subline spacing matches the other cards.

## Test plan
- [x] Open the home dashboard with a top attributor present and confirm the four card values and sublines align horizontally.
- [x] Confirm the empty-state leaderboard value (`—`) still looks correct.
- [x] Confirm the stats skeleton value placeholder height matches the live cards.


Made with [Cursor](https://cursor.com)