### PR TITLE
Handle incomplete SoftMax kinetic exports in SpectraMax parser

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,17 @@
 # AGENTS.md
 
+## Commits and pull requests
+
+Do **not** put sensitive information from internal environments (production, staging, or a coworker's machine) into commit messages, PR titles/bodies, review comments, or committed files. That includes:
+
+- Credentials and secrets: PATs (`dhub_…`), `AUTH_SECRET`, AWS keys/session tokens, database passwords, webhook secrets
+- Pre-signed or authenticated URLs (S3 download links, anything with `X-Amz-Security-Token` / signature query params)
+- Identifiers from internal environments: instrument IDs, run IDs, file IDs, and real filenames from those runs
+- Raw dumps from internal MCP tools, API responses, or logs that embed the above
+- `.env` contents or other gitignored config copied into the diff
+
+Safe to reference: public docs URLs, redacted error messages, and synthetic fixtures. When a PR needs to describe a production incident, summarize the failure mode — don't paste tokens, signed URLs, IDs, or full internal payloads.
+
 ## Documentation
 
 User-, operator-, and admin-facing documentation — installing a watcher, setting up an instrument, managing tokens, security/permissions — lives on the docs site at https://datahub.arcadiascience.com/docs, **not in this repository**. Search there first for "how do I use Data Hub" questions; don't rely on training data or guess at UI flows, since the site's `/docs/llms.txt` and `/docs/llms-full.txt` routes (and a `.md` suffix on any page URL) serve clean Markdown that's cheap to fetch.

--- a/lambda/src/data_hub_lambda/spectramax_plate_reader/utils.py
+++ b/lambda/src/data_hub_lambda/spectramax_plate_reader/utils.py
@@ -13,6 +13,10 @@ reading (1 for Endpoint, *N* for Kinetic time-points or Well Scan
 positions).  Each reading group is followed by an empty separator line.
 A summary table (no ``Temperature`` column header) follows the last
 group before ``~End``.
+
+SoftMax may declare more Kinetic readings in the plate header than it
+exports (e.g. a 48 h protocol stopped early).  The parser emits the
+groups that are present and stops at the summary table or ``~End``.
 """
 
 from __future__ import annotations
@@ -53,6 +57,34 @@ _ROW_LABELS = "ABCDEFGHIJKLMNOP"
 # that downstream code can distinguish a "well was attempted but failed"
 # from a "well was never read" (which remains absent from the output).
 _WELL_VALUE_SENTINELS = frozenset({"Path?", "Range?"})
+
+# SoftMax elapsed time: ``HH:MM:SS`` within the first day, then
+# ``D.HH:MM:SS`` once the run crosses 24 h (e.g. ``1.00:05:20``).
+_ELAPSED_TIME_RE = re.compile(r"^(?:\d+\.)?\d{1,2}:\d{2}:\d{2}$")
+
+
+def _at_plate_end(lines: list[str], i: int) -> bool:
+    return i >= len(lines) or lines[i].startswith("~End")
+
+
+def _kinetic_reading_present(lines: list[str], i: int, num_rows: int) -> bool:
+    """Return whether ``lines[i:i+num_rows]`` still holds a Kinetic group.
+
+    After the last exported reading, SoftMax writes a summary table or
+    ``~End``. Neither carries an elapsed-time token, so an overstated
+    ``num_readings`` in the plate header must not consume those lines as
+    well data.
+    """
+    if _at_plate_end(lines, i):
+        return False
+    end = min(i + num_rows, len(lines))
+    for j in range(i, end):
+        if lines[j].startswith("~End"):
+            return False
+        fields = lines[j].split("\t")
+        if fields and _ELAPSED_TIME_RE.match(fields[0].strip()):
+            return True
+    return False
 
 
 def _parse_well_value(val_str: str) -> float:
@@ -317,6 +349,13 @@ def parse_raw_well_data(file_path: Path) -> pd.DataFrame:
         if layout.format == "flat":
             wl = wavelengths[0] if wavelengths else None
             for _ in range(header.num_readings):
+                if _at_plate_end(lines, i):
+                    break
+                if header.measurement_type == "Kinetic" and not _kinetic_reading_present(
+                    lines, i, 1
+                ):
+                    break
+
                 row_fields = lines[i].split("\t")
                 time_str = row_fields[0].strip()
                 time_val: str | None = time_str if time_str else None
@@ -356,6 +395,13 @@ def parse_raw_well_data(file_path: Path) -> pd.DataFrame:
 
             offsets = layout.group_offsets or (2,)
             for _ in range(header.num_readings):
+                if _at_plate_end(lines, i):
+                    break
+                if header.measurement_type == "Kinetic" and not _kinetic_reading_present(
+                    lines, i, num_rows
+                ):
+                    break
+
                 time_val = None
                 temp_val = None
 

--- a/lambda/tests/spectramax_plate_reader/test_parse_raw_well_data.py
+++ b/lambda/tests/spectramax_plate_reader/test_parse_raw_well_data.py
@@ -290,6 +290,62 @@ class TestKineticEdgeWellsSkipped:
         assert first["value"] == pytest.approx(0.1120)
 
 
+class TestIncompleteKinetic:
+    """SoftMax may declare more Kinetic readings than it exports when a run
+    stops early. Emit the groups that are present (including day-prefixed
+    times after 24 h) and stop before the summary / ``~End``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _load(self, tmp_path: Path) -> None:
+        prefix = "Plate:\tPlate1\t1.3\tPlateFormat"
+        # Header claims 4 readings; file only has 2 (+ summary).
+        middle = "\tRaw\tFALSE\t4\t\t\t\t\t\t1"
+        header = f"{prefix}\tKinetic\tAbsorbance{middle}\t595\t1\t2\t4\t1\t2\n"
+        col_header = "\tTemperature(\xa1C)\t1\t2\t\n"
+        r0 = "00:00:00\t30.0\t0.10\t0.20\t\n"
+        r1 = "\t\t0.30\t0.40\t\n"
+        blank = "\n"
+        # Day-prefixed elapsed time once the run crosses 24 h.
+        r2 = "1.00:05:20\t30.1\t0.11\t0.21\t\n"
+        r3 = "\t\t0.31\t0.41\t\n"
+        summary = "\t\t1\t2\t\n\t\t0.10\t0.20\t\n\t\t0.30\t0.40\t\n"
+        content = f"##BLOCKS= 1\n{header}{col_header}{r0}{r1}{blank}{r2}{r3}{blank}{summary}~End\n"
+        path = tmp_path / "incomplete_kinetic.xls"
+        path.write_text(content, encoding="utf-16")
+        self.df = parse_raw_well_data(path)
+
+    def test_columns(self) -> None:
+        assert list(self.df.columns) == _EXPECTED_COLUMNS
+
+    def test_shape_uses_exported_readings_only(self) -> None:
+        # 2 exported readings × 4 wells — not the declared 4, and not the summary.
+        assert self.df.shape == (8, 8)
+
+    def test_times_include_day_prefix(self) -> None:
+        assert self.df["time"].unique().tolist() == ["00:00:00", "1.00:05:20"]
+
+    def test_values(self) -> None:
+        t0 = self.df[self.df["time"] == "00:00:00"]["value"].tolist()
+        t1 = self.df[self.df["time"] == "1.00:05:20"]["value"].tolist()
+        assert t0 == pytest.approx([0.10, 0.20, 0.30, 0.40])
+        assert t1 == pytest.approx([0.11, 0.21, 0.31, 0.41])
+
+    def test_stops_at_end_without_summary(self, tmp_path: Path) -> None:
+        prefix = "Plate:\tPlate1\t1.3\tPlateFormat"
+        middle = "\tRaw\tFALSE\t3\t\t\t\t\t\t1"
+        header = f"{prefix}\tKinetic\tAbsorbance{middle}\t595\t1\t2\t4\t1\t2\n"
+        col_header = "\tTemperature(\xa1C)\t1\t2\t\n"
+        r0 = "00:00:00\t30.0\t0.10\t0.20\t\n"
+        r1 = "\t\t0.30\t0.40\t\n"
+        content = f"##BLOCKS= 1\n{header}{col_header}{r0}{r1}\n~End\n"
+        path = tmp_path / "incomplete_kinetic_no_summary.xls"
+        path.write_text(content, encoding="utf-16")
+        df = parse_raw_well_data(path)
+        assert df.shape == (4, 8)
+        assert df["time"].unique().tolist() == ["00:00:00"]
+
+
 class TestEndpointFlat:
     """Endpoint / Absorbance / 595 nm — flat layout where all 96 wells appear
     on a single data line with well-position column headers (A1, A2, …, H12).


### PR DESCRIPTION
## Summary

When SoftMax stops a Kinetic run early, the plate header’s `num_readings` can exceed the exported groups. The old loop kept consuming the summary (or hit `~End` badly). The new path:

1. Stops at `~End` / EOF (`_at_plate_end`)
2. For Kinetic only, requires an elapsed-time token in the next group window (`_kinetic_reading_present` + `_ELAPSED_TIME_RE`, including `D.HH:MM:SS`)

Applied in both flat and grid layouts. Tests cover overstated count + summary, day-prefixed times, and stop-at-`~End` without summary. `AGENTS.md` adds a no-internal-secrets-in-PRs rule (sensible; slightly orthogonal to the parser fix).

## Changes

- SoftMax Pro can declare more Kinetic readings in the plate header than it exports when a run stops early; the SpectraMax parser now stops at the summary table or `~End` instead of raising `IndexError`.
- Add unit coverage for overstated `num_readings`, including day-prefixed elapsed times after 24 h (`D.HH:MM:SS`).
- Document in `AGENTS.md` that agents must not put internal-environment secrets, signed URLs, or instrument/run/file IDs into commits or PRs.

## Test plan
- [x] `uv run pytest lambda/tests/spectramax_plate_reader/test_parse_raw_well_data.py -q`
- [ ] Reprocess a previously failing incomplete Kinetic plate-reader file after deploy and confirm it reaches processed status

Made with [Cursor](https://cursor.com)