### PR TITLE
Fix multi-day kinetic plate map time sorting and layout

### DIFF
--- a/web/components/runs/plate-map-grid.tsx
+++ b/web/components/runs/plate-map-grid.tsx
@@ -156,7 +156,7 @@ export function PlateMapGrid({
   const colLabels = Array.from({ length: cols }, (_, i) => String(i + 1));
 
   return (
-    <div className="flex w-fit flex-col gap-3">
+    <div className="flex w-full min-w-[75%] flex-col gap-3">
       {(plateName || wavelength) && (
         <div className="flex items-baseline justify-between gap-4">
           <h4 className="font-medium font-mono text-foreground text-sm leading-snug">
@@ -171,9 +171,9 @@ export function PlateMapGrid({
       )}
       <div className="overflow-x-auto">
         <div
-          className="inline-grid gap-0.5 text-center"
+          className="grid w-full gap-0.5 text-center"
           style={{
-            gridTemplateColumns: `2rem repeat(${cols}, minmax(3rem, 1fr))`,
+            gridTemplateColumns: `2rem repeat(${cols}, minmax(0, 1fr))`,
           }}
         >
           {/* Column headers */}
@@ -256,8 +256,10 @@ export function PlateMapGrid({
 
 function PlasmaColorBar({ min, max }: { min: number; max: number }) {
   return (
-    <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
-      <span className="font-mono">{formatCellValue(min)}</span>
+    <div className="flex items-center gap-2 text-muted-foreground text-xs">
+      <span className="shrink-0 font-mono tabular-nums">
+        {formatCellValue(min)}
+      </span>
       <div
         className="h-3 flex-1 rounded-sm"
         style={{
@@ -265,7 +267,9 @@ function PlasmaColorBar({ min, max }: { min: number; max: number }) {
             "linear-gradient(to right, rgb(13,8,135), rgb(189,55,134), rgb(253,202,38), rgb(240,249,33))",
         }}
       />
-      <span className="font-mono">{formatCellValue(max)}</span>
+      <span className="shrink-0 font-mono tabular-nums">
+        {formatCellValue(max)}
+      </span>
     </div>
   );
 }
@@ -326,7 +330,7 @@ export function KineticPlateMapWithTimeSlider({
   }
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex w-full min-w-[75%] flex-col gap-3">
       <PlateMapGrid
         data={frames[selectedIndex]}
         heatmap={heatmap}
@@ -338,18 +342,12 @@ export function KineticPlateMapWithTimeSlider({
         <div className="flex flex-col gap-2">
           <div className="flex items-center justify-between gap-2 text-muted-foreground text-xs">
             <span>Time</span>
-            <span
-              className="min-w-0 truncate font-mono text-foreground tabular-nums"
-              title={timeLabels[selectedIndex] ?? ""}
-            >
+            <span className="font-mono text-foreground tabular-nums">
               {timeLabels[selectedIndex] ?? "—"}
             </span>
           </div>
           <div className="flex items-center gap-2">
-            <span
-              className="w-10 shrink-0 truncate text-center font-mono text-[10px] text-muted-foreground"
-              title={timeLabels[0]}
-            >
+            <span className="shrink-0 font-mono text-muted-foreground text-xs tabular-nums">
               {timeLabels[0]}
             </span>
             <Slider
@@ -361,10 +359,7 @@ export function KineticPlateMapWithTimeSlider({
               step={1}
               value={[selectedIndex]}
             />
-            <span
-              className="w-10 shrink-0 truncate text-center font-mono text-[10px] text-muted-foreground"
-              title={timeLabels[maxIdx]}
-            >
+            <span className="shrink-0 font-mono text-muted-foreground text-xs tabular-nums">
               {timeLabels[maxIdx]}
             </span>
           </div>

--- a/web/components/runs/plate-map-grid.tsx
+++ b/web/components/runs/plate-map-grid.tsx
@@ -7,6 +7,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 
 export interface PlateWellData {
   value: unknown;
@@ -84,6 +85,7 @@ function heatmapColor(
 }
 
 interface PlateMapGridProps {
+  className?: string;
   data: unknown;
   heatmap?: boolean;
   /** When heatmap is on, use this scale instead of inferring min/max from `data`. */
@@ -93,6 +95,7 @@ interface PlateMapGridProps {
 }
 
 export function PlateMapGrid({
+  className,
   data,
   heatmap = false,
   heatmapRange,
@@ -156,7 +159,7 @@ export function PlateMapGrid({
   const colLabels = Array.from({ length: cols }, (_, i) => String(i + 1));
 
   return (
-    <div className="flex w-full min-w-[75%] flex-col gap-3">
+    <div className={cn("flex w-3/4 flex-col gap-3", className)}>
       {(plateName || wavelength) && (
         <div className="flex items-baseline justify-between gap-4">
           <h4 className="font-medium font-mono text-foreground text-sm leading-snug">
@@ -173,13 +176,17 @@ export function PlateMapGrid({
         <div
           className="grid w-full gap-0.5 text-center"
           style={{
-            gridTemplateColumns: `2rem repeat(${cols}, minmax(0, 1fr))`,
+            // Extra column for the vertical color bar, sized to its labels.
+            gridTemplateColumns:
+              heatmap && hasRange
+                ? `2rem repeat(${cols}, minmax(0, 1fr)) auto`
+                : `2rem repeat(${cols}, minmax(0, 1fr))`,
           }}
         >
           {/* Column headers */}
           {colLabels.map((c, ci) => (
             <div
-              className="py-1 font-medium text-muted-foreground text-xs"
+              className="py-1 font-medium text-muted-foreground text-sm"
               key={c}
               style={{ gridRow: 1, gridColumn: ci + 2 }}
             >
@@ -191,7 +198,7 @@ export function PlateMapGrid({
           {rowLabels.map((rowLabel, ri) => (
             <Fragment key={rowLabel}>
               <div
-                className="flex items-center justify-center font-medium text-muted-foreground text-xs"
+                className="flex items-center justify-center font-medium text-muted-foreground text-sm"
                 style={{ gridRow: ri + 2, gridColumn: 1 }}
               >
                 {rowLabel}
@@ -215,8 +222,8 @@ export function PlateMapGrid({
                       <div
                         className={
                           useHeatmap
-                            ? "flex aspect-square items-center justify-center rounded font-mono text-[10px] transition-colors"
-                            : `flex aspect-square items-center justify-center rounded border font-mono text-xs ${
+                            ? "flex aspect-square items-center justify-center rounded font-mono text-xs transition-colors"
+                            : `flex aspect-square items-center justify-center rounded border font-mono text-sm ${
                                 hasValue
                                   ? "border-border bg-muted/50"
                                   : "border-transparent"
@@ -246,30 +253,42 @@ export function PlateMapGrid({
               })}
             </Fragment>
           ))}
+
+          {/*
+            Color bar shares the plate grid so the rectangle aligns with wells
+            A…H; max/min sit in the header row and a trailing row.
+          */}
+          {heatmap && hasRange && (
+            <>
+              <div
+                className="ml-4 flex items-end justify-center pb-0.5 text-muted-foreground text-xs"
+                style={{ gridRow: 1, gridColumn: cols + 3 }}
+              >
+                <span className="font-mono tabular-nums">
+                  {formatCellValue(vMax)}
+                </span>
+              </div>
+              <div
+                className="ml-4 w-4 self-stretch overflow-hidden rounded-md"
+                style={{
+                  gridRow: `2 / ${rows + 2}`,
+                  gridColumn: cols + 3,
+                  background:
+                    "linear-gradient(to top, rgb(13,8,135), rgb(189,55,134), rgb(253,202,38), rgb(240,249,33))",
+                }}
+              />
+              <div
+                className="ml-4 flex items-start justify-center pt-0.5 text-muted-foreground text-xs"
+                style={{ gridRow: rows + 2, gridColumn: cols + 3 }}
+              >
+                <span className="font-mono tabular-nums">
+                  {formatCellValue(vMin)}
+                </span>
+              </div>
+            </>
+          )}
         </div>
       </div>
-
-      {heatmap && hasRange && <PlasmaColorBar max={vMax} min={vMin} />}
-    </div>
-  );
-}
-
-function PlasmaColorBar({ min, max }: { min: number; max: number }) {
-  return (
-    <div className="flex items-center gap-2 text-muted-foreground text-xs">
-      <span className="shrink-0 font-mono tabular-nums">
-        {formatCellValue(min)}
-      </span>
-      <div
-        className="h-3 flex-1 rounded-sm"
-        style={{
-          background:
-            "linear-gradient(to right, rgb(13,8,135), rgb(189,55,134), rgb(253,202,38), rgb(240,249,33))",
-        }}
-      />
-      <span className="shrink-0 font-mono tabular-nums">
-        {formatCellValue(max)}
-      </span>
     </div>
   );
 }
@@ -329,9 +348,13 @@ export function KineticPlateMapWithTimeSlider({
     return null;
   }
 
+  // Thumb centers track from 0–100%; avoid div-by-zero on a single frame.
+  const thumbPercent = maxIdx === 0 ? 0 : (selectedIndex / maxIdx) * 100;
+
   return (
-    <div className="flex w-full min-w-[75%] flex-col gap-3">
+    <div className="flex w-3/4 flex-col gap-3">
       <PlateMapGrid
+        className="w-full"
         data={frames[selectedIndex]}
         heatmap={heatmap}
         heatmapRange={heatmapRange}
@@ -339,30 +362,31 @@ export function KineticPlateMapWithTimeSlider({
         wavelength={wavelength}
       />
       {frames.length > 1 && (
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center justify-between gap-2 text-muted-foreground text-xs">
-            <span>Time</span>
-            <span className="font-mono text-foreground tabular-nums">
+        <div className="mt-3 flex items-center gap-2">
+          <span className="shrink-0 font-mono text-muted-foreground text-xs tabular-nums">
+            {timeLabels[0]}
+          </span>
+          <div className="relative min-w-0 flex-1">
+            <div
+              aria-hidden
+              className="pointer-events-none absolute bottom-full z-10 mb-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-foreground px-1.5 py-0.5 font-mono text-background text-xs tabular-nums"
+              style={{ left: `${thumbPercent}%` }}
+            >
               {timeLabels[selectedIndex] ?? "—"}
-            </span>
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="shrink-0 font-mono text-muted-foreground text-xs tabular-nums">
-              {timeLabels[0]}
-            </span>
+            </div>
             <Slider
               aria-label="Select measurement time"
-              className="flex-1 py-1"
+              className="w-full py-1"
               max={maxIdx}
               min={0}
               onValueChange={(v) => setIndex(v[0] ?? 0)}
               step={1}
               value={[selectedIndex]}
             />
-            <span className="shrink-0 font-mono text-muted-foreground text-xs tabular-nums">
-              {timeLabels[maxIdx]}
-            </span>
           </div>
+          <span className="shrink-0 font-mono text-muted-foreground text-xs tabular-nums">
+            {timeLabels[maxIdx]}
+          </span>
         </div>
       )}
     </div>

--- a/web/components/runs/variants/plate-reader-run-detail.tsx
+++ b/web/components/runs/variants/plate-reader-run-detail.tsx
@@ -14,6 +14,7 @@ import {
 import { RunSectionHeading } from "@/components/runs/run-section-heading";
 import { Card, CardContent } from "@/components/ui/card";
 import type { RawWellRow } from "@/lib/api/instrument-runs";
+import { sortTimeKeys } from "@/lib/runs/sort-kinetic-time-keys";
 
 /** Measurement types whose well values are numeric and benefit from color-coded heatmaps. */
 const HEATMAP_MEASUREMENT_TYPES = new Set(["Endpoint", "Well Scan", "Kinetic"]);
@@ -49,27 +50,6 @@ type PlateMapGroup =
       timeLabels: string[];
       frames: PlateWellData[][];
     };
-
-/**
- * Sort time-point keys so kinetic slider frames appear in chronological order.
- * Numeric timestamps (e.g. seconds) are sorted numerically; non-numeric labels
- * fall back to locale-aware natural sort.
- */
-function sortTimeKeys(keys: string[]): string[] {
-  const unique = [...new Set(keys)];
-  const allNumeric = unique.every((k) => {
-    if (k === "") {
-      return false;
-    }
-    return Number.isFinite(Number(k));
-  });
-  if (allNumeric) {
-    return unique.sort((a, b) => Number(a) - Number(b));
-  }
-  return unique.sort((a, b) =>
-    a.localeCompare(b, undefined, { numeric: true })
-  );
-}
 
 /**
  * Groups kinetic CSV rows into time-indexed plate map frames, one group per

--- a/web/lib/runs/sort-kinetic-time-keys.ts
+++ b/web/lib/runs/sort-kinetic-time-keys.ts
@@ -1,0 +1,66 @@
+/**
+ * SoftMax Pro kinetic elapsed times are `HH:MM:SS` within the first day and
+ * `D.HH:MM:SS` once the run crosses midnight. Lexicographic / numeric string
+ * sorts interleave day prefixes with hour digits (e.g. `03:00:39` after
+ * `2.02:11:12`), so we parse to total seconds before ordering.
+ */
+function parseElapsedTimeToSeconds(label: string): number | null {
+  const withDays = label.match(
+    /^(\d+)\.(\d{1,2}):(\d{2}):(\d{2})(?:\.(\d+))?$/
+  );
+  if (withDays) {
+    const days = Number(withDays[1]);
+    const hours = Number(withDays[2]);
+    const minutes = Number(withDays[3]);
+    const seconds = Number(withDays[4]);
+    const frac = withDays[5] ? Number(`0.${withDays[5]}`) : 0;
+    return days * 86_400 + hours * 3600 + minutes * 60 + seconds + frac;
+  }
+
+  const hms = label.match(/^(\d{1,2}):(\d{2}):(\d{2})(?:\.(\d+))?$/);
+  if (hms) {
+    const hours = Number(hms[1]);
+    const minutes = Number(hms[2]);
+    const seconds = Number(hms[3]);
+    const frac = hms[4] ? Number(`0.${hms[4]}`) : 0;
+    return hours * 3600 + minutes * 60 + seconds + frac;
+  }
+
+  return null;
+}
+
+/**
+ * Sort time-point keys so kinetic slider frames appear in chronological order.
+ * Prefers numeric timestamps (scan indices / seconds), then SoftMax elapsed
+ * durations, then locale-aware natural sort as a last resort.
+ */
+export function sortTimeKeys(keys: string[]): string[] {
+  const unique = [...new Set(keys)];
+  const allNumeric = unique.every((k) => {
+    if (k === "") {
+      return false;
+    }
+    return Number.isFinite(Number(k));
+  });
+  if (allNumeric) {
+    return unique.sort((a, b) => Number(a) - Number(b));
+  }
+
+  const parsed = new Map<string, number>();
+  let allElapsed = true;
+  for (const k of unique) {
+    const seconds = parseElapsedTimeToSeconds(k);
+    if (seconds === null) {
+      allElapsed = false;
+      break;
+    }
+    parsed.set(k, seconds);
+  }
+  if (allElapsed) {
+    return unique.sort((a, b) => (parsed.get(a) ?? 0) - (parsed.get(b) ?? 0));
+  }
+
+  return unique.sort((a, b) =>
+    a.localeCompare(b, undefined, { numeric: true })
+  );
+}

--- a/web/tests/unit/sort-kinetic-time-keys.test.ts
+++ b/web/tests/unit/sort-kinetic-time-keys.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { sortTimeKeys } from "@/lib/runs/sort-kinetic-time-keys";
+
+describe("sortTimeKeys", () => {
+  it("sorts SoftMax multi-day elapsed times chronologically", () => {
+    const keys = [
+      "2.02:11:12",
+      "01:50:24",
+      "03:00:39",
+      "1.00:15:25",
+      "00:00:00",
+      "23:55:00",
+    ];
+    expect(sortTimeKeys(keys)).toEqual([
+      "00:00:00",
+      "01:50:24",
+      "03:00:39",
+      "23:55:00",
+      "1.00:15:25",
+      "2.02:11:12",
+    ]);
+  });
+
+  it("keeps same-day HH:MM:SS order", () => {
+    expect(sortTimeKeys(["01:50:24", "00:00:00", "00:15:00"])).toEqual([
+      "00:00:00",
+      "00:15:00",
+      "01:50:24",
+    ]);
+  });
+
+  it("sorts numeric scan indices numerically", () => {
+    expect(sortTimeKeys(["10", "2", "1"])).toEqual(["1", "2", "10"]);
+  });
+
+  it("deduplicates keys", () => {
+    expect(sortTimeKeys(["00:00:00", "00:00:00", "01:00:00"])).toEqual([
+      "00:00:00",
+      "01:00:00",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Sort SoftMax kinetic elapsed times (`HH:MM:SS` / `D.HH:MM:SS`) by total seconds so multi-day runs scrub chronologically instead of string-sorting day prefixes into the wrong order.
- Move the heatmap scale to a vertical bar aligned with the wells, constrain the plate map to three-quarters width, and add a thumb-following time label with clearer typography.

## Test plan
- [x] Open a multi-day kinetic plate-reader run and scrub the time slider across day 0 → day 1 → day 2 boundaries (no jumps back to earlier HH:MM:SS labels).
- [x] Confirm unit tests: `npm run test:unit -- tests/unit/sort-kinetic-time-keys.test.ts`
- [x] Check plate map layout: vertical color bar aligned to rows A–H, max/min labels above/below, slider labels readable and aligned with the track.

Made with [Cursor](https://cursor.com)