### PR TITLE
Add PyPI-backed watcher version dropdowns and drop unused channel field

### DIFF
--- a/packages/shared/src/data_hub_shared/testing.py
+++ b/packages/shared/src/data_hub_shared/testing.py
@@ -167,7 +167,6 @@ def seed_watcher_release(
     *,
     latest_version: str = "9.9.9",
     min_supported_version: str = "0.1.0",
-    channel: str = "stable",
     mandatory: bool = False,
 ) -> None:
     """Upsert the singleton ``watcher_release_config`` row.
@@ -182,16 +181,15 @@ def seed_watcher_release(
     with conn.cursor() as cur:
         cur.execute(
             """INSERT INTO watcher_release_config
-                   (id, latest_version, min_supported_version, channel, mandatory)
+                   (id, latest_version, min_supported_version, mandatory)
                VALUES
-                   (true, %s, %s, %s, %s)
+                   (true, %s, %s, %s)
                ON CONFLICT (id) DO UPDATE SET
                    latest_version = EXCLUDED.latest_version,
                    min_supported_version = EXCLUDED.min_supported_version,
-                   channel = EXCLUDED.channel,
                    mandatory = EXCLUDED.mandatory,
                    updated_at = now()""",
-            (latest_version, min_supported_version, channel, mandatory),
+            (latest_version, min_supported_version, mandatory),
         )
     conn.close()
 

--- a/watcher/src/data_hub_watcher/cli.py
+++ b/watcher/src/data_hub_watcher/cli.py
@@ -1219,7 +1219,7 @@ def self_update(ctx: click.Context, check: bool, force: bool) -> None:
 
     target_label = info.latest_version or "(none configured)"
     mandatory_label = " [mandatory]" if info.mandatory else ""
-    click.echo(f"Server target:   {target_label} (channel={info.channel}){mandatory_label}")
+    click.echo(f"Server target:   {target_label}{mandatory_label}")
 
     decision = evaluate_update(info, force=force)
 

--- a/watcher/src/data_hub_watcher/models.py
+++ b/watcher/src/data_hub_watcher/models.py
@@ -311,5 +311,4 @@ class WatcherUpdateInfoResponse(BaseModel):
 
     latest_version: str | None = None
     min_supported_version: str | None = None
-    channel: str = "stable"
     mandatory: bool = False

--- a/watcher/src/data_hub_watcher/self_update.py
+++ b/watcher/src/data_hub_watcher/self_update.py
@@ -36,8 +36,7 @@ logger = logging.getLogger(__name__)
 
 PACKAGE_NAME = "data-hub-watcher"
 
-# Default index for `pip install` invocations. PyPI is hard-coded for now;
-# can be made configurable per channel later.
+# Default index for `pip install` / `uv tool install` invocations.
 DEFAULT_INDEX_URL = "https://pypi.org/simple/"
 
 

--- a/watcher/src/data_hub_watcher/updater.py
+++ b/watcher/src/data_hub_watcher/updater.py
@@ -542,7 +542,6 @@ class Updater:
         details_started: dict[str, Any] = {
             "current_version": WATCHER_VERSION,
             "target_version": target,
-            "channel": info.channel,
             "mandatory": info.mandatory,
             "install_method": method.value,
         }
@@ -752,7 +751,6 @@ class Updater:
         details_started: dict[str, Any] = {
             "current_version": WATCHER_VERSION,
             "target_version": target,
-            "channel": info.channel,
             "mandatory": info.mandatory,
             "install_method": method.value,
             "via_worker": True,

--- a/watcher/tests/integration/test_update_check.py
+++ b/watcher/tests/integration/test_update_check.py
@@ -28,7 +28,6 @@ class TestUpdateCheck:
         # regardless of where the real release line is.
         assert info.latest_version == "9.9.9"
         assert info.min_supported_version == "0.1.0"
-        assert info.channel == "stable"
         assert info.mandatory is False
 
     def test_get_update_info_returns_404_for_soft_deleted_watcher(

--- a/watcher/tests/test_cli_self_update.py
+++ b/watcher/tests/test_cli_self_update.py
@@ -73,7 +73,6 @@ def configured(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     fake_client = MagicMock(name="DataHubClient")
     fake_client.get_update_info.return_value = WatcherUpdateInfoResponse(
         latest_version="9.9.9",
-        channel="stable",
         mandatory=False,
     )
     monkeypatch.setattr(cli_module, "DataHubClient", lambda *_a, **_kw: fake_client)

--- a/watcher/tests/test_self_update.py
+++ b/watcher/tests/test_self_update.py
@@ -121,13 +121,11 @@ def _info(
     *,
     latest: str | None = "0.3.0",
     minimum: str | None = None,
-    channel: str = "stable",
     mandatory: bool = False,
 ) -> WatcherUpdateInfoResponse:
     return WatcherUpdateInfoResponse(
         latest_version=latest,
         min_supported_version=minimum,
-        channel=channel,
         mandatory=mandatory,
     )
 

--- a/watcher/tests/test_updater.py
+++ b/watcher/tests/test_updater.py
@@ -54,7 +54,6 @@ def _info(
 ) -> WatcherUpdateInfoResponse:
     return WatcherUpdateInfoResponse(
         latest_version=latest,
-        channel="stable",
         mandatory=mandatory,
     )
 

--- a/web/app/api/v1/settings/watcher-release/route.ts
+++ b/web/app/api/v1/settings/watcher-release/route.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/api/auth";
 import { apiError, VALIDATION_ERROR } from "@/lib/api/errors";
+import { VERSION_REGEX } from "@/lib/api/watcher-versions";
 import { db } from "@/lib/db";
 import { users, watcherReleaseConfig } from "@/lib/db/schema";
 
@@ -11,13 +12,6 @@ import { users, watcherReleaseConfig } from "@/lib/db/schema";
 // the same row but is open to any watcher-scoped PAT — this route is
 // the privileged write path and is therefore session-only via
 // `requireAdmin()`, matching the `/api/v1/users/[userId]` PATCH model.
-
-// Loose PEP-440-style version match — covers the values we already
-// advertise (`9.9.9`, `0.1.0`) plus the common `1.2.3rc1` / `1.2.3.post1`
-// shapes. We intentionally don't validate against PyPI here; a typo will
-// surface to operators as an `update_failed` event from the fleet, which
-// is the same failure mode they already debug today.
-const VERSION_REGEX = /^\d+\.\d+\.\d+([.-].+)?$/;
 
 // Trim and collapse `""` to `null` so the wire contract stays "empty
 // means unset" everywhere — operators don't have to remember to send

--- a/web/app/api/v1/settings/watcher-release/route.ts
+++ b/web/app/api/v1/settings/watcher-release/route.ts
@@ -32,10 +32,9 @@ function normalizeVersionInput(v: string | null | undefined): string | null {
 
 // PUT semantics: missing fields take their defaults rather than
 // silently preserving the existing row's value. The form always sends
-// all four, so this only affects hand-crafted callers — for whom a
+// all three, so this only affects hand-crafted callers — for whom a
 // uniform "replace with these (or defaults)" rule is far less surprising
-// than the previous mix where `channel`/`mandatory` defaulted but
-// `latest_version`/`min_supported_version` were preserved.
+// than a mix where some fields defaulted and others were preserved.
 const PutBodySchema = z.strictObject({
   latest_version: z
     .string()
@@ -51,13 +50,6 @@ const PutBodySchema = z.strictObject({
     .refine((v) => v === null || VERSION_REGEX.test(v), {
       message: "min_supported_version is not a valid PEP 440-style version",
     }),
-  channel: z
-    .string()
-    .optional()
-    .transform((v) => (v ?? "stable").trim())
-    .refine((v) => v.length > 0, {
-      message: "channel must be a non-empty string",
-    }),
   mandatory: z
     .boolean()
     .optional()
@@ -65,7 +57,6 @@ const PutBodySchema = z.strictObject({
 });
 
 interface WatcherReleaseResponse {
-  channel: string;
   latest_version: string | null;
   mandatory: boolean;
   min_supported_version: string | null;
@@ -80,7 +71,6 @@ interface WatcherReleaseResponse {
 const EMPTY_RESPONSE: WatcherReleaseResponse = {
   latest_version: null,
   min_supported_version: null,
-  channel: "stable",
   mandatory: false,
   updated_at: null,
   updated_by: null,
@@ -94,7 +84,6 @@ async function readCurrent(): Promise<WatcherReleaseResponse> {
     .select({
       latestVersion: watcherReleaseConfig.latestVersion,
       minSupportedVersion: watcherReleaseConfig.minSupportedVersion,
-      channel: watcherReleaseConfig.channel,
       mandatory: watcherReleaseConfig.mandatory,
       updatedAt: watcherReleaseConfig.updatedAt,
       updatedById: users.id,
@@ -111,7 +100,6 @@ async function readCurrent(): Promise<WatcherReleaseResponse> {
   return {
     latest_version: row.latestVersion,
     min_supported_version: row.minSupportedVersion,
-    channel: row.channel,
     mandatory: row.mandatory,
     updated_at: row.updatedAt.toISOString(),
     updated_by: row.updatedById
@@ -160,7 +148,6 @@ export async function PUT(request: NextRequest) {
   const {
     latest_version: latestVersion,
     min_supported_version: minSupportedVersion,
-    channel,
     mandatory,
   } = parsed.data;
 
@@ -174,7 +161,6 @@ export async function PUT(request: NextRequest) {
       id: true,
       latestVersion,
       minSupportedVersion,
-      channel,
       mandatory,
       updatedAt: now,
       updatedBy: authResult.userId,
@@ -184,7 +170,6 @@ export async function PUT(request: NextRequest) {
       set: {
         latestVersion,
         minSupportedVersion,
-        channel,
         mandatory,
         updatedAt: now,
         updatedBy: authResult.userId,

--- a/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
@@ -70,7 +70,6 @@ export async function POST(
     .select({
       minSupportedVersion: watcherReleaseConfig.minSupportedVersion,
       latestVersion: watcherReleaseConfig.latestVersion,
-      channel: watcherReleaseConfig.channel,
     })
     .from(watcherReleaseConfig);
 
@@ -86,7 +85,6 @@ export async function POST(
         current_version: reportedVersion,
         min_supported_version: releaseRow.minSupportedVersion,
         latest_version: releaseRow.latestVersion,
-        channel: releaseRow.channel,
       }
     );
   }

--- a/web/app/api/v1/watchers/[watcherId]/update-check/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/update-check/route.ts
@@ -16,7 +16,6 @@ import { watcherReleaseConfig } from "@/lib/db/schema";
  * client treats it as "no update available".
  */
 interface WatcherReleaseInfo {
-  channel: string;
   latest_version: string | null;
   mandatory: boolean;
   min_supported_version: string | null;
@@ -30,14 +29,12 @@ async function readReleaseInfo(): Promise<WatcherReleaseInfo> {
     return {
       latest_version: null,
       min_supported_version: null,
-      channel: "stable",
       mandatory: false,
     };
   }
   return {
     latest_version: row.latestVersion,
     min_supported_version: row.minSupportedVersion,
-    channel: row.channel,
     // Collapsing mandatory→false when no version is advertised keeps the
     // wire response self-consistent. The watcher's mandatory branch is
     // gated on `latest_version` anyway, but mirroring that invariant

--- a/web/app/settings/watchers/page.tsx
+++ b/web/app/settings/watchers/page.tsx
@@ -9,6 +9,7 @@ import { WatcherReleaseFormSkeleton } from "@/components/watcher-release/watcher
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { users, watcherReleaseConfig } from "@/lib/db/schema";
+import { fetchWatcherVersions } from "@/lib/pypi";
 
 export const metadata: Metadata = {
   title: "Watchers",
@@ -89,25 +90,30 @@ async function WatcherReleaseSection() {
   // "last updated by" line is a constant-cost query regardless of fleet
   // size. Returns `undefined` when no admin has saved yet — the form
   // renders blank defaults in that case.
-  const [row] = await db
-    .select({
-      latestVersion: watcherReleaseConfig.latestVersion,
-      minSupportedVersion: watcherReleaseConfig.minSupportedVersion,
-      channel: watcherReleaseConfig.channel,
-      mandatory: watcherReleaseConfig.mandatory,
-      updatedAt: watcherReleaseConfig.updatedAt,
-      updatedByName: users.name,
-      updatedByEmail: users.email,
-    })
-    .from(watcherReleaseConfig)
-    .leftJoin(users, eq(users.id, watcherReleaseConfig.updatedBy));
+  //
+  // PyPI versions are fetched in parallel with the DB read so the
+  // settings page doesn't waterfall (`async-parallel`).
+  const [[row], pypi] = await Promise.all([
+    db
+      .select({
+        latestVersion: watcherReleaseConfig.latestVersion,
+        minSupportedVersion: watcherReleaseConfig.minSupportedVersion,
+        mandatory: watcherReleaseConfig.mandatory,
+        updatedAt: watcherReleaseConfig.updatedAt,
+        updatedByName: users.name,
+        updatedByEmail: users.email,
+      })
+      .from(watcherReleaseConfig)
+      .leftJoin(users, eq(users.id, watcherReleaseConfig.updatedBy)),
+    fetchWatcherVersions(),
+  ]);
 
   return (
     <WatcherReleaseForm
+      availableVersions={pypi.versions}
       initial={{
         latestVersion: row?.latestVersion ?? "",
         minSupportedVersion: row?.minSupportedVersion ?? "",
-        channel: row?.channel ?? "stable",
         mandatory: row?.mandatory ?? false,
       }}
       // Only the primitive form values + the small "last updated"
@@ -122,6 +128,7 @@ async function WatcherReleaseSection() {
             }
           : null
       }
+      pypiReachable={pypi.ok}
     />
   );
 }

--- a/web/components/watcher-release/version-combobox.tsx
+++ b/web/components/watcher-release/version-combobox.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Check, ChevronsUpDown } from "lucide-react";
-import { useState } from "react";
+import { ChevronsUpDown } from "lucide-react";
+import { useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -45,6 +45,7 @@ export function VersionCombobox({
   versions,
 }: VersionComboboxProps) {
   const [open, setOpen] = useState(false);
+  const listId = useId();
   // Keep a saved value that isn't on PyPI selectable (test pins like
   // `9.9.9`, yanked releases, or a version published after our cache).
   const currentMissing =
@@ -67,6 +68,7 @@ export function VersionCombobox({
     >
       <PopoverTrigger asChild>
         <Button
+          aria-controls={listId}
           aria-expanded={open}
           aria-invalid={ariaInvalid}
           className="h-9 w-full justify-between font-mono font-normal"
@@ -88,7 +90,7 @@ export function VersionCombobox({
       >
         <Command>
           <CommandInput placeholder="Search versions..." />
-          <CommandList>
+          <CommandList id={listId}>
             <CommandEmpty>No versions found.</CommandEmpty>
             <CommandGroup>
               <CommandItem
@@ -96,12 +98,6 @@ export function VersionCombobox({
                 onSelect={() => select(NONE_VALUE)}
                 value={noneLabel}
               >
-                <Check
-                  className={cn(
-                    "size-4",
-                    value.length === 0 ? "opacity-100" : "opacity-0"
-                  )}
-                />
                 <span className="text-muted-foreground">{noneLabel}</span>
               </CommandItem>
             </CommandGroup>
@@ -110,11 +106,10 @@ export function VersionCombobox({
                 <CommandSeparator />
                 <CommandGroup heading="Current">
                   <CommandItem
-                    data-checked
+                    data-checked={true}
                     onSelect={() => select(currentMissing)}
                     value={`${currentMissing} current`}
                   >
-                    <Check className="size-4 opacity-100" />
                     <span className="font-mono">
                       {currentMissing}{" "}
                       <span className="text-muted-foreground">(current)</span>
@@ -125,25 +120,16 @@ export function VersionCombobox({
             ) : null}
             <CommandSeparator />
             <CommandGroup heading="PyPI releases">
-              {versions.map((version) => {
-                const selected = value === version;
-                return (
-                  <CommandItem
-                    data-checked={selected}
-                    key={version}
-                    onSelect={() => select(version)}
-                    value={version}
-                  >
-                    <Check
-                      className={cn(
-                        "size-4",
-                        selected ? "opacity-100" : "opacity-0"
-                      )}
-                    />
-                    <span className="font-mono">{version}</span>
-                  </CommandItem>
-                );
-              })}
+              {versions.map((version) => (
+                <CommandItem
+                  data-checked={value === version}
+                  key={version}
+                  onSelect={() => select(version)}
+                  value={version}
+                >
+                  <span className="font-mono">{version}</span>
+                </CommandItem>
+              ))}
             </CommandGroup>
           </CommandList>
         </Command>

--- a/web/components/watcher-release/version-combobox.tsx
+++ b/web/components/watcher-release/version-combobox.tsx
@@ -17,6 +17,8 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { formatDate } from "@/lib/date";
+import type { WatcherVersionOption } from "@/lib/pypi";
 import { cn } from "@/lib/utils";
 
 const NONE_VALUE = "";
@@ -30,7 +32,7 @@ interface VersionComboboxProps {
   onChange: (value: string) => void;
   placeholder?: string;
   value: string;
-  versions: string[];
+  versions: WatcherVersionOption[];
 }
 
 export function VersionCombobox({
@@ -49,7 +51,9 @@ export function VersionCombobox({
   // Keep a saved value that isn't on PyPI selectable (test pins like
   // `9.9.9`, yanked releases, or a version published after our cache).
   const currentMissing =
-    value.length > 0 && !versions.includes(value) ? value : null;
+    value.length > 0 && !versions.some((entry) => entry.version === value)
+      ? value
+      : null;
 
   function select(next: string) {
     onChange(next);
@@ -120,14 +124,21 @@ export function VersionCombobox({
             ) : null}
             <CommandSeparator />
             <CommandGroup heading="PyPI releases">
-              {versions.map((version) => (
+              {versions.map((entry) => (
                 <CommandItem
-                  data-checked={value === version}
-                  key={version}
-                  onSelect={() => select(version)}
-                  value={version}
+                  data-checked={value === entry.version}
+                  key={entry.version}
+                  onSelect={() => select(entry.version)}
+                  value={entry.version}
                 >
-                  <span className="font-mono">{version}</span>
+                  <span className="flex min-w-0 flex-1 items-center justify-between gap-3">
+                    <span className="font-mono">{entry.version}</span>
+                    {entry.uploadedAt ? (
+                      <span className="shrink-0 text-muted-foreground text-xs tabular-nums">
+                        {formatDate(new Date(entry.uploadedAt))}
+                      </span>
+                    ) : null}
+                  </span>
                 </CommandItem>
               ))}
             </CommandGroup>

--- a/web/components/watcher-release/version-combobox.tsx
+++ b/web/components/watcher-release/version-combobox.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { Check, ChevronsUpDown } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+const NONE_VALUE = "";
+
+interface VersionComboboxProps {
+  ariaInvalid?: boolean;
+  disabled?: boolean;
+  id: string;
+  noneLabel: string;
+  onBlur?: () => void;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  value: string;
+  versions: string[];
+}
+
+export function VersionCombobox({
+  ariaInvalid,
+  disabled,
+  id,
+  noneLabel,
+  onBlur,
+  onChange,
+  placeholder = "Select a version",
+  value,
+  versions,
+}: VersionComboboxProps) {
+  const [open, setOpen] = useState(false);
+  // Keep a saved value that isn't on PyPI selectable (test pins like
+  // `9.9.9`, yanked releases, or a version published after our cache).
+  const currentMissing =
+    value.length > 0 && !versions.includes(value) ? value : null;
+
+  function select(next: string) {
+    onChange(next);
+    setOpen(false);
+  }
+
+  return (
+    <Popover
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) {
+          onBlur?.();
+        }
+      }}
+      open={open}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          aria-expanded={open}
+          aria-invalid={ariaInvalid}
+          className="h-9 w-full justify-between font-mono font-normal"
+          disabled={disabled}
+          id={id}
+          role="combobox"
+          type="button"
+          variant="outline"
+        >
+          <span className={cn(value.length === 0 && "text-muted-foreground")}>
+            {value.length > 0 ? value : placeholder}
+          </span>
+          <ChevronsUpDown className="size-3.5 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+      >
+        <Command>
+          <CommandInput placeholder="Search versions..." />
+          <CommandList>
+            <CommandEmpty>No versions found.</CommandEmpty>
+            <CommandGroup>
+              <CommandItem
+                data-checked={value.length === 0}
+                onSelect={() => select(NONE_VALUE)}
+                value={noneLabel}
+              >
+                <Check
+                  className={cn(
+                    "size-4",
+                    value.length === 0 ? "opacity-100" : "opacity-0"
+                  )}
+                />
+                <span className="text-muted-foreground">{noneLabel}</span>
+              </CommandItem>
+            </CommandGroup>
+            {currentMissing ? (
+              <>
+                <CommandSeparator />
+                <CommandGroup heading="Current">
+                  <CommandItem
+                    data-checked
+                    onSelect={() => select(currentMissing)}
+                    value={`${currentMissing} current`}
+                  >
+                    <Check className="size-4 opacity-100" />
+                    <span className="font-mono">
+                      {currentMissing}{" "}
+                      <span className="text-muted-foreground">(current)</span>
+                    </span>
+                  </CommandItem>
+                </CommandGroup>
+              </>
+            ) : null}
+            <CommandSeparator />
+            <CommandGroup heading="PyPI releases">
+              {versions.map((version) => {
+                const selected = value === version;
+                return (
+                  <CommandItem
+                    data-checked={selected}
+                    key={version}
+                    onSelect={() => select(version)}
+                    value={version}
+                  >
+                    <Check
+                      className={cn(
+                        "size-4",
+                        selected ? "opacity-100" : "opacity-0"
+                      )}
+                    />
+                    <span className="font-mono">{version}</span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/components/watcher-release/version-field.tsx
+++ b/web/components/watcher-release/version-field.tsx
@@ -9,9 +9,10 @@ import {
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { VersionCombobox } from "@/components/watcher-release/version-combobox";
+import type { WatcherVersionOption } from "@/lib/pypi";
 
 interface VersionFieldProps {
-  availableVersions: string[];
+  availableVersions: WatcherVersionOption[];
   description: ReactNode;
   errors?: Array<{ message?: string } | undefined>;
   id: string;

--- a/web/components/watcher-release/version-field.tsx
+++ b/web/components/watcher-release/version-field.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { VersionCombobox } from "@/components/watcher-release/version-combobox";
+
+interface VersionFieldProps {
+  availableVersions: string[];
+  description: ReactNode;
+  errors?: Array<{ message?: string } | undefined>;
+  id: string;
+  isInvalid: boolean;
+  label: string;
+  noneLabel: string;
+  onBlur: () => void;
+  onChange: (value: string) => void;
+  placeholder: string;
+  pypiReachable: boolean;
+  value: string;
+}
+
+/**
+ * Shared latest / min-supported version control. Owns the PyPI combobox
+ * vs free-text fallback so the two form fields stay in sync.
+ */
+export function VersionField({
+  availableVersions,
+  description,
+  errors,
+  id,
+  isInvalid,
+  label,
+  noneLabel,
+  onBlur,
+  onChange,
+  placeholder,
+  pypiReachable,
+  value,
+}: VersionFieldProps) {
+  return (
+    <Field data-invalid={isInvalid}>
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      {pypiReachable ? (
+        <VersionCombobox
+          ariaInvalid={isInvalid}
+          id={id}
+          noneLabel={noneLabel}
+          onBlur={onBlur}
+          onChange={onChange}
+          placeholder="Select a version"
+          value={value}
+          versions={availableVersions}
+        />
+      ) : (
+        <Input
+          aria-invalid={isInvalid}
+          autoComplete="off"
+          className="font-mono"
+          id={id}
+          name={id}
+          onBlur={onBlur}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          spellCheck={false}
+          value={value}
+        />
+      )}
+      <FieldDescription>
+        {description}
+        {pypiReachable ? null : (
+          <> PyPI is unreachable, so versions must be entered manually.</>
+        )}
+      </FieldDescription>
+      {isInvalid ? <FieldError errors={errors} /> : null}
+    </Field>
+  );
+}

--- a/web/components/watcher-release/watcher-release-form-skeleton.tsx
+++ b/web/components/watcher-release/watcher-release-form-skeleton.tsx
@@ -49,7 +49,6 @@ export function WatcherReleaseFormSkeleton() {
         <div className="flex flex-col gap-7">
           <VersionFieldSkeleton labelWidth="w-28" />
           <VersionFieldSkeleton labelWidth="w-44" />
-          <VersionFieldSkeleton descriptionLines={1} labelWidth="w-28" />
           <MandatoryUpdateFieldSkeleton />
         </div>
       </CardContent>

--- a/web/components/watcher-release/watcher-release-form.tsx
+++ b/web/components/watcher-release/watcher-release-form.tsx
@@ -11,21 +11,13 @@ import {
   Field,
   FieldContent,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
 } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
-import { VersionCombobox } from "@/components/watcher-release/version-combobox";
+import { VersionField } from "@/components/watcher-release/version-field";
+import { VERSION_MESSAGE, VERSION_REGEX } from "@/lib/api/watcher-versions";
 import { formatRelativeTime } from "@/lib/utils";
-
-// Loose PEP 440-ish version match. Mirrors VERSION_REGEX in
-// app/api/v1/settings/watcher-release/route.ts so the client surfaces the
-// same rule the server enforces — typos are caught inline rather than
-// round-tripping through the API just to get a 400 back.
-const VERSION_REGEX = /^\d+\.\d+\.\d+([.-].+)?$/;
-const VERSION_MESSAGE = "Use a PEP 440-style version like 1.2.3 or 1.2.3rc1.";
 
 // Both version fields treat "" as "unset", so empty strings always pass —
 // the server's normaliser collapses "" → null on the wire. We only enforce
@@ -79,6 +71,11 @@ export function WatcherReleaseForm({
       onSubmit: formSchema,
     },
     onSubmit: async ({ value }) => {
+      // Trim before the wire and before reset so free-text whitespace
+      // doesn't leave isDirty=false with a value that differs from the
+      // server-persisted row after refresh.
+      const latestVersion = value.latestVersion.trim();
+      const minSupportedVersion = value.minSupportedVersion.trim();
       const res = await fetch("/api/v1/settings/watcher-release", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -86,8 +83,8 @@ export function WatcherReleaseForm({
           // Server accepts string|null; sending the trimmed string
           // (possibly empty) lets the server's normaliser convert ""→null
           // so the wire contract stays "empty means unset" everywhere.
-          latest_version: value.latestVersion.trim() || null,
-          min_supported_version: value.minSupportedVersion.trim() || null,
+          latest_version: latestVersion || null,
+          min_supported_version: minSupportedVersion || null,
           // The server collapses mandatory→false on read when
           // latest_version is null, so we don't need to mirror that on
           // write — keep the user's explicit choice in the row.
@@ -105,7 +102,11 @@ export function WatcherReleaseForm({
       // Re-baseline to the saved values so `isDirty` resets and the Save
       // button disables until the next edit. router.refresh() still re-runs
       // the server component so the "last updated by" line re-renders.
-      form.reset(value);
+      form.reset({
+        latestVersion,
+        minSupportedVersion,
+        mandatory: value.mandatory,
+      });
       router.refresh();
     },
   });
@@ -135,50 +136,28 @@ export function WatcherReleaseForm({
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid;
                 return (
-                  <Field data-invalid={isInvalid}>
-                    <FieldLabel htmlFor={field.name}>Latest version</FieldLabel>
-                    {pypiReachable ? (
-                      <VersionCombobox
-                        ariaInvalid={isInvalid}
-                        id={field.name}
-                        noneLabel="None — disable self-updates"
-                        onBlur={field.handleBlur}
-                        onChange={field.handleChange}
-                        placeholder="Select a version"
-                        value={field.state.value}
-                        versions={availableVersions}
-                      />
-                    ) : (
-                      <Input
-                        aria-invalid={isInvalid}
-                        autoComplete="off"
-                        className="font-mono"
-                        id={field.name}
-                        name={field.name}
-                        onBlur={field.handleBlur}
-                        onChange={(e) => field.handleChange(e.target.value)}
-                        placeholder="e.g. 0.4.2"
-                        spellCheck={false}
-                        value={field.state.value}
-                      />
-                    )}
-                    <FieldDescription>
-                      The release watchers will self-upgrade to. Leave blank to
-                      temporarily disable self-updates (the endpoint returns{" "}
-                      <code className="font-mono">latest_version: null</code>{" "}
-                      and clients skip the upgrade).
-                      {pypiReachable ? null : (
-                        <>
-                          {" "}
-                          PyPI is unreachable, so versions must be entered
-                          manually.
-                        </>
-                      )}
-                    </FieldDescription>
-                    {isInvalid && (
-                      <FieldError errors={field.state.meta.errors} />
-                    )}
-                  </Field>
+                  <VersionField
+                    availableVersions={availableVersions}
+                    description={
+                      <>
+                        The release watchers will self-upgrade to. Leave blank
+                        to temporarily disable self-updates (the endpoint
+                        returns{" "}
+                        <code className="font-mono">latest_version: null</code>{" "}
+                        and clients skip the upgrade).
+                      </>
+                    }
+                    errors={field.state.meta.errors}
+                    id={field.name}
+                    isInvalid={isInvalid}
+                    label="Latest version"
+                    noneLabel="None — disable self-updates"
+                    onBlur={field.handleBlur}
+                    onChange={field.handleChange}
+                    placeholder="e.g. 0.4.2"
+                    pypiReachable={pypiReachable}
+                    value={field.state.value}
+                  />
                 );
               }}
             </form.Field>
@@ -188,53 +167,28 @@ export function WatcherReleaseForm({
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid;
                 return (
-                  <Field data-invalid={isInvalid}>
-                    <FieldLabel htmlFor={field.name}>
-                      Minimum supported version
-                    </FieldLabel>
-                    {pypiReachable ? (
-                      <VersionCombobox
-                        ariaInvalid={isInvalid}
-                        id={field.name}
-                        noneLabel="None — no version floor"
-                        onBlur={field.handleBlur}
-                        onChange={field.handleChange}
-                        placeholder="Select a version"
-                        value={field.state.value}
-                        versions={availableVersions}
-                      />
-                    ) : (
-                      <Input
-                        aria-invalid={isInvalid}
-                        autoComplete="off"
-                        className="font-mono"
-                        id={field.name}
-                        name={field.name}
-                        onBlur={field.handleBlur}
-                        onChange={(e) => field.handleChange(e.target.value)}
-                        placeholder="e.g. 0.1.0"
-                        spellCheck={false}
-                        value={field.state.value}
-                      />
-                    )}
-                    <FieldDescription>
-                      Optional floor. Watchers reporting an installed version
-                      below this have their heartbeats rejected with{" "}
-                      <code className="font-mono">426 Upgrade Required</code>,
-                      forcing them to self-update before they can check in
-                      again. Leave blank to disable the floor.
-                      {pypiReachable ? null : (
-                        <>
-                          {" "}
-                          PyPI is unreachable, so versions must be entered
-                          manually.
-                        </>
-                      )}
-                    </FieldDescription>
-                    {isInvalid && (
-                      <FieldError errors={field.state.meta.errors} />
-                    )}
-                  </Field>
+                  <VersionField
+                    availableVersions={availableVersions}
+                    description={
+                      <>
+                        Optional floor. Watchers reporting an installed version
+                        below this have their heartbeats rejected with{" "}
+                        <code className="font-mono">426 Upgrade Required</code>,
+                        forcing them to self-update before they can check in
+                        again. Leave blank to disable the floor.
+                      </>
+                    }
+                    errors={field.state.meta.errors}
+                    id={field.name}
+                    isInvalid={isInvalid}
+                    label="Minimum supported version"
+                    noneLabel="None — no version floor"
+                    onBlur={field.handleBlur}
+                    onChange={field.handleChange}
+                    placeholder="e.g. 0.1.0"
+                    pypiReachable={pypiReachable}
+                    value={field.state.value}
+                  />
                 );
               }}
             </form.Field>

--- a/web/components/watcher-release/watcher-release-form.tsx
+++ b/web/components/watcher-release/watcher-release-form.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { VersionCombobox } from "@/components/watcher-release/version-combobox";
 import { formatRelativeTime } from "@/lib/utils";
 
 // Loose PEP 440-ish version match. Mirrors VERSION_REGEX in
@@ -40,9 +41,6 @@ const optionalVersion = z.string().refine(
 const formSchema = z.object({
   latestVersion: optionalVersion,
   minSupportedVersion: optionalVersion,
-  channel: z
-    .string()
-    .refine((v) => v.trim().length > 0, { message: "Channel can't be empty." }),
   mandatory: z.boolean(),
 });
 
@@ -55,13 +53,17 @@ interface LastUpdated {
 }
 
 interface WatcherReleaseFormProps {
+  availableVersions: string[];
   initial: WatcherReleaseFormValues;
   lastUpdated: LastUpdated | null;
+  pypiReachable: boolean;
 }
 
 export function WatcherReleaseForm({
+  availableVersions,
   initial,
   lastUpdated,
+  pypiReachable,
 }: WatcherReleaseFormProps) {
   const router = useRouter();
 
@@ -86,7 +88,6 @@ export function WatcherReleaseForm({
           // so the wire contract stays "empty means unset" everywhere.
           latest_version: value.latestVersion.trim() || null,
           min_supported_version: value.minSupportedVersion.trim() || null,
-          channel: value.channel.trim(),
           // The server collapses mandatory→false on read when
           // latest_version is null, so we don't need to mirror that on
           // write — keep the user's explicit choice in the row.
@@ -136,23 +137,43 @@ export function WatcherReleaseForm({
                 return (
                   <Field data-invalid={isInvalid}>
                     <FieldLabel htmlFor={field.name}>Latest version</FieldLabel>
-                    <Input
-                      aria-invalid={isInvalid}
-                      autoComplete="off"
-                      className="font-mono"
-                      id={field.name}
-                      name={field.name}
-                      onBlur={field.handleBlur}
-                      onChange={(e) => field.handleChange(e.target.value)}
-                      placeholder="e.g. 0.4.2"
-                      spellCheck={false}
-                      value={field.state.value}
-                    />
+                    {pypiReachable ? (
+                      <VersionCombobox
+                        ariaInvalid={isInvalid}
+                        id={field.name}
+                        noneLabel="None — disable self-updates"
+                        onBlur={field.handleBlur}
+                        onChange={field.handleChange}
+                        placeholder="Select a version"
+                        value={field.state.value}
+                        versions={availableVersions}
+                      />
+                    ) : (
+                      <Input
+                        aria-invalid={isInvalid}
+                        autoComplete="off"
+                        className="font-mono"
+                        id={field.name}
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        placeholder="e.g. 0.4.2"
+                        spellCheck={false}
+                        value={field.state.value}
+                      />
+                    )}
                     <FieldDescription>
                       The release watchers will self-upgrade to. Leave blank to
                       temporarily disable self-updates (the endpoint returns{" "}
                       <code className="font-mono">latest_version: null</code>{" "}
                       and clients skip the upgrade).
+                      {pypiReachable ? null : (
+                        <>
+                          {" "}
+                          PyPI is unreachable, so versions must be entered
+                          manually.
+                        </>
+                      )}
                     </FieldDescription>
                     {isInvalid && (
                       <FieldError errors={field.state.meta.errors} />
@@ -171,58 +192,44 @@ export function WatcherReleaseForm({
                     <FieldLabel htmlFor={field.name}>
                       Minimum supported version
                     </FieldLabel>
-                    <Input
-                      aria-invalid={isInvalid}
-                      autoComplete="off"
-                      className="font-mono"
-                      id={field.name}
-                      name={field.name}
-                      onBlur={field.handleBlur}
-                      onChange={(e) => field.handleChange(e.target.value)}
-                      placeholder="e.g. 0.1.0"
-                      spellCheck={false}
-                      value={field.state.value}
-                    />
+                    {pypiReachable ? (
+                      <VersionCombobox
+                        ariaInvalid={isInvalid}
+                        id={field.name}
+                        noneLabel="None — no version floor"
+                        onBlur={field.handleBlur}
+                        onChange={field.handleChange}
+                        placeholder="Select a version"
+                        value={field.state.value}
+                        versions={availableVersions}
+                      />
+                    ) : (
+                      <Input
+                        aria-invalid={isInvalid}
+                        autoComplete="off"
+                        className="font-mono"
+                        id={field.name}
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        placeholder="e.g. 0.1.0"
+                        spellCheck={false}
+                        value={field.state.value}
+                      />
+                    )}
                     <FieldDescription>
                       Optional floor. Watchers reporting an installed version
                       below this have their heartbeats rejected with{" "}
                       <code className="font-mono">426 Upgrade Required</code>,
                       forcing them to self-update before they can check in
                       again. Leave blank to disable the floor.
-                    </FieldDescription>
-                    {isInvalid && (
-                      <FieldError errors={field.state.meta.errors} />
-                    )}
-                  </Field>
-                );
-              }}
-            </form.Field>
-
-            <form.Field name="channel">
-              {(field) => {
-                const isInvalid =
-                  field.state.meta.isTouched && !field.state.meta.isValid;
-                return (
-                  <Field data-invalid={isInvalid}>
-                    <FieldLabel htmlFor={field.name}>
-                      Release channel
-                    </FieldLabel>
-                    <Input
-                      aria-invalid={isInvalid}
-                      autoComplete="off"
-                      className="font-mono"
-                      id={field.name}
-                      name={field.name}
-                      onBlur={field.handleBlur}
-                      onChange={(e) => field.handleChange(e.target.value)}
-                      placeholder="stable"
-                      spellCheck={false}
-                      value={field.state.value}
-                    />
-                    <FieldDescription>
-                      Defaults to <code className="font-mono">stable</code>.
-                      Surfaced in the response and shown in{" "}
-                      <code className="font-mono">self-update</code> output.
+                      {pypiReachable ? null : (
+                        <>
+                          {" "}
+                          PyPI is unreachable, so versions must be entered
+                          manually.
+                        </>
+                      )}
                     </FieldDescription>
                     {isInvalid && (
                       <FieldError errors={field.state.meta.errors} />
@@ -324,14 +331,10 @@ export function WatcherReleaseForm({
                 canSubmit: state.canSubmit,
                 isSubmitting: state.isSubmitting,
                 isDirty: state.isDirty,
-                channelEmpty: state.values.channel.trim().length === 0,
               })}
             >
-              {({ canSubmit, isSubmitting, isDirty, channelEmpty }) => (
-                <Button
-                  disabled={!canSubmit || channelEmpty || !isDirty}
-                  type="submit"
-                >
+              {({ canSubmit, isSubmitting, isDirty }) => (
+                <Button disabled={!(canSubmit && isDirty)} type="submit">
                   {isSubmitting ? (
                     <Loader2
                       className="animate-spin"

--- a/web/components/watcher-release/watcher-release-form.tsx
+++ b/web/components/watcher-release/watcher-release-form.tsx
@@ -17,6 +17,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { VersionField } from "@/components/watcher-release/version-field";
 import { VERSION_MESSAGE, VERSION_REGEX } from "@/lib/api/watcher-versions";
+import type { WatcherVersionOption } from "@/lib/pypi";
 import { formatRelativeTime } from "@/lib/utils";
 
 // Both version fields treat "" as "unset", so empty strings always pass —
@@ -45,7 +46,7 @@ interface LastUpdated {
 }
 
 interface WatcherReleaseFormProps {
-  availableVersions: string[];
+  availableVersions: WatcherVersionOption[];
   initial: WatcherReleaseFormValues;
   lastUpdated: LastUpdated | null;
   pypiReachable: boolean;

--- a/web/drizzle/0033_steady_wasp.sql
+++ b/web/drizzle/0033_steady_wasp.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "watcher_release_config" DROP COLUMN "channel";

--- a/web/drizzle/meta/0033_snapshot.json
+++ b/web/drizzle/meta/0033_snapshot.json
@@ -1,0 +1,2249 @@
+{
+  "id": "4d1e27f4-8927-43ba-a12c-b9db72e703a6",
+  "prevId": "befb0baf-5fc0-4805-96da-d48efb55f971",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": ["provider", "providerAccountId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archive_jobs": {
+      "name": "archive_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archive_bucket": {
+          "name": "archive_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_key": {
+          "name": "archive_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "archive_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_archive_jobs_inflight": {
+          "name": "uq_archive_jobs_inflight",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"archive_jobs\".\"status\" in ('pending', 'building')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_archive_jobs_run_fingerprint_status": {
+          "name": "idx_archive_jobs_run_fingerprint_status",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "archive_jobs_instrument_run_id_instrument_runs_id_fk": {
+          "name": "archive_jobs_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["instrument_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "archive_jobs_created_by_user_id_fk": {
+          "name": "archive_jobs_created_by_user_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "file_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raw'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_requested_at": {
+          "name": "upload_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_files_instrument_run_id_relative_path": {
+          "name": "uq_files_instrument_run_id_relative_path",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"relative_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_active_instrument_run_id_filename": {
+          "name": "uq_files_active_instrument_run_id_filename",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_s3_key": {
+          "name": "uq_files_s3_key",
+          "columns": [
+            {
+              "expression": "s3_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"s3_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_instrument_run_id": {
+          "name": "idx_files_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_status_instrument_run_id": {
+          "name": "idx_files_status_instrument_run_id",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_upload_queue": {
+          "name": "idx_files_upload_queue",
+          "columns": [
+            {
+              "expression": "upload_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"upload_requested_at\" is not null and \"files\".\"uploaded_at\" is null and \"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_metadata_gin": {
+          "name": "idx_files_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_files_filename_trgm": {
+          "name": "idx_files_filename_trgm",
+          "columns": [
+            {
+              "expression": "\"filename\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_instrument_run_id_instrument_runs_id_fk": {
+          "name": "files_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["instrument_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_notification_subscriptions": {
+      "name": "instrument_notification_subscriptions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_instrument_notification_subscriptions_user_id": {
+          "name": "idx_instrument_notification_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_notification_subscriptions_user_id_user_id_fk": {
+          "name": "instrument_notification_subscriptions_user_id_user_id_fk",
+          "tableFrom": "instrument_notification_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "instrument_notification_subscriptions_instrument_id_instruments_id_fk": {
+          "name": "instrument_notification_subscriptions_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_notification_subscriptions",
+          "tableTo": "instruments",
+          "columnsFrom": ["instrument_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "instrument_notification_subscriptions_user_id_instrument_id_pk": {
+          "name": "instrument_notification_subscriptions_user_id_instrument_id_pk",
+          "columns": ["user_id", "instrument_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_runs": {
+      "name": "instrument_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "instrument_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lambda'"
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instrument_runs_instrument_id_created_at": {
+          "name": "idx_instrument_runs_instrument_id_created_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active": {
+          "name": "idx_instrument_runs_active",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active_acquired_at": {
+          "name": "idx_instrument_runs_active_acquired_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"acquired_at\", \"created_at\") desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_metadata_gin": {
+          "name": "idx_instrument_runs_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_instrument_runs_run_id_trgm": {
+          "name": "idx_instrument_runs_run_id_trgm",
+          "columns": [
+            {
+              "expression": "\"run_id\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_runs_instrument_id_instruments_id_fk": {
+          "name": "instrument_runs_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "instruments",
+          "columnsFrom": ["instrument_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_watcher_id_watchers_id_fk": {
+          "name": "instrument_runs_watcher_id_watchers_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "watchers",
+          "columnsFrom": ["watcher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_deleted_by_user_id_fk": {
+          "name": "instrument_runs_deleted_by_user_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "user",
+          "columnsFrom": ["deleted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_instrument_runs_instrument_id_run_id": {
+          "name": "uq_instrument_runs_instrument_id_run_id",
+          "nullsNotDistinct": false,
+          "columns": ["instrument_id", "run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instruments": {
+      "name": "instruments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instrument_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instrument_type": {
+          "name": "instrument_type",
+          "type": "instrument_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_by": {
+          "name": "retired_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instruments_display_name_trgm": {
+          "name": "idx_instruments_display_name_trgm",
+          "columns": [
+            {
+              "expression": "\"display_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instruments_retired_by_user_id_fk": {
+          "name": "instruments_retired_by_user_id_fk",
+          "tableFrom": "instruments",
+          "tableTo": "user",
+          "columnsFrom": ["retired_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runs_all_muted": {
+          "name": "runs_all_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "comments_attributed_enabled": {
+          "name": "comments_attributed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "comments_participated_enabled": {
+          "name": "comments_participated_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "slack_runs_enabled": {
+          "name": "slack_runs_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slack_comments_attributed_enabled": {
+          "name": "slack_comments_attributed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slack_comments_participated_enabled": {
+          "name": "slack_comments_participated_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_user_id_fk": {
+          "name": "notification_preferences_user_id_user_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id_created_at": {
+          "name": "idx_notifications_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_id_unread": {
+          "name": "idx_notifications_user_id_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_run_id_instrument_runs_id_fk": {
+          "name": "notifications_run_id_instrument_runs_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_comment_id_run_comments_id_fk": {
+          "name": "notifications_comment_id_run_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "run_comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_user_id_user_id_fk": {
+          "name": "notifications_actor_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['*']::text[]"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_personal_access_tokens_user_id": {
+          "name": "idx_personal_access_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_user_id_fk": {
+          "name": "personal_access_tokens_user_id_user_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_attributions": {
+      "name": "run_attributions",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_attributions_run_id": {
+          "name": "idx_run_attributions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_attributions_user_id": {
+          "name": "idx_run_attributions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_attributions_run_id_instrument_runs_id_fk": {
+          "name": "run_attributions_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_attributions_user_id_user_id_fk": {
+          "name": "run_attributions_user_id_user_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_attributions_run_id_user_id_pk": {
+          "name": "run_attributions_run_id_user_id_pk",
+          "columns": ["run_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_comments": {
+      "name": "run_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_run_comments_run_id_created_at": {
+          "name": "idx_run_comments_run_id_created_at",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_comments_user_id": {
+          "name": "idx_run_comments_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_comments_body_trgm": {
+          "name": "idx_run_comments_body_trgm",
+          "columns": [
+            {
+              "expression": "\"body\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"run_comments\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_comments_run_id_instrument_runs_id_fk": {
+          "name": "run_comments_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_comments_user_id_user_id_fk": {
+          "name": "run_comments_user_id_user_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_channel_config": {
+      "name": "slack_channel_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_channel_config_updated_by_user_id_fk": {
+          "name": "slack_channel_config_updated_by_user_id_fk",
+          "tableFrom": "slack_channel_config",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "slack_channel_config_singleton": {
+          "name": "slack_channel_config_singleton",
+          "value": "\"slack_channel_config\".\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_connections": {
+      "name": "slack_connections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_name": {
+          "name": "slack_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_connections_user_id_user_id_fk": {
+          "name": "slack_connections_user_id_user_id_fk",
+          "tableFrom": "slack_connections",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_events": {
+      "name": "watcher_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "watcher_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_events_watcher_id_timestamp": {
+          "name": "idx_watcher_events_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_watcher_events_watcher_id_event_type": {
+          "name": "idx_watcher_events_watcher_id_event_type",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_events_watcher_id_watchers_id_fk": {
+          "name": "watcher_events_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_events",
+          "tableTo": "watchers",
+          "columnsFrom": ["watcher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_heartbeats": {
+      "name": "watcher_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_mode": {
+          "name": "upload_mode",
+          "type": "upload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_uploaded_since_last": {
+          "name": "files_uploaded_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "runs_reported_since_last": {
+          "name": "runs_reported_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_since_last": {
+          "name": "errors_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_heartbeats_watcher_id_timestamp": {
+          "name": "idx_watcher_heartbeats_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_heartbeats_watcher_id_watchers_id_fk": {
+          "name": "watcher_heartbeats_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_heartbeats",
+          "tableTo": "watchers",
+          "columnsFrom": ["watcher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_release_config": {
+      "name": "watcher_release_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_supported_version": {
+          "name": "min_supported_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mandatory": {
+          "name": "mandatory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watcher_release_config_updated_by_user_id_fk": {
+          "name": "watcher_release_config_updated_by_user_id_fk",
+          "tableFrom": "watcher_release_config",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "watcher_release_config_singleton": {
+          "name": "watcher_release_config_singleton",
+          "value": "\"watcher_release_config\".\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.watchers": {
+      "name": "watchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_info": {
+          "name": "os_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watcher_version": {
+          "name": "watcher_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_checksum": {
+          "name": "config_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_yaml": {
+          "name": "config_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "watcher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deregistered_by": {
+          "name": "deregistered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_by_token": {
+          "name": "registered_by_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_watchers_active_instrument_id": {
+          "name": "uq_watchers_active_instrument_id",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"watchers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchers_instrument_id_instruments_id_fk": {
+          "name": "watchers_instrument_id_instruments_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "instruments",
+          "columnsFrom": ["instrument_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "watchers_deregistered_by_user_id_fk": {
+          "name": "watchers_deregistered_by_user_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "user",
+          "columnsFrom": ["deregistered_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "watchers_registered_by_token_personal_access_tokens_id_fk": {
+          "name": "watchers_registered_by_token_personal_access_tokens_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "personal_access_tokens",
+          "columnsFrom": ["registered_by_token"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.archive_job_status": {
+      "name": "archive_job_status",
+      "schema": "public",
+      "values": ["pending", "building", "ready", "failed"]
+    },
+    "public.file_category": {
+      "name": "file_category",
+      "schema": "public",
+      "values": ["raw", "processed"]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "detected",
+        "upload_requested",
+        "uploaded",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.instrument_run_source": {
+      "name": "instrument_run_source",
+      "schema": "public",
+      "values": ["lambda", "watcher"]
+    },
+    "public.instrument_status": {
+      "name": "instrument_status",
+      "schema": "public",
+      "values": ["pending", "active", "inactive"]
+    },
+    "public.instrument_type": {
+      "name": "instrument_type",
+      "schema": "public",
+      "values": [
+        "generic",
+        "plate_reader",
+        "gel_doc",
+        "qpcr",
+        "tape_station",
+        "hina_microscope",
+        "epson_v700_scanner",
+        "instant_raman"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": ["run_created", "comment_attributed", "comment_participated"]
+    },
+    "public.upload_mode": {
+      "name": "upload_mode",
+      "schema": "public",
+      "values": ["auto", "manual"]
+    },
+    "public.watcher_event_type": {
+      "name": "watcher_event_type",
+      "schema": "public",
+      "values": [
+        "watcher_started",
+        "watcher_stopped",
+        "file_uploaded",
+        "upload_failed",
+        "run_reported",
+        "config_synced",
+        "error",
+        "update_started",
+        "update_succeeded",
+        "update_failed"
+      ]
+    },
+    "public.watcher_status": {
+      "name": "watcher_status",
+      "schema": "public",
+      "values": ["registered", "watching", "stopped"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1784308273738,
       "tag": "0032_add_run_comments_body_trgm",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1784320580169,
+      "tag": "0033_steady_wasp",
+      "breakpoints": true
     }
   ]
 }

--- a/web/lib/api/openapi/schemas/watchers.ts
+++ b/web/lib/api/openapi/schemas/watchers.ts
@@ -132,7 +132,6 @@ export const watcherUploadQueueResponse = z.object({
 });
 
 export const watcherUpdateCheckResponse = z.object({
-  channel: z.string(),
   latest_version: z.string().nullable(),
   mandatory: z.boolean(),
   min_supported_version: z.string().nullable(),

--- a/web/lib/api/watcher-versions.ts
+++ b/web/lib/api/watcher-versions.ts
@@ -1,11 +1,19 @@
-// Loose PEP 440-ish ordering. Mirrors the VERSION_REGEX used by
-// `app/api/v1/settings/watcher-release/route.ts` and the form in
-// `components/watcher-release/watcher-release-form.tsx` — together they're
-// the single source of truth for which version shapes the platform
-// understands. Doing real PEP 440 ordering here would mean either a
-// dependency or ~200 lines of spec code; the shapes we actually advertise
-// (X.Y.Z, X.Y.Z.postN, X.Y.ZrcN, X.Y.Z-dev0) all fit cleanly under this
-// simpler model so we keep the implementation small.
+// Loose PEP 440-ish version match / ordering. Shared by the admin
+// watcher-release PUT route, the settings form, and heartbeat floor
+// checks so a typo is rejected with the same rule everywhere.
+//
+// Covers the values we advertise (`9.9.9`, `0.1.0`) plus common
+// `1.2.3rc1` / `1.2.3.post1` shapes. We intentionally don't validate
+// against PyPI on write; a typo surfaces as an `update_failed` event
+// from the fleet — the same failure mode operators already debug.
+//
+// Real PEP 440 ordering would mean either a dependency or ~200 lines of
+// spec code; the shapes we actually use all fit this simpler model.
+
+export const VERSION_REGEX = /^(\d+)\.(\d+)\.(\d+)([.-].+)?$/;
+
+export const VERSION_MESSAGE =
+  "Use a PEP 440-style version like 1.2.3 or 1.2.3rc1.";
 
 interface ParsedVersion {
   core: [number, number, number];
@@ -15,7 +23,7 @@ interface ParsedVersion {
 }
 
 function parseLoose(v: string): ParsedVersion | null {
-  const m = /^(\d+)\.(\d+)\.(\d+)([.-].+)?$/.exec(v.trim());
+  const m = VERSION_REGEX.exec(v.trim());
   if (!m) {
     return null;
   }

--- a/web/lib/db/schema.ts
+++ b/web/lib/db/schema.ts
@@ -155,7 +155,7 @@ export const sessions = pgTable(
 // `GET /api/v1/watchers/:id/update-check` and edited via the admin-only
 // `/settings/watchers` page. Previously sourced from the
 // `WATCHER_LATEST_VERSION` / `WATCHER_MIN_SUPPORTED_VERSION` /
-// `WATCHER_RELEASE_CHANNEL` / `WATCHER_MANDATORY_UPDATE` env vars.
+// `WATCHER_MANDATORY_UPDATE` env vars.
 //
 // The `id boolean PRIMARY KEY DEFAULT true` + check constraint is the
 // standard Postgres singleton trick — schema-level guarantee of at most
@@ -177,9 +177,6 @@ export const watcherReleaseConfig = pgTable(
     // (see `app/api/v1/watchers/[watcherId]/heartbeat/route.ts`) so they
     // can't continue checking in without self-updating first.
     minSupportedVersion: text("min_supported_version"),
-    // Defaults to "stable"; surfaced in the response and shown in
-    // `self-update` output.
-    channel: text("channel").notNull().default("stable"),
     // When true, the release skips the watcher's activity-window guard so
     // mid-acquisition PCs upgrade immediately. Has no effect when
     // `latest_version` is NULL — `update-check` collapses it to false on

--- a/web/lib/db/seed.ts
+++ b/web/lib/db/seed.ts
@@ -130,13 +130,12 @@ export async function seedDevUser(
 export async function seedWatcherReleaseConfig(db: Db): Promise<void> {
   await db.execute(
     sql`INSERT INTO watcher_release_config
-       (id, latest_version, min_supported_version, channel, mandatory)
+       (id, latest_version, min_supported_version, mandatory)
      VALUES
-       (true, '9.9.9', '0.1.0', 'stable', false)
+       (true, '9.9.9', '0.1.0', false)
      ON CONFLICT (id) DO UPDATE SET
        latest_version = EXCLUDED.latest_version,
        min_supported_version = EXCLUDED.min_supported_version,
-       channel = EXCLUDED.channel,
        mandatory = EXCLUDED.mandatory,
        updated_at = now(),
        updated_by = NULL`

--- a/web/lib/pypi.ts
+++ b/web/lib/pypi.ts
@@ -16,14 +16,15 @@ export interface WatcherVersionsResult {
 
 /**
  * Fetches published `data-hub-watcher` versions from the PyPI JSON API.
- * Cached for an hour so the settings page doesn't hammer PyPI on every
- * admin visit. Returns `{ ok: false, versions: [] }` on any failure so
- * the form can fall back to free-text inputs.
+ * Cached for five minutes so the settings page stays responsive after a
+ * fresh publish without hammering PyPI on every admin visit. Returns
+ * `{ ok: false, versions: [] }` on any failure so the form can fall back
+ * to free-text inputs.
  */
 export async function fetchWatcherVersions(): Promise<WatcherVersionsResult> {
   try {
     const res = await fetch(PYPI_WATCHER_URL, {
-      next: { revalidate: 3600 },
+      next: { revalidate: 300 },
       headers: { Accept: "application/json" },
     });
     if (!res.ok) {

--- a/web/lib/pypi.ts
+++ b/web/lib/pypi.ts
@@ -1,0 +1,69 @@
+const PYPI_WATCHER_URL = "https://pypi.org/pypi/data-hub-watcher/json";
+
+interface PypiReleaseFile {
+  upload_time_iso_8601?: string;
+  yanked?: boolean;
+}
+
+interface PypiPackageJson {
+  releases?: Record<string, PypiReleaseFile[] | undefined>;
+}
+
+export interface WatcherVersionsResult {
+  ok: boolean;
+  versions: string[];
+}
+
+/**
+ * Fetches published `data-hub-watcher` versions from the PyPI JSON API.
+ * Cached for an hour so the settings page doesn't hammer PyPI on every
+ * admin visit. Returns `{ ok: false, versions: [] }` on any failure so
+ * the form can fall back to free-text inputs.
+ */
+export async function fetchWatcherVersions(): Promise<WatcherVersionsResult> {
+  try {
+    const res = await fetch(PYPI_WATCHER_URL, {
+      next: { revalidate: 3600 },
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) {
+      return { ok: false, versions: [] };
+    }
+
+    const data = (await res.json()) as PypiPackageJson;
+    const releases = data.releases;
+    if (!releases || typeof releases !== "object") {
+      return { ok: false, versions: [] };
+    }
+
+    const ranked: { version: string; uploadedAt: number }[] = [];
+    for (const [version, files] of Object.entries(releases)) {
+      if (!Array.isArray(files) || files.length === 0) {
+        continue;
+      }
+      // Drop fully-yanked releases so admins can't pin the fleet to a
+      // version PyPI will refuse to serve.
+      if (files.every((file) => file.yanked === true)) {
+        continue;
+      }
+      let maxUpload = 0;
+      for (const file of files) {
+        if (!file.upload_time_iso_8601) {
+          continue;
+        }
+        const ts = Date.parse(file.upload_time_iso_8601);
+        if (!Number.isNaN(ts) && ts > maxUpload) {
+          maxUpload = ts;
+        }
+      }
+      ranked.push({ version, uploadedAt: maxUpload });
+    }
+
+    // Newest-first by upload time matches PyPI's "Release history" order
+    // without reimplementing PEP 440 comparison in JS.
+    ranked.sort((a, b) => b.uploadedAt - a.uploadedAt);
+    return { ok: true, versions: ranked.map((entry) => entry.version) };
+  } catch {
+    return { ok: false, versions: [] };
+  }
+}

--- a/web/lib/pypi.ts
+++ b/web/lib/pypi.ts
@@ -9,9 +9,15 @@ interface PypiPackageJson {
   releases?: Record<string, PypiReleaseFile[] | undefined>;
 }
 
+export interface WatcherVersionOption {
+  /** ISO-8601 upload time of the newest file in the release; null if unknown. */
+  uploadedAt: string | null;
+  version: string;
+}
+
 export interface WatcherVersionsResult {
   ok: boolean;
-  versions: string[];
+  versions: WatcherVersionOption[];
 }
 
 /**
@@ -37,7 +43,7 @@ export async function fetchWatcherVersions(): Promise<WatcherVersionsResult> {
       return { ok: false, versions: [] };
     }
 
-    const ranked: { version: string; uploadedAt: number }[] = [];
+    const ranked: { version: string; uploadedAtMs: number }[] = [];
     for (const [version, files] of Object.entries(releases)) {
       if (!Array.isArray(files) || files.length === 0) {
         continue;
@@ -57,13 +63,22 @@ export async function fetchWatcherVersions(): Promise<WatcherVersionsResult> {
           maxUpload = ts;
         }
       }
-      ranked.push({ version, uploadedAt: maxUpload });
+      ranked.push({ version, uploadedAtMs: maxUpload });
     }
 
     // Newest-first by upload time matches PyPI's "Release history" order
     // without reimplementing PEP 440 comparison in JS.
-    ranked.sort((a, b) => b.uploadedAt - a.uploadedAt);
-    return { ok: true, versions: ranked.map((entry) => entry.version) };
+    ranked.sort((a, b) => b.uploadedAtMs - a.uploadedAtMs);
+    return {
+      ok: true,
+      versions: ranked.map((entry) => ({
+        version: entry.version,
+        uploadedAt:
+          entry.uploadedAtMs > 0
+            ? new Date(entry.uploadedAtMs).toISOString()
+            : null,
+      })),
+    };
   } catch {
     return { ok: false, versions: [] };
   }

--- a/web/tests/integration/global-setup.ts
+++ b/web/tests/integration/global-setup.ts
@@ -222,13 +222,12 @@ export async function setup() {
   try {
     await seedPool.query(`
       INSERT INTO watcher_release_config
-        (id, latest_version, min_supported_version, channel, mandatory)
+        (id, latest_version, min_supported_version, mandatory)
       VALUES
-        (true, '9.9.9', '0.1.0', 'stable', false)
+        (true, '9.9.9', '0.1.0', false)
       ON CONFLICT (id) DO UPDATE SET
         latest_version = excluded.latest_version,
         min_supported_version = excluded.min_supported_version,
-        channel = excluded.channel,
         mandatory = excluded.mandatory,
         updated_at = now()
     `);

--- a/web/tests/integration/watcher-release.test.ts
+++ b/web/tests/integration/watcher-release.test.ts
@@ -54,7 +54,6 @@ describe("Watcher Release API admin gate", () => {
       body: {
         latest_version: "1.0.0",
         min_supported_version: null,
-        channel: "stable",
         mandatory: false,
       },
     });
@@ -67,7 +66,6 @@ describe("Watcher Release API admin gate", () => {
       body: {
         latest_version: "1.0.0",
         min_supported_version: null,
-        channel: "stable",
         mandatory: false,
       },
     });
@@ -123,7 +121,6 @@ describe("Watcher Release singleton flows through update-check", () => {
         id: true,
         latestVersion: "9.9.9",
         minSupportedVersion: "0.1.0",
-        channel: "stable",
         mandatory: false,
       })
       .onConflictDoUpdate({
@@ -131,7 +128,6 @@ describe("Watcher Release singleton flows through update-check", () => {
         set: {
           latestVersion: "9.9.9",
           minSupportedVersion: "0.1.0",
-          channel: "stable",
           mandatory: false,
         },
       });
@@ -149,7 +145,6 @@ describe("Watcher Release singleton flows through update-check", () => {
         id: true,
         latestVersion: "1.2.3",
         minSupportedVersion: "1.0.0",
-        channel: "beta",
         mandatory: true,
       })
       .onConflictDoUpdate({
@@ -157,7 +152,6 @@ describe("Watcher Release singleton flows through update-check", () => {
         set: {
           latestVersion: "1.2.3",
           minSupportedVersion: "1.0.0",
-          channel: "beta",
           mandatory: true,
         },
       });
@@ -169,7 +163,6 @@ describe("Watcher Release singleton flows through update-check", () => {
     expect(await res.json()).toEqual({
       latest_version: "1.2.3",
       min_supported_version: "1.0.0",
-      channel: "beta",
       mandatory: true,
     });
   });
@@ -186,7 +179,6 @@ describe("Watcher Release singleton flows through update-check", () => {
         id: true,
         latestVersion: null,
         minSupportedVersion: null,
-        channel: "stable",
         mandatory: true,
       })
       .onConflictDoUpdate({
@@ -194,7 +186,6 @@ describe("Watcher Release singleton flows through update-check", () => {
         set: {
           latestVersion: null,
           minSupportedVersion: null,
-          channel: "stable",
           mandatory: true,
         },
       });
@@ -206,7 +197,6 @@ describe("Watcher Release singleton flows through update-check", () => {
     expect(await res.json()).toEqual({
       latest_version: null,
       min_supported_version: null,
-      channel: "stable",
       mandatory: false,
     });
   });
@@ -227,7 +217,6 @@ describe("Watcher Release singleton flows through update-check", () => {
     expect(await res.json()).toEqual({
       latest_version: null,
       min_supported_version: null,
-      channel: "stable",
       mandatory: false,
     });
   });
@@ -240,9 +229,7 @@ describe("Watcher Release singleton flows through update-check", () => {
     // halves of the invariant should break together.
     const db = getTestDb();
     await expect(
-      db.execute(
-        sql`INSERT INTO watcher_release_config (id, channel) VALUES (false, 'stable')`
-      )
+      db.execute(sql`INSERT INTO watcher_release_config (id) VALUES (false)`)
     ).rejects.toThrow();
   });
 });
@@ -269,7 +256,6 @@ describe("Heartbeat enforces watcher_release_config.min_supported_version", () =
         id: true,
         latestVersion: "9.9.9",
         minSupportedVersion: floor,
-        channel: "stable",
         mandatory: false,
       })
       .onConflictDoUpdate({
@@ -277,7 +263,6 @@ describe("Heartbeat enforces watcher_release_config.min_supported_version", () =
         set: {
           latestVersion: "9.9.9",
           minSupportedVersion: floor,
-          channel: "stable",
           mandatory: false,
         },
       });
@@ -342,7 +327,6 @@ describe("Heartbeat enforces watcher_release_config.min_supported_version", () =
           current_version: "0.5.0",
           min_supported_version: "1.0.0",
           latest_version: "9.9.9",
-          channel: "stable",
         },
       },
     });

--- a/web/tests/integration/watchers.test.ts
+++ b/web/tests/integration/watchers.test.ts
@@ -423,7 +423,6 @@ describe("Watchers API", () => {
     expect(data).toEqual({
       latest_version: "9.9.9",
       min_supported_version: "0.1.0",
-      channel: "stable",
       mandatory: false,
     });
     watcherUpdateCheckResponse.parse(data);

--- a/web/tests/unit/pypi.test.ts
+++ b/web/tests/unit/pypi.test.ts
@@ -30,7 +30,11 @@ describe("fetchWatcherVersions", () => {
 
     await expect(fetchWatcherVersions()).resolves.toEqual({
       ok: true,
-      versions: ["0.3.0", "0.2.0", "0.1.0"],
+      versions: [
+        { version: "0.3.0", uploadedAt: "2024-06-01T00:00:00.000Z" },
+        { version: "0.2.0", uploadedAt: "2024-03-01T00:00:00.000Z" },
+        { version: "0.1.0", uploadedAt: "2024-01-01T00:00:00.000Z" },
+      ],
     });
   });
 
@@ -69,7 +73,10 @@ describe("fetchWatcherVersions", () => {
 
     await expect(fetchWatcherVersions()).resolves.toEqual({
       ok: true,
-      versions: ["0.4.0-partial", "0.1.0"],
+      versions: [
+        { version: "0.4.0-partial", uploadedAt: "2024-04-02T00:00:00.000Z" },
+        { version: "0.1.0", uploadedAt: "2024-01-01T00:00:00.000Z" },
+      ],
     });
   });
 

--- a/web/tests/unit/pypi.test.ts
+++ b/web/tests/unit/pypi.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchWatcherVersions } from "@/lib/pypi";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("fetchWatcherVersions", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns versions newest-first by upload time", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({
+          releases: {
+            "0.1.0": [{ upload_time_iso_8601: "2024-01-01T00:00:00.000Z" }],
+            "0.3.0": [{ upload_time_iso_8601: "2024-06-01T00:00:00.000Z" }],
+            "0.2.0": [{ upload_time_iso_8601: "2024-03-01T00:00:00.000Z" }],
+          },
+        })
+      )
+    );
+
+    await expect(fetchWatcherVersions()).resolves.toEqual({
+      ok: true,
+      versions: ["0.3.0", "0.2.0", "0.1.0"],
+    });
+  });
+
+  it("drops fully-yanked releases and empty file lists", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({
+          releases: {
+            "0.1.0": [{ upload_time_iso_8601: "2024-01-01T00:00:00.000Z" }],
+            "0.2.0-yanked": [
+              {
+                upload_time_iso_8601: "2024-02-01T00:00:00.000Z",
+                yanked: true,
+              },
+              {
+                upload_time_iso_8601: "2024-02-02T00:00:00.000Z",
+                yanked: true,
+              },
+            ],
+            "0.3.0-empty": [],
+            "0.4.0-partial": [
+              {
+                upload_time_iso_8601: "2024-04-01T00:00:00.000Z",
+                yanked: true,
+              },
+              {
+                upload_time_iso_8601: "2024-04-02T00:00:00.000Z",
+                yanked: false,
+              },
+            ],
+          },
+        })
+      )
+    );
+
+    await expect(fetchWatcherVersions()).resolves.toEqual({
+      ok: true,
+      versions: ["0.4.0-partial", "0.1.0"],
+    });
+  });
+
+  it("returns ok:false when PyPI responds non-OK", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ detail: "gone" }, 503))
+    );
+
+    await expect(fetchWatcherVersions()).resolves.toEqual({
+      ok: false,
+      versions: [],
+    });
+  });
+
+  it("returns ok:false when the payload has no releases object", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(jsonResponse({ info: { name: "data-hub-watcher" } }))
+    );
+
+    await expect(fetchWatcherVersions()).resolves.toEqual({
+      ok: false,
+      versions: [],
+    });
+  });
+
+  it("returns ok:false when fetch throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("network down"))
+    );
+
+    await expect(fetchWatcherVersions()).resolves.toEqual({
+      ok: false,
+      versions: [],
+    });
+  });
+
+  it("uses a five-minute Next.js revalidate window", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ releases: {} }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchWatcherVersions();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://pypi.org/pypi/data-hub-watcher/json",
+      expect.objectContaining({
+        next: { revalidate: 300 },
+        headers: { Accept: "application/json" },
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Replace free-text latest/min-supported version inputs on `/settings/watchers` with searchable PyPI-backed comboboxes (free-text fallback when PyPI is unreachable)
- Remove the unused cosmetic `channel` field from the release config UI, API, OpenAPI schema, DB (migration `0033`), and watcher client
- Keep the currently saved version selectable even when it is not on PyPI (e.g. test pins like `9.9.9`)

## Test plan
- [x] Apply migration (`npm run db:migrate` or `db:push` in `web/`) and open `/settings/watchers` as an admin
- [x] Confirm Latest version and Minimum supported version show PyPI releases newest-first, with a None option
- [x] Save a version from the dropdown and verify `GET /api/v1/watchers/:id/update-check` returns it without a `channel` field
- [x] With a non-PyPI saved value (e.g. `9.9.9`), confirm it appears as `(current)` in the combobox
- [x] Run `make check-all` and relevant watcher/web tests

Made with [Cursor](https://cursor.com)