### PR TITLE
Bind watchers to their registering PAT

### DIFF
--- a/developer-docs/watcher.md
+++ b/developer-docs/watcher.md
@@ -132,6 +132,17 @@ Checks the API for a newer published version and runs the appropriate `uv tool i
 
 The config file lives at `~/.data-hub/config.yaml` by default. Override with `--config` or the `DATA_HUB_CONFIG_PATH` environment variable. The API key is stored separately in `~/.data-hub/.env.<environment>` (e.g. `.env.staging`, `.env.production`, or `.env.preview`); the legacy `~/.data-hub/.env` is also loaded for backwards compatibility, with the per-environment file taking precedence.
 
+### API key binding and rotation
+
+Each watcher is bound to the personal access token (PAT) that registered it. Heartbeats, config sync, events, upload-queue polls, and update-checks from a different PAT receive `403 Forbidden`. Prefer **one PAT per instrument PC** so a compromised key on one machine cannot control other watchers.
+
+When you rotate a PC's PAT:
+
+1. **Recommended for a straight rotation:** delete the old PAT in the Data Hub UI (Settings → Tokens). That nulls `watchers.registered_by_token`; the next check-in with the new key re-claims the binding (trust-on-first-use). Update `~/.data-hub/.env.<environment>` with the new key before the watcher checks in again.
+2. **Clean reinstall:** deregister the watcher in the UI (Watchers → open the watcher → Deregister), then re-run `data-hub-watcher init` on the PC with the new PAT. That registers a fresh watcher row bound to the new credential.
+
+There is no token-adoptable API for rebinding an already-claimed watcher — any such endpoint gated by `watchers:report` would reopen cross-watcher control.
+
 ### Config file format
 
 ```yaml

--- a/web/app/api/v1/watchers/[watcherId]/config-checksum/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/config-checksum/route.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from "next/server";
 import { authorize } from "@/lib/api/auth";
 import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { isValidUUID } from "@/lib/api/validators";
