### PR TITLE
Restrict `POST /files` to PAT-only authentication

### DIFF
--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/files/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/files/route.ts
@@ -1,6 +1,6 @@
 import { and, eq, isNull } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { authorize } from "@/lib/api/auth";
+import { authorizeToken } from "@/lib/api/auth";
 import { apiError, CONFLICT, NOT_FOUND } from "@/lib/api/errors";
 import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
 import { createFileBody, readJsonBody } from "@/lib/api/openapi";
@@ -23,12 +23,16 @@ interface RouteContext {
 // starts in "uploaded" status because the Lambda already has the file in S3
 // by the time it calls this endpoint.
 //
+// PAT-only (no browser sessions): session auth carries `*` scope, and
+// accepting it let any signed-in user overwrite a pre-upload file's
+// s3_bucket/s3_key via the adoption branch below (ENG-1455).
+//
 // Idempotent on s3_key: if a file with the same key already exists (partial
 // unique index), returns the existing record with 200 instead of 201.
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "files:create");
+  const authResult = await authorizeToken(request, "files:create");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/lib/api/auth.ts
+++ b/web/lib/api/auth.ts
@@ -209,3 +209,25 @@ export async function authorize(
   }
   return authResult;
 }
+
+// Same contract as {@link authorize}, but PAT-only — sessions are never
+// consulted. Use for machine-to-machine routes (e.g. Lambda file create)
+// where accepting a browser session would grant `*` scope and open an
+// attack surface that PATs with least-privilege scopes avoid.
+export async function authorizeToken(
+  request: NextRequest,
+  scope: Scope
+): Promise<AuthResult | Response> {
+  const authResult = await authenticateWithToken(request);
+  if (!authResult) {
+    return apiError(401, UNAUTHORIZED, "Authentication required");
+  }
+  if (!hasScope(authResult, scope)) {
+    return apiError(
+      403,
+      FORBIDDEN,
+      `Token is missing required scope: ${scope}`
+    );
+  }
+  return authResult;
+}

--- a/web/tests/integration/files.test.ts
+++ b/web/tests/integration/files.test.ts
@@ -285,6 +285,33 @@ describe("Files API", () => {
     expect(res.status).toBe(404);
   });
 
+  // Pins the scope check on authorizeToken (PAT-only helper used by this
+  // route). A valid PAT without files:create must not reach the create /
+  // adopt logic — the same surface a browser session with `*` used to
+  // abuse via S3 location injection (ENG-1455).
+  it("POST returns 403 without files:create scope", async () => {
+    const { token: scopedToken } = await seedTestUser({
+      scopes: ["files:read"],
+    });
+
+    const res = await api(
+      `/api/v1/instruments/${instrumentId}/runs/${runId}/files`,
+      {
+        method: "POST",
+        token: scopedToken,
+        body: {
+          s3_bucket: "test-bucket",
+          s3_key: `${instrumentId}/${runId}/scope-denied.csv`,
+          filename: "scope-denied.csv",
+        },
+      }
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.code).toBe("FORBIDDEN");
+    expect(body.error.message).toMatch(/missing required scope: files:create/);
+  });
+
   // -------------------------------------------------------------------------
   // PATCH /api/v1/files/:fileId — watcher path (detected → uploaded)
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Close S3 location injection on `POST /api/v1/instruments/:instrumentId/runs/:runId/files` by authenticating with PAT-only `authorizeToken`, so browser sessions (which carry `*` scope) can no longer reach the pre-upload adoption path that overwrites `s3_bucket`/`s3_key`.
- Add a reusable `authorizeToken` helper mirroring `authorize`, and a regression test that a PAT without `files:create` gets 403.

## Test plan
- [x] `make check-all`
- [x] `npx vitest run --config vitest.integration.config.ts tests/integration/files.test.ts` (26/26)
- [ ] Confirm Lambda `create_file` (PAT) still succeeds in staging after deploy
- [ ] Confirm a browser session cannot call POST `/files` (expect 401)

Made with [Cursor](https://cursor.com)