### PR TITLE
Add MCP catalog schema endpoint for docs generation

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -40,3 +40,6 @@ next-env.d.ts
 # Local OpenAPI dump from `npm run openapi:generate` (not committed;
 # production serves the schema from GET /api/v1/openapi.json).
 /openapi.json
+# Optional local dump from `npm run mcp-catalog:generate` (same idea;
+# production serves GET /api/v1/mcp/schema.json).
+/mcp-catalog.json

--- a/web/app/api/v1/mcp/schema.json/route.ts
+++ b/web/app/api/v1/mcp/schema.json/route.ts
@@ -1,0 +1,13 @@
+import { buildMcpCatalogDocument } from "@/lib/mcp/catalog";
+
+// Schema is pure (no DB/env); bake it into the build so every deploy
+// serves a fixed document without recomputing on each request.
+export const dynamic = "force-static";
+
+export function GET() {
+  return Response.json(buildMcpCatalogDocument(), {
+    headers: {
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/web/lib/mcp/catalog/document.ts
+++ b/web/lib/mcp/catalog/document.ts
@@ -1,0 +1,42 @@
+import { zodRecordToJsonSchema } from "@/lib/mcp/catalog/json-schema";
+import { MCP_TOOL_DEFS } from "@/lib/mcp/catalog/tools";
+import type { McpCatalogDocument } from "@/lib/mcp/catalog/types";
+import { MCP_PROMPT_DEFS } from "@/lib/mcp/prompts.defs";
+import { MCP_RESOURCE_DEFS } from "@/lib/mcp/resources.defs";
+
+export function buildMcpCatalogDocument(): McpCatalogDocument {
+  return {
+    mcpCatalog: "1.0.0",
+    info: {
+      title: "Data Hub MCP",
+      version: "1.0.0",
+      description:
+        "Model Context Protocol server for Data Hub. Authenticate with a personal access token (`Authorization: Bearer dhub_…`). Tools enforce the same `<resource>:<action>` scopes as their REST counterparts.",
+      endpoint: "/api/v1/mcp",
+      transport: "streamable-http",
+    },
+    tools: MCP_TOOL_DEFS.map((tool) => ({
+      name: tool.name,
+      title: tool.title,
+      description: tool.description,
+      group: tool.group,
+      ...(tool.scope ? { scope: tool.scope } : {}),
+      ...(tool.annotations ? { annotations: tool.annotations } : {}),
+      inputSchema: zodRecordToJsonSchema(tool.inputSchema),
+    })),
+    resources: MCP_RESOURCE_DEFS.map((resource) => ({
+      name: resource.name,
+      description: resource.description,
+      ...(resource.mimeType ? { mimeType: resource.mimeType } : {}),
+      ...(resource.kind === "static"
+        ? { uri: resource.uri }
+        : { uriTemplate: resource.uriTemplate }),
+    })),
+    prompts: MCP_PROMPT_DEFS.map((prompt) => ({
+      name: prompt.name,
+      title: prompt.title,
+      description: prompt.description,
+      argsSchema: zodRecordToJsonSchema(prompt.argsSchema),
+    })),
+  };
+}

--- a/web/lib/mcp/catalog/index.ts
+++ b/web/lib/mcp/catalog/index.ts
@@ -1,0 +1,18 @@
+// Public boundary for the MCP catalog document and defs used by registration.
+// biome-ignore lint/performance/noBarrelFile: Package entry for schema route + registrars.
+export { buildMcpCatalogDocument } from "@/lib/mcp/catalog/document";
+export {
+  promptRegistrationConfig,
+  toolRegistrationConfig,
+} from "@/lib/mcp/catalog/register";
+export { MCP_TOOL_DEFS } from "@/lib/mcp/catalog/tools";
+export {
+  MCP_TOOL_GROUPS,
+  type McpCatalogDocument,
+  type McpPromptDef,
+  type McpResourceDef,
+  type McpToolDef,
+  type McpToolGroup,
+} from "@/lib/mcp/catalog/types";
+export { MCP_PROMPT_DEFS } from "@/lib/mcp/prompts.defs";
+export { MCP_RESOURCE_DEFS } from "@/lib/mcp/resources.defs";

--- a/web/lib/mcp/catalog/json-schema.ts
+++ b/web/lib/mcp/catalog/json-schema.ts
@@ -5,11 +5,5 @@ import { z } from "zod";
 export function zodRecordToJsonSchema(
   fields: Record<string, ZodType> | undefined
 ): Record<string, unknown> {
-  if (!fields || Object.keys(fields).length === 0) {
-    return {
-      type: "object",
-      properties: {},
-    };
-  }
-  return z.toJSONSchema(z.object(fields)) as Record<string, unknown>;
+  return z.toJSONSchema(z.object(fields ?? {})) as Record<string, unknown>;
 }

--- a/web/lib/mcp/catalog/json-schema.ts
+++ b/web/lib/mcp/catalog/json-schema.ts
@@ -1,0 +1,15 @@
+import type { ZodType } from "zod";
+import { z } from "zod";
+
+/** Convert a Zod field record (MCP `inputSchema` / `argsSchema`) to JSON Schema. */
+export function zodRecordToJsonSchema(
+  fields: Record<string, ZodType> | undefined
+): Record<string, unknown> {
+  if (!fields || Object.keys(fields).length === 0) {
+    return {
+      type: "object",
+      properties: {},
+    };
+  }
+  return z.toJSONSchema(z.object(fields)) as Record<string, unknown>;
+}

--- a/web/lib/mcp/catalog/register.ts
+++ b/web/lib/mcp/catalog/register.ts
@@ -1,0 +1,44 @@
+import type { ZodType } from "zod";
+import type { McpToolAnnotations } from "@/lib/mcp/catalog/types";
+
+/** Config object passed to `server.registerTool` (name is separate). */
+export function toolRegistrationConfig<
+  TSchema extends Record<string, ZodType> | undefined,
+  TAnnotations extends McpToolAnnotations | undefined,
+>(def: {
+  title: string;
+  description: string;
+  inputSchema?: TSchema;
+  annotations?: TAnnotations;
+}): {
+  title: string;
+  description: string;
+  inputSchema: TSchema;
+  annotations: TAnnotations;
+} {
+  return {
+    title: def.title,
+    description: def.description,
+    inputSchema: def.inputSchema as TSchema,
+    annotations: def.annotations as TAnnotations,
+  };
+}
+
+/** Config object passed to `server.registerPrompt` (name is separate). */
+export function promptRegistrationConfig<
+  TSchema extends Record<string, ZodType> | undefined,
+>(def: {
+  title: string;
+  description: string;
+  argsSchema?: TSchema;
+}): {
+  title: string;
+  description: string;
+  argsSchema: TSchema;
+} {
+  return {
+    title: def.title,
+    description: def.description,
+    argsSchema: def.argsSchema as TSchema,
+  };
+}

--- a/web/lib/mcp/catalog/tools.ts
+++ b/web/lib/mcp/catalog/tools.ts
@@ -1,0 +1,15 @@
+import type { McpToolDef } from "@/lib/mcp/catalog/types";
+import { DISCOVERY_TOOL_DEFS } from "@/lib/mcp/tools/discovery.defs";
+import { FILE_TOOL_DEFS } from "@/lib/mcp/tools/files.defs";
+import { INSTRUMENT_TOOL_DEFS } from "@/lib/mcp/tools/instruments.defs";
+import { RUN_TOOL_DEFS } from "@/lib/mcp/tools/runs.defs";
+import { WATCHER_TOOL_DEFS } from "@/lib/mcp/tools/watchers.defs";
+
+/** All tool catalog entries — order matches registration for stable docs. */
+export const MCP_TOOL_DEFS: readonly McpToolDef[] = [
+  ...INSTRUMENT_TOOL_DEFS,
+  ...RUN_TOOL_DEFS,
+  ...FILE_TOOL_DEFS,
+  ...WATCHER_TOOL_DEFS,
+  ...DISCOVERY_TOOL_DEFS,
+];

--- a/web/lib/mcp/catalog/types.ts
+++ b/web/lib/mcp/catalog/types.ts
@@ -1,0 +1,80 @@
+import type { ZodType } from "zod";
+
+export const MCP_TOOL_GROUPS = {
+  instruments: "Instruments",
+  runs: "Runs",
+  attribution: "Run attribution",
+  comments: "Comments",
+  files: "Files",
+  watchers: "Watchers",
+  discovery: "Discovery",
+} as const;
+
+export type McpToolGroup = keyof typeof MCP_TOOL_GROUPS;
+
+export interface McpToolAnnotations {
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  readOnlyHint?: boolean;
+}
+
+export interface McpToolDef {
+  annotations?: McpToolAnnotations;
+  description: string;
+  group: McpToolGroup;
+  inputSchema?: Record<string, ZodType>;
+  name: string;
+  /** PAT scope checked by the tool handler (`resource:action`). */
+  scope?: string;
+  title: string;
+}
+
+export interface McpPromptDef {
+  argsSchema?: Record<string, ZodType>;
+  description: string;
+  name: string;
+  title: string;
+}
+
+export type McpResourceDef = {
+  name: string;
+  description: string;
+  mimeType?: string;
+} & (
+  | { kind: "static"; uri: string }
+  | { kind: "template"; uriTemplate: string }
+);
+
+/** Shape served by `GET /api/v1/mcp/schema.json`. */
+export interface McpCatalogDocument {
+  info: {
+    title: string;
+    version: string;
+    description: string;
+    endpoint: string;
+    transport: "streamable-http";
+  };
+  mcpCatalog: "1.0.0";
+  prompts: Array<{
+    name: string;
+    title: string;
+    description: string;
+    argsSchema: Record<string, unknown>;
+  }>;
+  resources: Array<{
+    name: string;
+    description: string;
+    mimeType?: string;
+    uri?: string;
+    uriTemplate?: string;
+  }>;
+  tools: Array<{
+    name: string;
+    title: string;
+    description: string;
+    group: McpToolGroup;
+    scope?: string;
+    annotations?: McpToolAnnotations;
+    inputSchema: Record<string, unknown>;
+  }>;
+}

--- a/web/lib/mcp/prompts.defs.ts
+++ b/web/lib/mcp/prompts.defs.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+import type { McpPromptDef } from "@/lib/mcp/catalog/types";
+
+export const dailySummaryPrompt = {
+  name: "daily_summary",
+  title: "Daily Summary",
+  description:
+    "Summarize all instrument activity for a given day, including run counts, failures, and system health.",
+  argsSchema: {
+    date: z
+      .string()
+      .optional()
+      .describe("Date to summarize (YYYY-MM-DD). Defaults to today."),
+  },
+} as const satisfies McpPromptDef;
+
+export const troubleshootInstrumentPrompt = {
+  name: "troubleshoot_instrument",
+  title: "Troubleshoot Instrument",
+  description:
+    "Diagnose connectivity or processing issues for an instrument by inspecting its status and watcher health.",
+  argsSchema: {
+    instrumentId: z.string().describe("Instrument identifier to troubleshoot"),
+  },
+} as const satisfies McpPromptDef;
+
+export const compareRunsPrompt = {
+  name: "compare_runs",
+  title: "Compare Runs",
+  description:
+    "Compare the results of two runs side by side, highlighting differences in experimental outcomes.",
+  argsSchema: {
+    instrumentId: z
+      .string()
+      .describe(
+        "Instrument identifier (both runs must be on the same instrument)"
+      ),
+    runId1: z.string().describe("First run identifier"),
+    runId2: z.string().describe("Second run identifier"),
+  },
+} as const satisfies McpPromptDef;
+
+export const findMyRunsPrompt = {
+  name: "find_my_runs",
+  title: "Find My Runs",
+  description:
+    "List runs claimed by the authenticated user, optionally scoped to an instrument and date range.",
+  argsSchema: {
+    instrumentId: z
+      .string()
+      .optional()
+      .describe("Optional instrument to narrow results"),
+    dateFrom: z
+      .string()
+      .optional()
+      .describe("Start date (YYYY-MM-DD), inclusive"),
+    dateTo: z.string().optional().describe("End date (YYYY-MM-DD), inclusive"),
+  },
+} as const satisfies McpPromptDef;
+
+export const explainFailedRunPrompt = {
+  name: "explain_failed_run",
+  title: "Explain Failed Run",
+  description:
+    "Diagnose why a run failed and suggest reprocess or upload fixes.",
+  argsSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    runId: z.string().describe("Run identifier within the instrument"),
+  },
+} as const satisfies McpPromptDef;
+
+export const claimUnattributedRunsPrompt = {
+  name: "claim_unattributed_runs",
+  title: "Claim Unattributed Runs",
+  description:
+    "Find unattributed runs on an instrument and claim them for the authenticated user after confirmation.",
+  argsSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    dateFrom: z
+      .string()
+      .optional()
+      .describe("Optional start date (YYYY-MM-DD)"),
+    dateTo: z.string().optional().describe("Optional end date (YYYY-MM-DD)"),
+  },
+} as const satisfies McpPromptDef;
+
+export const summarizeInstrumentWeekPrompt = {
+  name: "summarize_instrument_week",
+  title: "Summarize Instrument Week",
+  description:
+    "Summarize one instrument's activity over the last seven days (or a provided window).",
+  argsSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    dateFrom: z
+      .string()
+      .optional()
+      .describe("Start date (YYYY-MM-DD). Defaults to 7 days ago."),
+    dateTo: z
+      .string()
+      .optional()
+      .describe("End date (YYYY-MM-DD). Defaults to today."),
+  },
+} as const satisfies McpPromptDef;
+
+export const MCP_PROMPT_DEFS = [
+  dailySummaryPrompt,
+  troubleshootInstrumentPrompt,
+  compareRunsPrompt,
+  findMyRunsPrompt,
+  explainFailedRunPrompt,
+  claimUnattributedRunsPrompt,
+  summarizeInstrumentWeekPrompt,
+] as const;

--- a/web/lib/mcp/prompts.ts
+++ b/web/lib/mcp/prompts.ts
@@ -1,20 +1,19 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
+import { promptRegistrationConfig } from "@/lib/mcp/catalog/register";
+import {
+  claimUnattributedRunsPrompt,
+  compareRunsPrompt,
+  dailySummaryPrompt,
+  explainFailedRunPrompt,
+  findMyRunsPrompt,
+  summarizeInstrumentWeekPrompt,
+  troubleshootInstrumentPrompt,
+} from "./prompts.defs";
 
 export function registerPrompts(server: McpServer) {
   server.registerPrompt(
-    "daily_summary",
-    {
-      title: "Daily Summary",
-      description:
-        "Summarize all instrument activity for a given day, including run counts, failures, and system health.",
-      argsSchema: {
-        date: z
-          .string()
-          .optional()
-          .describe("Date to summarize (YYYY-MM-DD). Defaults to today."),
-      },
-    },
+    dailySummaryPrompt.name,
+    promptRegistrationConfig(dailySummaryPrompt),
     ({ date }) => {
       const targetDate = date || new Date().toISOString().slice(0, 10);
       return {
@@ -44,17 +43,8 @@ export function registerPrompts(server: McpServer) {
   );
 
   server.registerPrompt(
-    "troubleshoot_instrument",
-    {
-      title: "Troubleshoot Instrument",
-      description:
-        "Diagnose connectivity or processing issues for an instrument by inspecting its status and watcher health.",
-      argsSchema: {
-        instrumentId: z
-          .string()
-          .describe("Instrument identifier to troubleshoot"),
-      },
-    },
+    troubleshootInstrumentPrompt.name,
+    promptRegistrationConfig(troubleshootInstrumentPrompt),
     async ({ instrumentId }) => ({
       messages: [
         {
@@ -85,21 +75,8 @@ export function registerPrompts(server: McpServer) {
   );
 
   server.registerPrompt(
-    "compare_runs",
-    {
-      title: "Compare Runs",
-      description:
-        "Compare the results of two runs side by side, highlighting differences in experimental outcomes.",
-      argsSchema: {
-        instrumentId: z
-          .string()
-          .describe(
-            "Instrument identifier (both runs must be on the same instrument)"
-          ),
-        runId1: z.string().describe("First run identifier"),
-        runId2: z.string().describe("Second run identifier"),
-      },
-    },
+    compareRunsPrompt.name,
+    promptRegistrationConfig(compareRunsPrompt),
     async ({ instrumentId, runId1, runId2 }) => ({
       messages: [
         {
@@ -127,26 +104,8 @@ export function registerPrompts(server: McpServer) {
   );
 
   server.registerPrompt(
-    "find_my_runs",
-    {
-      title: "Find My Runs",
-      description:
-        "List runs claimed by the authenticated user, optionally scoped to an instrument and date range.",
-      argsSchema: {
-        instrumentId: z
-          .string()
-          .optional()
-          .describe("Optional instrument to narrow results"),
-        dateFrom: z
-          .string()
-          .optional()
-          .describe("Start date (YYYY-MM-DD), inclusive"),
-        dateTo: z
-          .string()
-          .optional()
-          .describe("End date (YYYY-MM-DD), inclusive"),
-      },
-    },
+    findMyRunsPrompt.name,
+    promptRegistrationConfig(findMyRunsPrompt),
     ({ instrumentId, dateFrom, dateTo }) => {
       const filters = [
         'ranBy="me"',
@@ -178,16 +137,8 @@ export function registerPrompts(server: McpServer) {
   );
 
   server.registerPrompt(
-    "explain_failed_run",
-    {
-      title: "Explain Failed Run",
-      description:
-        "Diagnose why a run failed and suggest reprocess or upload fixes.",
-      argsSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        runId: z.string().describe("Run identifier within the instrument"),
-      },
-    },
+    explainFailedRunPrompt.name,
+    promptRegistrationConfig(explainFailedRunPrompt),
     async ({ instrumentId, runId }) => ({
       messages: [
         {
@@ -211,23 +162,8 @@ export function registerPrompts(server: McpServer) {
   );
 
   server.registerPrompt(
-    "claim_unattributed_runs",
-    {
-      title: "Claim Unattributed Runs",
-      description:
-        "Find unattributed runs on an instrument and claim them for the authenticated user after confirmation.",
-      argsSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        dateFrom: z
-          .string()
-          .optional()
-          .describe("Optional start date (YYYY-MM-DD)"),
-        dateTo: z
-          .string()
-          .optional()
-          .describe("Optional end date (YYYY-MM-DD)"),
-      },
-    },
+    claimUnattributedRunsPrompt.name,
+    promptRegistrationConfig(claimUnattributedRunsPrompt),
     ({ instrumentId, dateFrom, dateTo }) => {
       const dateBits = [
         dateFrom ? `dateFrom="${dateFrom}"` : null,
@@ -258,23 +194,8 @@ export function registerPrompts(server: McpServer) {
   );
 
   server.registerPrompt(
-    "summarize_instrument_week",
-    {
-      title: "Summarize Instrument Week",
-      description:
-        "Summarize one instrument's activity over the last seven days (or a provided window).",
-      argsSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        dateFrom: z
-          .string()
-          .optional()
-          .describe("Start date (YYYY-MM-DD). Defaults to 7 days ago."),
-        dateTo: z
-          .string()
-          .optional()
-          .describe("End date (YYYY-MM-DD). Defaults to today."),
-      },
-    },
+    summarizeInstrumentWeekPrompt.name,
+    promptRegistrationConfig(summarizeInstrumentWeekPrompt),
     ({ instrumentId, dateFrom, dateTo }) => {
       const today = new Date();
       const defaultTo = today.toISOString().slice(0, 10);

--- a/web/lib/mcp/resources.defs.ts
+++ b/web/lib/mcp/resources.defs.ts
@@ -1,0 +1,44 @@
+import type { McpResourceDef } from "@/lib/mcp/catalog/types";
+
+export const instrumentsResource = {
+  name: "instruments",
+  description:
+    "List of all instrument IDs, display names, and types. Use as reference context when constructing tool calls.",
+  mimeType: "application/json",
+  kind: "static",
+  uri: "datahub://instruments",
+} as const satisfies McpResourceDef;
+
+export const meResource = {
+  name: "me",
+  description:
+    "Authenticated PAT owner's identity (id, name, email, image, isAdmin). Same payload as the get_me tool.",
+  mimeType: "application/json",
+  kind: "static",
+  uri: "datahub://me",
+} as const satisfies McpResourceDef;
+
+export const glossaryResource = {
+  name: "glossary",
+  description:
+    "Static reference: run status derivation, instrument types, ranBy literals, archive polling, and tool-routing tips.",
+  mimeType: "application/json",
+  kind: "static",
+  uri: "datahub://glossary",
+} as const satisfies McpResourceDef;
+
+export const instrumentFilterOptionsResource = {
+  name: "instrument-filter-options",
+  description:
+    "Available filter values for an instrument. Values map directly to search_runs metadata filter arguments (wavelength/measurementMode/measurementType for plate readers; captureType/imagingMode/gelWavelength/gelColor for gel-doc; dyeChannel for qPCR; hinaChannel/hinaDimension/hinaSize for Hina; dpi/colorMode for Epson).",
+  mimeType: "application/json",
+  kind: "template",
+  uriTemplate: "datahub://instruments/{instrumentId}/filter-options",
+} as const satisfies McpResourceDef;
+
+export const MCP_RESOURCE_DEFS = [
+  instrumentsResource,
+  meResource,
+  glossaryResource,
+  instrumentFilterOptionsResource,
+] as const;

--- a/web/lib/mcp/resources.ts
+++ b/web/lib/mcp/resources.ts
@@ -9,6 +9,12 @@ import {
 import type { InstrumentType } from "@/lib/db/schema";
 import { DATAHUB_GLOSSARY } from "@/lib/mcp/glossary";
 import { getMcpUserId } from "@/lib/mcp/tools/helpers";
+import {
+  glossaryResource,
+  instrumentFilterOptionsResource,
+  instrumentsResource,
+  meResource,
+} from "./resources.defs";
 
 // Instrument types with structured filter-options. Must match `search_runs` args.
 const FILTERABLE_INSTRUMENT_TYPES = new Set<InstrumentType>([
@@ -38,20 +44,19 @@ function filterOptionsDescription(instrumentType: InstrumentType): string {
 
 export function registerResources(server: McpServer) {
   server.registerResource(
-    "instruments",
-    "datahub://instruments",
+    instrumentsResource.name,
+    instrumentsResource.uri,
     {
-      description:
-        "List of all instrument IDs, display names, and types. Use as reference context when constructing tool calls.",
-      mimeType: "application/json",
+      description: instrumentsResource.description,
+      mimeType: instrumentsResource.mimeType,
     },
     async () => {
       const instruments = await getInstruments();
       return {
         contents: [
           {
-            uri: "datahub://instruments",
-            mimeType: "application/json",
+            uri: instrumentsResource.uri,
+            mimeType: instrumentsResource.mimeType,
             text: JSON.stringify(instruments, null, 2),
           },
         ],
@@ -60,12 +65,11 @@ export function registerResources(server: McpServer) {
   );
 
   server.registerResource(
-    "me",
-    "datahub://me",
+    meResource.name,
+    meResource.uri,
     {
-      description:
-        "Authenticated PAT owner's identity (id, name, email, image, isAdmin). Same payload as the get_me tool.",
-      mimeType: "application/json",
+      description: meResource.description,
+      mimeType: meResource.mimeType,
     },
     async (_uri, extra) => {
       const userId = getMcpUserId(extra.authInfo);
@@ -73,8 +77,8 @@ export function registerResources(server: McpServer) {
         return {
           contents: [
             {
-              uri: "datahub://me",
-              mimeType: "application/json",
+              uri: meResource.uri,
+              mimeType: meResource.mimeType,
               text: JSON.stringify(
                 { error: "Authenticated user not available on this session." },
                 null,
@@ -90,8 +94,8 @@ export function registerResources(server: McpServer) {
         return {
           contents: [
             {
-              uri: "datahub://me",
-              mimeType: "application/json",
+              uri: meResource.uri,
+              mimeType: meResource.mimeType,
               text: JSON.stringify(
                 { error: `User '${userId}' not found.` },
                 null,
@@ -105,8 +109,8 @@ export function registerResources(server: McpServer) {
       return {
         contents: [
           {
-            uri: "datahub://me",
-            mimeType: "application/json",
+            uri: meResource.uri,
+            mimeType: meResource.mimeType,
             text: JSON.stringify(user, null, 2),
           },
         ],
@@ -115,18 +119,17 @@ export function registerResources(server: McpServer) {
   );
 
   server.registerResource(
-    "glossary",
-    "datahub://glossary",
+    glossaryResource.name,
+    glossaryResource.uri,
     {
-      description:
-        "Static reference: run status derivation, instrument types, ranBy literals, archive polling, and tool-routing tips.",
-      mimeType: "application/json",
+      description: glossaryResource.description,
+      mimeType: glossaryResource.mimeType,
     },
     async () => ({
       contents: [
         {
-          uri: "datahub://glossary",
-          mimeType: "application/json",
+          uri: glossaryResource.uri,
+          mimeType: glossaryResource.mimeType,
           text: JSON.stringify(DATAHUB_GLOSSARY, null, 2),
         },
       ],
@@ -134,30 +137,26 @@ export function registerResources(server: McpServer) {
   );
 
   server.registerResource(
-    "instrument-filter-options",
-    new ResourceTemplate(
-      "datahub://instruments/{instrumentId}/filter-options",
-      {
-        list: async () => {
-          const instruments = await getInstrumentListWithCounts();
-          const filterable = instruments.filter((i) =>
-            FILTERABLE_INSTRUMENT_TYPES.has(i.instrumentType)
-          );
-          return {
-            resources: filterable.map((i) => ({
-              uri: `datahub://instruments/${i.id}/filter-options`,
-              name: `${i.displayName} filter options`,
-              description: `${filterOptionsDescription(i.instrumentType)} for ${i.displayName}`,
-              mimeType: "application/json",
-            })),
-          };
-        },
-      }
-    ),
+    instrumentFilterOptionsResource.name,
+    new ResourceTemplate(instrumentFilterOptionsResource.uriTemplate, {
+      list: async () => {
+        const instruments = await getInstrumentListWithCounts();
+        const filterable = instruments.filter((i) =>
+          FILTERABLE_INSTRUMENT_TYPES.has(i.instrumentType)
+        );
+        return {
+          resources: filterable.map((i) => ({
+            uri: `datahub://instruments/${i.id}/filter-options`,
+            name: `${i.displayName} filter options`,
+            description: `${filterOptionsDescription(i.instrumentType)} for ${i.displayName}`,
+            mimeType: "application/json",
+          })),
+        };
+      },
+    }),
     {
-      description:
-        "Available filter values for an instrument. Values map directly to search_runs metadata filter arguments (wavelength/measurementMode/measurementType for plate readers; captureType/imagingMode/gelWavelength/gelColor for gel-doc; dyeChannel for qPCR; hinaChannel/hinaDimension/hinaSize for Hina; dpi/colorMode for Epson).",
-      mimeType: "application/json",
+      description: instrumentFilterOptionsResource.description,
+      mimeType: instrumentFilterOptionsResource.mimeType,
     },
     async (_uri, variables) => {
       const instrumentId = Array.isArray(variables.instrumentId)

--- a/web/lib/mcp/tools/discovery.defs.ts
+++ b/web/lib/mcp/tools/discovery.defs.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import type { McpToolDef } from "@/lib/mcp/catalog/types";
+
+export const globalSearchTool = {
+  name: "global_search",
+  title: "Global Search",
+  description:
+    "Fuzzy search across runs, files, and instruments (same backend as the UI ⌘K palette). Prefer this over search_runs when the query may match a filename, instrument display name, or attributor name. Use search_runs for date/status/metadata filters. Queries shorter than 2 characters are rejected.",
+  group: "discovery",
+  scope: "runs:read",
+  inputSchema: {
+    query: z.string().describe("Search query (min 2 characters)"),
+    scope: z
+      .enum(["all", "runs", "files", "instruments"])
+      .optional()
+      .describe("Limit results to one entity type (default: all)"),
+  },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const getMeTool = {
+  name: "get_me",
+  title: "Get Me",
+  description:
+    'Return the authenticated PAT owner\'s identity (id, name, email, image, isAdmin). Use the returned id with search_runs ranBy=, or pass ranBy="me" instead.',
+  group: "discovery",
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const getSystemStatusTool = {
+  name: "get_system_status",
+  title: "Get System Status",
+  description:
+    "Get a dashboard-level overview: per-instrument run counts, watcher health (online/offline/no_watcher), and pending upload counts.",
+  group: "discovery",
+  scope: "instruments:read",
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const DISCOVERY_TOOL_DEFS = [
+  globalSearchTool,
+  getMeTool,
+  getSystemStatusTool,
+] as const;

--- a/web/lib/mcp/tools/discovery.ts
+++ b/web/lib/mcp/tools/discovery.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
 import { getInstrumentSummaries, getUserById } from "@/lib/api/dashboard";
 import { globalSearch } from "@/lib/api/search";
+import { toolRegistrationConfig } from "@/lib/mcp/catalog/register";
 import {
   errorResult,
   getMcpUserId,
@@ -9,23 +9,16 @@ import {
   textResult,
 } from "@/lib/mcp/tools/helpers";
 import { MIN_QUERY_LENGTH } from "@/lib/search-constants";
+import {
+  getMeTool,
+  getSystemStatusTool,
+  globalSearchTool,
+} from "./discovery.defs";
 
 export function registerDiscoveryTools(server: McpServer) {
   server.registerTool(
-    "global_search",
-    {
-      title: "Global Search",
-      description:
-        "Fuzzy search across runs, files, and instruments (same backend as the UI ⌘K palette). Prefer this over search_runs when the query may match a filename, instrument display name, or attributor name. Use search_runs for date/status/metadata filters. Queries shorter than 2 characters are rejected.",
-      inputSchema: {
-        query: z.string().describe("Search query (min 2 characters)"),
-        scope: z
-          .enum(["all", "runs", "files", "instruments"])
-          .optional()
-          .describe("Limit results to one entity type (default: all)"),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    globalSearchTool.name,
+    toolRegistrationConfig(globalSearchTool),
     async ({ query, scope }, { authInfo }) => {
       // Intentionally gated on runs:read alone, mirroring the REST palette
       // endpoint (`GET /api/v1/search`). A runs:read-only token can therefore
@@ -49,13 +42,8 @@ export function registerDiscoveryTools(server: McpServer) {
   );
 
   server.registerTool(
-    "get_me",
-    {
-      title: "Get Me",
-      description:
-        'Return the authenticated PAT owner\'s identity (id, name, email, image, isAdmin). Use the returned id with search_runs ranBy=, or pass ranBy="me" instead.',
-      annotations: { readOnlyHint: true },
-    },
+    getMeTool.name,
+    toolRegistrationConfig(getMeTool),
     async ({ authInfo }) => {
       const userId = getMcpUserId(authInfo);
       if (!userId) {
@@ -70,13 +58,8 @@ export function registerDiscoveryTools(server: McpServer) {
   );
 
   server.registerTool(
-    "get_system_status",
-    {
-      title: "Get System Status",
-      description:
-        "Get a dashboard-level overview: per-instrument run counts, watcher health (online/offline/no_watcher), and pending upload counts.",
-      annotations: { readOnlyHint: true },
-    },
+    getSystemStatusTool.name,
+    toolRegistrationConfig(getSystemStatusTool),
     // No inputSchema → the SDK passes the request `extra` as a single
     // argument; pull `authInfo` directly off it.
     async ({ authInfo }) => {

--- a/web/lib/mcp/tools/files.defs.ts
+++ b/web/lib/mcp/tools/files.defs.ts
@@ -45,6 +45,9 @@ export const reprocessFileTool = {
   group: "files",
   scope: "files:reprocess",
   inputSchema: { fileId: z.number().int().describe("Numeric file ID") },
+  // destructiveHint is true because the tool resets status/errorMessage/
+  // processedAt. The Lambda re-processes the file, but the mutation is
+  // irreversible from the tool's perspective and clients should confirm.
   annotations: { readOnlyHint: false, destructiveHint: true },
 } as const satisfies McpToolDef;
 

--- a/web/lib/mcp/tools/files.defs.ts
+++ b/web/lib/mcp/tools/files.defs.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import type { McpToolDef } from "@/lib/mcp/catalog/types";
+
+export const getFileTool = {
+  name: "get_file",
+  title: "Get File",
+  description:
+    "Get detailed metadata for a single file by its numeric ID, including status, S3 location, size, extracted metadata, and any error message.",
+  group: "files",
+  scope: "files:read",
+  inputSchema: { fileId: z.number().int().describe("Numeric file ID") },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const getFileDownloadUrlTool = {
+  name: "get_file_download_url",
+  title: "Get File Download URL",
+  description:
+    "Get a short-lived pre-signed S3 URL to download the raw file contents. URL expires after 15 minutes.",
+  group: "files",
+  scope: "files:read",
+  inputSchema: { fileId: z.number().int().describe("Numeric file ID") },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const getRunArchiveTool = {
+  name: "get_run_archive",
+  title: "Get Run Archive",
+  description:
+    "Get a downloadable ZIP archive of every active, uploaded file in a run. If the archive is already cached, returns a short-lived (15 min) pre-signed S3 URL the caller can fetch directly without auth — paste it into a browser or share it as a download link. If the archive isn't cached, kicks off an async build and returns `{ status: 'building', jobId, retryAfterSeconds }`; call this tool again after the suggested wait to poll for completion. Most archives finish in a few seconds; large runs may take a minute or two. Mirrors the REST `download-archive` route, including its dedup-by-fingerprint cache, so concurrent callers share a single Lambda invocation.",
+  group: "files",
+  scope: "files:read",
+  inputSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    runId: z.string().describe("Run identifier within the instrument"),
+  },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const reprocessFileTool = {
+  name: "reprocess_file",
+  title: "Reprocess File",
+  description:
+    "Re-run the Lambda processing workflow for a failed or completed file. Transitions the file back to 'processing'. Use this to retry after a parser fix or transient Lambda failure.",
+  group: "files",
+  scope: "files:reprocess",
+  inputSchema: { fileId: z.number().int().describe("Numeric file ID") },
+  annotations: { readOnlyHint: false, destructiveHint: true },
+} as const satisfies McpToolDef;
+
+export const dismissFileTool = {
+  name: "dismiss_file",
+  title: "Dismiss File",
+  description:
+    "Soft-delete a detected or upload_requested file (UI 'dismiss'). Uploaded files cannot be dismissed — delete the run instead. Idempotent: dismissing an already-dismissed file succeeds as a no-op.",
+  group: "files",
+  scope: "files:delete",
+  inputSchema: { fileId: z.number().int().describe("Numeric file ID") },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+  },
+} as const satisfies McpToolDef;
+
+export const FILE_TOOL_DEFS = [
+  getFileTool,
+  getFileDownloadUrlTool,
+  getRunArchiveTool,
+  reprocessFileTool,
+  dismissFileTool,
+] as const;

--- a/web/lib/mcp/tools/files.ts
+++ b/web/lib/mcp/tools/files.ts
@@ -1,5 +1,4 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
 import { reprocessFile } from "@/lib/api/file-reprocessing";
 import {
   dismissFile,
@@ -7,6 +6,7 @@ import {
   lookupFileForDownload,
 } from "@/lib/api/files";
 import { prepareRunArchive } from "@/lib/api/run-archive";
+import { toolRegistrationConfig } from "@/lib/mcp/catalog/register";
 import {
   errorResult,
   requireMcpScope,
@@ -16,19 +16,18 @@ import {
   getPresignedDownloadUrl,
   PRESIGNED_DOWNLOAD_URL_EXPIRY_SECONDS,
 } from "@/lib/s3";
+import {
+  dismissFileTool,
+  getFileDownloadUrlTool,
+  getFileTool,
+  getRunArchiveTool,
+  reprocessFileTool,
+} from "./files.defs";
 
 export function registerFileTools(server: McpServer) {
   server.registerTool(
-    "get_file",
-    {
-      title: "Get File",
-      description:
-        "Get detailed metadata for a single file by its numeric ID, including status, S3 location, size, extracted metadata, and any error message.",
-      inputSchema: {
-        fileId: z.number().int().describe("Numeric file ID"),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    getFileTool.name,
+    toolRegistrationConfig(getFileTool),
     async ({ fileId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "files:read");
       if (scopeError) {
@@ -43,16 +42,8 @@ export function registerFileTools(server: McpServer) {
   );
 
   server.registerTool(
-    "get_file_download_url",
-    {
-      title: "Get File Download URL",
-      description:
-        "Get a short-lived pre-signed S3 URL to download the raw file contents. URL expires after 15 minutes.",
-      inputSchema: {
-        fileId: z.number().int().describe("Numeric file ID"),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    getFileDownloadUrlTool.name,
+    toolRegistrationConfig(getFileDownloadUrlTool),
     async ({ fileId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "files:read");
       if (scopeError) {
@@ -84,20 +75,8 @@ export function registerFileTools(server: McpServer) {
   );
 
   server.registerTool(
-    "get_run_archive",
-    {
-      title: "Get Run Archive",
-      description:
-        "Get a downloadable ZIP archive of every active, uploaded file in a run. " +
-        "If the archive is already cached, returns a short-lived (15 min) pre-signed S3 URL the caller can fetch directly without auth — paste it into a browser or share it as a download link. " +
-        "If the archive isn't cached, kicks off an async build and returns `{ status: 'building', jobId, retryAfterSeconds }`; call this tool again after the suggested wait to poll for completion. " +
-        "Most archives finish in a few seconds; large runs may take a minute or two. Mirrors the REST `download-archive` route, including its dedup-by-fingerprint cache, so concurrent callers share a single Lambda invocation.",
-      inputSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        runId: z.string().describe("Run identifier within the instrument"),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    getRunArchiveTool.name,
+    toolRegistrationConfig(getRunArchiveTool),
     async ({ instrumentId, runId }, { authInfo }) => {
       // Mirror the REST archive route which is gated on `files:read`.
       const scopeError = requireMcpScope(authInfo, "files:read");
@@ -146,19 +125,8 @@ export function registerFileTools(server: McpServer) {
   );
 
   server.registerTool(
-    "reprocess_file",
-    {
-      title: "Reprocess File",
-      description:
-        "Re-run the Lambda processing workflow for a failed or completed file. Transitions the file back to 'processing'. Use this to retry after a parser fix or transient Lambda failure.",
-      inputSchema: {
-        fileId: z.number().int().describe("Numeric file ID"),
-      },
-      // destructiveHint is true because the tool resets status/errorMessage/
-      // processedAt. The Lambda re-processes the file, but the mutation is
-      // irreversible from the tool's perspective and clients should confirm.
-      annotations: { readOnlyHint: false, destructiveHint: true },
-    },
+    reprocessFileTool.name,
+    toolRegistrationConfig(reprocessFileTool),
     async ({ fileId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "files:reprocess");
       if (scopeError) {
@@ -173,20 +141,8 @@ export function registerFileTools(server: McpServer) {
   );
 
   server.registerTool(
-    "dismiss_file",
-    {
-      title: "Dismiss File",
-      description:
-        "Soft-delete a detected or upload_requested file (UI 'dismiss'). Uploaded files cannot be dismissed — delete the run instead. Idempotent: dismissing an already-dismissed file succeeds as a no-op.",
-      inputSchema: {
-        fileId: z.number().int().describe("Numeric file ID"),
-      },
-      annotations: {
-        readOnlyHint: false,
-        destructiveHint: true,
-        idempotentHint: true,
-      },
-    },
+    dismissFileTool.name,
+    toolRegistrationConfig(dismissFileTool),
     async ({ fileId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "files:delete");
       if (scopeError) {

--- a/web/lib/mcp/tools/instruments.defs.ts
+++ b/web/lib/mcp/tools/instruments.defs.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import type { McpToolDef } from "@/lib/mcp/catalog/types";
+
+export const listInstrumentsTool = {
+  name: "list_instruments",
+  title: "List Instruments",
+  description:
+    "List all registered lab instruments with run counts, watcher status, and file patterns. Optionally filter by status.",
+  group: "instruments",
+  scope: "instruments:read",
+  inputSchema: {
+    status: z
+      .enum(["pending", "active", "inactive"])
+      .optional()
+      .describe("Filter instruments by status"),
+  },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const getInstrumentTool = {
+  name: "get_instrument",
+  title: "Get Instrument",
+  description:
+    "Get detailed information about a specific instrument, including watcher online/offline counts and file patterns.",
+  group: "instruments",
+  scope: "instruments:read",
+  inputSchema: {
+    instrumentId: z
+      .string()
+      .describe(
+        "Kebab-case instrument identifier (e.g. 'spectramax-id3-plate-reader')"
+      ),
+  },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const INSTRUMENT_TOOL_DEFS = [
+  listInstrumentsTool,
+  getInstrumentTool,
+] as const;

--- a/web/lib/mcp/tools/instruments.ts
+++ b/web/lib/mcp/tools/instruments.ts
@@ -1,30 +1,20 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
 import {
   getInstrumentById,
   getInstrumentListWithCounts,
 } from "@/lib/api/instruments";
+import { toolRegistrationConfig } from "@/lib/mcp/catalog/register";
 import {
   errorResult,
   requireMcpScope,
   textResult,
 } from "@/lib/mcp/tools/helpers";
+import { getInstrumentTool, listInstrumentsTool } from "./instruments.defs";
 
 export function registerInstrumentTools(server: McpServer) {
   server.registerTool(
-    "list_instruments",
-    {
-      title: "List Instruments",
-      description:
-        "List all registered lab instruments with run counts, watcher status, and file patterns. Optionally filter by status.",
-      inputSchema: {
-        status: z
-          .enum(["pending", "active", "inactive"])
-          .optional()
-          .describe("Filter instruments by status"),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    listInstrumentsTool.name,
+    toolRegistrationConfig(listInstrumentsTool),
     async ({ status }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "instruments:read");
       if (scopeError) {
@@ -39,20 +29,8 @@ export function registerInstrumentTools(server: McpServer) {
   );
 
   server.registerTool(
-    "get_instrument",
-    {
-      title: "Get Instrument",
-      description:
-        "Get detailed information about a specific instrument, including watcher online/offline counts and file patterns.",
-      inputSchema: {
-        instrumentId: z
-          .string()
-          .describe(
-            "Kebab-case instrument identifier (e.g. 'spectramax-id3-plate-reader')"
-          ),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    getInstrumentTool.name,
+    toolRegistrationConfig(getInstrumentTool),
     async ({ instrumentId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "instruments:read");
       if (scopeError) {

--- a/web/lib/mcp/tools/runs.defs.ts
+++ b/web/lib/mcp/tools/runs.defs.ts
@@ -1,0 +1,358 @@
+import { z } from "zod";
+import { mcpMetadataFilterInputSchema } from "@/lib/api/run-metadata-filters";
+import type { McpToolDef } from "@/lib/mcp/catalog/types";
+import { RUN_STATUS_VALUES } from "@/lib/runs/run-status";
+
+export const searchRunsTool = {
+  name: "search_runs",
+  group: "runs",
+  scope: "runs:read",
+  title: "Search Runs",
+  description:
+    "Search instrument runs with filtering, pagination, and sorting. Supports run status filters and instrument-metadata filters (plate reader, gel-doc, qPCR, Hina microscope, Epson scanner). Prefer global_search when the query may match filenames, instrument names, or attributor names rather than run IDs. Discover valid metadata filter values via datahub://instruments/{id}/filter-options (or datahub://glossary for routing tips).",
+  inputSchema: {
+    instrumentId: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .describe("Filter to one or more instrument IDs"),
+    source: z
+      .enum(["lambda", "watcher"])
+      .optional()
+      .describe("Filter by run source"),
+    search: z
+      .string()
+      .optional()
+      .describe("Search text matched against run ID only"),
+    dateFrom: z
+      .string()
+      .optional()
+      .describe("Start date (inclusive, YYYY-MM-DD)"),
+    dateTo: z.string().optional().describe("End date (inclusive, YYYY-MM-DD)"),
+    sort: z
+      .enum(["acquired_at", "created_at", "updated_at"])
+      .optional()
+      .describe(
+        "Sort field (default: acquired_at — when the run actually happened on the instrument PC, falling back to created_at)"
+      ),
+    order: z
+      .enum(["asc", "desc"])
+      .optional()
+      .describe("Sort order (default: desc)"),
+    page: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe("Page number (default: 1)"),
+    perPage: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe("Results per page (default: 20, max: 100)"),
+    includeDeleted: z
+      .boolean()
+      .optional()
+      .describe("Include soft-deleted runs (default: false)"),
+    ...mcpMetadataFilterInputSchema,
+    ranBy: z
+      .string()
+      .optional()
+      .describe(
+        'Filter by attributor. Pass a user id, the literal "me" for the authenticated token owner, or "unattributed" for runs with no attributions. Use get_me for your user id, or list_run_attributors to discover colleagues.'
+      ),
+    status: z
+      .array(z.enum(RUN_STATUS_VALUES))
+      .optional()
+      .describe(
+        "Filter by derived run status (OR'd together). Status is derived from a run's raw file states, priority-exclusive: failed (any file failed), pending (files awaiting upload), uploaded, processing, completed (all done), empty (no files)."
+      ),
+  },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const getRunTool = {
+  name: "get_run",
+  group: "runs",
+  scope: "runs:read",
+  title: "Get Run",
+  description:
+    "Get details for a specific instrument run by its natural key (instrument ID + run ID). Returns metadata, timestamps, instrument info, and attributions by default. Pass include to attach the first page of files, comments, and/or a failure_summary without extra tool calls. For processed measurement samples prefer get_run_report.",
+  inputSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    runId: z.string().describe("Run identifier within the instrument"),
+    include: z
+      .array(z.enum(["files", "comments", "attributions", "failure_summary"]))
+      .optional()
+      .describe(
+        'Optional extras. "attributions" is accepted but redundant — attributions are always included. "files" returns the first page (50) via list_run_files shape.'
+      ),
+  },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const getRunReportTool = {
+  name: "get_run_report",
+  group: "runs",
+  scope: "files:read",
+  title: "Get Run Report",
+  description:
+    "Return an analysis-ready summary for a run: file counts, failure summary, image/report file refs, and a bounded processed-CSV sample (columns + first rows). Prefer this over downloading full CSVs when comparing or summarizing experimental results.",
+  inputSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    runId: z.string().describe("Run identifier within the instrument"),
+  },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const listRunFilesTool = {
+  name: "list_run_files",
+  group: "runs",
+  scope: "runs:read",
+  title: "List Run Files",
+  description:
+    "List files associated with a run (raw uploads and processed artifacts) with their status, category, and size. Paginated — runs can have thousands of files. Use the page/perPage arguments to walk the full list, and use get_file for full per-file detail including metadata and S3 location.",
+  inputSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    runId: z.string().describe("Run identifier within the instrument"),
+    page: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe("Page number (default: 1)"),
+    perPage: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe("Results per page (default: 50, max: 100)"),
+  },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const claimRunTool = {
+  name: "claim_run",
+  group: "attribution",
+  scope: "runs:attribute",
+  title: "Claim Run",
+  description:
+    "Mark a run as performed by the authenticated user. Idempotent — claiming a run you already claimed is a no-op. Only self-attribution is supported; you cannot claim a run on behalf of another user.",
+  inputSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    runId: z.string().describe("Run identifier within the instrument"),
+  },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+} as const satisfies McpToolDef;
+
+export const unclaimRunTool = {
+  name: "unclaim_run",
+  group: "attribution",
+  scope: "runs:attribute",
+  title: "Unclaim Run",
+  description:
+    "Remove the authenticated user's attribution from a run. Idempotent — unclaiming a run you don't currently claim is a no-op. Only self-attribution is supported; you cannot remove another user's attribution.",
+  inputSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    runId: z.string().describe("Run identifier within the instrument"),
+  },
+  // destructiveHint because removing an attribution is user-visible across
+  // dashboards and the runs table; clients should confirm before calling.
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+  },
+} as const satisfies McpToolDef;
+
+export const listRunAttributorsTool = {
+  name: "list_run_attributors",
+  group: "attribution",
+  scope: "runs:read",
+  title: "List Run Attributors",
+  description:
+    "List distinct users who have claimed at least one run on a given instrument. Use the returned userId with search_runs ranBy=<userId>.",
+  inputSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+  },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const listRunCommentsTool = {
+  name: "list_run_comments",
+  group: "comments",
+  scope: "runs:read",
+  title: "List Run Comments",
+  description:
+    "List comments on a run (oldest first), including author display info.",
+  inputSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    runId: z.string().describe("Run identifier within the instrument"),
+  },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const addRunCommentTool = {
+  name: "add_run_comment",
+  group: "comments",
+  scope: "runs:comment",
+  title: "Add Run Comment",
+  description:
+    "Add a comment on a run as the authenticated user. Author is taken from the token — you cannot comment as another user.",
+  inputSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    runId: z.string().describe("Run identifier within the instrument"),
+    body: z.string().describe("Markdown comment body"),
+  },
+  annotations: { readOnlyHint: false, destructiveHint: false },
+} as const satisfies McpToolDef;
+
+export const editRunCommentTool = {
+  name: "edit_run_comment",
+  group: "comments",
+  scope: "runs:comment",
+  title: "Edit Run Comment",
+  description:
+    "Edit one of your own comments. Returns an error if the comment is missing or authored by someone else.",
+  inputSchema: {
+    commentId: z.string().describe("Comment UUID"),
+    body: z.string().describe("Updated markdown body"),
+  },
+  annotations: { readOnlyHint: false, destructiveHint: false },
+} as const satisfies McpToolDef;
+
+export const deleteRunCommentTool = {
+  name: "delete_run_comment",
+  group: "comments",
+  scope: "runs:comment",
+  title: "Delete Run Comment",
+  description:
+    "Soft-delete one of your own comments. Idempotent if already deleted.",
+  inputSchema: {
+    commentId: z.string().describe("Comment UUID"),
+  },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+  },
+} as const satisfies McpToolDef;
+
+export const reprocessRunTool = {
+  name: "reprocess_run",
+  group: "runs",
+  scope: "runs:reprocess",
+  title: "Reprocess Run",
+  description:
+    "Re-run Lambda processing for every completed or failed file on a run. Prefer this over looping reprocess_file for bulk retries after a parser fix.",
+  inputSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    runId: z.string().describe("Run identifier within the instrument"),
+  },
+  // destructiveHint mirrors reprocess_file: this overwrites processed
+  // artifacts and resets per-file status in bulk, so clients should
+  // confirm even though no data is deleted.
+  annotations: { readOnlyHint: false, destructiveHint: true },
+} as const satisfies McpToolDef;
+
+export const deleteRunTool = {
+  name: "delete_run",
+  group: "runs",
+  scope: "runs:delete",
+  title: "Delete Run",
+  description:
+    "Soft-delete a run (sets deleted_at). Does not remove files or S3 objects. Use restore_run to undo. Idempotent: deleting an already-deleted run succeeds as a no-op.",
+  inputSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    runId: z.string().describe("Run identifier within the instrument"),
+  },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+  },
+} as const satisfies McpToolDef;
+
+export const restoreRunTool = {
+  name: "restore_run",
+  group: "runs",
+  scope: "runs:delete",
+  title: "Restore Run",
+  description:
+    "Restore a soft-deleted run by clearing deleted_at. Idempotent: restoring a run that is not deleted succeeds as a no-op.",
+  inputSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    runId: z.string().describe("Run identifier within the instrument"),
+  },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+} as const satisfies McpToolDef;
+
+export const requestRunUploadTool = {
+  name: "request_run_upload",
+  group: "runs",
+  scope: "runs:upload",
+  title: "Request Run Upload",
+  description:
+    "Queue specific detected files for watcher upload (max 100). Requires an online watcher. Idempotent for files already in upload_requested.",
+  inputSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    runId: z.string().describe("Run identifier within the instrument"),
+    fileIds: z
+      .array(z.number().int())
+      .min(1)
+      .max(100)
+      .describe("Numeric file IDs to queue"),
+  },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+} as const satisfies McpToolDef;
+
+export const requestRunUploadAllTool = {
+  name: "request_run_upload_all",
+  group: "runs",
+  scope: "runs:upload",
+  title: "Request Run Upload All",
+  description:
+    "Queue every detected file on a run for watcher upload. Requires an online watcher.",
+  inputSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    runId: z.string().describe("Run identifier within the instrument"),
+  },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+} as const satisfies McpToolDef;
+
+export const RUN_TOOL_DEFS = [
+  searchRunsTool,
+  getRunTool,
+  getRunReportTool,
+  listRunFilesTool,
+  claimRunTool,
+  unclaimRunTool,
+  listRunAttributorsTool,
+  listRunCommentsTool,
+  addRunCommentTool,
+  editRunCommentTool,
+  deleteRunCommentTool,
+  reprocessRunTool,
+  deleteRunTool,
+  restoreRunTool,
+  requestRunUploadTool,
+  requestRunUploadAllTool,
+] as const;

--- a/web/lib/mcp/tools/runs.ts
+++ b/web/lib/mcp/tools/runs.ts
@@ -1,6 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { and, eq } from "drizzle-orm";
-import { z } from "zod";
 import { reprocessRun } from "@/lib/api/file-reprocessing";
 import {
   buildRunListQuery,
@@ -19,14 +18,12 @@ import {
   validateCommentBody,
 } from "@/lib/api/run-comments";
 import { restoreRun, softDeleteRun } from "@/lib/api/run-lifecycle";
-import {
-  mcpMetadataFilterInputSchema,
-  pickMetadataFilterArgs,
-} from "@/lib/api/run-metadata-filters";
+import { pickMetadataFilterArgs } from "@/lib/api/run-metadata-filters";
 import { buildRunReport, getRunFailureSummary } from "@/lib/api/run-reports";
 import { requestAllRunUploads, requestRunUploads } from "@/lib/api/run-uploads";
 import { db } from "@/lib/db";
 import { runAttributions } from "@/lib/db/schema";
+import { toolRegistrationConfig } from "@/lib/mcp/catalog/register";
 import {
   errorResult,
   getMcpUserId,
@@ -36,82 +33,32 @@ import {
   toMcpFile,
 } from "@/lib/mcp/tools/helpers";
 import { validateSearchRunsMetadataFilters } from "@/lib/mcp/validate-run-filters";
-import { RUN_STATUS_VALUES } from "@/lib/runs/run-status";
+import {
+  addRunCommentTool,
+  claimRunTool,
+  deleteRunCommentTool,
+  deleteRunTool,
+  editRunCommentTool,
+  getRunReportTool,
+  getRunTool,
+  listRunAttributorsTool,
+  listRunCommentsTool,
+  listRunFilesTool,
+  reprocessRunTool,
+  requestRunUploadAllTool,
+  requestRunUploadTool,
+  restoreRunTool,
+  searchRunsTool,
+  unclaimRunTool,
+} from "./runs.defs";
 
 // Sentinel for `search_runs.ranBy`: resolve to the authenticated PAT owner.
 const RAN_BY_ME_SENTINEL = "me";
 
 export function registerRunTools(server: McpServer) {
   server.registerTool(
-    "search_runs",
-    {
-      title: "Search Runs",
-      description:
-        "Search instrument runs with filtering, pagination, and sorting. Supports run status filters and instrument-metadata filters (plate reader, gel-doc, qPCR, Hina microscope, Epson scanner). Prefer global_search when the query may match filenames, instrument names, or attributor names rather than run IDs. Discover valid metadata filter values via datahub://instruments/{id}/filter-options (or datahub://glossary for routing tips).",
-      inputSchema: {
-        instrumentId: z
-          .union([z.string(), z.array(z.string())])
-          .optional()
-          .describe("Filter to one or more instrument IDs"),
-        source: z
-          .enum(["lambda", "watcher"])
-          .optional()
-          .describe("Filter by run source"),
-        search: z
-          .string()
-          .optional()
-          .describe("Search text matched against run ID only"),
-        dateFrom: z
-          .string()
-          .optional()
-          .describe("Start date (inclusive, YYYY-MM-DD)"),
-        dateTo: z
-          .string()
-          .optional()
-          .describe("End date (inclusive, YYYY-MM-DD)"),
-        sort: z
-          .enum(["acquired_at", "created_at", "updated_at"])
-          .optional()
-          .describe(
-            "Sort field (default: acquired_at — when the run actually happened on the instrument PC, falling back to created_at)"
-          ),
-        order: z
-          .enum(["asc", "desc"])
-          .optional()
-          .describe("Sort order (default: desc)"),
-        page: z
-          .number()
-          .int()
-          .min(1)
-          .optional()
-          .describe("Page number (default: 1)"),
-        perPage: z
-          .number()
-          .int()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe("Results per page (default: 20, max: 100)"),
-        includeDeleted: z
-          .boolean()
-          .optional()
-          .describe("Include soft-deleted runs (default: false)"),
-        ...mcpMetadataFilterInputSchema,
-        ranBy: z
-          .string()
-          .optional()
-          .describe(
-            'Filter by attributor. Pass a user id, the literal "me" for the authenticated token owner, or "unattributed" for runs with no attributions. Use get_me for your user id, or list_run_attributors to discover colleagues.'
-          ),
-        status: z
-          .array(z.enum(RUN_STATUS_VALUES))
-          .optional()
-          .describe(
-            "Filter by derived run status (OR'd together). Status is derived from a run's raw file states, priority-exclusive: failed (any file failed), pending (files awaiting upload), uploaded, processing, completed (all done), empty (no files)."
-          ),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    searchRunsTool.name,
+    toolRegistrationConfig(searchRunsTool),
     async (args, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "runs:read");
       if (scopeError) {
@@ -162,25 +109,8 @@ export function registerRunTools(server: McpServer) {
   );
 
   server.registerTool(
-    "get_run",
-    {
-      title: "Get Run",
-      description:
-        "Get details for a specific instrument run by its natural key (instrument ID + run ID). Returns metadata, timestamps, instrument info, and attributions by default. Pass include to attach the first page of files, comments, and/or a failure_summary without extra tool calls. For processed measurement samples prefer get_run_report.",
-      inputSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        runId: z.string().describe("Run identifier within the instrument"),
-        include: z
-          .array(
-            z.enum(["files", "comments", "attributions", "failure_summary"])
-          )
-          .optional()
-          .describe(
-            'Optional extras. "attributions" is accepted but redundant — attributions are always included. "files" returns the first page (50) via list_run_files shape.'
-          ),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    getRunTool.name,
+    toolRegistrationConfig(getRunTool),
     async ({ instrumentId, runId, include }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "runs:read");
       if (scopeError) {
@@ -230,17 +160,8 @@ export function registerRunTools(server: McpServer) {
   );
 
   server.registerTool(
-    "get_run_report",
-    {
-      title: "Get Run Report",
-      description:
-        "Return an analysis-ready summary for a run: file counts, failure summary, image/report file refs, and a bounded processed-CSV sample (columns + first rows). Prefer this over downloading full CSVs when comparing or summarizing experimental results.",
-      inputSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        runId: z.string().describe("Run identifier within the instrument"),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    getRunReportTool.name,
+    toolRegistrationConfig(getRunReportTool),
     async ({ instrumentId, runId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "files:read");
       if (scopeError) {
@@ -255,30 +176,8 @@ export function registerRunTools(server: McpServer) {
   );
 
   server.registerTool(
-    "list_run_files",
-    {
-      title: "List Run Files",
-      description:
-        "List files associated with a run (raw uploads and processed artifacts) with their status, category, and size. Paginated — runs can have thousands of files. Use the page/perPage arguments to walk the full list, and use get_file for full per-file detail including metadata and S3 location.",
-      inputSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        runId: z.string().describe("Run identifier within the instrument"),
-        page: z
-          .number()
-          .int()
-          .min(1)
-          .optional()
-          .describe("Page number (default: 1)"),
-        perPage: z
-          .number()
-          .int()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe("Results per page (default: 50, max: 100)"),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    listRunFilesTool.name,
+    toolRegistrationConfig(listRunFilesTool),
     async ({ instrumentId, runId, page, perPage }, { authInfo }) => {
       // The tool is keyed by run and the result is "what files belong to
       // this run", which lives under the runs domain in the REST API too
@@ -303,21 +202,8 @@ export function registerRunTools(server: McpServer) {
   );
 
   server.registerTool(
-    "claim_run",
-    {
-      title: "Claim Run",
-      description:
-        "Mark a run as performed by the authenticated user. Idempotent — claiming a run you already claimed is a no-op. Only self-attribution is supported; you cannot claim a run on behalf of another user.",
-      inputSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        runId: z.string().describe("Run identifier within the instrument"),
-      },
-      annotations: {
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
-    },
+    claimRunTool.name,
+    toolRegistrationConfig(claimRunTool),
     async ({ instrumentId, runId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "runs:attribute");
       if (scopeError) {
@@ -347,23 +233,8 @@ export function registerRunTools(server: McpServer) {
   );
 
   server.registerTool(
-    "unclaim_run",
-    {
-      title: "Unclaim Run",
-      description:
-        "Remove the authenticated user's attribution from a run. Idempotent — unclaiming a run you don't currently claim is a no-op. Only self-attribution is supported; you cannot remove another user's attribution.",
-      inputSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        runId: z.string().describe("Run identifier within the instrument"),
-      },
-      // destructiveHint because removing an attribution is user-visible across
-      // dashboards and the runs table; clients should confirm before calling.
-      annotations: {
-        readOnlyHint: false,
-        destructiveHint: true,
-        idempotentHint: true,
-      },
-    },
+    unclaimRunTool.name,
+    toolRegistrationConfig(unclaimRunTool),
     async ({ instrumentId, runId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "runs:attribute");
       if (scopeError) {
@@ -397,16 +268,8 @@ export function registerRunTools(server: McpServer) {
   );
 
   server.registerTool(
-    "list_run_attributors",
-    {
-      title: "List Run Attributors",
-      description:
-        "List distinct users who have claimed at least one run on a given instrument. Use the returned userId with search_runs ranBy=<userId>.",
-      inputSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    listRunAttributorsTool.name,
+    toolRegistrationConfig(listRunAttributorsTool),
     async ({ instrumentId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "runs:read");
       if (scopeError) {
@@ -418,17 +281,8 @@ export function registerRunTools(server: McpServer) {
   );
 
   server.registerTool(
-    "list_run_comments",
-    {
-      title: "List Run Comments",
-      description:
-        "List comments on a run (oldest first), including author display info.",
-      inputSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        runId: z.string().describe("Run identifier within the instrument"),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    listRunCommentsTool.name,
+    toolRegistrationConfig(listRunCommentsTool),
     async ({ instrumentId, runId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "runs:read");
       if (scopeError) {
@@ -446,18 +300,8 @@ export function registerRunTools(server: McpServer) {
   );
 
   server.registerTool(
-    "add_run_comment",
-    {
-      title: "Add Run Comment",
-      description:
-        "Add a comment on a run as the authenticated user. Author is taken from the token — you cannot comment as another user.",
-      inputSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        runId: z.string().describe("Run identifier within the instrument"),
-        body: z.string().describe("Markdown comment body"),
-      },
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
+    addRunCommentTool.name,
+    toolRegistrationConfig(addRunCommentTool),
     async ({ instrumentId, runId, body }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "runs:comment");
       if (scopeError) {
@@ -502,17 +346,8 @@ export function registerRunTools(server: McpServer) {
   );
 
   server.registerTool(
-    "edit_run_comment",
-    {
-      title: "Edit Run Comment",
-      description:
-        "Edit one of your own comments. Returns an error if the comment is missing or authored by someone else.",
-      inputSchema: {
-        commentId: z.string().describe("Comment UUID"),
-        body: z.string().describe("Updated markdown body"),
-      },
-      annotations: { readOnlyHint: false, destructiveHint: false },
-    },
+    editRunCommentTool.name,
+    toolRegistrationConfig(editRunCommentTool),
     async ({ commentId, body }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "runs:comment");
       if (scopeError) {
@@ -548,20 +383,8 @@ export function registerRunTools(server: McpServer) {
   );
 
   server.registerTool(
-    "delete_run_comment",
-    {
-      title: "Delete Run Comment",
-      description:
-        "Soft-delete one of your own comments. Idempotent if already deleted.",
-      inputSchema: {
-        commentId: z.string().describe("Comment UUID"),
-      },
-      annotations: {
-        readOnlyHint: false,
-        destructiveHint: true,
-        idempotentHint: true,
-      },
-    },
+    deleteRunCommentTool.name,
+    toolRegistrationConfig(deleteRunCommentTool),
     async ({ commentId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "runs:comment");
       if (scopeError) {
@@ -589,20 +412,8 @@ export function registerRunTools(server: McpServer) {
   );
 
   server.registerTool(
-    "reprocess_run",
-    {
-      title: "Reprocess Run",
-      description:
-        "Re-run Lambda processing for every completed or failed file on a run. Prefer this over looping reprocess_file for bulk retries after a parser fix.",
-      inputSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        runId: z.string().describe("Run identifier within the instrument"),
-      },
-      // destructiveHint mirrors reprocess_file: this overwrites processed
-      // artifacts and resets per-file status in bulk, so clients should
-      // confirm even though no data is deleted.
-      annotations: { readOnlyHint: false, destructiveHint: true },
-    },
+    reprocessRunTool.name,
+    toolRegistrationConfig(reprocessRunTool),
     async ({ instrumentId, runId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "runs:reprocess");
       if (scopeError) {
@@ -622,21 +433,8 @@ export function registerRunTools(server: McpServer) {
   );
 
   server.registerTool(
-    "delete_run",
-    {
-      title: "Delete Run",
-      description:
-        "Soft-delete a run (sets deleted_at). Does not remove files or S3 objects. Use restore_run to undo. Idempotent: deleting an already-deleted run succeeds as a no-op.",
-      inputSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        runId: z.string().describe("Run identifier within the instrument"),
-      },
-      annotations: {
-        readOnlyHint: false,
-        destructiveHint: true,
-        idempotentHint: true,
-      },
-    },
+    deleteRunTool.name,
+    toolRegistrationConfig(deleteRunTool),
     async ({ instrumentId, runId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "runs:delete");
       if (scopeError) {
@@ -662,21 +460,8 @@ export function registerRunTools(server: McpServer) {
   );
 
   server.registerTool(
-    "restore_run",
-    {
-      title: "Restore Run",
-      description:
-        "Restore a soft-deleted run by clearing deleted_at. Idempotent: restoring a run that is not deleted succeeds as a no-op.",
-      inputSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        runId: z.string().describe("Run identifier within the instrument"),
-      },
-      annotations: {
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
-    },
+    restoreRunTool.name,
+    toolRegistrationConfig(restoreRunTool),
     async ({ instrumentId, runId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "runs:delete");
       if (scopeError) {
@@ -696,26 +481,8 @@ export function registerRunTools(server: McpServer) {
   );
 
   server.registerTool(
-    "request_run_upload",
-    {
-      title: "Request Run Upload",
-      description:
-        "Queue specific detected files for watcher upload (max 100). Requires an online watcher. Idempotent for files already in upload_requested.",
-      inputSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        runId: z.string().describe("Run identifier within the instrument"),
-        fileIds: z
-          .array(z.number().int())
-          .min(1)
-          .max(100)
-          .describe("Numeric file IDs to queue"),
-      },
-      annotations: {
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
-    },
+    requestRunUploadTool.name,
+    toolRegistrationConfig(requestRunUploadTool),
     async ({ instrumentId, runId, fileIds }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "runs:upload");
       if (scopeError) {
@@ -739,21 +506,8 @@ export function registerRunTools(server: McpServer) {
   );
 
   server.registerTool(
-    "request_run_upload_all",
-    {
-      title: "Request Run Upload All",
-      description:
-        "Queue every detected file on a run for watcher upload. Requires an online watcher.",
-      inputSchema: {
-        instrumentId: z.string().describe("Instrument identifier"),
-        runId: z.string().describe("Run identifier within the instrument"),
-      },
-      annotations: {
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
-    },
+    requestRunUploadAllTool.name,
+    toolRegistrationConfig(requestRunUploadAllTool),
     async ({ instrumentId, runId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "runs:upload");
       if (scopeError) {

--- a/web/lib/mcp/tools/watchers.defs.ts
+++ b/web/lib/mcp/tools/watchers.defs.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+import { watcherEventTypeEnum } from "@/lib/db/schema";
+import type { McpToolDef } from "@/lib/mcp/catalog/types";
+
+export const listWatchersTool = {
+  name: "list_watchers",
+  title: "List Watchers",
+  description:
+    "List watcher agents with effective status, hostname, instrument assignment, and last heartbeat. Optionally include deregistered watchers or filter by effective status.",
+  group: "watchers",
+  scope: "watchers:read",
+  inputSchema: {
+    instrumentId: z
+      .string()
+      .optional()
+      .describe("Filter watchers to a specific instrument"),
+    includeDeleted: z
+      .boolean()
+      .optional()
+      .describe(
+        "Include soft-deleted (deregistered) watchers (default: false)"
+      ),
+    status: z
+      .enum(["registered", "watching", "stopped", "stale"])
+      .optional()
+      .describe(
+        "Filter by effective status (stale is computed from heartbeat age)"
+      ),
+  },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const getWatcherTool = {
+  name: "get_watcher",
+  title: "Get Watcher",
+  description:
+    "Get watcher detail including config YAML, OS info, effective status, and deregistration actor when applicable.",
+  group: "watchers",
+  scope: "watchers:read",
+  inputSchema: { watcherId: z.string().describe("Watcher UUID") },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const listWatcherEventsTool = {
+  name: "list_watcher_events",
+  title: "List Watcher Events",
+  description:
+    "Paginated watcher event log (uploads, errors, config sync, update lifecycle). Useful after get_watcher_heartbeats when diagnosing failures.",
+  group: "watchers",
+  scope: "watchers:read",
+  inputSchema: {
+    watcherId: z.string().describe("Watcher UUID"),
+    hours: z
+      .number()
+      .int()
+      .min(1)
+      .max(168)
+      .optional()
+      .describe("Lookback window in hours (default: 24, max: 168)"),
+    eventTypes: z
+      .array(z.enum(watcherEventTypeEnum.enumValues))
+      .optional()
+      .describe("Filter to specific event types"),
+    page: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe("Page number (default: 1)"),
+    pageSize: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe("Results per page (default: 50, max: 100)"),
+  },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const getWatcherHeartbeatsTool = {
+  name: "get_watcher_heartbeats",
+  title: "Get Watcher Heartbeats",
+  description:
+    "Get recent heartbeat history for a watcher agent, useful for diagnosing connectivity gaps and error trends. Returns up to 100 most recent heartbeats within the lookback window.",
+  group: "watchers",
+  scope: "watchers:read",
+  inputSchema: {
+    watcherId: z.string().describe("Watcher UUID"),
+    hours: z
+      .number()
+      .int()
+      .min(1)
+      .max(168)
+      .optional()
+      .describe("Lookback window in hours (default: 24, max: 168)"),
+  },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
+export const WATCHER_TOOL_DEFS = [
+  listWatchersTool,
+  getWatcherTool,
+  listWatcherEventsTool,
+  getWatcherHeartbeatsTool,
+] as const;

--- a/web/lib/mcp/tools/watchers.ts
+++ b/web/lib/mcp/tools/watchers.ts
@@ -1,5 +1,4 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
 import {
   type EffectiveStatus,
   getWatcherById,
@@ -7,40 +6,23 @@ import {
   getWatcherHeartbeats,
   getWatcherList,
 } from "@/lib/api/watchers";
-import { watcherEventTypeEnum } from "@/lib/db/schema";
+import { toolRegistrationConfig } from "@/lib/mcp/catalog/register";
 import {
   errorResult,
   requireMcpScope,
   textResult,
 } from "@/lib/mcp/tools/helpers";
+import {
+  getWatcherHeartbeatsTool,
+  getWatcherTool,
+  listWatcherEventsTool,
+  listWatchersTool,
+} from "./watchers.defs";
 
 export function registerWatcherTools(server: McpServer) {
   server.registerTool(
-    "list_watchers",
-    {
-      title: "List Watchers",
-      description:
-        "List watcher agents with effective status, hostname, instrument assignment, and last heartbeat. Optionally include deregistered watchers or filter by effective status.",
-      inputSchema: {
-        instrumentId: z
-          .string()
-          .optional()
-          .describe("Filter watchers to a specific instrument"),
-        includeDeleted: z
-          .boolean()
-          .optional()
-          .describe(
-            "Include soft-deleted (deregistered) watchers (default: false)"
-          ),
-        status: z
-          .enum(["registered", "watching", "stopped", "stale"])
-          .optional()
-          .describe(
-            "Filter by effective status (stale is computed from heartbeat age)"
-          ),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    listWatchersTool.name,
+    toolRegistrationConfig(listWatchersTool),
     async ({ instrumentId, includeDeleted, status }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "watchers:read");
       if (scopeError) {
@@ -62,16 +44,8 @@ export function registerWatcherTools(server: McpServer) {
   );
 
   server.registerTool(
-    "get_watcher",
-    {
-      title: "Get Watcher",
-      description:
-        "Get watcher detail including config YAML, OS info, effective status, and deregistration actor when applicable.",
-      inputSchema: {
-        watcherId: z.string().describe("Watcher UUID"),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    getWatcherTool.name,
+    toolRegistrationConfig(getWatcherTool),
     async ({ watcherId }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "watchers:read");
       if (scopeError) {
@@ -86,40 +60,8 @@ export function registerWatcherTools(server: McpServer) {
   );
 
   server.registerTool(
-    "list_watcher_events",
-    {
-      title: "List Watcher Events",
-      description:
-        "Paginated watcher event log (uploads, errors, config sync, update lifecycle). Useful after get_watcher_heartbeats when diagnosing failures.",
-      inputSchema: {
-        watcherId: z.string().describe("Watcher UUID"),
-        hours: z
-          .number()
-          .int()
-          .min(1)
-          .max(168)
-          .optional()
-          .describe("Lookback window in hours (default: 24, max: 168)"),
-        eventTypes: z
-          .array(z.enum(watcherEventTypeEnum.enumValues))
-          .optional()
-          .describe("Filter to specific event types"),
-        page: z
-          .number()
-          .int()
-          .min(1)
-          .optional()
-          .describe("Page number (default: 1)"),
-        pageSize: z
-          .number()
-          .int()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe("Results per page (default: 50, max: 100)"),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    listWatcherEventsTool.name,
+    toolRegistrationConfig(listWatcherEventsTool),
     async ({ watcherId, hours, eventTypes, page, pageSize }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "watchers:read");
       if (scopeError) {
@@ -143,23 +85,8 @@ export function registerWatcherTools(server: McpServer) {
   );
 
   server.registerTool(
-    "get_watcher_heartbeats",
-    {
-      title: "Get Watcher Heartbeats",
-      description:
-        "Get recent heartbeat history for a watcher agent, useful for diagnosing connectivity gaps and error trends. Returns up to 100 most recent heartbeats within the lookback window.",
-      inputSchema: {
-        watcherId: z.string().describe("Watcher UUID"),
-        hours: z
-          .number()
-          .int()
-          .min(1)
-          .max(168)
-          .optional()
-          .describe("Lookback window in hours (default: 24, max: 168)"),
-      },
-      annotations: { readOnlyHint: true },
-    },
+    getWatcherHeartbeatsTool.name,
+    toolRegistrationConfig(getWatcherHeartbeatsTool),
     async ({ watcherId, hours }, { authInfo }) => {
       const scopeError = requireMcpScope(authInfo, "watchers:read");
       if (scopeError) {

--- a/web/package.json
+++ b/web/package.json
@@ -22,6 +22,7 @@
     "db:process-fixtures": "tsx scripts/process-seeded-fixtures.ts",
     "db:clear-runs": "tsx scripts/clear-run-file-records.ts",
     "openapi:generate": "tsx scripts/generate-openapi.ts",
+    "mcp-catalog:generate": "tsx scripts/generate-mcp-catalog.ts",
     "test:unit": "vitest run --config vitest.unit.config.ts",
     "test:unit:watch": "vitest --config vitest.unit.config.ts",
     "test:integration": "vitest run --config vitest.integration.config.ts",

--- a/web/scripts/generate-mcp-catalog.ts
+++ b/web/scripts/generate-mcp-catalog.ts
@@ -1,0 +1,9 @@
+// Optional local dump for inspection. Output is gitignored; production
+// serves the schema from GET /api/v1/mcp/schema.json (built statically).
+import { writeFile } from "node:fs/promises";
+import { buildMcpCatalogDocument } from "@/lib/mcp/catalog";
+
+await writeFile(
+  "mcp-catalog.json",
+  `${JSON.stringify(buildMcpCatalogDocument(), null, 2)}\n`
+);

--- a/web/tests/mcp/mcp-catalog.test.ts
+++ b/web/tests/mcp/mcp-catalog.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMcpCatalogDocument,
+  MCP_PROMPT_DEFS,
+  MCP_RESOURCE_DEFS,
+  MCP_TOOL_DEFS,
+} from "@/lib/mcp/catalog";
+
+describe("MCP catalog document", () => {
+  it("includes every catalog tool, prompt, and resource by name", () => {
+    const doc = buildMcpCatalogDocument();
+
+    expect(doc.tools.map((t) => t.name).sort()).toEqual(
+      [...MCP_TOOL_DEFS.map((t) => t.name)].sort()
+    );
+    expect(doc.prompts.map((p) => p.name).sort()).toEqual(
+      [...MCP_PROMPT_DEFS.map((p) => p.name)].sort()
+    );
+    expect(doc.resources.map((r) => r.name).sort()).toEqual(
+      [...MCP_RESOURCE_DEFS.map((r) => r.name)].sort()
+    );
+  });
+
+  it("emits JSON Schema objects for every tool and prompt", () => {
+    const doc = buildMcpCatalogDocument();
+    for (const tool of doc.tools) {
+      expect(tool.inputSchema).toMatchObject({ type: "object" });
+    }
+    for (const prompt of doc.prompts) {
+      expect(prompt.argsSchema).toMatchObject({ type: "object" });
+    }
+  });
+
+  it("documents static URIs and templates distinctly", () => {
+    const doc = buildMcpCatalogDocument();
+    const staticResources = doc.resources.filter((r) => r.uri);
+    const templates = doc.resources.filter((r) => r.uriTemplate);
+    expect(staticResources.length).toBeGreaterThan(0);
+    expect(templates.length).toBeGreaterThan(0);
+    for (const resource of doc.resources) {
+      expect(Boolean(resource.uri) !== Boolean(resource.uriTemplate)).toBe(
+        true
+      );
+    }
+  });
+});

--- a/web/tests/mcp/mcp-protocol.test.ts
+++ b/web/tests/mcp/mcp-protocol.test.ts
@@ -389,6 +389,12 @@ vi.mock("@/lib/s3", () => ({
 // Now import the registration functions (they'll pick up the mocked deps).
 // ---------------------------------------------------------------------------
 
+import {
+  buildMcpCatalogDocument,
+  MCP_PROMPT_DEFS,
+  MCP_RESOURCE_DEFS,
+  MCP_TOOL_DEFS,
+} from "@/lib/mcp/catalog";
 import { registerPrompts } from "@/lib/mcp/prompts";
 import { registerResources } from "@/lib/mcp/resources";
 import { registerTools } from "@/lib/mcp/tools";
@@ -479,6 +485,59 @@ describe("MCP Protocol (in-memory)", () => {
     const names = tools.map((t) => t.name);
     expect(names).toEqual(expect.arrayContaining([...EXPECTED_TOOLS]));
     expect(names).toHaveLength(EXPECTED_TOOLS.length);
+  });
+
+  it("registered tool names match the MCP catalog document", async () => {
+    const { tools } = await client.listTools();
+    const live = new Set(tools.map((t) => t.name));
+    const catalog = new Set(MCP_TOOL_DEFS.map((t) => t.name));
+    const document = new Set(
+      buildMcpCatalogDocument().tools.map((t) => t.name)
+    );
+    expect(live).toEqual(catalog);
+    expect(document).toEqual(catalog);
+  });
+
+  it("registered prompt names match the MCP catalog document", async () => {
+    const { prompts } = await client.listPrompts();
+    const live = new Set(prompts.map((p) => p.name));
+    const catalog = new Set(MCP_PROMPT_DEFS.map((p) => p.name));
+    const document = new Set(
+      buildMcpCatalogDocument().prompts.map((p) => p.name)
+    );
+    expect(live).toEqual(catalog);
+    expect(document).toEqual(catalog);
+  });
+
+  it("registered resource names match the MCP catalog document", async () => {
+    const { resources } = await client.listResources();
+    const { resourceTemplates } = await client.listResourceTemplates();
+    const document = buildMcpCatalogDocument();
+
+    const catalogStatic = MCP_RESOURCE_DEFS.filter((r) => r.kind === "static");
+    const catalogTemplates = MCP_RESOURCE_DEFS.filter(
+      (r) => r.kind === "template"
+    );
+
+    const liveStaticNames = new Set(
+      resources
+        .filter((r) => catalogStatic.some((c) => c.uri === r.uri))
+        .map((r) => r.name)
+    );
+    expect(liveStaticNames).toEqual(new Set(catalogStatic.map((r) => r.name)));
+    expect(
+      new Set(document.resources.filter((r) => r.uri).map((r) => r.name))
+    ).toEqual(new Set(catalogStatic.map((r) => r.name)));
+
+    const liveTemplateNames = new Set(resourceTemplates.map((r) => r.name));
+    expect(liveTemplateNames).toEqual(
+      new Set(catalogTemplates.map((r) => r.name))
+    );
+    expect(
+      new Set(
+        document.resources.filter((r) => r.uriTemplate).map((r) => r.name)
+      )
+    ).toEqual(new Set(catalogTemplates.map((r) => r.name)));
   });
 
   it("every tool has a non-empty description", async () => {

--- a/web/tests/mcp/mcp-protocol.test.ts
+++ b/web/tests/mcp/mcp-protocol.test.ts
@@ -432,38 +432,7 @@ describe("MCP Protocol (in-memory)", () => {
 
   // ---- Tool registration --------------------------------------------------
 
-  const EXPECTED_TOOLS = [
-    "list_instruments",
-    "get_instrument",
-    "search_runs",
-    "global_search",
-    "get_me",
-    "get_run",
-    "get_run_report",
-    "list_run_files",
-    "get_system_status",
-    "list_watchers",
-    "get_watcher",
-    "list_watcher_events",
-    "get_file",
-    "get_file_download_url",
-    "get_run_archive",
-    "reprocess_file",
-    "get_watcher_heartbeats",
-    "claim_run",
-    "unclaim_run",
-    "list_run_attributors",
-    "list_run_comments",
-    "add_run_comment",
-    "edit_run_comment",
-    "delete_run_comment",
-    "reprocess_run",
-    "delete_run",
-    "restore_run",
-    "request_run_upload",
-    "request_run_upload_all",
-    "dismiss_file",
-  ] as const;
+  const EXPECTED_TOOLS = MCP_TOOL_DEFS.map((t) => t.name);
 
   const WRITE_TOOLS = new Set([
     "reprocess_file",
@@ -1228,15 +1197,7 @@ describe("MCP Protocol (in-memory)", () => {
 
   // ---- Prompts -------------------------------------------------------------
 
-  const EXPECTED_PROMPTS = [
-    "daily_summary",
-    "troubleshoot_instrument",
-    "compare_runs",
-    "find_my_runs",
-    "explain_failed_run",
-    "claim_unattributed_runs",
-    "summarize_instrument_week",
-  ] as const;
+  const EXPECTED_PROMPTS = MCP_PROMPT_DEFS.map((p) => p.name);
 
   it("lists all expected prompts", async () => {
     const { prompts } = await client.listPrompts();


### PR DESCRIPTION
## Summary
- Colocates MCP tool/prompt/resource metadata in sibling `*.defs.ts` files next to their registrars, with a thin catalog aggregator.
- Serves a public, force-static `GET /api/v1/mcp/schema.json` (mirroring OpenAPI) so data-hub-docs can render tool/prompt/resource catalogs without drift.
- Adds drift tests that assert live `tools/list` / prompts / resources match the catalog document, plus `npm run mcp-catalog:generate` for local dumps.

## Test plan

- [x] `make check-all`
- [x] `cd web && npm run test:unit -- tests/mcp/`
- [x] `cd web && npm run mcp-catalog:generate` and inspect `mcp-catalog.json`
- [x] Hit `/api/v1/mcp/schema.json` locally (`make dev`) and confirm tools/prompts/resources are present
- [x] Confirm MCP clients still connect and tools/list matches the catalog names

Made with [Cursor](https://cursor.com)