### PR TITLE
Restrict watcher deregister to workspace admins

### DIFF
--- a/web/app/api/v1/watchers/[watcherId]/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/route.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { authorize } from "@/lib/api/auth";
+import { authorize, requireAdminForSession } from "@/lib/api/auth";
 import {
   apiError,
   CONFLICT,
@@ -63,6 +63,13 @@ export async function DELETE(
   const authResult = await authorize(request, "watchers:admin");
   if (authResult instanceof Response) {
     return authResult;
+  }
+
+  // Browser callers (the Deregister dialog on `/watchers`) must additionally
+  // be admins. PAT callers pass through purely on the `watchers:admin` scope.
+  const adminGate = await requireAdminForSession(authResult);
+  if (adminGate) {
+    return adminGate;
   }
 
   const { watcherId } = await params;

--- a/web/app/watchers/[watcherId]/page.tsx
+++ b/web/app/watchers/[watcherId]/page.tsx
@@ -61,13 +61,15 @@ export default async function WatcherDetailPage({
   const { watcherId } = await params;
   const filters = watcherDetailParamsCache.parse(await searchParams);
 
+  const isAdmin = session.user.isAdmin === true;
+
   // The header and the heartbeat/events tabs stream independently; the shared
   // `getWatcherById` lookup is `cache()`-deduped so both sections resolve
   // against a single query while their heavier data fetches run in parallel.
   return (
     <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-6 2xl:w-7xl">
       <Suspense fallback={<WatcherHeaderSkeleton />}>
-        <WatcherHeaderSection watcherId={watcherId} />
+        <WatcherHeaderSection isAdmin={isAdmin} watcherId={watcherId} />
       </Suspense>
       <Suspense fallback={<WatcherDetailTabsSkeleton />}>
         <WatcherTabsSection filters={filters} watcherId={watcherId} />
@@ -76,12 +78,18 @@ export default async function WatcherDetailPage({
   );
 }
 
-async function WatcherHeaderSection({ watcherId }: { watcherId: string }) {
+async function WatcherHeaderSection({
+  watcherId,
+  isAdmin,
+}: {
+  watcherId: string;
+  isAdmin: boolean;
+}) {
   const watcher = await getWatcherById(watcherId);
   if (!watcher) {
     notFound();
   }
-  return <WatcherHeader watcher={watcher} />;
+  return <WatcherHeader isAdmin={isAdmin} watcher={watcher} />;
 }
 
 async function WatcherTabsSection({

--- a/web/app/watchers/page.tsx
+++ b/web/app/watchers/page.tsx
@@ -27,19 +27,22 @@ export default async function WatchersPage() {
     );
   }
 
+  // Deregister is admin-only; everyone else sees the same listing tabs.
+  const isAdmin = session.user.isAdmin === true;
+
   return (
     <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-6 2xl:w-7xl">
       <div className="flex items-center justify-between">
         <h1 className="font-semibold text-2xl tracking-tight">Watchers</h1>
       </div>
-      <Suspense fallback={<WatchersViewSkeleton />}>
-        <WatchersListSection />
+      <Suspense fallback={<WatchersViewSkeleton isAdmin={isAdmin} />}>
+        <WatchersListSection isAdmin={isAdmin} />
       </Suspense>
     </div>
   );
 }
 
-async function WatchersListSection() {
+async function WatchersListSection({ isAdmin }: { isAdmin: boolean }) {
   // Fetch all watchers in a single query and partition client-side. The total
   // count is small (typically <50), so this avoids two separate DB round-trips
   // and lets the toggle between active/deregistered be instant (no refetch).
@@ -48,5 +51,11 @@ async function WatchersListSection() {
   const active = allWatchers.filter((w) => !w.deletedAt);
   const deregistered = allWatchers.filter((w) => w.deletedAt);
 
-  return <WatchersView activeData={active} deregisteredData={deregistered} />;
+  return (
+    <WatchersView
+      activeData={active}
+      deregisteredData={deregistered}
+      isAdmin={isAdmin}
+    />
+  );
 }

--- a/web/components/watchers/watcher-header.tsx
+++ b/web/components/watchers/watcher-header.tsx
@@ -45,7 +45,14 @@ export function WatcherHeaderSkeleton() {
   );
 }
 
-export function WatcherHeader({ watcher }: { watcher: WatcherDetail }) {
+export function WatcherHeader({
+  watcher,
+  isAdmin = false,
+}: {
+  watcher: WatcherDetail;
+  /** Admins get the Deregister action when the watcher is still active. */
+  isAdmin?: boolean;
+}) {
   const isDeregistered = !!watcher.deletedAt;
 
   return (
@@ -92,12 +99,12 @@ export function WatcherHeader({ watcher }: { watcher: WatcherDetail }) {
             {isDeregistered && <Badge variant="secondary">Deregistered</Badge>}
           </div>
 
-          {!isDeregistered && (
+          {isAdmin && !isDeregistered ? (
             <DeregisterDialog
               hostname={watcher.hostname}
               watcherId={watcher.id}
             />
-          )}
+          ) : null}
         </div>
 
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-muted-foreground text-sm">

--- a/web/components/watchers/watchers-table.tsx
+++ b/web/components/watchers/watchers-table.tsx
@@ -84,10 +84,15 @@ export function WatchersTableSkeleton({
 export function WatchersTable({
   data,
   isDeregisteredView = false,
+  isAdmin = false,
 }: {
   data: WatcherListItem[];
   isDeregisteredView?: boolean;
+  /** Admins get the inline Deregister action on active rows. */
+  isAdmin?: boolean;
 }) {
+  const showActions = !isDeregisteredView && isAdmin;
+
   if (data.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed bg-background py-16 dark:bg-muted">
@@ -112,7 +117,7 @@ export function WatchersTable({
             <TableHead>Version</TableHead>
             <TableHead>Status</TableHead>
             <TableHead>Last Heartbeat</TableHead>
-            {!isDeregisteredView && <TableHead className="w-[80px]" />}
+            {showActions ? <TableHead className="w-[80px]" /> : null}
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -160,7 +165,7 @@ export function WatchersTable({
                     : "—"}
                 </span>
               </TableCell>
-              {!isDeregisteredView && (
+              {showActions ? (
                 <TableCell onClick={(e) => e.stopPropagation()}>
                   {!row.deletedAt && (
                     <DeregisterDialog
@@ -169,7 +174,7 @@ export function WatchersTable({
                     />
                   )}
                 </TableCell>
-              )}
+              ) : null}
             </ClickableRow>
           ))}
         </TableBody>

--- a/web/components/watchers/watchers-view.tsx
+++ b/web/components/watchers/watchers-view.tsx
@@ -8,7 +8,11 @@ import {
 } from "@/components/watchers/watchers-table";
 import type { WatcherListItem } from "@/lib/api/watchers";
 
-export function WatchersViewSkeleton() {
+export function WatchersViewSkeleton({
+  isAdmin = false,
+}: {
+  isAdmin?: boolean;
+}) {
   return (
     <div aria-busy="true" aria-label="Loading watchers" role="status">
       <Tabs defaultValue="active">
@@ -17,10 +21,10 @@ export function WatchersViewSkeleton() {
           <TabsTrigger value="deregistered">Deregistered</TabsTrigger>
         </TabsList>
         <TabsContent className="mt-2" value="active">
-          <WatchersTableSkeleton />
+          <WatchersTableSkeleton withActions={isAdmin} />
         </TabsContent>
         <TabsContent className="mt-2" value="deregistered">
-          <WatchersTableSkeleton />
+          <WatchersTableSkeleton withActions={false} />
         </TabsContent>
       </Tabs>
     </div>
@@ -35,9 +39,12 @@ type Tab = "active" | "deregistered";
 export function WatchersView({
   activeData,
   deregisteredData,
+  isAdmin = false,
 }: {
   activeData: WatcherListItem[];
   deregisteredData: WatcherListItem[];
+  /** Admins get the inline Deregister action on active rows. */
+  isAdmin?: boolean;
 }) {
   const [tab, setTab] = useState<Tab>("active");
 
@@ -50,7 +57,7 @@ export function WatchersView({
         </TabsTrigger>
       </TabsList>
       <TabsContent className="mt-2" value="active">
-        <WatchersTable data={activeData} />
+        <WatchersTable data={activeData} isAdmin={isAdmin} />
       </TabsContent>
       <TabsContent className="mt-2" value="deregistered">
         <WatchersTable data={deregisteredData} isDeregisteredView />

--- a/web/tests/integration/watchers.test.ts
+++ b/web/tests/integration/watchers.test.ts
@@ -453,6 +453,23 @@ describe("Watchers API", () => {
   // DELETE /api/v1/watchers/:watcherId
   // -------------------------------------------------------------------------
 
+  it("DELETE /api/v1/watchers/:id returns 403 without watchers:admin scope", async () => {
+    const { token: readOnlyToken } = await seedTestUser({
+      scopes: ["watchers:read"],
+    });
+
+    const res = await api(`/api/v1/watchers/${watcherId}`, {
+      method: "DELETE",
+      token: readOnlyToken,
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.code).toBe("FORBIDDEN");
+    expect(body.error.message).toMatch(
+      /missing required scope: watchers:admin/
+    );
+  });
+
   // Watchers are soft-deleted (deleted_at set) rather than physically removed,
   // preserving the audit trail of heartbeats and events for debugging.
   it("DELETE /api/v1/watchers/:id soft-deletes the watcher", async () => {


### PR DESCRIPTION
## Summary
- Gate `DELETE /api/v1/watchers/:id` with `requireAdminForSession` so browser sessions must be workspace admins (PATs still authorize via `watchers:admin`).
- Hide the Deregister UI on the watchers list and detail pages for non-admins.
- Add an integration test covering 403 when a PAT lacks `watchers:admin`.

## Test plan
- [x] As a non-admin signed-in user, confirm Deregister is hidden on `/watchers` and `/watchers/:id`
- [x] As an admin, deregister a watcher from the list and detail page
- [x] Confirm a PAT with `watchers:admin` can still DELETE; a PAT with only `watchers:read` gets 403
- [x] `make check-all`


Made with [Cursor](https://cursor.com)