-import { findActiveWatcher } from "@/lib/api/watchers";
+import { enforceWatcherBinding, findActiveWatcher } from "@/lib/api/watchers";
 
 export async function GET(
   request: NextRequest,
@@ -21,6 +21,11 @@ export async function GET(
   const watcher = await findActiveWatcher(watcherId);
   if (!watcher) {
     return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  const bindingError = await enforceWatcherBinding(authResult, watcher);
+  if (bindingError) {
+    return bindingError;
   }
 
   if (!watcher.configChecksum) {

--- a/web/app/api/v1/watchers/[watcherId]/config/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/config/route.ts
@@ -5,6 +5,7 @@ import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { readJsonBody, watcherConfigBody } from "@/lib/api/openapi";
 import { isValidUUID } from "@/lib/api/validators";
 import {
+  enforceWatcherBinding,
   extractWatchDirectory,
   findActiveWatcher,
   revertPendingUploadRequests,
@@ -29,6 +30,11 @@ export async function PUT(
   const watcher = await findActiveWatcher(watcherId);
   if (!watcher) {
     return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  const bindingError = await enforceWatcherBinding(authResult, watcher);
+  if (bindingError) {
+    return bindingError;
   }
 
   const body = await readJsonBody(request, watcherConfigBody);

--- a/web/app/api/v1/watchers/[watcherId]/events/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/events/route.ts
@@ -8,7 +8,7 @@ import {
   parseDateParam,
   parseIntParam,
 } from "@/lib/api/validators";
-import { findActiveWatcher } from "@/lib/api/watchers";
+import { enforceWatcherBinding, findActiveWatcher } from "@/lib/api/watchers";
 import { db } from "@/lib/db";
 import { watcherEvents, watcherEventTypeEnum } from "@/lib/db/schema";
 
@@ -35,6 +35,11 @@ export async function POST(
   const watcher = await findActiveWatcher(watcherId);
   if (!watcher) {
     return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  const bindingError = await enforceWatcherBinding(authResult, watcher);
+  if (bindingError) {
+    return bindingError;
   }
 
   const body = await readJsonBody(request, watcherEventBody);

--- a/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
@@ -11,6 +11,7 @@ import { heartbeatBody, readJsonBody } from "@/lib/api/openapi";
 import { isValidUUID } from "@/lib/api/validators";
 import { isBelowFloor } from "@/lib/api/watcher-versions";
 import {
+  enforceWatcherBinding,
   findActiveWatcher,
   revertUploadQueueIfWatcherOffline,
 } from "@/lib/api/watchers";
@@ -38,6 +39,11 @@ export async function POST(
   const watcher = await findActiveWatcher(watcherId);
   if (!watcher) {
     return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  const bindingError = await enforceWatcherBinding(authResult, watcher);
+  if (bindingError) {
+    return bindingError;
   }
 
   const body = await readJsonBody(request, heartbeatBody);

--- a/web/app/api/v1/watchers/[watcherId]/update-check/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/update-check/route.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from "next/server";
 import { authorize } from "@/lib/api/auth";
 import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { isValidUUID } from "@/lib/api/validators";
-import { findActiveWatcher } from "@/lib/api/watchers";
+import { enforceWatcherBinding, findActiveWatcher } from "@/lib/api/watchers";
 import { db } from "@/lib/db";
 import { watcherReleaseConfig } from "@/lib/db/schema";
 
@@ -67,6 +67,11 @@ export async function GET(
   const watcher = await findActiveWatcher(watcherId);
   if (!watcher) {
     return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  const bindingError = await enforceWatcherBinding(authResult, watcher);
+  if (bindingError) {
+    return bindingError;
   }
 
   return Response.json(await readReleaseInfo());

--- a/web/app/api/v1/watchers/[watcherId]/upload-queue/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/upload-queue/route.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from "next/server";
 import { authorize } from "@/lib/api/auth";
 import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { isValidUUID } from "@/lib/api/validators";
-import { findActiveWatcher } from "@/lib/api/watchers";
+import { enforceWatcherBinding, findActiveWatcher } from "@/lib/api/watchers";
 import { db } from "@/lib/db";
 import { files, instrumentRuns } from "@/lib/db/schema";
 
@@ -24,6 +24,11 @@ export async function GET(
   const watcher = await findActiveWatcher(watcherId);
   if (!watcher) {
     return apiError(404, NOT_FOUND, `Watcher '${watcherId}' not found`);
+  }
+
+  const bindingError = await enforceWatcherBinding(authResult, watcher);
+  if (bindingError) {
+    return bindingError;
   }
 
   // A file is "pending upload" when a user requested it via the web UI

--- a/web/app/api/v1/watchers/register/route.ts
+++ b/web/app/api/v1/watchers/register/route.ts
@@ -72,6 +72,9 @@ export async function POST(request: NextRequest) {
       hostname: body.hostname ?? null,
       osInfo: body.os_info ?? null,
       status: "registered",
+      // Bind this watcher to the registering PAT so later ops can't be
+      // driven by a different watchers:report token (cross-control IDOR).
+      registeredByToken: authResult.tokenId,
     })
     .returning({ id: watchers.id });
 

--- a/web/drizzle/0031_add_watcher_registered_by_token.sql
+++ b/web/drizzle/0031_add_watcher_registered_by_token.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "watchers" ADD COLUMN "registered_by_token" uuid;--> statement-breakpoint
+ALTER TABLE "watchers" ADD CONSTRAINT "watchers_registered_by_token_personal_access_tokens_id_fk" FOREIGN KEY ("registered_by_token") REFERENCES "public"."personal_access_tokens"("id") ON DELETE set null ON UPDATE no action;

--- a/web/drizzle/meta/0031_snapshot.json
+++ b/web/drizzle/meta/0031_snapshot.json
@@ -1,0 +1,2240 @@
+{
+  "id": "93851944-2c53-41db-8585-b31f2d7578bc",
+  "prevId": "e00a4a46-d808-4a76-a6a3-46c9a8ab0def",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": ["provider", "providerAccountId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archive_jobs": {
+      "name": "archive_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archive_bucket": {
+          "name": "archive_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_key": {
+          "name": "archive_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "archive_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_archive_jobs_inflight": {
+          "name": "uq_archive_jobs_inflight",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"archive_jobs\".\"status\" in ('pending', 'building')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_archive_jobs_run_fingerprint_status": {
+          "name": "idx_archive_jobs_run_fingerprint_status",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "archive_jobs_instrument_run_id_instrument_runs_id_fk": {
+          "name": "archive_jobs_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["instrument_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "archive_jobs_created_by_user_id_fk": {
+          "name": "archive_jobs_created_by_user_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "file_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raw'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_requested_at": {
+          "name": "upload_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_files_instrument_run_id_relative_path": {
+          "name": "uq_files_instrument_run_id_relative_path",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"relative_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_active_instrument_run_id_filename": {
+          "name": "uq_files_active_instrument_run_id_filename",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_s3_key": {
+          "name": "uq_files_s3_key",
+          "columns": [
+            {
+              "expression": "s3_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"s3_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_instrument_run_id": {
+          "name": "idx_files_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_status_instrument_run_id": {
+          "name": "idx_files_status_instrument_run_id",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_upload_queue": {
+          "name": "idx_files_upload_queue",
+          "columns": [
+            {
+              "expression": "upload_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"upload_requested_at\" is not null and \"files\".\"uploaded_at\" is null and \"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_metadata_gin": {
+          "name": "idx_files_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_files_filename_trgm": {
+          "name": "idx_files_filename_trgm",
+          "columns": [
+            {
+              "expression": "\"filename\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_instrument_run_id_instrument_runs_id_fk": {
+          "name": "files_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["instrument_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_notification_subscriptions": {
+      "name": "instrument_notification_subscriptions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_instrument_notification_subscriptions_user_id": {
+          "name": "idx_instrument_notification_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_notification_subscriptions_user_id_user_id_fk": {
+          "name": "instrument_notification_subscriptions_user_id_user_id_fk",
+          "tableFrom": "instrument_notification_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "instrument_notification_subscriptions_instrument_id_instruments_id_fk": {
+          "name": "instrument_notification_subscriptions_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_notification_subscriptions",
+          "tableTo": "instruments",
+          "columnsFrom": ["instrument_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "instrument_notification_subscriptions_user_id_instrument_id_pk": {
+          "name": "instrument_notification_subscriptions_user_id_instrument_id_pk",
+          "columns": ["user_id", "instrument_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_runs": {
+      "name": "instrument_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "instrument_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lambda'"
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instrument_runs_instrument_id_created_at": {
+          "name": "idx_instrument_runs_instrument_id_created_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active": {
+          "name": "idx_instrument_runs_active",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active_acquired_at": {
+          "name": "idx_instrument_runs_active_acquired_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"acquired_at\", \"created_at\") desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_metadata_gin": {
+          "name": "idx_instrument_runs_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_instrument_runs_run_id_trgm": {
+          "name": "idx_instrument_runs_run_id_trgm",
+          "columns": [
+            {
+              "expression": "\"run_id\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_runs_instrument_id_instruments_id_fk": {
+          "name": "instrument_runs_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "instruments",
+          "columnsFrom": ["instrument_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_watcher_id_watchers_id_fk": {
+          "name": "instrument_runs_watcher_id_watchers_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "watchers",
+          "columnsFrom": ["watcher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_deleted_by_user_id_fk": {
+          "name": "instrument_runs_deleted_by_user_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "user",
+          "columnsFrom": ["deleted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_instrument_runs_instrument_id_run_id": {
+          "name": "uq_instrument_runs_instrument_id_run_id",
+          "nullsNotDistinct": false,
+          "columns": ["instrument_id", "run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instruments": {
+      "name": "instruments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instrument_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instrument_type": {
+          "name": "instrument_type",
+          "type": "instrument_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_by": {
+          "name": "retired_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instruments_display_name_trgm": {
+          "name": "idx_instruments_display_name_trgm",
+          "columns": [
+            {
+              "expression": "\"display_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instruments_retired_by_user_id_fk": {
+          "name": "instruments_retired_by_user_id_fk",
+          "tableFrom": "instruments",
+          "tableTo": "user",
+          "columnsFrom": ["retired_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runs_all_muted": {
+          "name": "runs_all_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "comments_attributed_enabled": {
+          "name": "comments_attributed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "comments_participated_enabled": {
+          "name": "comments_participated_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "slack_runs_enabled": {
+          "name": "slack_runs_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slack_comments_attributed_enabled": {
+          "name": "slack_comments_attributed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slack_comments_participated_enabled": {
+          "name": "slack_comments_participated_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_user_id_fk": {
+          "name": "notification_preferences_user_id_user_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id_created_at": {
+          "name": "idx_notifications_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_id_unread": {
+          "name": "idx_notifications_user_id_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_run_id_instrument_runs_id_fk": {
+          "name": "notifications_run_id_instrument_runs_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_comment_id_run_comments_id_fk": {
+          "name": "notifications_comment_id_run_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "run_comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_user_id_user_id_fk": {
+          "name": "notifications_actor_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['*']::text[]"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_personal_access_tokens_user_id": {
+          "name": "idx_personal_access_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_user_id_fk": {
+          "name": "personal_access_tokens_user_id_user_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_attributions": {
+      "name": "run_attributions",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_attributions_run_id": {
+          "name": "idx_run_attributions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_attributions_user_id": {
+          "name": "idx_run_attributions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_attributions_run_id_instrument_runs_id_fk": {
+          "name": "run_attributions_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_attributions_user_id_user_id_fk": {
+          "name": "run_attributions_user_id_user_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_attributions_run_id_user_id_pk": {
+          "name": "run_attributions_run_id_user_id_pk",
+          "columns": ["run_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_comments": {
+      "name": "run_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_run_comments_run_id_created_at": {
+          "name": "idx_run_comments_run_id_created_at",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_comments_user_id": {
+          "name": "idx_run_comments_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_comments_run_id_instrument_runs_id_fk": {
+          "name": "run_comments_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_comments_user_id_user_id_fk": {
+          "name": "run_comments_user_id_user_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_channel_config": {
+      "name": "slack_channel_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_channel_config_updated_by_user_id_fk": {
+          "name": "slack_channel_config_updated_by_user_id_fk",
+          "tableFrom": "slack_channel_config",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "slack_channel_config_singleton": {
+          "name": "slack_channel_config_singleton",
+          "value": "\"slack_channel_config\".\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_connections": {
+      "name": "slack_connections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_name": {
+          "name": "slack_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_connections_user_id_user_id_fk": {
+          "name": "slack_connections_user_id_user_id_fk",
+          "tableFrom": "slack_connections",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_events": {
+      "name": "watcher_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "watcher_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_events_watcher_id_timestamp": {
+          "name": "idx_watcher_events_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_watcher_events_watcher_id_event_type": {
+          "name": "idx_watcher_events_watcher_id_event_type",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_events_watcher_id_watchers_id_fk": {
+          "name": "watcher_events_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_events",
+          "tableTo": "watchers",
+          "columnsFrom": ["watcher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_heartbeats": {
+      "name": "watcher_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_mode": {
+          "name": "upload_mode",
+          "type": "upload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_uploaded_since_last": {
+          "name": "files_uploaded_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "runs_reported_since_last": {
+          "name": "runs_reported_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_since_last": {
+          "name": "errors_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_heartbeats_watcher_id_timestamp": {
+          "name": "idx_watcher_heartbeats_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_heartbeats_watcher_id_watchers_id_fk": {
+          "name": "watcher_heartbeats_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_heartbeats",
+          "tableTo": "watchers",
+          "columnsFrom": ["watcher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_release_config": {
+      "name": "watcher_release_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_supported_version": {
+          "name": "min_supported_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stable'"
+        },
+        "mandatory": {
+          "name": "mandatory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watcher_release_config_updated_by_user_id_fk": {
+          "name": "watcher_release_config_updated_by_user_id_fk",
+          "tableFrom": "watcher_release_config",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "watcher_release_config_singleton": {
+          "name": "watcher_release_config_singleton",
+          "value": "\"watcher_release_config\".\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.watchers": {
+      "name": "watchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_info": {
+          "name": "os_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watcher_version": {
+          "name": "watcher_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_checksum": {
+          "name": "config_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_yaml": {
+          "name": "config_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "watcher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deregistered_by": {
+          "name": "deregistered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_by_token": {
+          "name": "registered_by_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_watchers_active_instrument_id": {
+          "name": "uq_watchers_active_instrument_id",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"watchers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchers_instrument_id_instruments_id_fk": {
+          "name": "watchers_instrument_id_instruments_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "instruments",
+          "columnsFrom": ["instrument_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "watchers_deregistered_by_user_id_fk": {
+          "name": "watchers_deregistered_by_user_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "user",
+          "columnsFrom": ["deregistered_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "watchers_registered_by_token_personal_access_tokens_id_fk": {
+          "name": "watchers_registered_by_token_personal_access_tokens_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "personal_access_tokens",
+          "columnsFrom": ["registered_by_token"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.archive_job_status": {
+      "name": "archive_job_status",
+      "schema": "public",
+      "values": ["pending", "building", "ready", "failed"]
+    },
+    "public.file_category": {
+      "name": "file_category",
+      "schema": "public",
+      "values": ["raw", "processed"]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "detected",
+        "upload_requested",
+        "uploaded",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.instrument_run_source": {
+      "name": "instrument_run_source",
+      "schema": "public",
+      "values": ["lambda", "watcher"]
+    },
+    "public.instrument_status": {
+      "name": "instrument_status",
+      "schema": "public",
+      "values": ["pending", "active", "inactive"]
+    },
+    "public.instrument_type": {
+      "name": "instrument_type",
+      "schema": "public",
+      "values": [
+        "generic",
+        "plate_reader",
+        "gel_doc",
+        "qpcr",
+        "tape_station",
+        "hina_microscope",
+        "epson_v700_scanner",
+        "instant_raman"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": ["run_created", "comment_attributed", "comment_participated"]
+    },
+    "public.upload_mode": {
+      "name": "upload_mode",
+      "schema": "public",
+      "values": ["auto", "manual"]
+    },
+    "public.watcher_event_type": {
+      "name": "watcher_event_type",
+      "schema": "public",
+      "values": [
+        "watcher_started",
+        "watcher_stopped",
+        "file_uploaded",
+        "upload_failed",
+        "run_reported",
+        "config_synced",
+        "error",
+        "update_started",
+        "update_succeeded",
+        "update_failed"
+      ]
+    },
+    "public.watcher_status": {
+      "name": "watcher_status",
+      "schema": "public",
+      "values": ["registered", "watching", "stopped"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1783557726363,
       "tag": "0030_mature_manta",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1784234686620,
+      "tag": "0031_add_watcher_registered_by_token",
+      "breakpoints": true
     }
   ]
 }

--- a/web/lib/api/auth.ts
+++ b/web/lib/api/auth.ts
@@ -15,6 +15,9 @@ export interface AuthResult {
   // (NextAuth) authentication is treated as fully privileged and always
   // returns `["*"]`, so `hasScope` is a no-op for browser sessions.
   scopes: string[];
+  // PAT row id for token auth; null for sessions. Used to bind watchers to
+  // the credential that registered them (see `enforceWatcherBinding`).
+  tokenId: string | null;
   userId: string;
 }
 
@@ -66,7 +69,12 @@ async function validatePat(
       .where(eq(personalAccessTokens.id, pat.id));
   });
 
-  return { userId: pat.userId, authMethod: "token", scopes: pat.scopes };
+  return {
+    userId: pat.userId,
+    authMethod: "token",
+    scopes: pat.scopes,
+    tokenId: pat.id,
+  };
 }
 
 /**
@@ -83,7 +91,12 @@ export async function authenticateRequest(
 ): Promise<AuthResult | null> {
   const session = await auth();
   if (session?.user?.id) {
-    return { userId: session.user.id, authMethod: "session", scopes: ["*"] };
+    return {
+      userId: session.user.id,
+      authMethod: "session",
+      scopes: ["*"],
+      tokenId: null,
+    };
   }
 
   return validatePat(request.headers.get("authorization"));
@@ -103,7 +116,12 @@ export async function authenticateWithToken(
 export async function requireSession(): Promise<AuthResult | null> {
   const session = await auth();
   if (session?.user?.id) {
-    return { userId: session.user.id, authMethod: "session", scopes: ["*"] };
+    return {
+      userId: session.user.id,
+      authMethod: "session",
+      scopes: ["*"],
+      tokenId: null,
+    };
   }
   return null;
 }

--- a/web/lib/api/watchers.ts
+++ b/web/lib/api/watchers.ts
@@ -2,6 +2,8 @@ import { and, asc, count, desc, eq, gte, inArray, isNull } from "drizzle-orm";
 import { cache } from "react";
 import YAML from "yaml";
 import { type ActorUser, resolveActorUser } from "@/lib/api/actor";
+import type { AuthResult } from "@/lib/api/auth";
+import { apiError, FORBIDDEN } from "@/lib/api/errors";
 import { instrumentHasOnlineWatcher } from "@/lib/api/instruments";
 import { type DbExecutor, db } from "@/lib/db";
 import {
@@ -25,6 +27,79 @@ export async function findActiveWatcher(watcherId: string) {
     .limit(1);
 
   return watcher ?? null;
+}
+
+export type WatcherBindingVerdict = "allow" | "deny" | "tofu";
+
+/**
+ * Pure binding decision used by {@link enforceWatcherBinding}. Extracted so
+ * session/match/mismatch can be unit-tested without a DB (the integration
+ * harness has no session cookies).
+ */
+export function decideWatcherBinding(
+  authResult: AuthResult,
+  registeredByToken: string | null
+): WatcherBindingVerdict {
+  if (authResult.authMethod === "session") {
+    return "allow";
+  }
+  if (!authResult.tokenId) {
+    return "deny";
+  }
+  if (registeredByToken === null) {
+    return "tofu";
+  }
+  return registeredByToken === authResult.tokenId ? "allow" : "deny";
+}
+
+/**
+ * Returns null when the caller may act on this watcher, or a Response the
+ * handler should return. Sessions are fully privileged (browser admins).
+ * Token callers must match the watcher's registered PAT. A null binding is
+ * claimed trust-on-first-use (atomic), then enforced thereafter.
+ */
+export async function enforceWatcherBinding(
+  authResult: AuthResult,
+  watcher: { id: string; registeredByToken: string | null }
+): Promise<Response | null> {
+  const verdict = decideWatcherBinding(authResult, watcher.registeredByToken);
+
+  if (verdict === "allow") {
+    return null;
+  }
+  if (verdict === "deny") {
+    return apiError(403, FORBIDDEN, "Token is not authorized for this watcher");
+  }
+
+  // `decideWatcherBinding` only returns "tofu" when tokenId is set.
+  const tokenId = authResult.tokenId;
+  if (!tokenId) {
+    return apiError(403, FORBIDDEN, "Token is not authorized for this watcher");
+  }
+
+  // TOFU: first token to check in claims the row. The `is null` guard
+  // makes concurrent claims atomic — the loser re-reads and is denied.
+  const claimed = await db
+    .update(watchers)
+    .set({ registeredByToken: tokenId })
+    .where(and(eq(watchers.id, watcher.id), isNull(watchers.registeredByToken)))
+    .returning({ id: watchers.id });
+
+  if (claimed.length > 0) {
+    return null;
+  }
+
+  const [current] = await db
+    .select({ registeredByToken: watchers.registeredByToken })
+    .from(watchers)
+    .where(eq(watchers.id, watcher.id))
+    .limit(1);
+
+  if (current?.registeredByToken === tokenId) {
+    return null;
+  }
+
+  return apiError(403, FORBIDDEN, "Token is not authorized for this watcher");
 }
 
 /**

--- a/web/lib/db/schema.ts
+++ b/web/lib/db/schema.ts
@@ -382,6 +382,14 @@ export const watchers = pgTable(
     deregisteredBy: text("deregistered_by").references(() => users.id, {
       onDelete: "set null",
     }),
+    // PAT that registered this watcher. Watcher-scoped ops (heartbeat, config,
+    // events, upload-queue, update-check) require the same PAT. NULL for
+    // pre-binding rows (claimed trust-on-first-use) and session registrations.
+    // `set null` on token delete so rotation can re-claim via TOFU.
+    registeredByToken: uuid("registered_by_token").references(
+      () => personalAccessTokens.id,
+      { onDelete: "set null" }
+    ),
   },
   (watcher) => [
     // Partial unique index — at most one active watcher per instrument.

--- a/web/lib/db/seed.ts
+++ b/web/lib/db/seed.ts
@@ -85,6 +85,9 @@ export interface SeedUserOptions {
 export interface SeedUserResult {
   email: string;
   token: string;
+  // PAT row id — used by watcher-binding tests that assert
+  // `watchers.registered_by_token` matches the registering credential.
+  tokenId: string;
   userId: string;
 }
 
@@ -103,16 +106,19 @@ export async function seedDevUser(
   });
 
   const plaintext = generateToken();
-  await db.insert(schema.personalAccessTokens).values({
-    userId,
-    name: "seeded-token",
-    tokenHash: hashToken(plaintext),
-    tokenPrefix: getTokenPrefix(plaintext),
-    scopes: options.scopes ?? ["*"],
-    expiresAt: options.expiresAt === undefined ? null : options.expiresAt,
-  });
+  const [pat] = await db
+    .insert(schema.personalAccessTokens)
+    .values({
+      userId,
+      name: "seeded-token",
+      tokenHash: hashToken(plaintext),
+      tokenPrefix: getTokenPrefix(plaintext),
+      scopes: options.scopes ?? ["*"],
+      expiresAt: options.expiresAt === undefined ? null : options.expiresAt,
+    })
+    .returning({ id: schema.personalAccessTokens.id });
 
-  return { userId, email, token: plaintext };
+  return { userId, email, token: plaintext, tokenId: pat.id };
 }
 
 // ---------------------------------------------------------------------------

--- a/web/tests/integration/helpers.ts
+++ b/web/tests/integration/helpers.ts
@@ -82,11 +82,11 @@ export async function resetDb() {
 export async function seedTestUser(
   options?: Pick<SeedUserOptions, "expiresAt" | "scopes" | "isAdmin">
 ) {
-  const { userId, token } = await seedDevUser(getTestDb(), {
+  const { userId, token, tokenId } = await seedDevUser(getTestDb(), {
     ...options,
     name: "Test User",
   });
-  return { userId, token };
+  return { userId, token, tokenId };
 }
 
 // ---------------------------------------------------------------------------

--- a/web/tests/integration/watcher-binding.test.ts
+++ b/web/tests/integration/watcher-binding.test.ts
@@ -1,0 +1,263 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { instruments, watchers } from "@/lib/db/schema";
+import {
+  api,
+  closeTestDb,
+  getTestDb,
+  resetDb,
+  seedTestUser,
+} from "@/tests/integration/helpers";
+
+// Cross-control IDOR guard: a watchers:report (or :read) PAT may only
+// operate on the watcher it registered. Bound endpoints are exercised
+// parametrically so none regress. Session exemption is covered by the
+// unit suite (`decideWatcherBinding`) — this harness has no cookies.
+
+const WATCHER_SCOPES = [
+  "watchers:report",
+  "watchers:read",
+  "instruments:read",
+  "instruments:write",
+] as const;
+
+describe("Watcher PAT binding", () => {
+  let tokenA: string;
+  let tokenIdA: string;
+  let tokenB: string;
+  let watcherAId: string;
+  let watcherBId: string;
+
+  beforeAll(async () => {
+    await resetDb();
+    ({ token: tokenA, tokenId: tokenIdA } = await seedTestUser({
+      scopes: [...WATCHER_SCOPES],
+    }));
+    ({ token: tokenB } = await seedTestUser({
+      scopes: [...WATCHER_SCOPES],
+    }));
+
+    const db = getTestDb();
+    await db.insert(instruments).values([
+      {
+        id: "binding-instr-a",
+        displayName: "Binding Instrument A",
+        status: "active",
+      },
+      {
+        id: "binding-instr-b",
+        displayName: "Binding Instrument B",
+        status: "active",
+      },
+    ]);
+
+    const regA = await api("/api/v1/watchers/register", {
+      method: "POST",
+      token: tokenA,
+      body: {
+        instrument_id: "binding-instr-a",
+        hostname: "pc-a",
+      },
+    });
+    expect(regA.status).toBe(201);
+    watcherAId = (await regA.json()).watcher_id;
+
+    const regB = await api("/api/v1/watchers/register", {
+      method: "POST",
+      token: tokenB,
+      body: {
+        instrument_id: "binding-instr-b",
+        hostname: "pc-b",
+      },
+    });
+    expect(regB.status).toBe(201);
+    watcherBId = (await regB.json()).watcher_id;
+
+    // Config push seeds a checksum so the config-checksum GET can return 200
+    // for the owner token (404 "no config" would mask a binding failure).
+    const cfgRes = await api(`/api/v1/watchers/${watcherAId}/config`, {
+      method: "PUT",
+      token: tokenA,
+      body: {
+        config_yaml: "instrument:\n  watch_directory: /tmp/a\n",
+        config_checksum: "checksum-a",
+      },
+    });
+    expect(cfgRes.status).toBe(200);
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  it("POST /watchers/register records registered_by_token for the PAT", async () => {
+    const db = getTestDb();
+    const [row] = await db
+      .select({ registeredByToken: watchers.registeredByToken })
+      .from(watchers)
+      .where(eq(watchers.id, watcherAId))
+      .limit(1);
+    expect(row?.registeredByToken).toBe(tokenIdA);
+  });
+
+  // Parametrized across the full watcher-operational surface so a future
+  // endpoint can't silently skip enforceWatcherBinding.
+  const boundCases: {
+    name: string;
+    method: "GET" | "POST" | "PUT";
+    path: (id: string) => string;
+    body?: unknown;
+    ownStatus: number;
+  }[] = [
+    {
+      name: "heartbeat",
+      method: "POST",
+      path: (id) => `/api/v1/watchers/${id}/heartbeat`,
+      body: { status: "watching" },
+      ownStatus: 200,
+    },
+    {
+      name: "config",
+      method: "PUT",
+      path: (id) => `/api/v1/watchers/${id}/config`,
+      body: {
+        config_yaml: "instrument:\n  watch_directory: /tmp/cross\n",
+        config_checksum: "checksum-cross",
+      },
+      ownStatus: 200,
+    },
+    {
+      name: "events",
+      method: "POST",
+      path: (id) => `/api/v1/watchers/${id}/events`,
+      body: {
+        events: [
+          {
+            event_type: "watcher_started",
+            timestamp: new Date().toISOString(),
+            message: "binding test",
+          },
+        ],
+      },
+      ownStatus: 201,
+    },
+    {
+      name: "config-checksum",
+      method: "GET",
+      path: (id) => `/api/v1/watchers/${id}/config-checksum`,
+      ownStatus: 200,
+    },
+    {
+      name: "upload-queue",
+      method: "GET",
+      path: (id) => `/api/v1/watchers/${id}/upload-queue`,
+      ownStatus: 200,
+    },
+    {
+      name: "update-check",
+      method: "GET",
+      path: (id) => `/api/v1/watchers/${id}/update-check`,
+      ownStatus: 200,
+    },
+  ];
+
+  for (const c of boundCases) {
+    it(`${c.name}: own token succeeds`, async () => {
+      const res = await api(c.path(watcherAId), {
+        method: c.method,
+        token: tokenA,
+        body: c.body,
+      });
+      expect(res.status).toBe(c.ownStatus);
+    });
+
+    it(`${c.name}: cross-token is forbidden`, async () => {
+      const res = await api(c.path(watcherAId), {
+        method: c.method,
+        token: tokenB,
+        body: c.body,
+      });
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error.code).toBe("FORBIDDEN");
+      expect(body.error.message).toMatch(/not authorized for this watcher/);
+    });
+  }
+
+  // Reciprocal: token A cannot drive watcher B either.
+  it("heartbeat: token A cannot drive watcher B", async () => {
+    const res = await api(`/api/v1/watchers/${watcherBId}/heartbeat`, {
+      method: "POST",
+      token: tokenA,
+      body: { status: "stopped" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  describe("TOFU claim on null binding", () => {
+    const tofuInstrumentId = "binding-instr-tofu";
+    let tofuWatcherId: string;
+
+    beforeEach(async () => {
+      await resetDb();
+      ({ token: tokenA, tokenId: tokenIdA } = await seedTestUser({
+        scopes: [...WATCHER_SCOPES],
+      }));
+      ({ token: tokenB } = await seedTestUser({
+        scopes: [...WATCHER_SCOPES],
+      }));
+
+      const db = getTestDb();
+      await db.insert(instruments).values({
+        id: tofuInstrumentId,
+        displayName: "TOFU Instrument",
+        status: "active",
+      });
+
+      // Pre-binding row: insert directly with null registered_by_token to
+      // simulate a watcher that existed before the binding column.
+      const [row] = await db
+        .insert(watchers)
+        .values({
+          instrumentId: tofuInstrumentId,
+          hostname: "tofu-pc",
+          status: "registered",
+          registeredByToken: null,
+        })
+        .returning({ id: watchers.id });
+      tofuWatcherId = row.id;
+    });
+
+    it("first token claims the null binding; second is denied", async () => {
+      const claim = await api(`/api/v1/watchers/${tofuWatcherId}/heartbeat`, {
+        method: "POST",
+        token: tokenA,
+        body: { status: "watching" },
+      });
+      expect(claim.status).toBe(200);
+
+      const db = getTestDb();
+      const [bound] = await db
+        .select({ registeredByToken: watchers.registeredByToken })
+        .from(watchers)
+        .where(eq(watchers.id, tofuWatcherId))
+        .limit(1);
+      expect(bound?.registeredByToken).toBe(tokenIdA);
+
+      const denied = await api(`/api/v1/watchers/${tofuWatcherId}/heartbeat`, {
+        method: "POST",
+        token: tokenB,
+        body: { status: "stopped" },
+      });
+      expect(denied.status).toBe(403);
+
+      // Claimant can keep operating.
+      const again = await api(`/api/v1/watchers/${tofuWatcherId}/heartbeat`, {
+        method: "POST",
+        token: tokenA,
+        body: { status: "watching" },
+      });
+      expect(again.status).toBe(200);
+    });
+  });
+});

--- a/web/tests/unit/watcher-binding.test.ts
+++ b/web/tests/unit/watcher-binding.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { AuthResult } from "@/lib/api/auth";
+import { decideWatcherBinding } from "@/lib/api/watchers";
+
+// Pure decision coverage for watcher↔PAT binding. The TOFU claim path and
+// HTTP 403/200 behaviour live in the integration suite — this file only
+// pins the session-exempt / match / mismatch branches that don't need a DB
+// (the integration harness has no session cookies).
+
+function sessionAuth(): AuthResult {
+  return {
+    userId: "session-user",
+    authMethod: "session",
+    scopes: ["*"],
+    tokenId: null,
+  };
+}
+
+function tokenAuth(tokenId: string): AuthResult {
+  return {
+    userId: "token-user",
+    authMethod: "token",
+    scopes: ["watchers:report"],
+    tokenId,
+  };
+}
+
+describe("decideWatcherBinding", () => {
+  it("allows browser sessions regardless of binding", () => {
+    expect(decideWatcherBinding(sessionAuth(), null)).toBe("allow");
+    expect(decideWatcherBinding(sessionAuth(), "some-pat-id")).toBe("allow");
+  });
+
+  it("allows a token that matches the registered PAT", () => {
+    expect(decideWatcherBinding(tokenAuth("pat-a"), "pat-a")).toBe("allow");
+  });
+
+  it("denies a token that does not match the registered PAT", () => {
+    expect(decideWatcherBinding(tokenAuth("pat-a"), "pat-b")).toBe("deny");
+  });
+
+  it("denies token auth with a missing tokenId", () => {
+    const broken: AuthResult = {
+      userId: "token-user",
+      authMethod: "token",
+      scopes: ["watchers:report"],
+      tokenId: null,
+    };
+    expect(decideWatcherBinding(broken, "pat-a")).toBe("deny");
+  });
+
+  it("returns tofu when the binding is still null", () => {
+    expect(decideWatcherBinding(tokenAuth("pat-a"), null)).toBe("tofu");
+  });
+});


### PR DESCRIPTION
## Summary
- Closes the watcher cross-control IDOR by binding each watcher to the PAT that registered it and enforcing that match on heartbeat, config, events, config-checksum, upload-queue, and update-check.
- Pre-migration rows with a null binding are claimed trust-on-first-use (TOFU) on first check-in; browser sessions remain exempt.
- Documents PAT rotation/rebind and adds unit + integration coverage for own-token, cross-token, and TOFU paths.

## Test plan
- [x] `make check-all`
- [x] Unit: `cd web && npm run test:unit -- tests/unit/watcher-binding.test.ts`
- [x] Integration: `cd web && npm run test:integration -- tests/integration/watcher-binding.test.ts tests/integration/watchers.test.ts`
- [ ] Confirm a watcher registered with PAT A gets 403 from PAT B on `/heartbeat` and `/config`
- [ ] Confirm a pre-existing null-bound watcher is claimed by the first PAT that heartbeats, then rejects others


Made with [Cursor](https://cursor.com)