### PR TITLE
Make the MCP server clearer and easier for agents to use

### DIFF
--- a/web/app/mcp/v1/route.ts
+++ b/web/app/mcp/v1/route.ts
@@ -2,6 +2,7 @@ import { createMcpHandler, withMcpAuth } from "mcp-handler";
 import { authBaseURL } from "@/lib/auth";
 import { MCP_ADVERTISED_SCOPES } from "@/lib/mcp/advertised-scopes";
 import { verifyMcpToken } from "@/lib/mcp/auth";
+import { MCP_SERVER_INSTRUCTIONS } from "@/lib/mcp/instructions";
 import { registerPrompts } from "@/lib/mcp/prompts";
 import { registerResources } from "@/lib/mcp/resources";
 import { registerTools } from "@/lib/mcp/tools";
@@ -16,6 +17,7 @@ const handler = createMcpHandler(
   },
   {
     serverInfo: { name: "data-hub", version: "1.0.0" },
+    instructions: MCP_SERVER_INSTRUCTIONS,
     capabilities: {
       tools: {},
       resources: {},

--- a/web/lib/api/instrument-runs.ts
+++ b/web/lib/api/instrument-runs.ts
@@ -943,7 +943,15 @@ export async function getFilteredFileIds(
 
 export async function getRunFilesPage(
   runInternalId: string,
-  { page, perPage }: { page: number; perPage: number }
+  {
+    page,
+    perPage,
+    statuses,
+  }: {
+    page: number;
+    perPage: number;
+    statuses?: RunFile["status"][];
+  }
 ): Promise<{
   data: RunFile[];
   pagination: {
@@ -957,15 +965,23 @@ export async function getRunFilesPage(
   const safePage = Math.max(page, 1);
   const offset = (safePage - 1) * safePerPage;
 
+  const where =
+    statuses && statuses.length > 0
+      ? and(
+          eq(files.instrumentRunId, runInternalId),
+          inArray(files.status, statuses)
+        )
+      : eq(files.instrumentRunId, runInternalId);
+
   const [{ total }] = await db
     .select({ total: sql<number>`count(*)::int` })
     .from(files)
-    .where(eq(files.instrumentRunId, runInternalId));
+    .where(where);
 
   const data = await db
     .select()
     .from(files)
-    .where(eq(files.instrumentRunId, runInternalId))
+    .where(where)
     .orderBy(files.createdAt)
     .limit(safePerPage)
     .offset(offset);

--- a/web/lib/api/instrument-runs.ts
+++ b/web/lib/api/instrument-runs.ts
@@ -171,6 +171,30 @@ export const lookupRunByNaturalKey = cache(async function lookupRunByNaturalKey(
   };
 });
 
+/** Natural runId → internal UUID for one instrument. Missing IDs are omitted. */
+export async function lookupRunUuidsByNaturalKeys(
+  instrumentId: string,
+  runIds: string[]
+): Promise<Map<string, string>> {
+  const unique = [...new Set(runIds.map((runId) => decodeURIComponent(runId)))];
+  if (unique.length === 0) {
+    return new Map();
+  }
+  const rows = await db
+    .select({
+      id: instrumentRuns.id,
+      runId: instrumentRuns.runId,
+    })
+    .from(instrumentRuns)
+    .where(
+      and(
+        eq(instrumentRuns.instrumentId, instrumentId),
+        inArray(instrumentRuns.runId, unique)
+      )
+    );
+  return new Map(rows.map((row) => [row.runId, row.id]));
+}
+
 // ---------------------------------------------------------------------------
 // acquired_at parsing for create/update payloads.
 //

--- a/web/lib/mcp/completions.ts
+++ b/web/lib/mcp/completions.ts
@@ -1,12 +1,13 @@
+import { getInstruments } from "@/lib/api/dashboard";
 import { buildRunListQuery } from "@/lib/api/instrument-runs";
-import { getInstrumentListWithCounts } from "@/lib/api/instruments";
 
 interface CompletionContext {
   arguments?: Record<string, string>;
 }
 
 export async function completeInstrumentId(value: string): Promise<string[]> {
-  const instruments = await getInstrumentListWithCounts();
+  // IDs only — avoid the run/watcher count join used by the instruments list.
+  const instruments = await getInstruments();
   const needle = value.toLowerCase();
   return instruments
     .map((i) => i.id)
@@ -21,16 +22,16 @@ export async function completeRunId(
   if (!instrumentId) {
     return [];
   }
+  // Push the typed prefix into the DB filter so we aren't limited to the
+  // 50 most recent runs. The SDK caps completion values at 100.
   const result = await buildRunListQuery({
     instrumentId,
+    search: value,
     page: 1,
-    perPage: 50,
+    perPage: 100,
     includeDeleted: false,
     sort: "acquired_at",
     order: "desc",
   });
-  const needle = value.toLowerCase();
-  return result.data
-    .map((row) => row.run_id)
-    .filter((id) => id.toLowerCase().startsWith(needle));
+  return result.data.map((row) => row.run_id);
 }

--- a/web/lib/mcp/completions.ts
+++ b/web/lib/mcp/completions.ts
@@ -1,0 +1,36 @@
+import { buildRunListQuery } from "@/lib/api/instrument-runs";
+import { getInstrumentListWithCounts } from "@/lib/api/instruments";
+
+interface CompletionContext {
+  arguments?: Record<string, string>;
+}
+
+export async function completeInstrumentId(value: string): Promise<string[]> {
+  const instruments = await getInstrumentListWithCounts();
+  const needle = value.toLowerCase();
+  return instruments
+    .map((i) => i.id)
+    .filter((id) => id.toLowerCase().startsWith(needle));
+}
+
+export async function completeRunId(
+  value: string,
+  context?: CompletionContext
+): Promise<string[]> {
+  const instrumentId = context?.arguments?.instrumentId;
+  if (!instrumentId) {
+    return [];
+  }
+  const result = await buildRunListQuery({
+    instrumentId,
+    page: 1,
+    perPage: 50,
+    includeDeleted: false,
+    sort: "acquired_at",
+    order: "desc",
+  });
+  const needle = value.toLowerCase();
+  return result.data
+    .map((row) => row.run_id)
+    .filter((id) => id.toLowerCase().startsWith(needle));
+}

--- a/web/lib/mcp/glossary.ts
+++ b/web/lib/mcp/glossary.ts
@@ -1,7 +1,7 @@
 import { VALID_INSTRUMENT_TYPES } from "@/lib/db/schema";
 import { RUN_STATUS_META, RUN_STATUS_VALUES } from "@/lib/runs/run-status";
 
-// Static reference for MCP clients — attach via `datahub://glossary` without a tool call.
+// Static reference for MCP clients — attach via `datahub://glossary`.
 export const DATAHUB_GLOSSARY = {
   runStatus: {
     derivation:
@@ -18,17 +18,8 @@ export const DATAHUB_GLOSSARY = {
     unattributed: "Runs with no claim attributions.",
     userId: "Concrete user UUID from list_run_attributors or get_me.",
   },
+  dates:
+    "dateFrom/dateTo are inclusive UTC calendar days matched against coalesce(acquired_at, created_at). The web dashboard computes “today” in the viewer's timezone, so daily counts can differ.",
   archivePolling:
     "get_run_archive may return { status: 'building', retryAfterSeconds }. Call again after the wait until status is 'ready'.",
-  toolRouting: {
-    vagueDiscovery:
-      "Prefer global_search when the query may match filenames, instrument names, user names/emails, or comment bodies (users scope is workspace-wide). Prefer search_runs for structured filters (date, status, metadata).",
-    myRuns: 'search_runs with ranBy="me", or get_me then ranBy=<id>.',
-    experimentalResults:
-      "Prefer get_run_report for bounded CSV samples and failure summaries over downloading full files.",
-    filterEnums:
-      "Read datahub://instruments/{instrumentId}/filter-options before setting metadata filters on search_runs.",
-    watcherDiagnosis:
-      "list_watchers → get_watcher_heartbeats → list_watcher_events for unhealthy agents.",
-  },
 } as const;

--- a/web/lib/mcp/instructions.ts
+++ b/web/lib/mcp/instructions.ts
@@ -1,0 +1,22 @@
+/** Delivered to every MCP client at initialize — reachable without resources. */
+export const MCP_SERVER_INSTRUCTIONS = [
+  "Data Hub MCP stores lab instrument runs, files, watchers, and attributions.",
+  "",
+  "Dates: dateFrom/dateTo and prompt date defaults are UTC calendar days",
+  "(inclusive), matched against coalesce(acquired_at, created_at). The web",
+  "dashboard uses the viewer's timezone for “today”, so counts can differ.",
+  "",
+  "Run status is derived from raw file states, priority-exclusive:",
+  "failed > pending (detected/upload_requested) > uploaded > processing >",
+  "completed > empty.",
+  "",
+  "Tool routing:",
+  "- Prefer global_search for filenames, instrument names, users, or comments.",
+  "- Prefer search_runs for date/status/metadata filters.",
+  '- My runs: search_runs with ranBy="me" (or get_me then ranBy=<id>).',
+  "- Prefer get_run_report for bounded CSV samples over downloading full files.",
+  "- Metadata filter enums: get_instrument_filter_options or",
+  "  datahub://instruments/{id}/filter-options.",
+  "- Watcher diagnosis: list_watchers → get_watcher_heartbeats →",
+  "  list_watcher_events (unhealthy agents only).",
+].join("\n");

--- a/web/lib/mcp/instrument-filter-options.ts
+++ b/web/lib/mcp/instrument-filter-options.ts
@@ -1,0 +1,29 @@
+import { getInstrumentFilterOptions } from "@/lib/api/instrument-runs";
+import { getInstrumentById } from "@/lib/api/instruments";
+
+export type ResolveInstrumentFilterOptionsResult =
+  | { ok: true; options: object }
+  | { ok: false; error: string };
+
+/** Shared lookup for the filter-options resource and MCP tool. */
+export async function resolveInstrumentFilterOptions(
+  instrumentId: string
+): Promise<ResolveInstrumentFilterOptionsResult> {
+  const instrument = await getInstrumentById(instrumentId);
+  if (!instrument) {
+    return { ok: false, error: `Instrument '${instrumentId}' not found` };
+  }
+
+  const result = await getInstrumentFilterOptions(
+    instrument.instrumentType,
+    instrumentId
+  );
+  if (result.kind === "default") {
+    return {
+      ok: false,
+      error: `Instrument type '${instrument.instrumentType}' has no structured filter options`,
+    };
+  }
+
+  return { ok: true, options: result.options };
+}

--- a/web/lib/mcp/prompts.defs.ts
+++ b/web/lib/mcp/prompts.defs.ts
@@ -10,7 +10,9 @@ export const dailySummaryPrompt = {
     date: z
       .string()
       .optional()
-      .describe("Date to summarize (YYYY-MM-DD). Defaults to today."),
+      .describe(
+        "Date to summarize (YYYY-MM-DD, UTC calendar day). Defaults to the current UTC day."
+      ),
   },
 } as const satisfies McpPromptDef;
 
@@ -53,8 +55,11 @@ export const findMyRunsPrompt = {
     dateFrom: z
       .string()
       .optional()
-      .describe("Start date (YYYY-MM-DD), inclusive"),
-    dateTo: z.string().optional().describe("End date (YYYY-MM-DD), inclusive"),
+      .describe("Start date (YYYY-MM-DD, UTC), inclusive"),
+    dateTo: z
+      .string()
+      .optional()
+      .describe("End date (YYYY-MM-DD, UTC), inclusive"),
   },
 } as const satisfies McpPromptDef;
 
@@ -79,8 +84,11 @@ export const claimUnattributedRunsPrompt = {
     dateFrom: z
       .string()
       .optional()
-      .describe("Optional start date (YYYY-MM-DD)"),
-    dateTo: z.string().optional().describe("Optional end date (YYYY-MM-DD)"),
+      .describe("Optional start date (YYYY-MM-DD, UTC)"),
+    dateTo: z
+      .string()
+      .optional()
+      .describe("Optional end date (YYYY-MM-DD, UTC)"),
   },
 } as const satisfies McpPromptDef;
 
@@ -94,11 +102,11 @@ export const summarizeInstrumentWeekPrompt = {
     dateFrom: z
       .string()
       .optional()
-      .describe("Start date (YYYY-MM-DD). Defaults to 7 days ago."),
+      .describe("Start date (YYYY-MM-DD, UTC). Defaults to 7 days ago (UTC)."),
     dateTo: z
       .string()
       .optional()
-      .describe("End date (YYYY-MM-DD). Defaults to today."),
+      .describe("End date (YYYY-MM-DD, UTC). Defaults to today (UTC)."),
   },
 } as const satisfies McpPromptDef;
 

--- a/web/lib/mcp/prompts.ts
+++ b/web/lib/mcp/prompts.ts
@@ -1,5 +1,7 @@
-import type { McpServer } from "@modelcontextprotocol/server";
+import { completable, type McpServer } from "@modelcontextprotocol/server";
+import { z } from "zod";
 import { promptRegistrationConfig } from "@/lib/mcp/catalog/register";
+import { completeInstrumentId, completeRunId } from "@/lib/mcp/completions";
 import {
   claimUnattributedRunsPrompt,
   compareRunsPrompt,
@@ -9,6 +11,19 @@ import {
   summarizeInstrumentWeekPrompt,
   troubleshootInstrumentPrompt,
 } from "./prompts.defs";
+
+// Fresh Zod schemas each registration — `completable()` mutates the schema,
+// so reusing defs' instances breaks when the server is rebuilt (e.g. tests).
+function instrumentIdComplete(description: string, optional = false) {
+  const base = z.string().describe(description);
+  return completable(optional ? base.optional() : base, (value) =>
+    completeInstrumentId(typeof value === "string" ? value : "")
+  );
+}
+
+function runIdComplete(description: string) {
+  return completable(z.string().describe(description), completeRunId);
+}
 
 export function registerPrompts(server: McpServer) {
   server.registerPrompt(
@@ -23,7 +38,9 @@ export function registerPrompts(server: McpServer) {
             content: {
               type: "text" as const,
               text: [
-                `Give me a summary of all lab instrument activity for ${targetDate}.`,
+                `Give me a summary of all lab instrument activity for ${targetDate} (UTC).`,
+                "",
+                "The default date is the current UTC calendar day; an explicit date overrides it. Day boundaries are UTC.",
                 "",
                 "Steps:",
                 "1. Call get_system_status to get an overview of all instruments and their watcher health.",
@@ -44,7 +61,14 @@ export function registerPrompts(server: McpServer) {
 
   server.registerPrompt(
     troubleshootInstrumentPrompt.name,
-    promptRegistrationConfig(troubleshootInstrumentPrompt),
+    promptRegistrationConfig({
+      ...troubleshootInstrumentPrompt,
+      argsSchema: {
+        instrumentId: instrumentIdComplete(
+          "Instrument identifier to troubleshoot"
+        ),
+      },
+    }),
     async ({ instrumentId }) => ({
       messages: [
         {
@@ -76,7 +100,16 @@ export function registerPrompts(server: McpServer) {
 
   server.registerPrompt(
     compareRunsPrompt.name,
-    promptRegistrationConfig(compareRunsPrompt),
+    promptRegistrationConfig({
+      ...compareRunsPrompt,
+      argsSchema: {
+        instrumentId: instrumentIdComplete(
+          "Instrument identifier (both runs must be on the same instrument)"
+        ),
+        runId1: runIdComplete("First run identifier"),
+        runId2: runIdComplete("Second run identifier"),
+      },
+    }),
     async ({ instrumentId, runId1, runId2 }) => ({
       messages: [
         {
@@ -105,7 +138,17 @@ export function registerPrompts(server: McpServer) {
 
   server.registerPrompt(
     findMyRunsPrompt.name,
-    promptRegistrationConfig(findMyRunsPrompt),
+    promptRegistrationConfig({
+      ...findMyRunsPrompt,
+      argsSchema: {
+        instrumentId: instrumentIdComplete(
+          "Optional instrument to narrow results",
+          true
+        ),
+        dateFrom: findMyRunsPrompt.argsSchema.dateFrom,
+        dateTo: findMyRunsPrompt.argsSchema.dateTo,
+      },
+    }),
     ({ instrumentId, dateFrom, dateTo }) => {
       const filters = [
         'ranBy="me"',
@@ -124,6 +167,8 @@ export function registerPrompts(server: McpServer) {
               text: [
                 "Find runs I have claimed.",
                 "",
+                "Date filters use UTC calendar days when provided.",
+                "",
                 "Steps:",
                 "1. Optionally call get_me to confirm the authenticated identity.",
                 `2. Call search_runs with ${filters}.`,
@@ -138,7 +183,13 @@ export function registerPrompts(server: McpServer) {
 
   server.registerPrompt(
     explainFailedRunPrompt.name,
-    promptRegistrationConfig(explainFailedRunPrompt),
+    promptRegistrationConfig({
+      ...explainFailedRunPrompt,
+      argsSchema: {
+        instrumentId: instrumentIdComplete("Instrument identifier"),
+        runId: runIdComplete("Run identifier within the instrument"),
+      },
+    }),
     async ({ instrumentId, runId }) => ({
       messages: [
         {
@@ -163,7 +214,14 @@ export function registerPrompts(server: McpServer) {
 
   server.registerPrompt(
     claimUnattributedRunsPrompt.name,
-    promptRegistrationConfig(claimUnattributedRunsPrompt),
+    promptRegistrationConfig({
+      ...claimUnattributedRunsPrompt,
+      argsSchema: {
+        instrumentId: instrumentIdComplete("Instrument identifier"),
+        dateFrom: claimUnattributedRunsPrompt.argsSchema.dateFrom,
+        dateTo: claimUnattributedRunsPrompt.argsSchema.dateTo,
+      },
+    }),
     ({ instrumentId, dateFrom, dateTo }) => {
       const dateBits = [
         dateFrom ? `dateFrom="${dateFrom}"` : null,
@@ -180,10 +238,12 @@ export function registerPrompts(server: McpServer) {
               text: [
                 `Find unattributed runs on instrument "${instrumentId}" that I should claim.`,
                 "",
+                "Date filters use UTC calendar days when provided.",
+                "",
                 "Steps:",
                 `1. Call search_runs with instrumentId="${instrumentId}", ranBy="unattributed"${dateBits ? `, ${dateBits}` : ""}.`,
                 "2. Present the candidate run IDs and ask me to confirm which ones to claim (do not claim automatically).",
-                "3. After confirmation, call claim_run for each approved run.",
+                "3. After confirmation, call claim_runs once with the approved runIds.",
                 "4. Summarize what was claimed.",
               ].join("\n"),
             },
@@ -195,7 +255,14 @@ export function registerPrompts(server: McpServer) {
 
   server.registerPrompt(
     summarizeInstrumentWeekPrompt.name,
-    promptRegistrationConfig(summarizeInstrumentWeekPrompt),
+    promptRegistrationConfig({
+      ...summarizeInstrumentWeekPrompt,
+      argsSchema: {
+        instrumentId: instrumentIdComplete("Instrument identifier"),
+        dateFrom: summarizeInstrumentWeekPrompt.argsSchema.dateFrom,
+        dateTo: summarizeInstrumentWeekPrompt.argsSchema.dateTo,
+      },
+    }),
     ({ instrumentId, dateFrom, dateTo }) => {
       const today = new Date();
       const defaultTo = today.toISOString().slice(0, 10);
@@ -211,7 +278,9 @@ export function registerPrompts(server: McpServer) {
             content: {
               type: "text" as const,
               text: [
-                `Summarize activity for instrument "${instrumentId}" from ${from} to ${to}.`,
+                `Summarize activity for instrument "${instrumentId}" from ${from} (UTC) to ${to} (UTC).`,
+                "",
+                "Defaults are the last seven UTC calendar days; explicit dates override them. Day boundaries are UTC.",
                 "",
                 "Steps:",
                 `1. Call get_instrument with instrumentId="${instrumentId}".`,

--- a/web/lib/mcp/prompts.ts
+++ b/web/lib/mcp/prompts.ts
@@ -14,15 +14,33 @@ import {
 
 // Fresh Zod schemas each registration — `completable()` mutates the schema,
 // so reusing defs' instances breaks when the server is rebuilt (e.g. tests).
-function instrumentIdComplete(description: string, optional = false) {
-  const base = z.string().describe(description);
-  return completable(optional ? base.optional() : base, (value) =>
-    completeInstrumentId(typeof value === "string" ? value : "")
-  );
+// Descriptions stay on the defs; these helpers copy them onto the completable
+// clones. Apply completable before optional: the SDK unwraps ZodOptional first
+// and then looks for the completable marker on the inner schema.
+function fieldDescription(
+  schema: z.ZodString | z.ZodOptional<z.ZodString>
+): string {
+  const inner =
+    schema instanceof z.ZodOptional ? (schema.unwrap() as z.ZodString) : schema;
+  return inner.description ?? "";
 }
 
-function runIdComplete(description: string) {
-  return completable(z.string().describe(description), completeRunId);
+function instrumentIdComplete(
+  schema: z.ZodString | z.ZodOptional<z.ZodString>
+) {
+  const optional = schema instanceof z.ZodOptional;
+  const field = completable(
+    z.string().describe(fieldDescription(schema)),
+    (value) => completeInstrumentId(typeof value === "string" ? value : "")
+  );
+  return optional ? field.optional() : field;
+}
+
+function runIdComplete(schema: z.ZodString) {
+  return completable(
+    z.string().describe(fieldDescription(schema)),
+    completeRunId
+  );
 }
 
 export function registerPrompts(server: McpServer) {
@@ -65,7 +83,7 @@ export function registerPrompts(server: McpServer) {
       ...troubleshootInstrumentPrompt,
       argsSchema: {
         instrumentId: instrumentIdComplete(
-          "Instrument identifier to troubleshoot"
+          troubleshootInstrumentPrompt.argsSchema.instrumentId
         ),
       },
     }),
@@ -104,10 +122,10 @@ export function registerPrompts(server: McpServer) {
       ...compareRunsPrompt,
       argsSchema: {
         instrumentId: instrumentIdComplete(
-          "Instrument identifier (both runs must be on the same instrument)"
+          compareRunsPrompt.argsSchema.instrumentId
         ),
-        runId1: runIdComplete("First run identifier"),
-        runId2: runIdComplete("Second run identifier"),
+        runId1: runIdComplete(compareRunsPrompt.argsSchema.runId1),
+        runId2: runIdComplete(compareRunsPrompt.argsSchema.runId2),
       },
     }),
     async ({ instrumentId, runId1, runId2 }) => ({
@@ -142,8 +160,7 @@ export function registerPrompts(server: McpServer) {
       ...findMyRunsPrompt,
       argsSchema: {
         instrumentId: instrumentIdComplete(
-          "Optional instrument to narrow results",
-          true
+          findMyRunsPrompt.argsSchema.instrumentId
         ),
         dateFrom: findMyRunsPrompt.argsSchema.dateFrom,
         dateTo: findMyRunsPrompt.argsSchema.dateTo,
@@ -186,8 +203,10 @@ export function registerPrompts(server: McpServer) {
     promptRegistrationConfig({
       ...explainFailedRunPrompt,
       argsSchema: {
-        instrumentId: instrumentIdComplete("Instrument identifier"),
-        runId: runIdComplete("Run identifier within the instrument"),
+        instrumentId: instrumentIdComplete(
+          explainFailedRunPrompt.argsSchema.instrumentId
+        ),
+        runId: runIdComplete(explainFailedRunPrompt.argsSchema.runId),
       },
     }),
     async ({ instrumentId, runId }) => ({
@@ -217,7 +236,9 @@ export function registerPrompts(server: McpServer) {
     promptRegistrationConfig({
       ...claimUnattributedRunsPrompt,
       argsSchema: {
-        instrumentId: instrumentIdComplete("Instrument identifier"),
+        instrumentId: instrumentIdComplete(
+          claimUnattributedRunsPrompt.argsSchema.instrumentId
+        ),
         dateFrom: claimUnattributedRunsPrompt.argsSchema.dateFrom,
         dateTo: claimUnattributedRunsPrompt.argsSchema.dateTo,
       },
@@ -258,17 +279,19 @@ export function registerPrompts(server: McpServer) {
     promptRegistrationConfig({
       ...summarizeInstrumentWeekPrompt,
       argsSchema: {
-        instrumentId: instrumentIdComplete("Instrument identifier"),
+        instrumentId: instrumentIdComplete(
+          summarizeInstrumentWeekPrompt.argsSchema.instrumentId
+        ),
         dateFrom: summarizeInstrumentWeekPrompt.argsSchema.dateFrom,
         dateTo: summarizeInstrumentWeekPrompt.argsSchema.dateTo,
       },
     }),
     ({ instrumentId, dateFrom, dateTo }) => {
-      const today = new Date();
-      const defaultTo = today.toISOString().slice(0, 10);
-      const weekAgo = new Date(today);
-      weekAgo.setDate(weekAgo.getDate() - 7);
-      const defaultFrom = weekAgo.toISOString().slice(0, 10);
+      // UTC calendar days only — setDate/getDate would shift near local midnight.
+      const defaultTo = new Date().toISOString().slice(0, 10);
+      const fromUtc = new Date(`${defaultTo}T00:00:00.000Z`);
+      fromUtc.setUTCDate(fromUtc.getUTCDate() - 7);
+      const defaultFrom = fromUtc.toISOString().slice(0, 10);
       const from = dateFrom || defaultFrom;
       const to = dateTo || defaultTo;
       return {

--- a/web/lib/mcp/resources.defs.ts
+++ b/web/lib/mcp/resources.defs.ts
@@ -21,7 +21,7 @@ export const meResource = {
 export const glossaryResource = {
   name: "glossary",
   description:
-    "Static reference: run status derivation, instrument types, ranBy literals, archive polling, and tool-routing tips.",
+    "Static reference: run status derivation, instrument types, ranBy literals, UTC date semantics, and archive polling.",
   mimeType: "application/json",
   kind: "static",
   uri: "datahub://glossary",

--- a/web/lib/mcp/resources.ts
+++ b/web/lib/mcp/resources.ts
@@ -1,12 +1,10 @@
 import { type McpServer, ResourceTemplate } from "@modelcontextprotocol/server";
 import { getInstruments, getUserById } from "@/lib/api/dashboard";
-import { getInstrumentFilterOptions } from "@/lib/api/instrument-runs";
-import {
-  getInstrumentById,
-  getInstrumentListWithCounts,
-} from "@/lib/api/instruments";
+import { getInstrumentListWithCounts } from "@/lib/api/instruments";
 import type { InstrumentType } from "@/lib/db/schema";
+import { completeInstrumentId } from "@/lib/mcp/completions";
 import { DATAHUB_GLOSSARY } from "@/lib/mcp/glossary";
+import { resolveInstrumentFilterOptions } from "@/lib/mcp/instrument-filter-options";
 import { getMcpUserId } from "@/lib/mcp/tools/helpers";
 import {
   glossaryResource,
@@ -152,6 +150,9 @@ export function registerResources(server: McpServer) {
           })),
         };
       },
+      complete: {
+        instrumentId: completeInstrumentId,
+      },
     }),
     {
       description: instrumentFilterOptionsResource.description,
@@ -177,34 +178,8 @@ export function registerResources(server: McpServer) {
         };
       }
 
-      const instrument = await getInstrumentById(instrumentId);
-      if (!instrument) {
-        return {
-          contents: [
-            {
-              uri: _uri.href,
-              mimeType: "application/json",
-              text: JSON.stringify(
-                { error: `Instrument '${instrumentId}' not found` },
-                null,
-                2
-              ),
-            },
-          ],
-        };
-      }
-
-      const result = await getInstrumentFilterOptions(
-        instrument.instrumentType,
-        instrumentId
-      );
-
-      const payload =
-        result.kind === "default"
-          ? {
-              error: `Instrument type '${instrument.instrumentType}' has no structured filter options`,
-            }
-          : result.options;
+      const result = await resolveInstrumentFilterOptions(instrumentId);
+      const payload = result.ok ? result.options : { error: result.error };
 
       return {
         contents: [

--- a/web/lib/mcp/tools/instruments.defs.ts
+++ b/web/lib/mcp/tools/instruments.defs.ts
@@ -34,7 +34,25 @@ export const getInstrumentTool = {
   annotations: { readOnlyHint: true },
 } as const satisfies McpToolDef;
 
+export const getInstrumentFilterOptionsTool = {
+  name: "get_instrument_filter_options",
+  title: "Get Instrument Filter Options",
+  description:
+    "Return the valid search_runs metadata filter values for one instrument (wavelengths, dye channels, etc.). Prefer the datahub://instruments/{id}/filter-options resource when the client supports resources.",
+  group: "instruments",
+  scope: "instruments:read",
+  inputSchema: {
+    instrumentId: z
+      .string()
+      .describe(
+        "Kebab-case instrument identifier (e.g. 'spectramax-id3-plate-reader')"
+      ),
+  },
+  annotations: { readOnlyHint: true },
+} as const satisfies McpToolDef;
+
 export const INSTRUMENT_TOOL_DEFS = [
   listInstrumentsTool,
   getInstrumentTool,
+  getInstrumentFilterOptionsTool,
 ] as const;

--- a/web/lib/mcp/tools/instruments.ts
+++ b/web/lib/mcp/tools/instruments.ts
@@ -4,8 +4,13 @@ import {
   getInstrumentListWithCounts,
 } from "@/lib/api/instruments";
 import { toolRegistrationConfig } from "@/lib/mcp/catalog/register";
+import { resolveInstrumentFilterOptions } from "@/lib/mcp/instrument-filter-options";
 import { errorResult, textResult } from "@/lib/mcp/tools/helpers";
-import { getInstrumentTool, listInstrumentsTool } from "./instruments.defs";
+import {
+  getInstrumentFilterOptionsTool,
+  getInstrumentTool,
+  listInstrumentsTool,
+} from "./instruments.defs";
 
 export function registerInstrumentTools(server: McpServer) {
   server.registerTool(
@@ -29,6 +34,18 @@ export function registerInstrumentTools(server: McpServer) {
         return errorResult(`Instrument '${instrumentId}' not found.`);
       }
       return textResult(instrument);
+    }
+  );
+
+  server.registerTool(
+    getInstrumentFilterOptionsTool.name,
+    toolRegistrationConfig(getInstrumentFilterOptionsTool),
+    async ({ instrumentId }) => {
+      const result = await resolveInstrumentFilterOptions(instrumentId);
+      if (!result.ok) {
+        return errorResult(result.error);
+      }
+      return textResult({ instrumentId, options: result.options });
     }
   );
 }

--- a/web/lib/mcp/tools/runs.defs.ts
+++ b/web/lib/mcp/tools/runs.defs.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { mcpMetadataFilterInputSchema } from "@/lib/api/run-metadata-filters";
+import { fileStatusEnum } from "@/lib/db/schema";
 import type { McpToolDef } from "@/lib/mcp/catalog/types";
 import { RUN_STATUS_VALUES } from "@/lib/runs/run-status";
 
@@ -9,7 +10,7 @@ export const searchRunsTool = {
   scope: "runs:read",
   title: "Search Runs",
   description:
-    "Search instrument runs with filtering, pagination, and sorting. Supports run status filters and instrument-metadata filters (plate reader, gel-doc, qPCR, Hina microscope, Epson scanner). Prefer global_search when the query may match filenames, instrument names, or attributor names rather than run IDs. Discover valid metadata filter values via datahub://instruments/{id}/filter-options (or datahub://glossary for routing tips).",
+    "Search instrument runs with filtering, pagination, and sorting. Supports run status filters and instrument-metadata filters (plate reader, gel-doc, qPCR, Hina microscope, Epson scanner). Prefer global_search when the query may match filenames, instrument names, or attributor names rather than run IDs. Discover valid metadata filter values via get_instrument_filter_options or datahub://instruments/{id}/filter-options.",
   inputSchema: {
     instrumentId: z
       .union([z.string(), z.array(z.string())])
@@ -26,8 +27,15 @@ export const searchRunsTool = {
     dateFrom: z
       .string()
       .optional()
-      .describe("Start date (inclusive, YYYY-MM-DD)"),
-    dateTo: z.string().optional().describe("End date (inclusive, YYYY-MM-DD)"),
+      .describe(
+        "Start date (inclusive, YYYY-MM-DD). Day boundary is UTC, not the viewer's timezone."
+      ),
+    dateTo: z
+      .string()
+      .optional()
+      .describe(
+        "End date (inclusive, YYYY-MM-DD). Day boundary is UTC, not the viewer's timezone."
+      ),
     sort: z
       .enum(["acquired_at", "created_at", "updated_at"])
       .optional()
@@ -112,10 +120,16 @@ export const listRunFilesTool = {
   scope: "runs:read",
   title: "List Run Files",
   description:
-    "List files associated with a run (raw uploads and processed artifacts) with their status, category, and size. Paginated — runs can have thousands of files. Use the page/perPage arguments to walk the full list, and use get_file for full per-file detail including metadata and S3 location.",
+    "List files associated with a run (raw uploads and processed artifacts) with their status, category, and size. Paginated — runs can have thousands of files. Filter by status to gather fileIds for request_run_upload (e.g. status=['detected']). Use get_file for full per-file detail including metadata and S3 location.",
   inputSchema: {
     instrumentId: z.string().describe("Instrument identifier"),
     runId: z.string().describe("Run identifier within the instrument"),
+    status: z
+      .array(z.enum(fileStatusEnum.enumValues))
+      .optional()
+      .describe(
+        "Filter to one or more file statuses (OR'd). Omit to return all statuses."
+      ),
     page: z
       .number()
       .int()
@@ -139,10 +153,32 @@ export const claimRunTool = {
   scope: "runs:attribute",
   title: "Claim Run",
   description:
-    "Mark a run as performed by the authenticated user. Idempotent — claiming a run you already claimed is a no-op. Only self-attribution is supported; you cannot claim a run on behalf of another user.",
+    "Mark a run as performed by the authenticated user. Idempotent — claiming a run you already claimed is a no-op. Only self-attribution is supported; you cannot claim a run on behalf of another user. Prefer claim_runs when attributing multiple runs.",
   inputSchema: {
     instrumentId: z.string().describe("Instrument identifier"),
     runId: z.string().describe("Run identifier within the instrument"),
+  },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+} as const satisfies McpToolDef;
+
+export const claimRunsTool = {
+  name: "claim_runs",
+  group: "attribution",
+  scope: "runs:attribute",
+  title: "Claim Runs",
+  description:
+    "Mark multiple runs on one instrument as performed by the authenticated user (max 100). Idempotent per run. Returns claimed runs and any runIds that were not found; a missing ID does not fail the whole batch. Only self-attribution is supported.",
+  inputSchema: {
+    instrumentId: z.string().describe("Instrument identifier"),
+    runIds: z
+      .array(z.string())
+      .min(1)
+      .max(100)
+      .describe("Run identifiers within the instrument (1–100)"),
   },
   annotations: {
     readOnlyHint: false,
@@ -344,6 +380,7 @@ export const RUN_TOOL_DEFS = [
   getRunReportTool,
   listRunFilesTool,
   claimRunTool,
+  claimRunsTool,
   unclaimRunTool,
   listRunAttributorsTool,
   listRunCommentsTool,

--- a/web/lib/mcp/tools/runs.ts
+++ b/web/lib/mcp/tools/runs.ts
@@ -7,6 +7,7 @@ import {
   getRanByFilterOptions,
   getRunFilesPage,
   lookupRunByNaturalKey,
+  type RunAttribution,
 } from "@/lib/api/instrument-runs";
 import {
   createCommentAndNotify,
@@ -35,6 +36,7 @@ import {
 import { validateSearchRunsMetadataFilters } from "@/lib/mcp/validate-run-filters";
 import {
   addRunCommentTool,
+  claimRunsTool,
   claimRunTool,
   deleteRunCommentTool,
   deleteRunTool,
@@ -167,7 +169,7 @@ export function registerRunTools(server: McpServer) {
   server.registerTool(
     listRunFilesTool.name,
     toolRegistrationConfig(listRunFilesTool),
-    async ({ instrumentId, runId, page, perPage }) => {
+    async ({ instrumentId, runId, status, page, perPage }) => {
       const run = await lookupRunByNaturalKey(instrumentId, runId);
       if (!run) {
         return errorResult(
@@ -177,6 +179,7 @@ export function registerRunTools(server: McpServer) {
       const { data, pagination } = await getRunFilesPage(run.id, {
         page: page ?? 1,
         perPage: perPage ?? 50,
+        ...(status ? { statuses: status } : {}),
       });
       return textResult({ data: data.map(toMcpFile), pagination });
     }
@@ -211,6 +214,59 @@ export function registerRunTools(server: McpServer) {
         runId,
         attributions: byRun.get(resolved.runUuid) ?? [],
       });
+    }
+  );
+
+  server.registerTool(
+    claimRunsTool.name,
+    toolRegistrationConfig(claimRunsTool),
+    async ({ instrumentId, runIds }, ctx) => {
+      const authInfo = ctx.http?.authInfo;
+      const writeError = requireMcpWrite(authInfo);
+      if (writeError) {
+        return writeError;
+      }
+      const userId = getMcpUserId(authInfo);
+      if (!userId) {
+        return errorResult("Authenticated user not available on this session.");
+      }
+
+      const claimed: Array<{ runId: string; attributions: RunAttribution[] }> =
+        [];
+      const notFound: string[] = [];
+      const runUuids: string[] = [];
+      const runIdByUuid = new Map<string, string>();
+
+      for (const runId of runIds) {
+        const run = await lookupRunByNaturalKey(instrumentId, runId);
+        if (!run) {
+          notFound.push(runId);
+          continue;
+        }
+        runUuids.push(run.id);
+        runIdByUuid.set(run.id, runId);
+      }
+
+      if (runUuids.length > 0) {
+        await db
+          .insert(runAttributions)
+          .values(runUuids.map((runUuid) => ({ runId: runUuid, userId })))
+          .onConflictDoNothing();
+
+        const byRun = await getAttributionsByRunIds(runUuids);
+        for (const runUuid of runUuids) {
+          const runId = runIdByUuid.get(runUuid);
+          if (!runId) {
+            continue;
+          }
+          claimed.push({
+            runId,
+            attributions: byRun.get(runUuid) ?? [],
+          });
+        }
+      }
+
+      return textResult({ instrumentId, claimed, notFound });
     }
   );
 

--- a/web/lib/mcp/tools/runs.ts
+++ b/web/lib/mcp/tools/runs.ts
@@ -7,6 +7,7 @@ import {
   getRanByFilterOptions,
   getRunFilesPage,
   lookupRunByNaturalKey,
+  lookupRunUuidsByNaturalKeys,
   type RunAttribution,
 } from "@/lib/api/instrument-runs";
 import {
@@ -231,34 +232,29 @@ export function registerRunTools(server: McpServer) {
         return errorResult("Authenticated user not available on this session.");
       }
 
+      const uniqueRunIds = [...new Set(runIds)];
+      const found = await lookupRunUuidsByNaturalKeys(
+        instrumentId,
+        uniqueRunIds
+      );
+      const notFound = uniqueRunIds.filter((runId) => !found.has(runId));
+      const resolved = uniqueRunIds.flatMap((runId) => {
+        const runUuid = found.get(runId);
+        return runUuid ? [{ runId, runUuid }] : [];
+      });
+
       const claimed: Array<{ runId: string; attributions: RunAttribution[] }> =
         [];
-      const notFound: string[] = [];
-      const runUuids: string[] = [];
-      const runIdByUuid = new Map<string, string>();
-
-      for (const runId of runIds) {
-        const run = await lookupRunByNaturalKey(instrumentId, runId);
-        if (!run) {
-          notFound.push(runId);
-          continue;
-        }
-        runUuids.push(run.id);
-        runIdByUuid.set(run.id, runId);
-      }
-
-      if (runUuids.length > 0) {
+      if (resolved.length > 0) {
         await db
           .insert(runAttributions)
-          .values(runUuids.map((runUuid) => ({ runId: runUuid, userId })))
+          .values(resolved.map(({ runUuid }) => ({ runId: runUuid, userId })))
           .onConflictDoNothing();
 
-        const byRun = await getAttributionsByRunIds(runUuids);
-        for (const runUuid of runUuids) {
-          const runId = runIdByUuid.get(runUuid);
-          if (!runId) {
-            continue;
-          }
+        const byRun = await getAttributionsByRunIds(
+          resolved.map(({ runUuid }) => runUuid)
+        );
+        for (const { runId, runUuid } of resolved) {
           claimed.push({
             runId,
             attributions: byRun.get(runUuid) ?? [],

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1461,9 +1461,9 @@
       "license": "MIT"
     },
     "node_modules/@better-auth/core": {
-      "version": "1.6.25",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.25.tgz",
-      "integrity": "sha512-lMTlhtwyK4NpY9kPF+2rQCRKYpg136d3gM2xl8esxT1PjJx5Nh5YwZvxcYCIjDuO759sx6TCloJTuwcZGG6ZBw==",
+      "version": "1.6.27",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.27.tgz",
+      "integrity": "sha512-A6/mQW4AT2kSHCRZDh9+k8jPUqnCUUCymzBgIroK0l60wLioMtJdcmZiTwrAn6KVUw+4XWw64MgaRn7LOie3wg==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.39.0",
@@ -1475,7 +1475,7 @@
         "@better-fetch/fetch": "1.3.1",
         "@cloudflare/workers-types": ">=4",
         "@opentelemetry/api": "^1.9.0",
-        "better-call": "1.3.7",
+        "better-call": "1.4.0",
         "jose": "^6.1.0",
         "kysely": "^0.28.5 || ^0.29.0",
         "nanostores": "^1.0.1"
@@ -1490,12 +1490,12 @@
       }
     },
     "node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.6.25",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.25.tgz",
-      "integrity": "sha512-ru/DeKjFPQUVeKkxF/ScazmPqIY7lwfkAV5Yt4j24wmn1Y8vFwoiPRnHgXUeZqBs10+nubaRwEqLF39CP6EhRw==",
+      "version": "1.6.27",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.27.tgz",
+      "integrity": "sha512-BDJ02ra/fji/ah3aIpxjjNOu/JQVex0UisxS4S0vGZZyiAs+DL24mn3/iovyD5dWB3u3NaGg1n8zpTOntiIXcg==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.25",
+        "@better-auth/core": "^1.6.27",
         "@better-auth/utils": "0.4.2",
         "drizzle-orm": "^0.45.2"
       },
@@ -1506,12 +1506,12 @@
       }
     },
     "node_modules/@better-auth/kysely-adapter": {
-      "version": "1.6.25",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.25.tgz",
-      "integrity": "sha512-zxiePhtN1YClS1irKYPVwWfN6kYp+QoYlz1hdQUOj8hXyo2aE/ny4RNAb6v332b0+U6Vu88EhYITRPdmvCo6uA==",
+      "version": "1.6.27",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.27.tgz",
+      "integrity": "sha512-aavv7W4+b3QVObYo166baplWvwocCk8ORDxRqQ9ytzVl/waiUpSXAOtDHdXZHFsoVHFVPtEzyEq0Tqr3Qvvfig==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.25",
+        "@better-auth/core": "^1.6.27",
         "@better-auth/utils": "0.4.2",
         "kysely": "^0.28.17 || ^0.29.0"
       },
@@ -1522,22 +1522,22 @@
       }
     },
     "node_modules/@better-auth/memory-adapter": {
-      "version": "1.6.25",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.25.tgz",
-      "integrity": "sha512-GhEzTumc8yfTz+OZ6pMg06BA49xob49x1bX+1mEl/FStDJoSF+6mTfI5M2ytFxaiN89336/aUjkW8u+qRyLexw==",
+      "version": "1.6.27",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.27.tgz",
+      "integrity": "sha512-p4NB37MdaVFkxkpLEAKjORgTPhaOAPu1M2zgQXiTJJ3F6Uq3Y1YcCgoz+VxJu0TQfxibCsJD/dZlJMVgf+CF7A==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.25",
+        "@better-auth/core": "^1.6.27",
         "@better-auth/utils": "0.4.2"
       }
     },
     "node_modules/@better-auth/mongo-adapter": {
-      "version": "1.6.25",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.25.tgz",
-      "integrity": "sha512-ZtMmjcOdXR2Ziqx5y8ptTOaNpe0snNfALbBUPXJsgeyeRkDJDYzyLZ8MpuvNBTNllNeIFDbiXWAK5k+pEBZrUQ==",
+      "version": "1.6.27",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.27.tgz",
+      "integrity": "sha512-IOYbJMIjEC//f+JpFlmIQjh6x1R/rGAfdzlojFk6HeAJqbsELuMcI+27dIoesbfHLF/icTrSpZtK986XhJrCfA==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.25",
+        "@better-auth/core": "^1.6.27",
         "@better-auth/utils": "0.4.2",
         "mongodb": "^6.0.0 || ^7.0.0"
       },
@@ -1548,29 +1548,29 @@
       }
     },
     "node_modules/@better-auth/oauth-provider": {
-      "version": "1.6.25",
-      "resolved": "https://registry.npmjs.org/@better-auth/oauth-provider/-/oauth-provider-1.6.25.tgz",
-      "integrity": "sha512-YwOFwDKJL3XUS2QPvMIfR5MvpHlGsB0opk3s5L+OIkYJDzawk3NZOd2K8hUSd1K3YvCJznpoNKKaKsdVjoxvxA==",
+      "version": "1.6.27",
+      "resolved": "https://registry.npmjs.org/@better-auth/oauth-provider/-/oauth-provider-1.6.27.tgz",
+      "integrity": "sha512-xUQ8GgbWUOYesO5wocrzbHdGa0Jojrxh59Vdew/1xzRRDYfXPEP/vq8Sj754BBwXjGAoKkvU/u6BaLXLBNOlYA==",
       "license": "MIT",
       "dependencies": {
         "jose": "^6.1.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
-        "@better-auth/core": "^1.6.25",
+        "@better-auth/core": "^1.6.27",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1",
-        "better-auth": "^1.6.25",
-        "better-call": "1.3.7"
+        "better-auth": "^1.6.27",
+        "better-call": "1.4.0"
       }
     },
     "node_modules/@better-auth/prisma-adapter": {
-      "version": "1.6.25",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.25.tgz",
-      "integrity": "sha512-ym7B6Iqcry+/4aQnYpFwqP/GBIiXvjrm/5B6+0qmx8mkTY/apHFTpHuGzUYYNf4vPTtzF3eYY2+s2GOsomKaRg==",
+      "version": "1.6.27",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.27.tgz",
+      "integrity": "sha512-v7DXVyaFbkrfLoiFDtcVF7BkEZgFa/DgEGE7XjrAXmMACa5pjDvb7lm8W5X+/qgIbQP04eThhgFQ6EWOsjr8OQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.25",
+        "@better-auth/core": "^1.6.27",
         "@better-auth/utils": "0.4.2",
         "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
@@ -1585,12 +1585,12 @@
       }
     },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.6.25",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.25.tgz",
-      "integrity": "sha512-2ZfC9lp7tU6Jw/q2Lz/bKfQqGMdMwc/IQDTYdBhvtGi24qInYVnhp2ZCW57hHM9j+fq1ULOtxgg6M3T1LEaihw==",
+      "version": "1.6.27",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.27.tgz",
+      "integrity": "sha512-aYrSiVWQfua8w5YX8X1cM6ca48EdS0t5k+CvYXIsruaNIpR1DXMe1DOD0M5FWAVABnlCf9joyHXbFRSIZSNY/A==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.25",
+        "@better-auth/core": "^1.6.27",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1"
       }
@@ -7478,23 +7478,23 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.6.25",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.25.tgz",
-      "integrity": "sha512-fvoq+oCO+FF5fpP3XfU7znRyGFpHB77UG2EyxsKNy+Cak7Q5pELu+auvvDveQbWQxcoKugZ7jYQQPFQLpUTGOw==",
+      "version": "1.6.27",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.27.tgz",
+      "integrity": "sha512-x3jyxpAiBSsMO/DaXMFSVwM8bTqnYZlCKsZxBV43zL3ZtsGa/CzeUuNKxPT2Lsz7ahTBY90Ku1tibN6nRpVEbw==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.6.25",
-        "@better-auth/drizzle-adapter": "1.6.25",
-        "@better-auth/kysely-adapter": "1.6.25",
-        "@better-auth/memory-adapter": "1.6.25",
-        "@better-auth/mongo-adapter": "1.6.25",
-        "@better-auth/prisma-adapter": "1.6.25",
-        "@better-auth/telemetry": "1.6.25",
+        "@better-auth/core": "1.6.27",
+        "@better-auth/drizzle-adapter": "1.6.27",
+        "@better-auth/kysely-adapter": "1.6.27",
+        "@better-auth/memory-adapter": "1.6.27",
+        "@better-auth/mongo-adapter": "1.6.27",
+        "@better-auth/prisma-adapter": "1.6.27",
+        "@better-auth/telemetry": "1.6.27",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1",
         "@noble/ciphers": "^2.1.1",
         "@noble/hashes": "^2.0.1",
-        "better-call": "1.3.7",
+        "better-call": "1.4.0",
         "defu": "^6.1.4",
         "jose": "^6.1.3",
         "kysely": "^0.28.17 || ^0.29.0",
@@ -7607,15 +7607,15 @@
       }
     },
     "node_modules/better-call": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.7.tgz",
-      "integrity": "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.4.0.tgz",
+      "integrity": "sha512-bBKOT4vv1kZLDgxVePdilk/Jwkn+dtRRsmi3DzHcDP+WnswyVl6dR59l2HEeP/0cB+bDoopASAesWDPIdd/zZA==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/utils": "^0.4.0",
-        "@better-fetch/fetch": "^1.1.21",
-        "rou3": "^0.7.12",
-        "set-cookie-parser": "^3.0.1"
+        "@better-auth/utils": "^0.5.0",
+        "@better-fetch/fetch": "^1.3.1",
+        "rou3": "^0.9.1",
+        "set-cookie-parser": "^3.1.2"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
@@ -7624,6 +7624,27 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/better-call/node_modules/@better-auth/utils": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.5.0.tgz",
+      "integrity": "sha512-BL8W4EfIZFwlu0r54m3v1ztjDhu6dDe/amLTm0xybmbZaNgYUqhD3SjpAsnq0q8YD6/ki4iwIgxJNLP/N3TxiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
+    },
+    "node_modules/better-call/node_modules/@noble/hashes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/body-parser": {
@@ -9959,9 +9980,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -11439,9 +11460,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -12872,9 +12893,9 @@
       }
     },
     "node_modules/rou3": {
-      "version": "0.7.12",
-      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
-      "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.9.2.tgz",
+      "integrity": "sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ==",
       "license": "MIT"
     },
     "node_modules/router": {

--- a/web/tests/integration/mcp.test.ts
+++ b/web/tests/integration/mcp.test.ts
@@ -1,7 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 // biome-ignore lint/performance/noNamespaceImport: integration tests need the full schema module for Db typing
 import * as schema from "@/lib/db/schema";
-import { MCP_TOOL_DEFS } from "@/lib/mcp/catalog";
 import {
   api,
   closeTestDb,
@@ -10,6 +9,9 @@ import {
   resetDb,
   seedTestUser,
 } from "@/tests/integration/helpers";
+
+/** Bump when adding/removing an MCP tool so the change shows up in review. */
+const EXPECTED_MCP_TOOL_COUNT = 32;
 
 function jsonRpc(method: string, params: unknown = {}, id = 1) {
   return {
@@ -181,7 +183,7 @@ describe("MCP Server (HTTP)", () => {
     expect(toolNames).toContain("list_watcher_events");
     expect(toolNames).toContain("claim_runs");
     expect(toolNames).toContain("get_instrument_filter_options");
-    expect(toolNames).toHaveLength(MCP_TOOL_DEFS.length);
+    expect(toolNames).toHaveLength(EXPECTED_MCP_TOOL_COUNT);
   });
 
   // ---- Tool execution (end-to-end) -----------------------------------------

--- a/web/tests/integration/mcp.test.ts
+++ b/web/tests/integration/mcp.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 // biome-ignore lint/performance/noNamespaceImport: integration tests need the full schema module for Db typing
 import * as schema from "@/lib/db/schema";
+import { MCP_TOOL_DEFS } from "@/lib/mcp/catalog";
 import {
   api,
   closeTestDb,
@@ -178,7 +179,9 @@ describe("MCP Server (HTTP)", () => {
     expect(toolNames).toContain("get_run_report");
     expect(toolNames).toContain("get_watcher");
     expect(toolNames).toContain("list_watcher_events");
-    expect(toolNames).toHaveLength(30);
+    expect(toolNames).toContain("claim_runs");
+    expect(toolNames).toContain("get_instrument_filter_options");
+    expect(toolNames).toHaveLength(MCP_TOOL_DEFS.length);
   });
 
   // ---- Tool execution (end-to-end) -----------------------------------------

--- a/web/tests/mcp/mcp-protocol.test.ts
+++ b/web/tests/mcp/mcp-protocol.test.ts
@@ -103,6 +103,20 @@ vi.mock("@/lib/api/instrument-runs", () => ({
       }
       return null;
     }),
+  lookupRunUuidsByNaturalKeys: vi
+    .fn()
+    .mockImplementation((_instId: string, runIds: string[]) => {
+      const map = new Map<string, string>();
+      for (const runId of runIds) {
+        if (runId === "run-1") {
+          map.set(runId, "internal-1");
+        }
+        if (runId === "run-2") {
+          map.set(runId, "internal-2");
+        }
+      }
+      return map;
+    }),
   getRunFilesPage: vi.fn().mockResolvedValue({
     data: [],
     pagination: { page: 1, per_page: 50, total: 0, total_pages: 0 },
@@ -168,7 +182,12 @@ vi.mock("@/lib/api/dashboard", () => ({
     {
       id: "test-plate-reader",
       displayName: "Test Plate Reader",
-      instrumentType: "plate_reader",
+      status: "active",
+    },
+    {
+      id: "test-gel-doc",
+      displayName: "Test Gel Doc",
+      status: "active",
     },
   ]),
   getUserById: vi.fn().mockImplementation(async (id: string) =>
@@ -1339,12 +1358,28 @@ describe("MCP Protocol (in-memory)", () => {
     expect(result.completion.values).toContain("test-plate-reader");
   });
 
+  it("completes optional instrumentId on find_my_runs", async () => {
+    const result = await client.complete({
+      ref: { type: "ref/prompt", name: "find_my_runs" },
+      argument: { name: "instrumentId", value: "test-" },
+    });
+    expect(result.completion.values).toContain("test-plate-reader");
+  });
+
   it("completes runId on compare_runs using instrument context", async () => {
+    const { buildRunListQuery } = await import("@/lib/api/instrument-runs");
     const result = await client.complete({
       ref: { type: "ref/prompt", name: "compare_runs" },
       argument: { name: "runId1", value: "run-" },
       context: { arguments: { instrumentId: "test-plate-reader" } },
     });
+    expect(buildRunListQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instrumentId: "test-plate-reader",
+        search: "run-",
+        perPage: 100,
+      })
+    );
     expect(result.completion.values).toEqual(
       expect.arrayContaining(["run-1", "run-2"])
     );

--- a/web/tests/mcp/mcp-protocol.test.ts
+++ b/web/tests/mcp/mcp-protocol.test.ts
@@ -88,16 +88,21 @@ vi.mock("@/lib/api/instruments", () => ({
 }));
 
 vi.mock("@/lib/api/instrument-runs", () => ({
-  buildRunListQuery: vi
-    .fn()
-    .mockResolvedValue({ runs: [], total: 0, page: 1, perPage: 20 }),
+  buildRunListQuery: vi.fn().mockResolvedValue({
+    data: [{ run_id: "run-1" }, { run_id: "run-2" }],
+    pagination: { page: 1, per_page: 50, total: 2, total_pages: 1 },
+  }),
   lookupRunByNaturalKey: vi
     .fn()
-    .mockImplementation(async (_instId: string, runId: string) =>
-      runId === "run-1"
-        ? { id: "internal-1", instrumentId: _instId, runId }
-        : null
-    ),
+    .mockImplementation((_instId: string, runId: string) => {
+      if (runId === "run-1") {
+        return { id: "internal-1", instrumentId: _instId, runId };
+      }
+      if (runId === "run-2") {
+        return { id: "internal-2", instrumentId: _instId, runId };
+      }
+      return null;
+    }),
   getRunFilesPage: vi.fn().mockResolvedValue({
     data: [],
     pagination: { page: 1, per_page: 50, total: 0, total_pages: 0 },
@@ -403,6 +408,7 @@ import {
   MCP_RESOURCE_DEFS,
   MCP_TOOL_DEFS,
 } from "@/lib/mcp/catalog";
+import { MCP_SERVER_INSTRUCTIONS } from "@/lib/mcp/instructions";
 import { registerPrompts } from "@/lib/mcp/prompts";
 import { registerResources } from "@/lib/mcp/resources";
 import { registerTools } from "@/lib/mcp/tools";
@@ -418,7 +424,10 @@ describe("MCP Protocol (in-memory)", () => {
   beforeEach(async () => {
     mcpServer = new McpServer(
       { name: "data-hub-test", version: "1.0.0" },
-      { capabilities: { tools: {}, resources: {}, prompts: {} } }
+      {
+        capabilities: { tools: {}, resources: {}, prompts: {} },
+        instructions: MCP_SERVER_INSTRUCTIONS,
+      }
     );
     registerTools(mcpServer);
     registerResources(mcpServer);
@@ -445,6 +454,7 @@ describe("MCP Protocol (in-memory)", () => {
   const WRITE_TOOLS = new Set([
     "reprocess_file",
     "claim_run",
+    "claim_runs",
     "unclaim_run",
     "add_run_comment",
     "edit_run_comment",
@@ -603,6 +613,14 @@ describe("MCP Protocol (in-memory)", () => {
     expect(tool?.annotations?.idempotentHint).toBe(true);
   });
 
+  it("claim_runs is annotated as write / non-destructive / idempotent", async () => {
+    const { tools } = await client.listTools();
+    const tool = tools.find((t) => t.name === "claim_runs");
+    expect(tool?.annotations?.readOnlyHint).toBe(false);
+    expect(tool?.annotations?.destructiveHint).toBe(false);
+    expect(tool?.annotations?.idempotentHint).toBe(true);
+  });
+
   it("unclaim_run is annotated as write / destructive / idempotent", async () => {
     const { tools } = await client.listTools();
     const tool = tools.find((t) => t.name === "unclaim_run");
@@ -678,8 +696,8 @@ describe("MCP Protocol (in-memory)", () => {
     });
     expect(result.isError).toBeFalsy();
     const parsed = parseText(result.content);
-    expect(parsed).toHaveProperty("runs");
-    expect(parsed).toHaveProperty("total");
+    expect(parsed).toHaveProperty("data");
+    expect(parsed).toHaveProperty("pagination");
   });
 
   it("search_runs rejects invalid metadata filters with allowed values", async () => {
@@ -998,6 +1016,7 @@ describe("MCP Protocol (in-memory)", () => {
         runId: "run-1",
         page: 2,
         perPage: 10,
+        status: ["detected", "upload_requested"],
       },
     });
 
@@ -1005,6 +1024,7 @@ describe("MCP Protocol (in-memory)", () => {
     expect(getRunFilesPage).toHaveBeenCalledWith("internal-1", {
       page: 2,
       perPage: 10,
+      statuses: ["detected", "upload_requested"],
     });
     const payload = parseText(result.content) as {
       data: Record<string, unknown>[];
@@ -1089,6 +1109,20 @@ describe("MCP Protocol (in-memory)", () => {
     expect(text).toContain("Authenticated user not available");
   });
 
+  it("claim_runs without authInfo reports an authenticated-user error", async () => {
+    const result = await client.callTool({
+      name: "claim_runs",
+      arguments: {
+        instrumentId: "test-plate-reader",
+        runIds: ["run-1", "missing"],
+      },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("Authenticated user not available");
+  });
+
   it("unclaim_run without authInfo reports an authenticated-user error", async () => {
     const result = await client.callTool({
       name: "unclaim_run",
@@ -1098,6 +1132,31 @@ describe("MCP Protocol (in-memory)", () => {
     const text = (result.content as Array<{ type: string; text: string }>)[0]
       .text;
     expect(text).toContain("Authenticated user not available");
+  });
+
+  it("get_instrument_filter_options returns plate-reader options", async () => {
+    const result = await client.callTool({
+      name: "get_instrument_filter_options",
+      arguments: { instrumentId: "test-plate-reader" },
+    });
+    expect(result.isError).toBeFalsy();
+    const payload = parseText(result.content) as {
+      instrumentId: string;
+      options: { wavelengths: string[] };
+    };
+    expect(payload.instrumentId).toBe("test-plate-reader");
+    expect(payload.options.wavelengths).toContain("450");
+  });
+
+  it("get_instrument_filter_options errors for unknown instruments", async () => {
+    const result = await client.callTool({
+      name: "get_instrument_filter_options",
+      arguments: { instrumentId: "does-not-exist" },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("not found");
   });
 
   // ---- Resources -----------------------------------------------------------
@@ -1118,7 +1177,12 @@ describe("MCP Protocol (in-memory)", () => {
       (contents[0] as { uri: string; text: string }).text
     );
     expect(parsed).toHaveProperty("runStatus");
-    expect(parsed).toHaveProperty("toolRouting");
+    expect(parsed).toHaveProperty("dates");
+    expect(parsed).not.toHaveProperty("toolRouting");
+  });
+
+  it("exposes server instructions after initialize", () => {
+    expect(client.getInstructions()).toBe(MCP_SERVER_INSTRUCTIONS);
   });
 
   it("reads the instruments resource", async () => {
@@ -1233,9 +1297,8 @@ describe("MCP Protocol (in-memory)", () => {
     });
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0].role).toBe("user");
-    expect((result.messages[0].content as { text: string }).text).toContain(
-      "2025-06-01"
-    );
+    const text = (result.messages[0].content as { text: string }).text;
+    expect(text).toContain("2025-06-01 (UTC)");
   });
 
   it("troubleshoot_instrument prompt references heartbeat tool", async () => {
@@ -1257,5 +1320,44 @@ describe("MCP Protocol (in-memory)", () => {
     const text = (result.messages[0].content as { text: string }).text;
     expect(text).toContain("run-1");
     expect(text).toContain("run-2");
+  });
+
+  it("claim_unattributed_runs prompt uses claim_runs", async () => {
+    const result = await client.getPrompt({
+      name: "claim_unattributed_runs",
+      arguments: { instrumentId: "my-inst" },
+    });
+    const text = (result.messages[0].content as { text: string }).text;
+    expect(text).toContain("claim_runs");
+  });
+
+  it("completes instrumentId on troubleshoot_instrument", async () => {
+    const result = await client.complete({
+      ref: { type: "ref/prompt", name: "troubleshoot_instrument" },
+      argument: { name: "instrumentId", value: "test-" },
+    });
+    expect(result.completion.values).toContain("test-plate-reader");
+  });
+
+  it("completes runId on compare_runs using instrument context", async () => {
+    const result = await client.complete({
+      ref: { type: "ref/prompt", name: "compare_runs" },
+      argument: { name: "runId1", value: "run-" },
+      context: { arguments: { instrumentId: "test-plate-reader" } },
+    });
+    expect(result.completion.values).toEqual(
+      expect.arrayContaining(["run-1", "run-2"])
+    );
+  });
+
+  it("completes instrumentId on the filter-options resource template", async () => {
+    const result = await client.complete({
+      ref: {
+        type: "ref/resource",
+        uri: "datahub://instruments/{instrumentId}/filter-options",
+      },
+      argument: { name: "instrumentId", value: "test-" },
+    });
+    expect(result.completion.values).toContain("test-plate-reader");
   });
 });


### PR DESCRIPTION
## Summary

- Say up front how the server works (including that date filters use UTC days, which can differ from the dashboard).
- Let agents filter a run’s files by status, claim many runs in one step, and look up valid search filters without digging through secondary docs.
- Offer autocomplete for instrument and run IDs when filling in prompts.

As a driveby change, ran `npm audit fix` in `web/` to address security vulnerabilities.

## Test plan
- [x] MCP unit tests pass (`npm run test:unit -- tests/mcp` from `web/`)
- [x] Spot-check: connect an MCP client and confirm the new instructions appear on connect
- [x] Spot-check: `list_run_files` with a status filter, `claim_runs`, and `get_instrument_filter_options`
- [x] Spot-check: prompt autocomplete suggests instrument IDs


Made with [Cursor](https://cursor.com)