### PR TITLE
Fix path traversal in watcher upload queue

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -416,7 +416,7 @@ requires-dist = [
 
 [[package]]
 name = "data-hub-watcher"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "watcher" }
 dependencies = [
     { name = "click" },

--- a/watcher/pyproject.toml
+++ b/watcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-hub-watcher"
-version = "0.5.1"
+version = "0.5.2"
 description = "File-watcher agent for lab instrument PCs that ingests data into Data Hub."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/watcher/src/data_hub_watcher/uploader.py
+++ b/watcher/src/data_hub_watcher/uploader.py
@@ -54,6 +54,24 @@ def _guess_content_type(path: Path) -> str | None:
     return content_type
 
 
+def _resolve_within(watch_dir: Path, relative: str) -> Path | None:
+    """Resolve *relative* under *watch_dir*, or ``None`` if it escapes.
+
+    Defense-in-depth against path traversal in server-supplied queue paths:
+    the server validates ``relative_path`` too, but the watcher must never
+    read outside its watch directory even if a malicious or buggy
+    server sends ``../`` or an absolute path. Containment is checked on the
+    *resolved* paths, not the raw string, because ``..`` segments (and an
+    absolute ``relative`` that discards ``watch_dir`` entirely) only collapse
+    after resolution.
+    """
+    base = watch_dir.resolve()
+    candidate = (base / relative).resolve()
+    if candidate == base or base in candidate.parents:
+        return candidate
+    return None
+
+
 def _relative_path(path: Path, watch_dir: Path) -> str:
     """Return *path* as a forward-slash relative to *watch_dir*.
 
@@ -317,7 +335,31 @@ class Uploader:
             self._cancel_queued_file(qf, attempt.reason if attempt else "unknown")
             return
 
-        local_path = self._watch_dir / (qf.relative_path or qf.filename)
+        raw_relative = qf.relative_path or qf.filename
+        local_path = _resolve_within(self._watch_dir, raw_relative)
+        if local_path is None:
+            # Path escapes the watch directory (traversal or absolute).
+            # Cancel rather than retry -- a re-poll resolves identically.
+            logger.error(
+                "Rejected queued file with unsafe path: %r (file_id=%s)",
+                raw_relative,
+                qf.id,
+            )
+            self._reporter.queue_event(
+                WatcherEvent(
+                    event_type=EventType.ERROR,
+                    message=f"Rejected unsafe upload path: {qf.filename}",
+                    details={
+                        "kind": "unsafe_upload_path",
+                        "file_id": qf.id,
+                        "relative_path": raw_relative,
+                    },
+                )
+            )
+            self._bump_errors()
+            self._cancel_queued_file(qf, "unsafe_path")
+            return
+
         if local_path.exists():
             ok = self._upload_single(local_path, qf.run_id)
             reason = "upload_failed"

--- a/watcher/tests/test_uploader.py
+++ b/watcher/tests/test_uploader.py
@@ -747,7 +747,7 @@ class TestPollUploadQueueAttemptCap:
 class TestUploadQueuePathTraversal:
     """A queued file whose path escapes the watch directory is refused.
 
-    Defense-in-depth for ENG-1452: even if a malicious or buggy server sends
+    Defense-in-depth: even if a malicious or buggy server sends
     a ``relative_path`` with ``..`` segments or an absolute path, the watcher
     must never read (and upload) a file from outside its watch directory. The
     request is cancelled immediately rather than retried, since a re-poll

--- a/watcher/tests/test_uploader.py
+++ b/watcher/tests/test_uploader.py
@@ -744,6 +744,90 @@ class TestPollUploadQueueAttemptCap:
         assert mock_client.cancel_upload_request.call_count == 2
 
 
+class TestUploadQueuePathTraversal:
+    """A queued file whose path escapes the watch directory is refused.
+
+    Defense-in-depth for ENG-1452: even if a malicious or buggy server sends
+    a ``relative_path`` with ``..`` segments or an absolute path, the watcher
+    must never read (and upload) a file from outside its watch directory. The
+    request is cancelled immediately rather than retried, since a re-poll
+    would resolve to the same unsafe path.
+    """
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            "../../etc/passwd",
+            "../outside.txt",
+            "sub/../../escape.txt",
+            "/etc/passwd",
+        ],
+    )
+    def test_unsafe_path_is_refused_and_cancelled(
+        self,
+        uploader: Uploader,
+        mock_client: MagicMock,
+        tmp_path: Path,
+        relative_path: str,
+    ) -> None:
+        # Create the would-be target outside the watch dir to prove that even
+        # an existing file is never read when the path escapes containment.
+        outside = tmp_path.parent / "escape.txt"
+        outside.write_text("secret")
+
+        mock_client.get_upload_queue.return_value = UploadQueueResponse(
+            files=[
+                UploadQueueFile(
+                    id=99,
+                    instrument_id="test-instrument",
+                    run_id="RUN-EVIL",
+                    filename="passwd",
+                    relative_path=relative_path,
+                )
+            ]
+        )
+
+        with patch.object(uploader, "_upload_single") as mock_upload:
+            uploader.poll_upload_queue()
+
+        # Never read/uploaded, and the request is cancelled on the first poll.
+        mock_upload.assert_not_called()
+        mock_client.cancel_upload_request.assert_called_once_with(99)
+        assert uploader._counters.errors == 1
+
+        reporter_mock = cast(MagicMock, uploader._reporter)
+        event = reporter_mock.queue_event.call_args.args[0]
+        assert event.details["kind"] == "unsafe_upload_path"
+
+    def test_safe_nested_relative_path_is_allowed(
+        self,
+        uploader: Uploader,
+        mock_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        nested = tmp_path / "sub" / "dir"
+        nested.mkdir(parents=True)
+        (nested / "data.csv").write_text("x")
+
+        mock_client.get_upload_queue.return_value = UploadQueueResponse(
+            files=[
+                UploadQueueFile(
+                    id=7,
+                    instrument_id="test-instrument",
+                    run_id="RUN-OK",
+                    filename="data.csv",
+                    relative_path="sub/dir/data.csv",
+                )
+            ]
+        )
+
+        with patch.object(uploader, "_upload_single", return_value=True) as mock_upload:
+            uploader.poll_upload_queue()
+
+        mock_upload.assert_called_once()
+        mock_client.cancel_upload_request.assert_not_called()
+
+
 class TestUploaderStopEvent:
     """A shutdown must interrupt uploads without recording a spurious failure."""
 

--- a/web/components/pagination-nav.tsx
+++ b/web/components/pagination-nav.tsx
@@ -62,7 +62,7 @@ export function PaginationNav({
     pageParam,
     parseAsInteger
       .withDefault(1)
-      .withOptions({ shallow: false, startTransition })
+      .withOptions({ shallow: false, history: "push", startTransition })
   );
 
   if (totalPages <= 1) {

--- a/web/lib/api/openapi/schemas/runs.ts
+++ b/web/lib/api/openapi/schemas/runs.ts
@@ -11,7 +11,7 @@ import {
 // Rejects path traversal in watcher-reported file locations. The watcher
 // joins these onto its watch directory and reads the result, so an
 // unchecked `..` segment or absolute path lets a malicious run exfiltrate
-// arbitrary files from the instrument PC (ENG-1452). Watchers run on
+// arbitrary files from the instrument PC. Watchers run on
 // Windows too, hence we also reject `\` and drive paths, not just `/`.
 function isSafeRelativePath(value: string): boolean {
   if (value.includes("\0")) {
@@ -214,7 +214,10 @@ export const requestUploadBody = z.object({
   file_ids: z.array(z.union([z.string(), z.number()])).min(1),
 });
 export const requestUploadUrlBody = z.object({
-  filename: z.string().min(1),
+  // Persisted as `relative_path` and joined into the S3 key, so it flows to
+  // the watcher's upload queue just like `detected_files`; guard it with the
+  // same path-traversal check.
+  filename: safeRelativePath,
   content_type: z.string().optional(),
   size_bytes: z.number().optional(),
   file_created_at: isoDateTime.optional(),

--- a/web/lib/api/openapi/schemas/runs.ts
+++ b/web/lib/api/openapi/schemas/runs.ts
@@ -8,9 +8,32 @@ import {
   runStatusSchema,
 } from "./common";
 
+// Rejects path traversal in watcher-reported file locations. The watcher
+// joins these onto its watch directory and reads the result, so an
+// unchecked `..` segment or absolute path lets a malicious run exfiltrate
+// arbitrary files from the instrument PC (ENG-1452). Watchers run on
+// Windows too, hence we also reject `\` and drive paths, not just `/`.
+function isSafeRelativePath(value: string): boolean {
+  if (value.includes("\0")) {
+    return false;
+  }
+  // Absolute: POSIX `/foo`, Windows UNC/drive-relative `\foo`, or drive
+  // paths like `C:\foo`/`C:foo`.
+  if (/^([/\\]|[a-zA-Z]:)/.test(value)) {
+    return false;
+  }
+  // Any `..` segment (either separator) can escape the watch directory.
+  return !value.split(/[/\\]/).includes("..");
+}
+
+const safeRelativePath = z.string().min(1).refine(isSafeRelativePath, {
+  message:
+    "must be a relative path without '..' segments, absolute prefixes, or null bytes",
+});
+
 export const detectedFileSchema = z.object({
-  relative_path: z.string().min(1),
-  filename: z.string().min(1),
+  relative_path: safeRelativePath,
+  filename: safeRelativePath,
   size_bytes: z.number().int().nonnegative().optional(),
   file_created_at: isoDateTime.optional(),
 });

--- a/web/tests/integration/instrument-runs.test.ts
+++ b/web/tests/integration/instrument-runs.test.ts
@@ -135,7 +135,7 @@ describe("Instrument Runs API", () => {
     expect(detailData.files.length).toBe(2);
   });
 
-  // Path traversal guard (ENG-1452): the watcher joins `relative_path` onto
+  // Path traversal guard: the watcher joins `relative_path` onto
   // its watch directory and reads the result, so a `..`/absolute path would
   // let an attacker exfiltrate arbitrary files from the instrument PC. The
   // API must reject such payloads before they ever reach the files table.

--- a/web/tests/integration/instrument-runs.test.ts
+++ b/web/tests/integration/instrument-runs.test.ts
@@ -135,6 +135,45 @@ describe("Instrument Runs API", () => {
     expect(detailData.files.length).toBe(2);
   });
 
+  // Path traversal guard (ENG-1452): the watcher joins `relative_path` onto
+  // its watch directory and reads the result, so a `..`/absolute path would
+  // let an attacker exfiltrate arbitrary files from the instrument PC. The
+  // API must reject such payloads before they ever reach the files table.
+  it.each([
+    "../../etc/passwd",
+    "../escape.csv",
+    "sub/../../escape.csv",
+    "/etc/passwd",
+    "C:\\Windows\\system32\\config\\SAM",
+    "..\\..\\secret.csv",
+  ])("POST rejects detected_files with unsafe relative_path %s", async (bad) => {
+    const res = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: {
+        run_id: `traversal-${encodeURIComponent(bad)}`,
+        source: "watcher",
+        detected_files: [{ relative_path: bad, filename: "passwd" }],
+      },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST rejects detected_files with unsafe filename", async () => {
+    const res = await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: {
+        run_id: "traversal-filename",
+        source: "watcher",
+        detected_files: [
+          { relative_path: "safe.csv", filename: "../../etc/passwd" },
+        ],
+      },
+    });
+    expect(res.status).toBe(400);
+  });
+
   // -------------------------------------------------------------------------
   // GET /api/v1/instruments/:instrumentId/runs
   // -------------------------------------------------------------------------

--- a/web/tests/integration/request-upload-url.test.ts
+++ b/web/tests/integration/request-upload-url.test.ts
@@ -158,6 +158,28 @@ describe("Request Upload URL API", () => {
     expect(res.status).toBe(400);
   });
 
+  // Path traversal guard: the filename is persisted as
+  // `relative_path` and joined into the S3 key, so a `..`/absolute value must
+  // be rejected before it can reach the watcher's upload queue.
+  it.each([
+    "../../etc/passwd",
+    "../escape.csv",
+    "sub/../../escape.csv",
+    "/etc/passwd",
+    "C:\\Windows\\system32\\config\\SAM",
+    "..\\..\\secret.csv",
+  ])("rejects unsafe filename %s", async (bad) => {
+    const res = await api(
+      `/api/v1/instruments/${instrumentId}/runs/${runId}/request-upload-url`,
+      {
+        method: "POST",
+        token,
+        body: { filename: bad },
+      }
+    );
+    expect(res.status).toBe(400);
+  });
+
   it("returns 404 for nonexistent instrument/run", async () => {
     const res = await api(
       `/api/v1/instruments/${instrumentId}/runs/nonexistent-run/request-upload-url`,


### PR DESCRIPTION
## Summary

- **Security fix:** a malicious run could set `detected_files[].relative_path` (or `filename`) to a `..`/absolute path; the watcher joined it onto its watch directory and uploaded the resolved file, allowing arbitrary file read/exfiltration from the instrument PC.
- **Server-side:** `detectedFileSchema` now rejects `..` segments, absolute prefixes, and null bytes in `relative_path`/`filename`, across both POSIX (`/`) and Windows (`\`, `C:\`) separators.
- **Watcher (defense-in-depth):** `_process_queued_file` resolves each queued path and refuses/cancels anything that escapes the watch directory, so it never reads outside it even from a malicious/buggy server.
- **Driveby:** pagination nav now uses nuqs `history: "push"` so paging is reflected in browser history and the back button works.

## Test plan

- [x] `make check-all` (format, lint, typecheck — Python + web)
- [x] New watcher unit tests: `TestUploadQueuePathTraversal` (escaping paths refused/cancelled and never read; safe nested paths still upload)
- [x] New API integration tests: rejection of traversal/absolute/Windows `relative_path` and unsafe `filename`
- [x] Manual: verify pagination back/forward navigation

Made with [Cursor](https://cursor.com)