### PR TITLE
Remove the MCP personal access token scope preset

### DIFF
--- a/web/lib/api/scope-catalog.ts
+++ b/web/lib/api/scope-catalog.ts
@@ -122,9 +122,8 @@ export interface ScopePreset {
 
 // Curated starting points offered above the granular grid. Machine presets
 // (Watcher, Lambda) mirror the exact endpoints those agents call so a token
-// minted from them is already least-privilege; MCP mirrors the scopes the
-// MCP tools check, giving a member an MCP-client surface analogous to the
-// web UI. Custom (no preset) leaves the grid untouched for fine-tuning.
+// minted from them is already least-privilege. Custom (no preset) leaves the
+// grid untouched for fine-tuning.
 export const SCOPE_PRESETS: ScopePreset[] = [
   {
     id: "read-only",
@@ -136,25 +135,6 @@ export const SCOPE_PRESETS: ScopePreset[] = [
       "files:read",
       "watchers:read",
       "archive-jobs:read",
-    ],
-  },
-  {
-    id: "mcp",
-    label: "MCP",
-    description:
-      "For an MCP client — browse, download, claim, comment, reprocess, delete/restore runs, request uploads, and dismiss pending files, like the web UI.",
-    scopes: [
-      "instruments:read",
-      "runs:read",
-      "runs:attribute",
-      "runs:comment",
-      "runs:reprocess",
-      "runs:delete",
-      "runs:upload",
-      "files:read",
-      "files:reprocess",
-      "files:delete",
-      "watchers:read",
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Removes the MCP preset from the personal access token scope picker in Settings
- Leaves Read-only, Watcher, and Lambda presets unchanged

## Test plan
- [x] Open Settings → create a personal access token
- [x] Confirm the MCP preset is gone and Read-only / Watcher / Lambda still apply the expected scopes


Made with [Cursor](https://cursor.com)