### PR TITLE
Add users and comments to global search

### DIFF
--- a/web/app/api/v1/search/route.ts
+++ b/web/app/api/v1/search/route.ts
@@ -8,7 +8,9 @@ import { globalSearch, type SearchScope } from "@/lib/api/search";
 // Cross-entity global search powering the ⌘K palette. Returns grouped,
 // relevance-ordered matches over runs, files, instruments, users, and
 // comments. There is no row-level scoping in Data Hub, so any caller with
-// `runs:read` sees the same set the rest of the app exposes.
+// `runs:read` sees the same set the rest of the app exposes — including
+// workspace member names and emails under the Users scope (intentional;
+// mirrors the members directory / attributor picker).
 // ---------------------------------------------------------------------------
 
 const VALID_SCOPES: ReadonlySet<SearchScope> = new Set([

--- a/web/app/api/v1/search/route.ts
+++ b/web/app/api/v1/search/route.ts
@@ -3,12 +3,12 @@ import { authorize } from "@/lib/api/auth";
 import { globalSearch, type SearchScope } from "@/lib/api/search";
 
 // ---------------------------------------------------------------------------
-// GET /api/v1/search?q=…&scope=all|runs|files|instruments
+// GET /api/v1/search?q=…&scope=all|runs|files|instruments|users|comments
 //
 // Cross-entity global search powering the ⌘K palette. Returns grouped,
-// relevance-ordered matches over runs, files, and instruments. There is no
-// row-level scoping in Data Hub, so any caller with `runs:read` sees the same
-// set the rest of the app exposes.
+// relevance-ordered matches over runs, files, instruments, users, and
+// comments. There is no row-level scoping in Data Hub, so any caller with
+// `runs:read` sees the same set the rest of the app exposes.
 // ---------------------------------------------------------------------------
 
 const VALID_SCOPES: ReadonlySet<SearchScope> = new Set([
@@ -16,6 +16,8 @@ const VALID_SCOPES: ReadonlySet<SearchScope> = new Set([
   "runs",
   "files",
   "instruments",
+  "users",
+  "comments",
 ]);
 
 function parseScope(raw: string | null): SearchScope {

--- a/web/components/members/members-table.tsx
+++ b/web/components/members/members-table.tsx
@@ -44,14 +44,14 @@ export function MembersTableSkeleton({
     <div
       aria-busy="true"
       aria-label={ariaLabel}
-      className="rounded-lg border bg-background dark:bg-muted"
+      className="overflow-hidden rounded-lg border bg-background dark:bg-muted"
       role="status"
     >
-      <Table>
+      <Table className="table-fixed">
         <TableHeader>
           <TableRow>
-            <TableHead>Member</TableHead>
-            <TableHead>Email</TableHead>
+            <TableHead className="w-[40%]">Member</TableHead>
+            <TableHead className="w-[35%]">Email</TableHead>
             <TableHead>Role</TableHead>
             <TableHead className="w-28 text-right">Admin</TableHead>
           </TableRow>
@@ -60,18 +60,18 @@ export function MembersTableSkeleton({
           {Array.from({ length: rows }).map((_, i) => (
             <TableRow key={i}>
               <TableCell>
-                <div className="flex items-center gap-3">
+                <div className="flex min-w-0 items-center gap-3">
                   <Skeleton className="size-6 shrink-0 rounded-full" />
-                  <Skeleton className="h-4 w-28" />
+                  <Skeleton className="h-4 w-28 max-w-full" />
                 </div>
               </TableCell>
               <TableCell>
-                <Skeleton className="h-4 w-36" />
+                <Skeleton className="h-4 w-36 max-w-full" />
               </TableCell>
               <TableCell>
                 <Skeleton className="h-5 w-16 rounded-full" />
               </TableCell>
-              <TableCell className="text-right">
+              <TableCell className="overflow-hidden text-right">
                 <div className="flex justify-end">
                   <Skeleton className="h-[18.4px] w-8 rounded-full" />
                 </div>
@@ -86,12 +86,14 @@ export function MembersTableSkeleton({
 
 export function MembersTable({ data, currentUserId }: MembersTableProps) {
   return (
-    <div className="rounded-lg border bg-background dark:bg-muted">
-      <Table>
+    // overflow-hidden clips sub-pixel / switch hit-target bleed that otherwise
+    // leaves a ~5px horizontal scrollbar on the shared table container.
+    <div className="overflow-hidden rounded-lg border bg-background dark:bg-muted">
+      <Table className="table-fixed">
         <TableHeader>
           <TableRow>
-            <TableHead>Member</TableHead>
-            <TableHead>Email</TableHead>
+            <TableHead className="w-[40%]">Member</TableHead>
+            <TableHead className="w-[35%]">Email</TableHead>
             <TableHead>Role</TableHead>
             <TableHead className="w-28 text-right">Admin</TableHead>
           </TableRow>
@@ -102,9 +104,9 @@ export function MembersTable({ data, currentUserId }: MembersTableProps) {
             const isSelf = member.id === currentUserId;
             return (
               <TableRow key={member.id}>
-                <TableCell>
+                <TableCell className="max-w-0">
                   <UserAvatarLink
-                    className="gap-3"
+                    className="flex w-full min-w-0 gap-3"
                     size="sm"
                     user={{
                       userId: member.id,
@@ -113,7 +115,7 @@ export function MembersTable({ data, currentUserId }: MembersTableProps) {
                       avatarUrl: member.image,
                     }}
                   >
-                    <span className="font-medium">
+                    <span className="truncate font-medium">
                       {displayName}
                       {isSelf ? (
                         <span className="ml-1.5 text-muted-foreground text-xs">
@@ -123,7 +125,7 @@ export function MembersTable({ data, currentUserId }: MembersTableProps) {
                     </span>
                   </UserAvatarLink>
                 </TableCell>
-                <TableCell className="text-muted-foreground">
+                <TableCell className="max-w-0 truncate text-muted-foreground">
                   {member.email ?? "—"}
                 </TableCell>
                 <TableCell>
@@ -135,7 +137,7 @@ export function MembersTable({ data, currentUserId }: MembersTableProps) {
                     <Badge variant="outline">Member</Badge>
                   )}
                 </TableCell>
-                <TableCell className="text-right">
+                <TableCell className="overflow-hidden text-right">
                   <div className="flex justify-end">
                     <AdminToggle
                       displayName={displayName}

--- a/web/components/runs/run-comment-item.tsx
+++ b/web/components/runs/run-comment-item.tsx
@@ -2,7 +2,7 @@
 
 import { Loader2, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import dynamic from "next/dynamic";
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { RelativeTime } from "@/components/dashboard/relative-time";
 import {
@@ -67,6 +67,16 @@ export function RunCommentItem({
   const [isDeleting, startDeletingTransition] = useTransition();
 
   const isAuthor = currentUserId !== null && comment.user.id === currentUserId;
+  const anchorId = `comment-${comment.id}`;
+
+  // Deep links from notifications / global search use `#comment-{id}`; scroll
+  // the matching article into view once it mounts.
+  useEffect(() => {
+    if (window.location.hash !== `#${anchorId}`) {
+      return;
+    }
+    document.getElementById(anchorId)?.scrollIntoView({ block: "center" });
+  }, [anchorId]);
 
   const trimmed = draft.trim();
   const tooLong = draft.length > MAX_BODY_LENGTH;
@@ -109,7 +119,7 @@ export function RunCommentItem({
 
   return (
     <>
-      <article className="flex flex-col gap-1.5">
+      <article className="flex flex-col gap-1.5" id={anchorId}>
         <div className="flex items-start justify-between gap-2">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-muted-foreground text-sm">
             <UserAvatarLink

--- a/web/components/runs/run-comment-item.tsx
+++ b/web/components/runs/run-comment-item.tsx
@@ -2,7 +2,7 @@
 
 import { Loader2, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import dynamic from "next/dynamic";
-import { useEffect, useState, useTransition } from "react";
+import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { RelativeTime } from "@/components/dashboard/relative-time";
 import {
@@ -67,16 +67,10 @@ export function RunCommentItem({
   const [isDeleting, startDeletingTransition] = useTransition();
 
   const isAuthor = currentUserId !== null && comment.user.id === currentUserId;
+  // Deep-link target for notifications / global search (`#comment-{id}`).
+  // Scroll-into-view lives on `RunCommentsList` so one listener covers the
+  // whole list (including same-page hash changes).
   const anchorId = `comment-${comment.id}`;
-
-  // Deep links from notifications / global search use `#comment-{id}`; scroll
-  // the matching article into view once it mounts.
-  useEffect(() => {
-    if (window.location.hash !== `#${anchorId}`) {
-      return;
-    }
-    document.getElementById(anchorId)?.scrollIntoView({ block: "center" });
-  }, [anchorId]);
 
   const trimmed = draft.trim();
   const tooLong = draft.length > MAX_BODY_LENGTH;

--- a/web/components/runs/run-comments-list.tsx
+++ b/web/components/runs/run-comments-list.tsx
@@ -1,12 +1,22 @@
 "use client";
 
 import { useSession } from "next-auth/react";
-import { useOptimistic, useState } from "react";
+import { useEffect, useOptimistic, useState } from "react";
 import { RunCommentForm } from "@/components/runs/run-comment-form";
 import { RunCommentItem } from "@/components/runs/run-comment-item";
 import { Card } from "@/components/ui/card";
 import type { RunCommentDto } from "@/lib/api/run-comments";
 import { toInitials } from "@/lib/utils";
+
+const COMMENT_HASH_PREFIX = "#comment-";
+
+function scrollToCommentHash() {
+  const { hash } = window.location;
+  if (!hash.startsWith(COMMENT_HASH_PREFIX)) {
+    return;
+  }
+  document.getElementById(hash.slice(1))?.scrollIntoView({ block: "center" });
+}
 
 type Action =
   | { kind: "create"; comment: RunCommentDto }
@@ -60,6 +70,15 @@ export function RunCommentsList({
 
   const [committed, setCommitted] = useState(initialComments);
   const [optimistic, dispatch] = useOptimistic(committed, applyOptimistic);
+
+  // One listener for the whole list (not per-item). Covers initial deep links
+  // and same-page `#comment-{id}` changes; `global-search` dispatches
+  // `hashchange` after pushState because App Router won't.
+  useEffect(() => {
+    scrollToCommentHash();
+    window.addEventListener("hashchange", scrollToCommentHash);
+    return () => window.removeEventListener("hashchange", scrollToCommentHash);
+  }, []);
 
   // Build a comment-shaped object for the optimistic create. The id is a
   // client-generated `temp-…` so the row is keyable; the real id replaces

--- a/web/components/search/global-search.tsx
+++ b/web/components/search/global-search.tsx
@@ -189,7 +189,7 @@ export function GlobalSearch({
         </DialogDescription>
 
         <CommandPrimitive
-          className="flex w-full flex-col"
+          className="flex w-full min-w-0 max-w-full flex-col overflow-hidden"
           label="Search runs, files, instruments, users, or comments"
           loop
           shouldFilter={false}
@@ -238,7 +238,7 @@ export function GlobalSearch({
             </div>
           ) : null}
 
-          <CommandList className="max-h-[420px] px-2 pb-2">
+          <CommandList className="max-h-[420px] min-w-0 px-2 pb-2">
             {showRecent ? (
               <RecentSearches
                 onSelect={(value) => setQuery(value)}

--- a/web/components/search/global-search.tsx
+++ b/web/components/search/global-search.tsx
@@ -169,6 +169,30 @@ export function GlobalSearch({
     (href: string) => {
       addRecent(trimmed);
       onOpenChange(false);
+
+      // Same-pathname `#comment-{id}` links must not go through App Router
+      // `push` alone — it uses pushState and does not fire `hashchange`, so
+      // the comments list would never scroll when already on the run page.
+      const url = new URL(href, window.location.origin);
+      if (
+        url.hash.startsWith("#comment-") &&
+        url.pathname === window.location.pathname
+      ) {
+        if (url.hash === window.location.hash) {
+          document
+            .getElementById(url.hash.slice(1))
+            ?.scrollIntoView({ block: "center" });
+        } else {
+          window.history.pushState(
+            null,
+            "",
+            `${url.pathname}${url.search}${url.hash}`
+          );
+          window.dispatchEvent(new HashChangeEvent("hashchange"));
+        }
+        return;
+      }
+
       router.push(href);
     },
     [addRecent, trimmed, onOpenChange, router]

--- a/web/components/search/global-search.tsx
+++ b/web/components/search/global-search.tsx
@@ -5,9 +5,11 @@ import { Clock, SearchIcon, SearchX } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import {
+  SearchCommentRow,
   SearchFileRow,
   SearchInstrumentRow,
   SearchRunRow,
+  SearchUserRow,
 } from "@/components/search/search-result-item";
 import { useRecentSearches } from "@/components/search/use-recent-searches";
 import {
@@ -23,10 +25,12 @@ import {
 } from "@/components/ui/dialog";
 import type {
   GlobalSearchResult,
+  SearchCommentResult,
   SearchFileResult,
   SearchInstrumentResult,
   SearchRunResult,
   SearchScope,
+  SearchUserResult,
 } from "@/lib/api/search";
 import { MIN_QUERY_LENGTH } from "@/lib/search-constants";
 import { cn } from "@/lib/utils";
@@ -38,13 +42,24 @@ const SCOPE_TABS: { id: SearchScope; label: string }[] = [
   { id: "runs", label: "Runs" },
   { id: "files", label: "Files" },
   { id: "instruments", label: "Instruments" },
+  { id: "users", label: "Users" },
+  { id: "comments", label: "Comments" },
 ];
 
 const EMPTY_RESULT: GlobalSearchResult = {
   runs: [],
   files: [],
   instruments: [],
-  counts: { runs: 0, files: 0, instruments: 0, total: 0 },
+  users: [],
+  comments: [],
+  counts: {
+    runs: 0,
+    files: 0,
+    instruments: 0,
+    users: 0,
+    comments: 0,
+    total: 0,
+  },
 };
 
 function runHref(run: SearchRunResult): string {
@@ -61,6 +76,16 @@ function fileHref(file: SearchFileResult): string {
 
 function instrumentHref(instrument: SearchInstrumentResult): string {
   return `/instruments/${instrument.id}`;
+}
+
+function userHref(user: SearchUserResult): string {
+  return `/users/${user.id}`;
+}
+
+function commentHref(comment: SearchCommentResult): string {
+  return `/instruments/${comment.instrumentId}/runs/${encodeURIComponent(
+    comment.runId
+  )}#comment-${comment.id}`;
 }
 
 function Kbd({ children }: { children: React.ReactNode }) {
@@ -160,12 +185,12 @@ export function GlobalSearch({
       >
         <DialogTitle className="sr-only">Search Data Hub</DialogTitle>
         <DialogDescription className="sr-only">
-          Search across runs, files, and instruments.
+          Search across runs, files, instruments, users, and comments.
         </DialogDescription>
 
         <CommandPrimitive
           className="flex w-full flex-col"
-          label="Search runs, files, or instruments"
+          label="Search runs, files, instruments, users, or comments"
           loop
           shouldFilter={false}
         >
@@ -176,17 +201,17 @@ export function GlobalSearch({
             <CommandPrimitive.Input
               className="flex h-12 w-full bg-transparent text-base outline-none placeholder:text-muted-foreground"
               onValueChange={setQuery}
-              placeholder="Search runs, files, or instruments"
+              placeholder="Search runs, files, instruments, users, or comments"
               value={query}
             />
             <Kbd>esc</Kbd>
           </div>
 
-          <div className="flex items-center gap-1 border-b px-2 py-2">
+          <div className="flex items-center gap-0.5 overflow-x-auto border-b px-2 py-2">
             {SCOPE_TABS.map((tab) => (
               <button
                 className={cn(
-                  "rounded-md px-3 py-1 font-medium text-sm transition-colors",
+                  "shrink-0 rounded-md px-2.5 py-1 font-medium text-sm transition-colors",
                   scope === tab.id
                     ? "bg-primary/10 text-primary"
                     : "text-muted-foreground hover:bg-muted hover:text-foreground"
@@ -271,6 +296,34 @@ export function GlobalSearch({
                     ))}
                   </CommandGroup>
                 ) : null}
+
+                {result.users.length > 0 ? (
+                  <CommandGroup heading="Users">
+                    {result.users.map((user) => (
+                      <CommandItem
+                        key={user.id}
+                        onSelect={() => navigate(userHref(user))}
+                        value={`user:${user.id}`}
+                      >
+                        <SearchUserRow query={trimmed} result={user} />
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                ) : null}
+
+                {result.comments.length > 0 ? (
+                  <CommandGroup heading="Comments">
+                    {result.comments.map((comment) => (
+                      <CommandItem
+                        key={comment.id}
+                        onSelect={() => navigate(commentHref(comment))}
+                        value={`comment:${comment.id}`}
+                      >
+                        <SearchCommentRow query={trimmed} result={comment} />
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                ) : null}
               </>
             ) : null}
           </CommandList>
@@ -306,7 +359,7 @@ function RecentSearches({
       <div className="flex flex-col items-center justify-center gap-2 py-12 text-center">
         <SearchIcon className="size-7 text-muted-foreground" />
         <p className="text-muted-foreground text-sm">
-          Search runs, files, or instruments
+          Search runs, files, instruments, users, or comments
         </p>
       </div>
     );

--- a/web/components/search/search-result-item.tsx
+++ b/web/components/search/search-result-item.tsx
@@ -8,14 +8,18 @@ import {
   FileText,
   Image as ImageIcon,
   type LucideIcon,
+  MessageSquare,
+  User,
 } from "lucide-react";
 import { InstrumentStatusBadge } from "@/components/instruments/instrument-status-badge";
 import { Highlight } from "@/components/search/highlight";
 import { WatcherStatusBadge } from "@/components/watchers/watcher-status-badge";
 import type {
+  SearchCommentResult,
   SearchFileResult,
   SearchInstrumentResult,
   SearchRunResult,
+  SearchUserResult,
 } from "@/lib/api/search";
 import { cn, formatBytes, formatRelativeTime } from "@/lib/utils";
 
@@ -65,15 +69,17 @@ function ResultRowShell({
 }: {
   icon: LucideIcon;
   children: React.ReactNode;
-  stat: React.ReactNode;
+  stat?: React.ReactNode;
 }) {
   return (
     <>
       <Icon className="size-4 shrink-0 text-muted-foreground" />
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">{children}</div>
-      <div className="ml-auto shrink-0 whitespace-nowrap pl-2 text-muted-foreground text-xs">
-        {stat}
-      </div>
+      {stat == null ? null : (
+        <div className="ml-auto shrink-0 whitespace-nowrap pl-2 text-muted-foreground text-xs">
+          {stat}
+        </div>
+      )}
     </>
   );
 }
@@ -95,15 +101,15 @@ export function SearchRunRow({
       icon={Activity}
       stat={`${result.fileCount} ${result.fileCount === 1 ? "file" : "files"} · ${formatBytes(result.totalSizeBytes)}`}
     >
-      <span className="truncate font-medium font-mono text-sm">
+      <span className="block truncate font-medium font-mono text-sm">
         <Highlight query={query} text={result.runId} />
       </span>
-      <span className="truncate text-muted-foreground text-xs">
+      <span className="block truncate text-muted-foreground text-xs">
         <Highlight query={query} text={result.instrumentName} /> ·{" "}
         {formatRelativeTime(when)}
       </span>
       {result.matchReason === "file" && result.matchedFilename ? (
-        <span className="truncate text-muted-foreground text-xs">
+        <span className="block truncate text-muted-foreground text-xs">
           Contains{" "}
           <span className="font-mono">
             <Highlight query={query} text={result.matchedFilename} />
@@ -126,10 +132,10 @@ export function SearchFileRow({
       icon={iconForFilename(result.filename)}
       stat={formatBytes(result.sizeBytes)}
     >
-      <span className="truncate font-medium font-mono text-sm">
+      <span className="block truncate font-medium font-mono text-sm">
         <Highlight query={query} text={result.filename} />
       </span>
-      <span className="flex min-w-0 items-center gap-1 truncate text-muted-foreground text-xs">
+      <span className="flex min-w-0 items-center gap-1 text-muted-foreground text-xs">
         <span className="truncate">{result.instrumentName}</span>
         <span aria-hidden="true">›</span>
         <span className="truncate font-mono">{result.runId}</span>
@@ -165,10 +171,10 @@ export function SearchInstrumentRow({
         )
       }
     >
-      <span className={cn("truncate font-medium text-sm")}>
+      <span className={cn("block truncate font-medium text-sm")}>
         <Highlight query={query} text={result.displayName} />
       </span>
-      <span className="truncate text-muted-foreground text-xs">
+      <span className="block truncate text-muted-foreground text-xs">
         {result.matchReason === "pattern" && result.matchedPattern ? (
           <>
             Matches pattern{" "}
@@ -180,6 +186,54 @@ export function SearchInstrumentRow({
         ) : (
           pluralRuns(result.runCount)
         )}
+      </span>
+    </ResultRowShell>
+  );
+}
+
+export function SearchUserRow({
+  result,
+  query,
+}: {
+  result: SearchUserResult;
+  query: string;
+}) {
+  const title = result.name ?? result.email ?? "Unknown";
+  return (
+    <ResultRowShell icon={User}>
+      <span className="block truncate font-medium text-sm">
+        <Highlight query={query} text={title} />
+      </span>
+      {result.email && result.name ? (
+        <span className="block truncate text-muted-foreground text-xs">
+          <Highlight query={query} text={result.email} />
+        </span>
+      ) : null}
+    </ResultRowShell>
+  );
+}
+
+export function SearchCommentRow({
+  result,
+  query,
+}: {
+  result: SearchCommentResult;
+  query: string;
+}) {
+  return (
+    <ResultRowShell
+      icon={MessageSquare}
+      stat={formatRelativeTime(result.createdAt)}
+    >
+      <span className="block truncate font-medium text-sm">
+        <Highlight query={query} text={result.bodyPreview} />
+      </span>
+      <span className="flex min-w-0 items-center gap-1 text-muted-foreground text-xs">
+        <span className="truncate">{result.userName}</span>
+        <span aria-hidden="true">·</span>
+        <span className="truncate">{result.instrumentName}</span>
+        <span aria-hidden="true">›</span>
+        <span className="truncate font-mono">{result.runId}</span>
       </span>
     </ResultRowShell>
   );

--- a/web/components/search/search-result-item.tsx
+++ b/web/components/search/search-result-item.tsx
@@ -9,10 +9,10 @@ import {
   Image as ImageIcon,
   type LucideIcon,
   MessageSquare,
-  User,
 } from "lucide-react";
 import { InstrumentStatusBadge } from "@/components/instruments/instrument-status-badge";
 import { Highlight } from "@/components/search/highlight";
+import { UserAvatar } from "@/components/user-avatar";
 import { WatcherStatusBadge } from "@/components/watchers/watcher-status-badge";
 import type {
   SearchCommentResult,
@@ -21,7 +21,7 @@ import type {
   SearchRunResult,
   SearchUserResult,
 } from "@/lib/api/search";
-import { cn, formatBytes, formatRelativeTime } from "@/lib/utils";
+import { cn, formatBytes, formatRelativeTime, toInitials } from "@/lib/utils";
 
 const IMAGE_EXTENSIONS = new Set([
   "png",
@@ -61,19 +61,25 @@ function iconForFilename(filename: string): LucideIcon {
   return FileIcon;
 }
 
-// Shared row scaffold: leading icon, a flexible text column, and a right stat.
+function ResultRowIcon({ icon: Icon }: { icon: LucideIcon }) {
+  return <Icon className="size-4 shrink-0 text-muted-foreground" />;
+}
+
+// Shared row scaffold: leading glyph/avatar, a flexible text column, and an
+// optional right-hand stat. `leading` is a slot so user rows can pass an
+// avatar without a boolean mode on the shell.
 function ResultRowShell({
-  icon: Icon,
+  leading,
   children,
   stat,
 }: {
-  icon: LucideIcon;
+  leading: React.ReactNode;
   children: React.ReactNode;
   stat?: React.ReactNode;
 }) {
   return (
     <>
-      <Icon className="size-4 shrink-0 text-muted-foreground" />
+      {leading}
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">{children}</div>
       {stat == null ? null : (
         <div className="ml-auto shrink-0 whitespace-nowrap pl-2 text-muted-foreground text-xs">
@@ -98,7 +104,7 @@ export function SearchRunRow({
   const when = result.acquiredAt ?? result.createdAt;
   return (
     <ResultRowShell
-      icon={Activity}
+      leading={<ResultRowIcon icon={Activity} />}
       stat={`${result.fileCount} ${result.fileCount === 1 ? "file" : "files"} · ${formatBytes(result.totalSizeBytes)}`}
     >
       <span className="block truncate font-medium font-mono text-sm">
@@ -129,7 +135,7 @@ export function SearchFileRow({
 }) {
   return (
     <ResultRowShell
-      icon={iconForFilename(result.filename)}
+      leading={<ResultRowIcon icon={iconForFilename(result.filename)} />}
       stat={formatBytes(result.sizeBytes)}
     >
       <span className="block truncate font-medium font-mono text-sm">
@@ -153,7 +159,7 @@ export function SearchInstrumentRow({
 }) {
   return (
     <ResultRowShell
-      icon={Cpu}
+      leading={<ResultRowIcon icon={Cpu} />}
       stat={
         // Lifecycle badge for `pending`/`inactive`, watcher badge otherwise
         // (mirrors the instruments table).
@@ -200,7 +206,19 @@ export function SearchUserRow({
 }) {
   const title = result.name ?? result.email ?? "Unknown";
   return (
-    <ResultRowShell icon={User}>
+    <ResultRowShell
+      leading={
+        <UserAvatar
+          size="sm"
+          user={{
+            userId: result.id,
+            displayName: title,
+            initials: toInitials(title),
+            avatarUrl: result.image,
+          }}
+        />
+      }
+    >
       <span className="block truncate font-medium text-sm">
         <Highlight query={query} text={title} />
       </span>
@@ -222,7 +240,7 @@ export function SearchCommentRow({
 }) {
   return (
     <ResultRowShell
-      icon={MessageSquare}
+      leading={<ResultRowIcon icon={MessageSquare} />}
       stat={formatRelativeTime(result.createdAt)}
     >
       <span className="block truncate font-medium text-sm">

--- a/web/components/ui/command.tsx
+++ b/web/components/ui/command.tsx
@@ -157,7 +157,9 @@ function CommandItem({
       {...props}
     >
       {children}
-      <CheckIcon className="ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100" />
+      {/* Unchecked checkmarks must leave the layout so search rows keep full
+          width for truncation; checked menus still show the glyph. */}
+      <CheckIcon className="ml-auto hidden group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:block" />
     </CommandPrimitive.Item>
   );
 }

--- a/web/components/ui/command.tsx
+++ b/web/components/ui/command.tsx
@@ -150,7 +150,7 @@ function CommandItem({
   return (
     <CommandPrimitive.Item
       className={cn(
-        "group/command-item relative flex cursor-default select-none items-center gap-2 in-data-[slot=dialog-content]:rounded-lg! rounded-sm px-2 py-1.5 text-sm outline-hidden data-[disabled=true]:pointer-events-none data-selected:bg-muted data-selected:text-foreground data-[disabled=true]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 data-selected:**:[svg]:text-foreground",
+        "group/command-item relative flex min-w-0 cursor-default select-none items-center gap-2 overflow-hidden in-data-[slot=dialog-content]:rounded-lg! rounded-sm px-2 py-1.5 text-sm outline-hidden data-[disabled=true]:pointer-events-none data-selected:bg-muted data-selected:text-foreground data-[disabled=true]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 data-selected:**:[svg]:text-foreground",
         className
       )}
       data-slot="command-item"

--- a/web/drizzle/0032_add_run_comments_body_trgm.sql
+++ b/web/drizzle/0032_add_run_comments_body_trgm.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "idx_run_comments_body_trgm" ON "run_comments" USING gin ("body" gin_trgm_ops) WHERE "run_comments"."deleted_at" is null;

--- a/web/drizzle/meta/0032_snapshot.json
+++ b/web/drizzle/meta/0032_snapshot.json
@@ -1,0 +1,2256 @@
+{
+  "id": "befb0baf-5fc0-4805-96da-d48efb55f971",
+  "prevId": "93851944-2c53-41db-8585-b31f2d7578bc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": ["provider", "providerAccountId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archive_jobs": {
+      "name": "archive_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archive_bucket": {
+          "name": "archive_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_key": {
+          "name": "archive_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "archive_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_archive_jobs_inflight": {
+          "name": "uq_archive_jobs_inflight",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"archive_jobs\".\"status\" in ('pending', 'building')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_archive_jobs_run_fingerprint_status": {
+          "name": "idx_archive_jobs_run_fingerprint_status",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "archive_jobs_instrument_run_id_instrument_runs_id_fk": {
+          "name": "archive_jobs_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["instrument_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "archive_jobs_created_by_user_id_fk": {
+          "name": "archive_jobs_created_by_user_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "file_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raw'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_requested_at": {
+          "name": "upload_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_files_instrument_run_id_relative_path": {
+          "name": "uq_files_instrument_run_id_relative_path",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"relative_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_active_instrument_run_id_filename": {
+          "name": "uq_files_active_instrument_run_id_filename",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_s3_key": {
+          "name": "uq_files_s3_key",
+          "columns": [
+            {
+              "expression": "s3_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"s3_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_instrument_run_id": {
+          "name": "idx_files_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_status_instrument_run_id": {
+          "name": "idx_files_status_instrument_run_id",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_upload_queue": {
+          "name": "idx_files_upload_queue",
+          "columns": [
+            {
+              "expression": "upload_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"upload_requested_at\" is not null and \"files\".\"uploaded_at\" is null and \"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_metadata_gin": {
+          "name": "idx_files_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_files_filename_trgm": {
+          "name": "idx_files_filename_trgm",
+          "columns": [
+            {
+              "expression": "\"filename\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_instrument_run_id_instrument_runs_id_fk": {
+          "name": "files_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["instrument_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_notification_subscriptions": {
+      "name": "instrument_notification_subscriptions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_instrument_notification_subscriptions_user_id": {
+          "name": "idx_instrument_notification_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_notification_subscriptions_user_id_user_id_fk": {
+          "name": "instrument_notification_subscriptions_user_id_user_id_fk",
+          "tableFrom": "instrument_notification_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "instrument_notification_subscriptions_instrument_id_instruments_id_fk": {
+          "name": "instrument_notification_subscriptions_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_notification_subscriptions",
+          "tableTo": "instruments",
+          "columnsFrom": ["instrument_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "instrument_notification_subscriptions_user_id_instrument_id_pk": {
+          "name": "instrument_notification_subscriptions_user_id_instrument_id_pk",
+          "columns": ["user_id", "instrument_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_runs": {
+      "name": "instrument_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "instrument_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lambda'"
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instrument_runs_instrument_id_created_at": {
+          "name": "idx_instrument_runs_instrument_id_created_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active": {
+          "name": "idx_instrument_runs_active",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active_acquired_at": {
+          "name": "idx_instrument_runs_active_acquired_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"acquired_at\", \"created_at\") desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_metadata_gin": {
+          "name": "idx_instrument_runs_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_instrument_runs_run_id_trgm": {
+          "name": "idx_instrument_runs_run_id_trgm",
+          "columns": [
+            {
+              "expression": "\"run_id\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_runs_instrument_id_instruments_id_fk": {
+          "name": "instrument_runs_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "instruments",
+          "columnsFrom": ["instrument_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_watcher_id_watchers_id_fk": {
+          "name": "instrument_runs_watcher_id_watchers_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "watchers",
+          "columnsFrom": ["watcher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_deleted_by_user_id_fk": {
+          "name": "instrument_runs_deleted_by_user_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "user",
+          "columnsFrom": ["deleted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_instrument_runs_instrument_id_run_id": {
+          "name": "uq_instrument_runs_instrument_id_run_id",
+          "nullsNotDistinct": false,
+          "columns": ["instrument_id", "run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instruments": {
+      "name": "instruments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instrument_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instrument_type": {
+          "name": "instrument_type",
+          "type": "instrument_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_by": {
+          "name": "retired_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instruments_display_name_trgm": {
+          "name": "idx_instruments_display_name_trgm",
+          "columns": [
+            {
+              "expression": "\"display_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instruments_retired_by_user_id_fk": {
+          "name": "instruments_retired_by_user_id_fk",
+          "tableFrom": "instruments",
+          "tableTo": "user",
+          "columnsFrom": ["retired_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runs_all_muted": {
+          "name": "runs_all_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "comments_attributed_enabled": {
+          "name": "comments_attributed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "comments_participated_enabled": {
+          "name": "comments_participated_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "slack_runs_enabled": {
+          "name": "slack_runs_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slack_comments_attributed_enabled": {
+          "name": "slack_comments_attributed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slack_comments_participated_enabled": {
+          "name": "slack_comments_participated_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_user_id_fk": {
+          "name": "notification_preferences_user_id_user_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id_created_at": {
+          "name": "idx_notifications_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_id_unread": {
+          "name": "idx_notifications_user_id_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_run_id_instrument_runs_id_fk": {
+          "name": "notifications_run_id_instrument_runs_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_comment_id_run_comments_id_fk": {
+          "name": "notifications_comment_id_run_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "run_comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_user_id_user_id_fk": {
+          "name": "notifications_actor_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['*']::text[]"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_personal_access_tokens_user_id": {
+          "name": "idx_personal_access_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_user_id_fk": {
+          "name": "personal_access_tokens_user_id_user_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_attributions": {
+      "name": "run_attributions",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_attributions_run_id": {
+          "name": "idx_run_attributions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_attributions_user_id": {
+          "name": "idx_run_attributions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_attributions_run_id_instrument_runs_id_fk": {
+          "name": "run_attributions_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_attributions_user_id_user_id_fk": {
+          "name": "run_attributions_user_id_user_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_attributions_run_id_user_id_pk": {
+          "name": "run_attributions_run_id_user_id_pk",
+          "columns": ["run_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_comments": {
+      "name": "run_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_run_comments_run_id_created_at": {
+          "name": "idx_run_comments_run_id_created_at",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_comments_user_id": {
+          "name": "idx_run_comments_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_comments_body_trgm": {
+          "name": "idx_run_comments_body_trgm",
+          "columns": [
+            {
+              "expression": "\"body\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"run_comments\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_comments_run_id_instrument_runs_id_fk": {
+          "name": "run_comments_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_comments_user_id_user_id_fk": {
+          "name": "run_comments_user_id_user_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_channel_config": {
+      "name": "slack_channel_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_channel_config_updated_by_user_id_fk": {
+          "name": "slack_channel_config_updated_by_user_id_fk",
+          "tableFrom": "slack_channel_config",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "slack_channel_config_singleton": {
+          "name": "slack_channel_config_singleton",
+          "value": "\"slack_channel_config\".\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_connections": {
+      "name": "slack_connections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_name": {
+          "name": "slack_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_connections_user_id_user_id_fk": {
+          "name": "slack_connections_user_id_user_id_fk",
+          "tableFrom": "slack_connections",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_events": {
+      "name": "watcher_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "watcher_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_events_watcher_id_timestamp": {
+          "name": "idx_watcher_events_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_watcher_events_watcher_id_event_type": {
+          "name": "idx_watcher_events_watcher_id_event_type",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_events_watcher_id_watchers_id_fk": {
+          "name": "watcher_events_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_events",
+          "tableTo": "watchers",
+          "columnsFrom": ["watcher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_heartbeats": {
+      "name": "watcher_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_mode": {
+          "name": "upload_mode",
+          "type": "upload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_uploaded_since_last": {
+          "name": "files_uploaded_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "runs_reported_since_last": {
+          "name": "runs_reported_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_since_last": {
+          "name": "errors_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_heartbeats_watcher_id_timestamp": {
+          "name": "idx_watcher_heartbeats_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_heartbeats_watcher_id_watchers_id_fk": {
+          "name": "watcher_heartbeats_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_heartbeats",
+          "tableTo": "watchers",
+          "columnsFrom": ["watcher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_release_config": {
+      "name": "watcher_release_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_supported_version": {
+          "name": "min_supported_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stable'"
+        },
+        "mandatory": {
+          "name": "mandatory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watcher_release_config_updated_by_user_id_fk": {
+          "name": "watcher_release_config_updated_by_user_id_fk",
+          "tableFrom": "watcher_release_config",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "watcher_release_config_singleton": {
+          "name": "watcher_release_config_singleton",
+          "value": "\"watcher_release_config\".\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.watchers": {
+      "name": "watchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_info": {
+          "name": "os_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watcher_version": {
+          "name": "watcher_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_checksum": {
+          "name": "config_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_yaml": {
+          "name": "config_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "watcher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deregistered_by": {
+          "name": "deregistered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_by_token": {
+          "name": "registered_by_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_watchers_active_instrument_id": {
+          "name": "uq_watchers_active_instrument_id",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"watchers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchers_instrument_id_instruments_id_fk": {
+          "name": "watchers_instrument_id_instruments_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "instruments",
+          "columnsFrom": ["instrument_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "watchers_deregistered_by_user_id_fk": {
+          "name": "watchers_deregistered_by_user_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "user",
+          "columnsFrom": ["deregistered_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "watchers_registered_by_token_personal_access_tokens_id_fk": {
+          "name": "watchers_registered_by_token_personal_access_tokens_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "personal_access_tokens",
+          "columnsFrom": ["registered_by_token"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.archive_job_status": {
+      "name": "archive_job_status",
+      "schema": "public",
+      "values": ["pending", "building", "ready", "failed"]
+    },
+    "public.file_category": {
+      "name": "file_category",
+      "schema": "public",
+      "values": ["raw", "processed"]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "detected",
+        "upload_requested",
+        "uploaded",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.instrument_run_source": {
+      "name": "instrument_run_source",
+      "schema": "public",
+      "values": ["lambda", "watcher"]
+    },
+    "public.instrument_status": {
+      "name": "instrument_status",
+      "schema": "public",
+      "values": ["pending", "active", "inactive"]
+    },
+    "public.instrument_type": {
+      "name": "instrument_type",
+      "schema": "public",
+      "values": [
+        "generic",
+        "plate_reader",
+        "gel_doc",
+        "qpcr",
+        "tape_station",
+        "hina_microscope",
+        "epson_v700_scanner",
+        "instant_raman"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": ["run_created", "comment_attributed", "comment_participated"]
+    },
+    "public.upload_mode": {
+      "name": "upload_mode",
+      "schema": "public",
+      "values": ["auto", "manual"]
+    },
+    "public.watcher_event_type": {
+      "name": "watcher_event_type",
+      "schema": "public",
+      "values": [
+        "watcher_started",
+        "watcher_stopped",
+        "file_uploaded",
+        "upload_failed",
+        "run_reported",
+        "config_synced",
+        "error",
+        "update_started",
+        "update_succeeded",
+        "update_failed"
+      ]
+    },
+    "public.watcher_status": {
+      "name": "watcher_status",
+      "schema": "public",
+      "values": ["registered", "watching", "stopped"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1784234686620,
       "tag": "0031_add_watcher_registered_by_token",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1784308273738,
+      "tag": "0032_add_run_comments_body_trgm",
+      "breakpoints": true
     }
   ]
 }

--- a/web/lib/api/openapi/schemas/search.ts
+++ b/web/lib/api/openapi/schemas/search.ts
@@ -2,11 +2,15 @@ import { z } from "zod";
 
 export const searchQuery = z.object({
   q: z.string().optional(),
-  scope: z.enum(["all", "runs", "files", "instruments"]).optional(),
+  scope: z
+    .enum(["all", "runs", "files", "instruments", "users", "comments"])
+    .optional(),
 });
 
 export const searchResponse = z.object({
   runs: z.array(z.record(z.string(), z.unknown())),
   files: z.array(z.record(z.string(), z.unknown())),
   instruments: z.array(z.record(z.string(), z.unknown())),
+  users: z.array(z.record(z.string(), z.unknown())),
+  comments: z.array(z.record(z.string(), z.unknown())),
 });

--- a/web/lib/api/search.ts
+++ b/web/lib/api/search.ts
@@ -1,4 +1,14 @@
-import { and, desc, eq, ilike, isNull, or, type SQL, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  ilike,
+  isNull,
+  or,
+  type SQL,
+  sql,
+} from "drizzle-orm";
 import {
   getWatcherOnlineStatus,
   type WatcherOnlineStatus,
@@ -10,21 +20,30 @@ import {
   instrumentRuns,
   instruments,
   runAttributions,
+  runComments,
   users,
 } from "@/lib/db/schema";
 import { MIN_QUERY_LENGTH } from "@/lib/search-constants";
 
-// Global search across the three top-level entities. Backed by the pg_trgm
-// GIN indexes added in migration 0029 so the `ilike '%…%'` scans stay fast as
-// the run/file tables grow (one instrument alone already carries 600+ runs).
+// Global search across top-level entities. Backed by the pg_trgm GIN indexes
+// so the `ilike '%…%'` scans stay fast as the run/file/comment tables grow.
 
-export type SearchScope = "all" | "runs" | "files" | "instruments";
+export type SearchScope =
+  | "all"
+  | "runs"
+  | "files"
+  | "instruments"
+  | "users"
+  | "comments";
 
 // Per-group cap when searching everything at once ("All" tab). Matches the
 // mockups. A scoped search (single tab) uses SCOPED_LIMIT so "Show all"
 // surfaces a longer list without a dedicated results page.
 const ALL_TAB_PER_GROUP = 5;
 const SCOPED_LIMIT = 25;
+
+// Short plain-text snippet for the ⌘K list — full body is matched in SQL.
+const COMMENT_PREVIEW_MAX = 120;
 
 // Why a run surfaced. `run_id` is the run's own title (highest relevance);
 // `file` means a contained filename matched (drives the "Contains …" line);
@@ -74,18 +93,42 @@ export interface SearchInstrumentResult {
   watcherStatus: WatcherOnlineStatus | "deregistered";
 }
 
+export interface SearchUserResult {
+  email: string | null;
+  id: string;
+  image: string | null;
+  name: string | null;
+  type: "user";
+}
+
+export interface SearchCommentResult {
+  bodyPreview: string;
+  createdAt: string;
+  id: string;
+  instrumentId: string;
+  instrumentName: string;
+  runId: string;
+  type: "comment";
+  userId: string;
+  userName: string;
+}
+
 export interface GlobalSearchResult {
+  comments: SearchCommentResult[];
   counts: {
-    runs: number;
+    comments: number;
     files: number;
     instruments: number;
+    runs: number;
     // Sum of the *visible* (capped) results — this is the "N results for …"
     // figure the header shows, matching what the user actually sees.
     total: number;
+    users: number;
   };
   files: SearchFileResult[];
   instruments: SearchInstrumentResult[];
   runs: SearchRunResult[];
+  users: SearchUserResult[];
 }
 
 // Escapes LIKE wildcards so user input matches literally. A filename like
@@ -93,6 +136,14 @@ export interface GlobalSearchResult {
 // pattern. Mirrors the escaping already used in `buildRunListQuery`.
 function escapeLike(query: string): string {
   return query.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+}
+
+function commentBodyPreview(body: string): string {
+  const collapsed = body.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= COMMENT_PREVIEW_MAX) {
+    return collapsed;
+  }
+  return `${collapsed.slice(0, COMMENT_PREVIEW_MAX).trimEnd()}…`;
 }
 
 const acquiredOrCreated = sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt})`;
@@ -282,6 +333,111 @@ async function searchInstruments(
   return matched;
 }
 
+async function searchUsers(
+  query: string,
+  limit: number
+): Promise<SearchUserResult[]> {
+  const escaped = escapeLike(query);
+  const substring = `%${escaped}%`;
+  const prefix = `${escaped}%`;
+
+  // Prefix on display name outranks email prefix, then any substring hit.
+  const relevance = sql<number>`case
+    when ${users.name} ilike ${prefix} then 2
+    when ${users.email} ilike ${prefix} then 1
+    else 0
+  end`;
+
+  const rows = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      image: users.image,
+    })
+    .from(users)
+    .where(
+      or(ilike(users.name, substring), ilike(users.email, substring)) as SQL
+    )
+    .orderBy(desc(relevance), asc(users.name), asc(users.email))
+    .limit(limit);
+
+  return rows.map((row) => ({
+    type: "user" as const,
+    id: row.id,
+    name: row.name,
+    email: row.email,
+    image: row.image,
+  }));
+}
+
+async function searchComments(
+  query: string,
+  limit: number
+): Promise<SearchCommentResult[]> {
+  const escaped = escapeLike(query);
+  const substring = `%${escaped}%`;
+  const prefix = `${escaped}%`;
+
+  const relevance = sql<number>`case when ${runComments.body} ilike ${prefix} then 1 else 0 end`;
+
+  const rows = await db
+    .select({
+      id: runComments.id,
+      body: runComments.body,
+      createdAt: runComments.createdAt,
+      userId: users.id,
+      userName: users.name,
+      userEmail: users.email,
+      runId: instrumentRuns.runId,
+      instrumentId: instrumentRuns.instrumentId,
+      instrumentName: instruments.displayName,
+    })
+    .from(runComments)
+    .innerJoin(instrumentRuns, eq(runComments.runId, instrumentRuns.id))
+    .innerJoin(instruments, eq(instrumentRuns.instrumentId, instruments.id))
+    .innerJoin(users, eq(runComments.userId, users.id))
+    .where(
+      and(
+        isNull(runComments.deletedAt),
+        isNull(instrumentRuns.deletedAt),
+        ilike(runComments.body, substring)
+      )
+    )
+    .orderBy(desc(relevance), desc(runComments.createdAt))
+    .limit(limit);
+
+  return rows.map((row) => ({
+    type: "comment" as const,
+    id: row.id,
+    bodyPreview: commentBodyPreview(row.body),
+    createdAt: row.createdAt.toISOString(),
+    userId: row.userId,
+    userName: row.userName ?? row.userEmail ?? "Unknown",
+    runId: row.runId,
+    instrumentId: row.instrumentId,
+    instrumentName: row.instrumentName,
+  }));
+}
+
+function emptyResult(): GlobalSearchResult {
+  return {
+    runs: [],
+    files: [],
+    instruments: [],
+    users: [],
+    comments: [],
+    counts: {
+      runs: 0,
+      files: 0,
+      instruments: 0,
+      users: 0,
+      comments: 0,
+      total: 0,
+    },
+  };
+}
+
 export async function globalSearch({
   query,
   scope = "all",
@@ -291,15 +447,8 @@ export async function globalSearch({
 }): Promise<GlobalSearchResult> {
   const trimmed = query.trim();
 
-  const empty: GlobalSearchResult = {
-    runs: [],
-    files: [],
-    instruments: [],
-    counts: { runs: 0, files: 0, instruments: 0, total: 0 },
-  };
-
   if (trimmed.length < MIN_QUERY_LENGTH) {
-    return empty;
+    return emptyResult();
   }
 
   const runLimit =
@@ -312,24 +461,46 @@ export async function globalSearch({
       : scope === "instruments"
         ? SCOPED_LIMIT
         : 0;
+  const userLimit =
+    scope === "all" ? ALL_TAB_PER_GROUP : scope === "users" ? SCOPED_LIMIT : 0;
+  const commentLimit =
+    scope === "all"
+      ? ALL_TAB_PER_GROUP
+      : scope === "comments"
+        ? SCOPED_LIMIT
+        : 0;
 
-  const [runs, filesResult, instrumentsResult] = await Promise.all([
-    runLimit > 0 ? searchRuns(trimmed, runLimit) : Promise.resolve([]),
-    fileLimit > 0 ? searchFiles(trimmed, fileLimit) : Promise.resolve([]),
-    instrumentLimit > 0
-      ? searchInstruments(trimmed, instrumentLimit)
-      : Promise.resolve([]),
-  ]);
+  const [runs, filesResult, instrumentsResult, usersResult, commentsResult] =
+    await Promise.all([
+      runLimit > 0 ? searchRuns(trimmed, runLimit) : Promise.resolve([]),
+      fileLimit > 0 ? searchFiles(trimmed, fileLimit) : Promise.resolve([]),
+      instrumentLimit > 0
+        ? searchInstruments(trimmed, instrumentLimit)
+        : Promise.resolve([]),
+      userLimit > 0 ? searchUsers(trimmed, userLimit) : Promise.resolve([]),
+      commentLimit > 0
+        ? searchComments(trimmed, commentLimit)
+        : Promise.resolve([]),
+    ]);
 
   return {
     runs,
     files: filesResult,
     instruments: instrumentsResult,
+    users: usersResult,
+    comments: commentsResult,
     counts: {
       runs: runs.length,
       files: filesResult.length,
       instruments: instrumentsResult.length,
-      total: runs.length + filesResult.length + instrumentsResult.length,
+      users: usersResult.length,
+      comments: commentsResult.length,
+      total:
+        runs.length +
+        filesResult.length +
+        instrumentsResult.length +
+        usersResult.length +
+        commentsResult.length,
     },
   };
 }

--- a/web/lib/api/search.ts
+++ b/web/lib/api/search.ts
@@ -23,10 +23,14 @@ import {
   runComments,
   users,
 } from "@/lib/db/schema";
+import { commentBodyPreview } from "@/lib/search-comment-preview";
 import { MIN_QUERY_LENGTH } from "@/lib/search-constants";
 
 // Global search across top-level entities. Backed by the pg_trgm GIN indexes
 // so the `ilike '%…%'` scans stay fast as the run/file/comment tables grow.
+// Users (name/email) are intentionally searchable with the same `runs:read`
+// gate as everything else — Data Hub has no row-level member privacy, and the
+// Users scope mirrors the members directory / attributor picker.
 
 export type SearchScope =
   | "all"
@@ -41,9 +45,6 @@ export type SearchScope =
 // surfaces a longer list without a dedicated results page.
 const ALL_TAB_PER_GROUP = 5;
 const SCOPED_LIMIT = 25;
-
-// Short plain-text snippet for the ⌘K list — full body is matched in SQL.
-const COMMENT_PREVIEW_MAX = 120;
 
 // Why a run surfaced. `run_id` is the run's own title (highest relevance);
 // `file` means a contained filename matched (drives the "Contains …" line);
@@ -136,14 +137,6 @@ export interface GlobalSearchResult {
 // pattern. Mirrors the escaping already used in `buildRunListQuery`.
 function escapeLike(query: string): string {
   return query.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
-}
-
-function commentBodyPreview(body: string): string {
-  const collapsed = body.replace(/\s+/g, " ").trim();
-  if (collapsed.length <= COMMENT_PREVIEW_MAX) {
-    return collapsed;
-  }
-  return `${collapsed.slice(0, COMMENT_PREVIEW_MAX).trimEnd()}…`;
 }
 
 const acquiredOrCreated = sql`coalesce(${instrumentRuns.acquiredAt}, ${instrumentRuns.createdAt})`;
@@ -410,7 +403,7 @@ async function searchComments(
   return rows.map((row) => ({
     type: "comment" as const,
     id: row.id,
-    bodyPreview: commentBodyPreview(row.body),
+    bodyPreview: commentBodyPreview(row.body, query),
     createdAt: row.createdAt.toISOString(),
     userId: row.userId,
     userName: row.userName ?? row.userEmail ?? "Unknown",

--- a/web/lib/api/watcher-binding.ts
+++ b/web/lib/api/watcher-binding.ts
@@ -1,0 +1,27 @@
+import type { AuthResult } from "@/lib/api/auth";
+
+// Pure watcher↔PAT binding decision. Kept DB-free so the unit suite can
+// import it without loading `@/lib/db` (which requires DATABASE_URL).
+
+export type WatcherBindingVerdict = "allow" | "deny" | "tofu";
+
+/**
+ * Pure binding decision used by `enforceWatcherBinding` in `watchers.ts`.
+ * Session/match/mismatch branches are unit-tested here; the TOFU claim path
+ * and HTTP 403/200 behaviour live in the integration suite.
+ */
+export function decideWatcherBinding(
+  authResult: AuthResult,
+  registeredByToken: string | null
+): WatcherBindingVerdict {
+  if (authResult.authMethod === "session") {
+    return "allow";
+  }
+  if (!authResult.tokenId) {
+    return "deny";
+  }
+  if (registeredByToken === null) {
+    return "tofu";
+  }
+  return registeredByToken === authResult.tokenId ? "allow" : "deny";
+}

--- a/web/lib/api/watchers.ts
+++ b/web/lib/api/watchers.ts
@@ -5,6 +5,7 @@ import { type ActorUser, resolveActorUser } from "@/lib/api/actor";
 import type { AuthResult } from "@/lib/api/auth";
 import { apiError, FORBIDDEN } from "@/lib/api/errors";
 import { instrumentHasOnlineWatcher } from "@/lib/api/instruments";
+import { decideWatcherBinding } from "@/lib/api/watcher-binding";
 import { type DbExecutor, db } from "@/lib/db";
 import {
   files,
@@ -27,29 +28,6 @@ export async function findActiveWatcher(watcherId: string) {
     .limit(1);
 
   return watcher ?? null;
-}
-
-export type WatcherBindingVerdict = "allow" | "deny" | "tofu";
-
-/**
- * Pure binding decision used by {@link enforceWatcherBinding}. Extracted so
- * session/match/mismatch can be unit-tested without a DB (the integration
- * harness has no session cookies).
- */
-export function decideWatcherBinding(
-  authResult: AuthResult,
-  registeredByToken: string | null
-): WatcherBindingVerdict {
-  if (authResult.authMethod === "session") {
-    return "allow";
-  }
-  if (!authResult.tokenId) {
-    return "deny";
-  }
-  if (registeredByToken === null) {
-    return "tofu";
-  }
-  return registeredByToken === authResult.tokenId ? "allow" : "deny";
 }
 
 /**

--- a/web/lib/db/schema.ts
+++ b/web/lib/db/schema.ts
@@ -734,6 +734,11 @@ export const runComments = pgTable(
       comment.createdAt.desc()
     ),
     index("idx_run_comments_user_id").on(comment.userId),
+    // Trigram GIN index backing global-search `ilike '%…%'` on comment bodies.
+    // Scoped to active rows; requires `pg_trgm` (created in migration 0029).
+    index("idx_run_comments_body_trgm")
+      .using("gin", sql`${comment.body} gin_trgm_ops`)
+      .where(sql`${comment.deletedAt} is null`),
   ]
 );
 

--- a/web/lib/mcp/glossary.ts
+++ b/web/lib/mcp/glossary.ts
@@ -22,7 +22,7 @@ export const DATAHUB_GLOSSARY = {
     "get_run_archive may return { status: 'building', retryAfterSeconds }. Call again after the wait until status is 'ready'.",
   toolRouting: {
     vagueDiscovery:
-      "Prefer global_search when the query may match filenames, instrument names, or attributor names. Prefer search_runs for structured filters (date, status, metadata).",
+      "Prefer global_search when the query may match filenames, instrument names, user names/emails, or comment bodies. Prefer search_runs for structured filters (date, status, metadata).",
     myRuns: 'search_runs with ranBy="me", or get_me then ranBy=<id>.',
     experimentalResults:
       "Prefer get_run_report for bounded CSV samples and failure summaries over downloading full files.",

--- a/web/lib/mcp/glossary.ts
+++ b/web/lib/mcp/glossary.ts
@@ -22,7 +22,7 @@ export const DATAHUB_GLOSSARY = {
     "get_run_archive may return { status: 'building', retryAfterSeconds }. Call again after the wait until status is 'ready'.",
   toolRouting: {
     vagueDiscovery:
-      "Prefer global_search when the query may match filenames, instrument names, user names/emails, or comment bodies. Prefer search_runs for structured filters (date, status, metadata).",
+      "Prefer global_search when the query may match filenames, instrument names, user names/emails, or comment bodies (users scope is workspace-wide under runs:read). Prefer search_runs for structured filters (date, status, metadata).",
     myRuns: 'search_runs with ranBy="me", or get_me then ranBy=<id>.',
     experimentalResults:
       "Prefer get_run_report for bounded CSV samples and failure summaries over downloading full files.",

--- a/web/lib/mcp/tools/discovery.defs.ts
+++ b/web/lib/mcp/tools/discovery.defs.ts
@@ -5,7 +5,7 @@ export const globalSearchTool = {
   name: "global_search",
   title: "Global Search",
   description:
-    "Fuzzy search across runs, files, instruments, users, and comments (same backend as the UI ⌘K palette). Prefer this over search_runs when the query may match a filename, instrument display name, attributor name, user, or comment body. Use search_runs for date/status/metadata filters. Queries shorter than 2 characters are rejected.",
+    "Fuzzy search across runs, files, instruments, users, and comments (same backend as the UI ⌘K palette). Prefer this over search_runs when the query may match a filename, instrument display name, attributor name, user, or comment body. The users scope returns workspace member names/emails to any caller with runs:read (no row-level member privacy). Use search_runs for date/status/metadata filters. Queries shorter than 2 characters are rejected.",
   group: "discovery",
   scope: "runs:read",
   inputSchema: {

--- a/web/lib/mcp/tools/discovery.defs.ts
+++ b/web/lib/mcp/tools/discovery.defs.ts
@@ -5,13 +5,13 @@ export const globalSearchTool = {
   name: "global_search",
   title: "Global Search",
   description:
-    "Fuzzy search across runs, files, and instruments (same backend as the UI ⌘K palette). Prefer this over search_runs when the query may match a filename, instrument display name, or attributor name. Use search_runs for date/status/metadata filters. Queries shorter than 2 characters are rejected.",
+    "Fuzzy search across runs, files, instruments, users, and comments (same backend as the UI ⌘K palette). Prefer this over search_runs when the query may match a filename, instrument display name, attributor name, user, or comment body. Use search_runs for date/status/metadata filters. Queries shorter than 2 characters are rejected.",
   group: "discovery",
   scope: "runs:read",
   inputSchema: {
     query: z.string().describe("Search query (min 2 characters)"),
     scope: z
-      .enum(["all", "runs", "files", "instruments"])
+      .enum(["all", "runs", "files", "instruments", "users", "comments"])
       .optional()
       .describe("Limit results to one entity type (default: all)"),
   },

--- a/web/lib/search-comment-preview.ts
+++ b/web/lib/search-comment-preview.ts
@@ -1,0 +1,62 @@
+// Plain-text ⌘K snippets for comment search hits. Kept client-safe (no DB)
+// so unit tests and the server search builder can share the same helper.
+
+// Short enough for a single command-palette row; the full body is matched in SQL.
+export const COMMENT_PREVIEW_MAX = 120;
+
+/**
+ * Light markdown → plain text for one-line snippets. Not a full CommonMark
+ * pass — just strip markers that commonly pollute a preview.
+ */
+export function markdownToPlainText(body: string): string {
+  return (
+    body
+      // Fenced blocks rarely help a snippet; drop them entirely.
+      .replace(/```[\s\S]*?```/g, " ")
+      .replace(/`([^`]+)`/g, "$1")
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+      .replace(/^#{1,6}\s+/gm, "")
+      .replace(/(\*\*|__)(.+?)\1/g, "$2")
+      .replace(/(\*|_)(.+?)\1/g, "$2")
+      .replace(/~~(.+?)~~/g, "$1")
+      .replace(/^>\s+/gm, "")
+      .replace(/^[-*+]\s+/gm, "")
+      .replace(/^\d+\.\s+/gm, "")
+      .replace(/\s+/g, " ")
+      .trim()
+  );
+}
+
+/**
+ * Build a plain-text preview that keeps the first case-insensitive match for
+ * `query` in view. Falls back to a head slice when the query isn't present in
+ * the stripped text (e.g. the hit was only in markdown syntax we removed).
+ */
+export function commentBodyPreview(body: string, query: string): string {
+  const plain = markdownToPlainText(body);
+  if (plain.length <= COMMENT_PREVIEW_MAX) {
+    return plain;
+  }
+
+  const needle = query.trim().toLowerCase();
+  const matchIndex =
+    needle.length > 0 ? plain.toLowerCase().indexOf(needle) : -1;
+
+  if (matchIndex < 0) {
+    return `${plain.slice(0, COMMENT_PREVIEW_MAX).trimEnd()}…`;
+  }
+
+  // Bias a little lead-in before the match so the highlight isn't flush left.
+  const contextBefore = Math.floor((COMMENT_PREVIEW_MAX - needle.length) / 3);
+  let start = Math.max(0, matchIndex - contextBefore);
+  let end = start + COMMENT_PREVIEW_MAX;
+  if (end > plain.length) {
+    end = plain.length;
+    start = Math.max(0, end - COMMENT_PREVIEW_MAX);
+  }
+
+  const prefix = start > 0 ? "…" : "";
+  const suffix = end < plain.length ? "…" : "";
+  return `${prefix}${plain.slice(start, end).trim()}${suffix}`;
+}

--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,7 @@
     "test:unit:watch": "vitest --config vitest.unit.config.ts",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:integration:watch": "vitest --config vitest.integration.config.ts",
+    "test": "npm run test:unit && npm run test:integration",
     "check": "npm run lint:check && npm run typecheck",
     "check-all": "npm run check && npm run test-all && npm run build"
   },

--- a/web/tests/integration/helpers.ts
+++ b/web/tests/integration/helpers.ts
@@ -80,11 +80,14 @@ export async function resetDb() {
 // but exposing the option here keeps the seeding helper future-proof for
 // any cookie-based session test harness layered on later.
 export async function seedTestUser(
-  options?: Pick<SeedUserOptions, "expiresAt" | "scopes" | "isAdmin">
+  options?: Pick<
+    SeedUserOptions,
+    "expiresAt" | "scopes" | "isAdmin" | "name" | "email"
+  >
 ) {
   const { userId, token, tokenId } = await seedDevUser(getTestDb(), {
-    ...options,
     name: "Test User",
+    ...options,
   });
   return { userId, token, tokenId };
 }

--- a/web/tests/integration/search.test.ts
+++ b/web/tests/integration/search.test.ts
@@ -116,6 +116,13 @@ describe("Global search API", () => {
         body: "Soft-deleted note about UBE2A should not match",
         deletedAt: new Date(),
       },
+      {
+        runId: specialRunUuid,
+        userId: authorUserId,
+        // Match sits past the preview window; markdown should be stripped and
+        // the snippet should recenter on the hit rather than the head.
+        body: `${"**pad** ".repeat(40)}late marker ZYZZYVA-TOKEN in **bold**`,
+      },
     ]);
   });
 
@@ -227,6 +234,15 @@ describe("Global search API", () => {
     expect(result.comments[0]?.instrumentId).toBe("hina-microscope");
     expect(result.comments[0]?.userId).toBe(authorUserId);
     expect(result.users).toHaveLength(0);
+  });
+
+  it("windows comment previews around the match and strips markdown", async () => {
+    const result = await search(token, "ZYZZYVA-TOKEN", "comments");
+    expect(result.comments).toHaveLength(1);
+    const preview = result.comments[0]?.bodyPreview ?? "";
+    expect(preview).toContain("ZYZZYVA-TOKEN");
+    expect(preview).not.toContain("**");
+    expect(preview.startsWith("…")).toBe(true);
   });
 
   it("includes users and comments in all-scope counts", async () => {

--- a/web/tests/integration/search.test.ts
+++ b/web/tests/integration/search.test.ts
@@ -1,6 +1,12 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { GlobalSearchResult } from "@/lib/api/search";
-import { files, instrumentRuns, instruments, watchers } from "@/lib/db/schema";
+import {
+  files,
+  instrumentRuns,
+  instruments,
+  runComments,
+  watchers,
+} from "@/lib/db/schema";
 import {
   api,
   closeTestDb,
@@ -49,10 +55,16 @@ async function search(
 
 describe("Global search API", () => {
   let token: string;
+  let authorUserId: string;
+  let specialRunUuid: string;
 
   beforeAll(async () => {
     await resetDb();
     ({ token } = await seedTestUser());
+    ({ userId: authorUserId } = await seedTestUser({
+      name: "Dakota Lab",
+      email: "dakota.search@example.com",
+    }));
 
     const db = getTestDb();
     await db.insert(instruments).values([
@@ -87,9 +99,23 @@ describe("Global search API", () => {
     await seedRun("hina-microscope", "20260630_101502_204", ["scan_009.nd2"]);
     // Literal special characters: `photo.*jpg` must match a `.*jpg` query while
     // `photoXjpg` must not (the query is never treated as a regex/glob).
-    await seedRun("hina-microscope", "special-run", [
+    specialRunUuid = await seedRun("hina-microscope", "special-run", [
       "photo.*jpg",
       "photoXjpg",
+    ]);
+
+    await db.insert(runComments).values([
+      {
+        runId: specialRunUuid,
+        userId: authorUserId,
+        body: "Growth curve looks promising after UBE2A rescue",
+      },
+      {
+        runId: specialRunUuid,
+        userId: authorUserId,
+        body: "Soft-deleted note about UBE2A should not match",
+        deletedAt: new Date(),
+      },
     ]);
   });
 
@@ -108,6 +134,8 @@ describe("Global search API", () => {
     expect(result.runs).toHaveLength(0);
     expect(result.files).toHaveLength(0);
     expect(result.instruments).toHaveLength(0);
+    expect(result.users).toHaveLength(0);
+    expect(result.comments).toHaveLength(0);
   });
 
   it("matches a run by its run id", async () => {
@@ -157,6 +185,8 @@ describe("Global search API", () => {
     expect(result.runs.length).toBeGreaterThan(0);
     expect(result.files).toHaveLength(0);
     expect(result.instruments).toHaveLength(0);
+    expect(result.users).toHaveLength(0);
+    expect(result.comments).toHaveLength(0);
   });
 
   it("treats special characters in the query literally, not as a pattern", async () => {
@@ -174,5 +204,40 @@ describe("Global search API", () => {
     expect(instrument).toBeDefined();
     expect(instrument?.matchReason).toBe("pattern");
     expect(instrument?.runCount).toBe(0);
+  });
+
+  it("matches users by name and email", async () => {
+    const byName = await search(token, "Dakota", "users");
+    expect(byName.users).toHaveLength(1);
+    expect(byName.users[0]?.name).toBe("Dakota Lab");
+    expect(byName.users[0]?.email).toBe("dakota.search@example.com");
+    expect(byName.runs).toHaveLength(0);
+    expect(byName.comments).toHaveLength(0);
+
+    const byEmail = await search(token, "dakota.search", "users");
+    expect(byEmail.users).toHaveLength(1);
+    expect(byEmail.users[0]?.id).toBe(authorUserId);
+  });
+
+  it("matches comments by body and excludes soft-deleted comments", async () => {
+    const result = await search(token, "UBE2A", "comments");
+    expect(result.comments).toHaveLength(1);
+    expect(result.comments[0]?.bodyPreview).toContain("Growth curve");
+    expect(result.comments[0]?.runId).toBe("special-run");
+    expect(result.comments[0]?.instrumentId).toBe("hina-microscope");
+    expect(result.comments[0]?.userId).toBe(authorUserId);
+    expect(result.users).toHaveLength(0);
+  });
+
+  it("includes users and comments in all-scope counts", async () => {
+    const result = await search(token, "Dakota");
+    expect(result.counts.users).toBeGreaterThan(0);
+    expect(result.counts.total).toBe(
+      result.counts.runs +
+        result.counts.files +
+        result.counts.instruments +
+        result.counts.users +
+        result.counts.comments
+    );
   });
 });

--- a/web/tests/mcp/mcp-protocol.test.ts
+++ b/web/tests/mcp/mcp-protocol.test.ts
@@ -185,7 +185,16 @@ vi.mock("@/lib/api/search", () => ({
     runs: [],
     files: [],
     instruments: [],
-    counts: { runs: 0, files: 0, instruments: 0, total: 0 },
+    users: [],
+    comments: [],
+    counts: {
+      runs: 0,
+      files: 0,
+      instruments: 0,
+      users: 0,
+      comments: 0,
+      total: 0,
+    },
   }),
 }));
 

--- a/web/tests/mcp/mcp-protocol.test.ts
+++ b/web/tests/mcp/mcp-protocol.test.ts
@@ -732,6 +732,8 @@ describe("MCP Protocol (in-memory)", () => {
     expect(parsed).toHaveProperty("runs");
     expect(parsed).toHaveProperty("files");
     expect(parsed).toHaveProperty("instruments");
+    expect(parsed).toHaveProperty("users");
+    expect(parsed).toHaveProperty("comments");
     expect(parsed.counts).toHaveProperty("total");
   });
 

--- a/web/tests/unit/search-comment-preview.test.ts
+++ b/web/tests/unit/search-comment-preview.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMMENT_PREVIEW_MAX,
+  commentBodyPreview,
+  markdownToPlainText,
+} from "@/lib/search-comment-preview";
+
+describe("markdownToPlainText", () => {
+  it("strips common markdown markers while keeping readable text", () => {
+    expect(
+      markdownToPlainText(
+        "## Heading\n\n**Bold** and *italic* with a [link](https://example.com) and `code`."
+      )
+    ).toBe("Heading Bold and italic with a link and code.");
+  });
+
+  it("drops fenced code blocks", () => {
+    expect(markdownToPlainText("Before\n```ts\nconst x = 1;\n```\nAfter")).toBe(
+      "Before After"
+    );
+  });
+});
+
+describe("commentBodyPreview", () => {
+  it("returns short plain text unchanged", () => {
+    expect(commentBodyPreview("**Growth** looks good", "growth")).toBe(
+      "Growth looks good"
+    );
+  });
+
+  it("windows around a late match instead of always slicing from the start", () => {
+    const prefix = "alpha ".repeat(40);
+    const body = `${prefix}UBE2A rescue worked after titration`;
+    const preview = commentBodyPreview(body, "UBE2A");
+    expect(preview).toContain("UBE2A");
+    expect(preview.startsWith("…")).toBe(true);
+    // Ellipsis characters may add up to 2 chars beyond the soft max.
+    expect(preview.length).toBeLessThanOrEqual(COMMENT_PREVIEW_MAX + 2);
+    // A naive head slice would only contain the repeated prefix.
+    expect(preview.startsWith("alpha")).toBe(false);
+  });
+
+  it("strips markdown so markers do not burn the preview budget", () => {
+    const prefix = "**lead** ".repeat(40);
+    const body = `${prefix}and then **critical-token** in context`;
+    const preview = commentBodyPreview(body, "critical-token");
+    expect(preview).toContain("critical-token");
+    expect(preview).not.toContain("**");
+  });
+});

--- a/web/tests/unit/watcher-binding.test.ts
+++ b/web/tests/unit/watcher-binding.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { AuthResult } from "@/lib/api/auth";
-import { decideWatcherBinding } from "@/lib/api/watchers";
+import { decideWatcherBinding } from "@/lib/api/watcher-binding";
 
-// Pure decision coverage for watcher↔PAT binding. The TOFU claim path and
-// HTTP 403/200 behaviour live in the integration suite — this file only
-// pins the session-exempt / match / mismatch branches that don't need a DB
-// (the integration harness has no session cookies).
+// Pure decision coverage for watcher↔PAT binding. Imports the DB-free
+// helper directly so the unit suite never loads `@/lib/db`. The TOFU claim
+// path and HTTP 403/200 behaviour live in the integration suite (which has
+// no session cookies).
 
 function sessionAuth(): AuthResult {
   return {


### PR DESCRIPTION
## Summary
- Extend ⌘K / `GET /api/v1/search` (and MCP `global_search`) with Users and Comments scopes, including a trigram index on comment bodies
- Add search result rows and deep links to user profiles and `#comment-{id}` on run pages
- Fix long result titles overflowing the modal via flex `min-w-0` / `block truncate`

## Test plan
- [x] Open ⌘K and confirm Users / Comments tabs appear; search a teammate name/email and a comment phrase
- [x] Selecting a user opens `/users/{id}`; selecting a comment opens the run and scrolls to that comment
- [x] Long run/file names show ellipsis instead of crowding the modal edge
- [x] Soft-deleted comments do not appear in results
- [x] `npm run test:integration -- tests/integration/search.test.ts` passes

Made with [Cursor](https://cursor.com)