### PR TITLE
Allow reprocessing files stuck in uploaded status

### DIFF
--- a/developer-docs/lambda.md
+++ b/developer-docs/lambda.md
@@ -70,9 +70,11 @@ Slack channel notifications are sent by the **web app** (`web/lib/slack.ts`), no
 
 3. **Register the dispatch.** Add an `elif` branch in the `lambda_handler` function in `lambda/src/data_hub_lambda/handler.py` that maps the new instrument ID to your `process_file` function.
 
-4. **Add tests.** Add unit tests in `lambda/tests/` for the new processor.
+4. **Expose reprocess in the web app.** Add the instrument ID to `PROCESSABLE_INSTRUMENT_IDS` in `web/lib/instruments/processable-ids.ts` so the UI and API allow reprocessing for that instrument.
 
-5. **Configure the S3 trigger and deploy.** See [CI and deployment → Adding an S3 trigger for a new instrument](ci-and-deployment.md#adding-an-s3-trigger-for-a-new-instrument) for the `infra/template.yaml` trigger entry and the deploy steps.
+5. **Add tests.** Add unit tests in `lambda/tests/` for the new processor.
+
+6. **Configure the S3 trigger and deploy.** See [CI and deployment → Adding an S3 trigger for a new instrument](ci-and-deployment.md#adding-an-s3-trigger-for-a-new-instrument) for the `infra/template.yaml` trigger entry and the deploy steps.
 
 ## Local processing CLI
 

--- a/developer-docs/lambda.md
+++ b/developer-docs/lambda.md
@@ -19,7 +19,7 @@ Slack notifications are sent by the **web app**, not the Lambda — see [Slack n
 
 When a file fails processing (or needs to be re-run), users can trigger reprocessing from the run detail page in the web app. This invokes the Lambda's Function URL instead of going through S3:
 
-1. The user clicks **Reprocess** on a failed or completed file in the web dashboard.
+1. The user clicks **Reprocess** on an uploaded, failed, or completed file in the web dashboard.
 2. The web app's `POST /api/v1/files/:fileId/reprocess` endpoint transitions the file to `processing` status, clears any previous error, and sends a POST request to the Lambda Function URL.
 3. The Function URL is configured with `AuthType: AWS_IAM`, so the web app SigV4-signs the request using credentials it gets via Vercel OIDC federation (the `WebAppS3Role` IAM role, which has `lambda:InvokeFunctionUrl` on this function's ARN). The body is a JSON payload containing a synthetic S3 event.
 4. The Lambda handler detects the Function URL invocation (via `requestContext` in the event) and parses the S3 event from the request body. Inbound auth is enforced by AWS itself in front of the function — the handler never sees an unauthenticated request.

--- a/web/app/api/v1/files/[fileId]/reprocess/route.ts
+++ b/web/app/api/v1/files/[fileId]/reprocess/route.ts
@@ -14,8 +14,9 @@ interface RouteContext {
 // ---------------------------------------------------------------------------
 // POST /api/v1/files/:fileId/reprocess
 //
-// Transitions a failed or completed file back to "processing" and invokes
-// the Lambda Function URL to re-run the instrument's process_file workflow.
+// Transitions an uploaded, failed, or completed file back to "processing"
+// and invokes the Lambda Function URL to re-run the instrument's
+// process_file workflow.
 // The core logic lives in lib/api/file-reprocessing.ts so the MCP server
 // can reuse it.
 // ---------------------------------------------------------------------------

--- a/web/app/api/v1/files/[fileId]/route.ts
+++ b/web/app/api/v1/files/[fileId]/route.ts
@@ -22,7 +22,7 @@ interface RouteContext {
 // Enforced state machine for file status transitions:
 //   Watcher flow:   detected → [upload_requested →] uploaded → processing → completed|failed
 //   Lambda flow:    (created as "uploaded" via POST .../files) → processing → completed|failed
-//   Reprocessing:   completed|failed → processing → completed|failed
+//   Reprocessing:   uploaded|completed|failed → processing → completed|failed
 //   Cancel request: upload_requested → detected (watcher gave up locating
 //                   the local file after repeated polls; clears the queue
 //                   entry)

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/reprocess/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/reprocess/route.ts
@@ -10,8 +10,9 @@ interface RouteContext {
 // ---------------------------------------------------------------------------
 // POST /api/v1/instruments/:instrumentId/runs/:runId/reprocess
 //
-// Run-level convenience endpoint that reprocesses every `completed` or
-// `failed` file on the run. Used by the runs list row/bulk actions.
+// Run-level convenience endpoint that reprocesses every `uploaded`,
+// `completed`, or `failed` file on the run. Used by the runs list
+// row/bulk actions.
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest, { params }: RouteContext) {

--- a/web/components/instruments/runs-table/run-bulk-action-bar.tsx
+++ b/web/components/instruments/runs-table/run-bulk-action-bar.tsx
@@ -182,6 +182,7 @@ export function RunBulkActionBar() {
     runId: r.runId,
     filesCompleted: r.stats.filesCompleted,
     filesFailed: r.stats.filesFailed,
+    filesUploaded: r.stats.filesUploaded,
   }));
 
   // On desktop the expanded sidebar reserves space on the left, so anchor the

--- a/web/components/instruments/runs-table/run-row-actions.tsx
+++ b/web/components/instruments/runs-table/run-row-actions.tsx
@@ -199,6 +199,7 @@ export function RunRowActions({ row }: { row: RunRow }) {
             runId: row.run_id,
             filesCompleted: row.files_completed,
             filesFailed: row.files_failed,
+            filesUploaded: row.files_uploaded,
           },
         ]}
       />

--- a/web/components/instruments/runs-table/run-selection-provider.tsx
+++ b/web/components/instruments/runs-table/run-selection-provider.tsx
@@ -16,6 +16,7 @@ export interface RunStats {
   fileCount: number;
   filesCompleted: number;
   filesFailed: number;
+  filesUploaded: number;
 }
 
 export interface RunRef {

--- a/web/components/runs/file-selection-provider.tsx
+++ b/web/components/runs/file-selection-provider.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, use, useCallback, useMemo, useState } from "react";
 import type { RunFile } from "@/lib/api/instrument-runs";
+import { REPROCESSABLE_STATUSES } from "@/lib/runs/reprocessable-statuses";
 
 // ---------------------------------------------------------------------------
 // File selection provider for the run files table. Mirrors RunSelectionProvider
@@ -18,7 +19,7 @@ const DOWNLOADABLE_STATUSES = new Set([
   "failed",
 ]);
 
-const REPROCESSABLE_STATUSES = new Set(["completed", "failed"]);
+const REPROCESSABLE_STATUS_SET = new Set<string>(REPROCESSABLE_STATUSES);
 
 export interface FileCaps {
   dismiss: boolean;
@@ -43,7 +44,7 @@ export function buildFileRef(file: RunFile): FileRef | null {
   const isDetected = file.status === "detected";
   const canDownload = DOWNLOADABLE_STATUSES.has(file.status);
   const canReprocess =
-    REPROCESSABLE_STATUSES.has(file.status) && file.s3Key !== null;
+    REPROCESSABLE_STATUS_SET.has(file.status) && file.s3Key !== null;
   if (!(isDetected || canDownload)) {
     return null;
   }

--- a/web/components/runs/file-selection-provider.tsx
+++ b/web/components/runs/file-selection-provider.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, use, useCallback, useMemo, useState } from "react";
 import type { RunFile } from "@/lib/api/instrument-runs";
+import { isProcessableInstrument } from "@/lib/instruments/processable-ids";
 import { REPROCESSABLE_STATUSES } from "@/lib/runs/reprocessable-statuses";
 
 // ---------------------------------------------------------------------------
@@ -37,14 +38,19 @@ export interface FileRef {
 // Returns null for rows that should not participate in selection at all
 // (dismissed files, transient `upload_requested` rows). Caller treats null
 // the same as "no checkbox in this row".
-export function buildFileRef(file: RunFile): FileRef | null {
+export function buildFileRef(
+  file: RunFile,
+  instrumentId: string
+): FileRef | null {
   if (file.deletedAt !== null) {
     return null;
   }
   const isDetected = file.status === "detected";
   const canDownload = DOWNLOADABLE_STATUSES.has(file.status);
   const canReprocess =
-    REPROCESSABLE_STATUS_SET.has(file.status) && file.s3Key !== null;
+    isProcessableInstrument(instrumentId) &&
+    REPROCESSABLE_STATUS_SET.has(file.status) &&
+    file.s3Key !== null;
   if (!(isDetected || canDownload)) {
     return null;
   }

--- a/web/components/runs/reprocess-runs-dialog.tsx
+++ b/web/components/runs/reprocess-runs-dialog.tsx
@@ -18,6 +18,7 @@ import {
 export interface ReprocessRunTarget {
   filesCompleted: number;
   filesFailed: number;
+  filesUploaded: number;
   instrumentId: string;
   runId: string;
 }
@@ -76,7 +77,7 @@ export function ReprocessRunsDialog({
 
   const runCount = runs.length;
   const eligibleFiles = runs.reduce(
-    (sum, r) => sum + r.filesCompleted + r.filesFailed,
+    (sum, r) => sum + r.filesCompleted + r.filesFailed + r.filesUploaded,
     0
   );
 
@@ -115,8 +116,8 @@ export function ReprocessRunsDialog({
             This will re-run the processing pipeline on{" "}
             <strong>{eligibleFiles}</strong>{" "}
             {eligibleFiles === 1 ? "file" : "files"} currently in the{" "}
-            <em>completed</em> or <em>failed</em> state. Results will overwrite
-            any existing processed artifacts.
+            <em>uploaded</em>, <em>completed</em>, or <em>failed</em> state.
+            Results will overwrite any existing processed artifacts.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/web/components/runs/run-files-section.tsx
+++ b/web/components/runs/run-files-section.tsx
@@ -357,6 +357,7 @@ function RunFilesSectionContent({
           ) : isDeleted ? (
             <ReadOnlyRunFilesTable
               files={files}
+              instrumentId={instrumentId}
               isPending={isPending}
               onReprocess={(id) =>
                 handleSingleReprocess(id, startTransition, router)
@@ -365,6 +366,7 @@ function RunFilesSectionContent({
           ) : (
             <EditableRunFilesTable
               files={files}
+              instrumentId={instrumentId}
               isPending={isPending}
               onDismiss={(id) =>
                 handleSingleDismiss(id, startTransition, router)

--- a/web/components/runs/run-files-table.tsx
+++ b/web/components/runs/run-files-table.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/table";
 import type { RunFile } from "@/lib/api/instrument-runs";
 import { formatDateTime } from "@/lib/date";
+import { isProcessableInstrument } from "@/lib/instruments/processable-ids";
 import { REPROCESSABLE_STATUSES } from "@/lib/runs/reprocessable-statuses";
 import { cn, formatBytes } from "@/lib/utils";
 import {
@@ -213,9 +214,10 @@ function UploadDismissActions({
   );
 }
 
-function canReprocess(file: RunFile): boolean {
+function canReprocess(file: RunFile, instrumentId: string): boolean {
   return (
     file.deletedAt === null &&
+    isProcessableInstrument(instrumentId) &&
     REPROCESSABLE_STATUS_SET.has(file.status) &&
     file.s3Key !== null
   );
@@ -229,12 +231,14 @@ function canReprocess(file: RunFile): boolean {
 
 export interface ReadOnlyRunFilesTableProps {
   files: RunFile[];
+  instrumentId: string;
   isPending: boolean;
   onReprocess: (id: number) => void;
 }
 
 export function ReadOnlyRunFilesTable({
   files,
+  instrumentId,
   isPending,
   onReprocess,
 }: ReadOnlyRunFilesTableProps) {
@@ -256,7 +260,7 @@ export function ReadOnlyRunFilesTable({
             >
               <FileInfoCells file={file} />
               <TableCell className="py-2 pr-3">
-                {canReprocess(file) && (
+                {canReprocess(file, instrumentId) ? (
                   <div className="flex items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
                     <ReprocessAction
                       file={file}
@@ -264,7 +268,7 @@ export function ReadOnlyRunFilesTable({
                       onReprocess={onReprocess}
                     />
                   </div>
-                )}
+                ) : null}
               </TableCell>
             </TableRow>
           );
@@ -284,6 +288,7 @@ export function ReadOnlyRunFilesTable({
 
 export interface EditableRunFilesTableProps {
   files: RunFile[];
+  instrumentId: string;
   isPending: boolean;
   onDismiss: (id: number) => void;
   onReprocess: (id: number) => void;
@@ -292,6 +297,7 @@ export interface EditableRunFilesTableProps {
 
 export function EditableRunFilesTable({
   files,
+  instrumentId,
   isPending,
   onUpload,
   onDismiss,
@@ -306,7 +312,7 @@ export function EditableRunFilesTable({
   const visibleSelectableRefs: NonNullable<ReturnType<typeof buildFileRef>>[] =
     [];
   for (const file of files) {
-    const ref = buildFileRef(file);
+    const ref = buildFileRef(file, instrumentId);
     refsByFileId.set(file.id, ref);
     if (ref) {
       visibleSelectableRefs.push(ref);
@@ -335,7 +341,7 @@ export function EditableRunFilesTable({
           const ref = refsByFileId.get(file.id) ?? null;
           const isSelected = ref ? meta.isSelected(ref.id) : false;
           const canDoUploadDismiss = !isDismissed && file.status === "detected";
-          const canDoReprocess = canReprocess(file);
+          const canDoReprocess = canReprocess(file, instrumentId);
 
           // Reveal classes: hide per-row actions while a bulk selection is
           // active (the bar is the single entry point) but keep the JSX

--- a/web/components/runs/run-files-table.tsx
+++ b/web/components/runs/run-files-table.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/table";
 import type { RunFile } from "@/lib/api/instrument-runs";
 import { formatDateTime } from "@/lib/date";
+import { REPROCESSABLE_STATUSES } from "@/lib/runs/reprocessable-statuses";
 import { cn, formatBytes } from "@/lib/utils";
 import {
   FileSelectAllCheckbox,
@@ -41,7 +42,7 @@ const DOWNLOADABLE_STATUSES = new Set([
   "failed",
 ]);
 
-const REPROCESSABLE_STATUSES = new Set(["completed", "failed"]);
+const REPROCESSABLE_STATUS_SET = new Set<string>(REPROCESSABLE_STATUSES);
 
 const CATEGORY_BADGE_CLASSES: Record<string, string> = {
   raw: "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
@@ -215,15 +216,15 @@ function UploadDismissActions({
 function canReprocess(file: RunFile): boolean {
   return (
     file.deletedAt === null &&
-    REPROCESSABLE_STATUSES.has(file.status) &&
+    REPROCESSABLE_STATUS_SET.has(file.status) &&
     file.s3Key !== null
   );
 }
 
 // ---------------------------------------------------------------------------
 // Read-only variant: no selection column, no upload/dismiss. Reprocessing is
-// still allowed for completed/failed files so operators can recover report
-// data without restoring the run.
+// still allowed for uploaded/completed/failed files so operators can recover
+// report data or kick stuck uploads without restoring the run.
 // ---------------------------------------------------------------------------
 
 export interface ReadOnlyRunFilesTableProps {

--- a/web/lib/api/file-reprocessing.ts
+++ b/web/lib/api/file-reprocessing.ts
@@ -4,8 +4,7 @@ import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
 import { db } from "@/lib/db";
 import { files, instrumentRuns } from "@/lib/db/schema";
 import { hasInvokeCredentials, signLambdaInvoke } from "@/lib/lambda";
-
-const REPROCESSABLE_STATUSES = ["failed", "completed"] as const;
+import { REPROCESSABLE_STATUSES } from "@/lib/runs/reprocessable-statuses";
 
 function getLambdaUrl(): string | null {
   const url = process.env.LAMBDA_FUNCTION_URL;
@@ -61,7 +60,7 @@ export async function reprocessFile(fileId: number): Promise<ReprocessResult> {
       ok: false,
       status: 409,
       code: "CONFLICT",
-      message: `Cannot reprocess a file in '${file.status}' status — only 'failed' or 'completed' files can be reprocessed`,
+      message: `Cannot reprocess a file in '${file.status}' status — only 'uploaded', 'failed', or 'completed' files can be reprocessed`,
     };
   }
 

--- a/web/lib/api/file-reprocessing.ts
+++ b/web/lib/api/file-reprocessing.ts
@@ -3,6 +3,7 @@ import { after } from "next/server";
 import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
 import { db } from "@/lib/db";
 import { files, instrumentRuns } from "@/lib/db/schema";
+import { isProcessableInstrument } from "@/lib/instruments/processable-ids";
 import { hasInvokeCredentials, signLambdaInvoke } from "@/lib/lambda";
 import { REPROCESSABLE_STATUSES } from "@/lib/runs/reprocessable-statuses";
 
@@ -74,7 +75,10 @@ export async function reprocessFile(fileId: number): Promise<ReprocessResult> {
   }
 
   const [parentRun] = await db
-    .select({ deletedAt: instrumentRuns.deletedAt })
+    .select({
+      deletedAt: instrumentRuns.deletedAt,
+      instrumentId: instrumentRuns.instrumentId,
+    })
     .from(instrumentRuns)
     .where(eq(instrumentRuns.id, file.instrumentRunId))
     .limit(1);
@@ -85,6 +89,17 @@ export async function reprocessFile(fileId: number): Promise<ReprocessResult> {
       status: 409,
       code: "CONFLICT",
       message: "Cannot reprocess a file whose parent run is soft-deleted",
+    };
+  }
+
+  if (!(parentRun && isProcessableInstrument(parentRun.instrumentId))) {
+    return {
+      ok: false,
+      status: 409,
+      code: "CONFLICT",
+      message: parentRun
+        ? `Instrument '${parentRun.instrumentId}' has no Lambda processor — cannot reprocess`
+        : "Cannot reprocess a file with no parent run",
     };
   }
 
@@ -174,6 +189,15 @@ export async function reprocessRun(
   instrumentId: string,
   runId: string
 ): Promise<ReprocessRunResult> {
+  if (!isProcessableInstrument(instrumentId)) {
+    return {
+      ok: false,
+      status: 409,
+      code: "CONFLICT",
+      message: `Instrument '${instrumentId}' has no Lambda processor — cannot reprocess`,
+    };
+  }
+
   const run = await lookupRunByNaturalKey(instrumentId, runId);
 
   if (!run) {

--- a/web/lib/api/openapi/paths/files.ts
+++ b/web/lib/api/openapi/paths/files.ts
@@ -85,7 +85,8 @@ registry.registerPath({
   path: "/files/{fileId}/reprocess",
   operationId: "reprocessFile",
   summary: "Reprocess a file",
-  description: "Requires scope `files:reprocess`.",
+  description:
+    "Requires scope `files:reprocess`. Eligible statuses: `uploaded`, `failed`, or `completed` (file must have an S3 location).",
   tags: ["Files"],
   security: bearerSecurity,
   request: { params: fileParams },

--- a/web/lib/api/openapi/paths/files.ts
+++ b/web/lib/api/openapi/paths/files.ts
@@ -86,7 +86,7 @@ registry.registerPath({
   operationId: "reprocessFile",
   summary: "Reprocess a file",
   description:
-    "Requires scope `files:reprocess`. Eligible statuses: `uploaded`, `failed`, or `completed` (file must have an S3 location).",
+    "Requires scope `files:reprocess`. Eligible statuses: `uploaded`, `failed`, or `completed` (file must have an S3 location). The file's instrument must have a Lambda processor.",
   tags: ["Files"],
   security: bearerSecurity,
   request: { params: fileParams },

--- a/web/lib/api/openapi/paths/runs.ts
+++ b/web/lib/api/openapi/paths/runs.ts
@@ -139,7 +139,7 @@ registry.registerPath({
   path: "/instruments/{instrumentId}/runs/{runId}/reprocess",
   operationId: "reprocessInstrumentRun",
   summary: "Reprocess a run",
-  description: scoped("runs:reprocess"),
+  description: `${scoped("runs:reprocess")} Reprocesses every \`uploaded\`, \`failed\`, or \`completed\` file on the run.`,
   tags: tag,
   security: bearerSecurity,
   request: { params: runParams },

--- a/web/lib/api/openapi/paths/runs.ts
+++ b/web/lib/api/openapi/paths/runs.ts
@@ -139,7 +139,7 @@ registry.registerPath({
   path: "/instruments/{instrumentId}/runs/{runId}/reprocess",
   operationId: "reprocessInstrumentRun",
   summary: "Reprocess a run",
-  description: `${scoped("runs:reprocess")} Reprocesses every \`uploaded\`, \`failed\`, or \`completed\` file on the run.`,
+  description: `${scoped("runs:reprocess")} Reprocesses every \`uploaded\`, \`failed\`, or \`completed\` file on the run. The instrument must have a Lambda processor.`,
   tags: tag,
   security: bearerSecurity,
   request: { params: runParams },

--- a/web/lib/instruments/processable-ids.ts
+++ b/web/lib/instruments/processable-ids.ts
@@ -1,0 +1,19 @@
+// Instrument IDs that have a `process_file` branch in
+// `lambda/src/data_hub_lambda/handler.py`. Keep in sync when adding a
+// processor — instruments without a handler (e.g. InstantRaman) stay out.
+export const PROCESSABLE_INSTRUMENT_IDS = [
+  "akta-fplc",
+  "agilent-4150-tapestation",
+  "azure-600-gel-doc",
+  "azure-cielo-qpcr",
+  "epson-v700-scanner",
+  "hina-microscope",
+  "spectramax-id3-plate-reader",
+  "spectramax-id5-plate-reader",
+] as const;
+
+const PROCESSABLE_SET = new Set<string>(PROCESSABLE_INSTRUMENT_IDS);
+
+export function isProcessableInstrument(instrumentId: string): boolean {
+  return PROCESSABLE_SET.has(instrumentId);
+}

--- a/web/lib/mcp/tools/files.defs.ts
+++ b/web/lib/mcp/tools/files.defs.ts
@@ -41,7 +41,7 @@ export const reprocessFileTool = {
   name: "reprocess_file",
   title: "Reprocess File",
   description:
-    "Re-run the Lambda processing workflow for an uploaded, failed, or completed file. Transitions the file back to 'processing'. Use this to retry after a parser fix, transient Lambda failure, or a stuck upload that never entered processing.",
+    "Re-run the Lambda processing workflow for an uploaded, failed, or completed file on an instrument that has a Lambda processor. Transitions the file back to 'processing'. Use this to retry after a parser fix, transient Lambda failure, or a stuck upload that never entered processing.",
   group: "files",
   scope: "files:reprocess",
   inputSchema: { fileId: z.number().int().describe("Numeric file ID") },

--- a/web/lib/mcp/tools/files.defs.ts
+++ b/web/lib/mcp/tools/files.defs.ts
@@ -41,7 +41,7 @@ export const reprocessFileTool = {
   name: "reprocess_file",
   title: "Reprocess File",
   description:
-    "Re-run the Lambda processing workflow for a failed or completed file. Transitions the file back to 'processing'. Use this to retry after a parser fix or transient Lambda failure.",
+    "Re-run the Lambda processing workflow for an uploaded, failed, or completed file. Transitions the file back to 'processing'. Use this to retry after a parser fix, transient Lambda failure, or a stuck upload that never entered processing.",
   group: "files",
   scope: "files:reprocess",
   inputSchema: { fileId: z.number().int().describe("Numeric file ID") },

--- a/web/lib/mcp/tools/runs.defs.ts
+++ b/web/lib/mcp/tools/runs.defs.ts
@@ -250,7 +250,7 @@ export const reprocessRunTool = {
   scope: "runs:reprocess",
   title: "Reprocess Run",
   description:
-    "Re-run Lambda processing for every uploaded, completed, or failed file on a run. Prefer this over looping reprocess_file for bulk retries after a parser fix or to kick stuck uploads.",
+    "Re-run Lambda processing for every uploaded, completed, or failed file on a run. The instrument must have a Lambda processor. Prefer this over looping reprocess_file for bulk retries after a parser fix or to kick stuck uploads.",
   inputSchema: {
     instrumentId: z.string().describe("Instrument identifier"),
     runId: z.string().describe("Run identifier within the instrument"),

--- a/web/lib/mcp/tools/runs.defs.ts
+++ b/web/lib/mcp/tools/runs.defs.ts
@@ -250,7 +250,7 @@ export const reprocessRunTool = {
   scope: "runs:reprocess",
   title: "Reprocess Run",
   description:
-    "Re-run Lambda processing for every completed or failed file on a run. Prefer this over looping reprocess_file for bulk retries after a parser fix.",
+    "Re-run Lambda processing for every uploaded, completed, or failed file on a run. Prefer this over looping reprocess_file for bulk retries after a parser fix or to kick stuck uploads.",
   inputSchema: {
     instrumentId: z.string().describe("Instrument identifier"),
     runId: z.string().describe("Run identifier within the instrument"),

--- a/web/lib/runs/reprocessable-statuses.ts
+++ b/web/lib/runs/reprocessable-statuses.ts
@@ -1,0 +1,8 @@
+// Statuses eligible for POST /files/:id/reprocess (and run-level reprocess).
+// Includes `uploaded` so stuck S3 uploads can be kicked when the Lambda
+// trigger never fired. Client-safe — imported by UI tables and the API.
+export const REPROCESSABLE_STATUSES = [
+  "uploaded",
+  "failed",
+  "completed",
+] as const;

--- a/web/lib/runs/row-actions.ts
+++ b/web/lib/runs/row-actions.ts
@@ -13,7 +13,7 @@ import type {
 // - Upload:    at least one file still waiting to be uploaded.
 // - Download:  at least one file has made it to S3 (i.e. is not `detected`
 //              or `upload_requested`).
-// - Reprocess: at least one file is in `completed` or `failed` status.
+// - Reprocess: at least one file is in `uploaded`, `completed`, or `failed`.
 // - Delete:    the run isn't already soft-deleted.
 // ---------------------------------------------------------------------------
 
@@ -30,7 +30,10 @@ export function canDownloadRun(row: RunRow): boolean {
 }
 
 export function canReprocessRun(row: RunRow): boolean {
-  return row.deleted_at === null && row.files_completed + row.files_failed > 0;
+  return (
+    row.deleted_at === null &&
+    row.files_completed + row.files_failed + row.files_uploaded > 0
+  );
 }
 
 export function canDeleteRun(row: RunRow): boolean {
@@ -51,6 +54,7 @@ export function computeRunStats(row: RunRow): RunStats {
     fileCount: row.file_count,
     filesCompleted: row.files_completed,
     filesFailed: row.files_failed,
+    filesUploaded: row.files_uploaded,
   };
 }
 

--- a/web/lib/runs/row-actions.ts
+++ b/web/lib/runs/row-actions.ts
@@ -4,6 +4,7 @@ import type {
   RunRef,
   RunStats,
 } from "@/components/instruments/runs-table/run-selection-provider";
+import { isProcessableInstrument } from "@/lib/instruments/processable-ids";
 
 // ---------------------------------------------------------------------------
 // Predicates that decide which row-level / bulk actions are available for a
@@ -13,7 +14,8 @@ import type {
 // - Upload:    at least one file still waiting to be uploaded.
 // - Download:  at least one file has made it to S3 (i.e. is not `detected`
 //              or `upload_requested`).
-// - Reprocess: at least one file is in `uploaded`, `completed`, or `failed`.
+// - Reprocess: instrument has a Lambda processor and at least one file is in
+//              `uploaded`, `completed`, or `failed`.
 // - Delete:    the run isn't already soft-deleted.
 // ---------------------------------------------------------------------------
 
@@ -32,6 +34,7 @@ export function canDownloadRun(row: RunRow): boolean {
 export function canReprocessRun(row: RunRow): boolean {
   return (
     row.deleted_at === null &&
+    isProcessableInstrument(row.instrument_id) &&
     row.files_completed + row.files_failed + row.files_uploaded > 0
   );
 }

--- a/web/tests/integration/files.test.ts
+++ b/web/tests/integration/files.test.ts
@@ -23,7 +23,9 @@ import {
 // Tests drive each through its full lifecycle to verify the state machine.
 describe("Files API", () => {
   let token: string;
-  const instrumentId = "files-test-instrument";
+  // Use a known processable instrument ID so reprocess eligibility reaches
+  // the Lambda-config check (see `isProcessableInstrument`).
+  const instrumentId = "akta-fplc";
   const runId = "files-test-run";
   let fileId: number;
   let secondFileId: number;
@@ -37,7 +39,7 @@ describe("Files API", () => {
     const db = getTestDb();
     await db.insert(instruments).values({
       id: instrumentId,
-      displayName: "Files Test Instrument",
+      displayName: "Akta FPLC",
       status: "active",
     });
 
@@ -637,5 +639,43 @@ describe("Files API", () => {
     expect(res.status).toBe(503);
     const data = await res.json();
     expect(data.error.message).toContain("not configured");
+  });
+
+  it("REPROCESS returns 409 for instrument without a Lambda processor", async () => {
+    const noProcessorId = "files-no-processor-instrument";
+    const db = getTestDb();
+    await db.insert(instruments).values({
+      id: noProcessorId,
+      displayName: "No Processor Instrument",
+      status: "active",
+    });
+    const noProcessorRunId = "reprocess-no-processor-run";
+    await api(`/api/v1/instruments/${noProcessorId}/runs`, {
+      method: "POST",
+      token,
+      body: { run_id: noProcessorRunId, source: "lambda" },
+    });
+    const createFileRes = await api(
+      `/api/v1/instruments/${noProcessorId}/runs/${noProcessorRunId}/files`,
+      {
+        method: "POST",
+        token,
+        body: {
+          s3_bucket: "test-bucket",
+          s3_key: `${noProcessorId}/${noProcessorRunId}/data.csv`,
+          filename: "data.csv",
+        },
+      }
+    );
+    expect(createFileRes.status).toBe(201);
+    const createdFile = await createFileRes.json();
+
+    const res = await api(`/api/v1/files/${createdFile.id}/reprocess`, {
+      method: "POST",
+      token,
+    });
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.error.message).toContain("no Lambda processor");
   });
 });

--- a/web/tests/integration/files.test.ts
+++ b/web/tests/integration/files.test.ts
@@ -487,6 +487,7 @@ describe("Files API", () => {
   //   secondFileId (sample2.csv)      → detected, soft-deleted
   //   thirdFileId (sample3.csv)       → detected, not deleted
   //   lambdaFileId (processed_output) → failed, has S3 info
+  // Uploaded eligibility is covered by a dedicated run/file created below.
   // -------------------------------------------------------------------------
 
   it("REPROCESS returns 401 without auth", async () => {
@@ -583,7 +584,7 @@ describe("Files API", () => {
     expect(data.error.message).toContain("parent run");
   });
 
-  // These two tests verify that both reprocessable statuses (failed and
+  // These tests verify that reprocessable statuses (uploaded, failed, and
   // completed) pass all validation guards. They return 503 because the
   // test server has no LAMBDA_FUNCTION_URL configured.
   it("REPROCESS returns 503 for failed file when Lambda is not configured", async () => {
@@ -598,6 +599,38 @@ describe("Files API", () => {
 
   it("REPROCESS returns 503 for completed file when Lambda is not configured", async () => {
     const res = await api(`/api/v1/files/${fileId}/reprocess`, {
+      method: "POST",
+      token,
+    });
+    expect(res.status).toBe(503);
+    const data = await res.json();
+    expect(data.error.message).toContain("not configured");
+  });
+
+  it("REPROCESS returns 503 for uploaded file when Lambda is not configured", async () => {
+    const uploadedRunId = "reprocess-uploaded-run";
+    await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: { run_id: uploadedRunId, source: "lambda" },
+    });
+    const createFileRes = await api(
+      `/api/v1/instruments/${instrumentId}/runs/${uploadedRunId}/files`,
+      {
+        method: "POST",
+        token,
+        body: {
+          s3_bucket: "test-bucket",
+          s3_key: `${instrumentId}/${uploadedRunId}/stuck.csv`,
+          filename: "stuck.csv",
+        },
+      }
+    );
+    expect(createFileRes.status).toBe(201);
+    const createdFile = await createFileRes.json();
+    expect(createdFile.status).toBe("uploaded");
+
+    const res = await api(`/api/v1/files/${createdFile.id}/reprocess`, {
       method: "POST",
       token,
     });


### PR DESCRIPTION
## Summary
- Expand reprocess eligibility to include `uploaded` files that already have an S3 location, so stuck uploads can be kicked when the Lambda trigger never fired.
- Gate reprocess (UI + API/MCP) on instruments that have a Lambda `process_file` handler, via a shared allowlist mirroring `handler.py` dispatch.
- Share reprocessable-status and processable-instrument checks across API/MCP and the UI (file row, bulk actions, and run-level menus/dialogs).
- Update docs/OpenAPI/MCP copy and add integration coverage for the uploaded path and the no-processor reject path.

## Test plan
- [x] Confirm Reprocess appears on an `uploaded` file with an S3 key in the run files table (and bulk bar when all selected files qualify).
- [x] Confirm run-level Reprocess is available for a run that only has `uploaded` files (no completed/failed).
- [x] Confirm Reprocess is hidden for instruments without a Lambda processor (e.g. InstantRaman / custom IDs).
- [ ] POST `/api/v1/files/:id/reprocess` for an uploaded file on a processable instrument transitions it to `processing` and invokes Lambda.
- [x] `detected` / soft-deleted files still return 409.
- [x] Reprocess for a non-processable instrument returns 409.
- [ ] After deploy, reprocess production file `392453` on Hina run `20260721_134352_331` and confirm it completes.
