### PR TITLE
Let agents read MCP tool results as fields, not text

### DIFF
--- a/web/lib/api/dashboard.ts
+++ b/web/lib/api/dashboard.ts
@@ -94,7 +94,9 @@ export const getInstrumentSummaries = cache(
         displayName: row.displayName,
         status: row.status,
         runCount: row.runCount,
-        lastRunAt: row.lastRunAt,
+        // SQL `max(...)` can land as a Postgres timestamp string; normalize
+        // like `hydrateInstrumentRow` so callers get a real Date.
+        lastRunAt: row.lastRunAt ? new Date(row.lastRunAt) : null,
         filesPendingUpload: row.filesPendingUpload,
         watcherStatus,
       };

--- a/web/lib/mcp/catalog/document.ts
+++ b/web/lib/mcp/catalog/document.ts
@@ -26,9 +26,7 @@ export function buildMcpCatalogDocument(): McpCatalogDocument {
       ...(tool.scope ? { scope: tool.scope } : {}),
       ...(tool.annotations ? { annotations: tool.annotations } : {}),
       inputSchema: zodRecordToJsonSchema(tool.inputSchema),
-      ...(tool.outputSchema
-        ? { outputSchema: zodTypeToJsonSchema(tool.outputSchema) }
-        : {}),
+      outputSchema: zodTypeToJsonSchema(tool.outputSchema),
     })),
     resources: MCP_RESOURCE_DEFS.map((resource) => ({
       name: resource.name,

--- a/web/lib/mcp/catalog/document.ts
+++ b/web/lib/mcp/catalog/document.ts
@@ -1,4 +1,7 @@
-import { zodRecordToJsonSchema } from "@/lib/mcp/catalog/json-schema";
+import {
+  zodRecordToJsonSchema,
+  zodTypeToJsonSchema,
+} from "@/lib/mcp/catalog/json-schema";
 import { MCP_TOOL_DEFS } from "@/lib/mcp/catalog/tools";
 import type { McpCatalogDocument } from "@/lib/mcp/catalog/types";
 import { MCP_PROMPT_DEFS } from "@/lib/mcp/prompts.defs";
@@ -23,6 +26,9 @@ export function buildMcpCatalogDocument(): McpCatalogDocument {
       ...(tool.scope ? { scope: tool.scope } : {}),
       ...(tool.annotations ? { annotations: tool.annotations } : {}),
       inputSchema: zodRecordToJsonSchema(tool.inputSchema),
+      ...(tool.outputSchema
+        ? { outputSchema: zodTypeToJsonSchema(tool.outputSchema) }
+        : {}),
     })),
     resources: MCP_RESOURCE_DEFS.map((resource) => ({
       name: resource.name,

--- a/web/lib/mcp/catalog/json-schema.ts
+++ b/web/lib/mcp/catalog/json-schema.ts
@@ -7,3 +7,8 @@ export function zodRecordToJsonSchema(
 ): Record<string, unknown> {
   return z.toJSONSchema(z.object(fields ?? {})) as Record<string, unknown>;
 }
+
+/** Convert a whole Zod schema (tool `outputSchema`) to JSON Schema. */
+export function zodTypeToJsonSchema(schema: ZodType): Record<string, unknown> {
+  return z.toJSONSchema(schema) as Record<string, unknown>;
+}

--- a/web/lib/mcp/catalog/json-schema.ts
+++ b/web/lib/mcp/catalog/json-schema.ts
@@ -10,5 +10,42 @@ export function zodRecordToJsonSchema(
 
 /** Convert a whole Zod schema (tool `outputSchema`) to JSON Schema. */
 export function zodTypeToJsonSchema(schema: ZodType): Record<string, unknown> {
-  return z.toJSONSchema(schema) as Record<string, unknown>;
+  // Same options the MCP SDK uses for `tools/list`, so
+  // `GET /mcp/v1/schema.json` stays aligned with the live wire shape.
+  const json = z.toJSONSchema(schema, {
+    target: "draft-2020-12",
+    io: "output",
+  }) as Record<string, unknown>;
+  // Discriminated unions emit `oneOf` without `type`. The SDK stamps
+  // `type: "object"` so 2025-era clients don't wrap the payload as
+  // `{ result: ... }`.
+  if (json.type === undefined && isObjectShapedJsonSchema(json)) {
+    return { type: "object", ...json };
+  }
+  return json;
+}
+
+function isObjectShapedJsonSchema(schema: Record<string, unknown>): boolean {
+  if (
+    "properties" in schema ||
+    "patternProperties" in schema ||
+    "additionalProperties" in schema ||
+    "required" in schema
+  ) {
+    return true;
+  }
+  for (const key of ["oneOf", "anyOf", "allOf"] as const) {
+    const members = schema[key];
+    if (Array.isArray(members) && members.length > 0) {
+      return members.every(
+        (member) =>
+          member !== null &&
+          typeof member === "object" &&
+          ("type" in member
+            ? member.type === "object"
+            : isObjectShapedJsonSchema(member as Record<string, unknown>))
+      );
+    }
+  }
+  return false;
 }

--- a/web/lib/mcp/catalog/register.ts
+++ b/web/lib/mcp/catalog/register.ts
@@ -5,33 +5,40 @@ import type { McpToolAnnotations } from "@/lib/mcp/catalog/types";
 export function toolRegistrationConfig<
   TSchema extends Record<string, ZodType>,
   TAnnotations extends McpToolAnnotations | undefined,
+  TOutput extends ZodType | undefined = undefined,
 >(def: {
   title: string;
   description: string;
   inputSchema: TSchema;
+  outputSchema?: TOutput;
   annotations?: TAnnotations;
 }): {
   title: string;
   description: string;
   inputSchema: z.ZodObject<TSchema>;
+  outputSchema?: TOutput;
   annotations: TAnnotations;
 };
 export function toolRegistrationConfig<
   TAnnotations extends McpToolAnnotations | undefined,
+  TOutput extends ZodType | undefined = undefined,
 >(def: {
   title: string;
   description: string;
   inputSchema?: undefined;
+  outputSchema?: TOutput;
   annotations?: TAnnotations;
 }): {
   title: string;
   description: string;
+  outputSchema?: TOutput;
   annotations: TAnnotations;
 };
 export function toolRegistrationConfig(def: {
   title: string;
   description: string;
   inputSchema?: Record<string, ZodType>;
+  outputSchema?: ZodType;
   annotations?: McpToolAnnotations;
 }) {
   return {
@@ -41,6 +48,9 @@ export function toolRegistrationConfig(def: {
     // still iterate field metadata without unwrapping. Omit the key when
     // absent so registerTool picks the no-args callback overload.
     ...(def.inputSchema ? { inputSchema: z.object(def.inputSchema) } : {}),
+    // Pass through as a whole schema — do not wrap with z.object().
+    // Discriminated unions (e.g. get_run_archive) must stay intact.
+    ...(def.outputSchema ? { outputSchema: def.outputSchema } : {}),
     annotations: def.annotations,
   };
 }

--- a/web/lib/mcp/catalog/types.ts
+++ b/web/lib/mcp/catalog/types.ts
@@ -25,6 +25,13 @@ export interface McpToolDef {
   inputSchema?: Record<string, ZodType>;
   name: string;
   /**
+   * Full Zod schema for the tool's success payload (object or discriminated
+   * union). Unlike `inputSchema`, this is not a field map. Prefer object
+   * roots for list tools — bare arrays are re-wrapped as `{ result }` on
+   * 2025-era MCP wire shapes.
+   */
+  outputSchema: ZodType;
+  /**
    * REST-equivalent capability tag for the public catalog
    * (`GET /mcp/v1/schema.json`). MCP transport auth uses coarse OAuth
    * `read` / `write`; this field documents the finer-grained surface for
@@ -81,5 +88,6 @@ export interface McpCatalogDocument {
     scope?: string;
     annotations?: McpToolAnnotations;
     inputSchema: Record<string, unknown>;
+    outputSchema?: Record<string, unknown>;
   }>;
 }

--- a/web/lib/mcp/catalog/types.ts
+++ b/web/lib/mcp/catalog/types.ts
@@ -88,6 +88,6 @@ export interface McpCatalogDocument {
     scope?: string;
     annotations?: McpToolAnnotations;
     inputSchema: Record<string, unknown>;
-    outputSchema?: Record<string, unknown>;
+    outputSchema: Record<string, unknown>;
   }>;
 }

--- a/web/lib/mcp/tools/common.output.ts
+++ b/web/lib/mcp/tools/common.output.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+// Shared `ActorUser` wire shape: retired/deregistered/deleted-by actors and
+// run attributions all round-trip the same four fields.
+export const mcpActorUserSchema = z.object({
+  userId: z.string(),
+  displayName: z.string(),
+  initials: z.string(),
+  avatarUrl: z.string().nullable(),
+});

--- a/web/lib/mcp/tools/discovery.defs.ts
+++ b/web/lib/mcp/tools/discovery.defs.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 import type { McpToolDef } from "@/lib/mcp/catalog/types";
+import {
+  getMeOutputSchema,
+  getSystemStatusOutputSchema,
+  globalSearchOutputSchema,
+} from "./discovery.output";
 
 export const globalSearchTool = {
   name: "global_search",
@@ -15,6 +20,7 @@ export const globalSearchTool = {
       .optional()
       .describe("Limit results to one entity type (default: all)"),
   },
+  outputSchema: globalSearchOutputSchema,
   annotations: { readOnlyHint: true },
 } as const satisfies McpToolDef;
 
@@ -24,6 +30,7 @@ export const getMeTool = {
   description:
     'Return the authenticated user\'s identity (id, name, email, image, isAdmin). Use the returned id with search_runs ranBy=, or pass ranBy="me" instead.',
   group: "discovery",
+  outputSchema: getMeOutputSchema,
   annotations: { readOnlyHint: true },
 } as const satisfies McpToolDef;
 
@@ -34,6 +41,7 @@ export const getSystemStatusTool = {
     "Get a dashboard-level overview: per-instrument run counts, watcher health (online/offline/no_watcher), and pending upload counts.",
   group: "discovery",
   scope: "instruments:read",
+  outputSchema: getSystemStatusOutputSchema,
   annotations: { readOnlyHint: true },
 } as const satisfies McpToolDef;
 

--- a/web/lib/mcp/tools/discovery.output.ts
+++ b/web/lib/mcp/tools/discovery.output.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+import {
+  instrumentStatusSchema,
+  isoDateTime,
+} from "@/lib/api/openapi/schemas/common";
+
+/** Success shape for `get_me` — matches `AuthenticatedUser` from `getUserById`. */
+export const getMeOutputSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  email: z.string().nullable(),
+  image: z.string().nullable(),
+  isAdmin: z.boolean(),
+});
+
+const searchRunResultSchema = z.object({
+  type: z.literal("run"),
+  id: z.string(),
+  runId: z.string(),
+  instrumentId: z.string(),
+  instrumentName: z.string(),
+  acquiredAt: isoDateTime.nullable(),
+  createdAt: isoDateTime,
+  fileCount: z.number().int(),
+  totalSizeBytes: z.number(),
+  matchReason: z.enum(["run_id", "file", "instrument", "ran_by"]),
+  matchedFilename: z.string().nullable(),
+});
+
+const searchFileResultSchema = z.object({
+  type: z.literal("file"),
+  id: z.number().int(),
+  filename: z.string(),
+  instrumentId: z.string(),
+  instrumentName: z.string(),
+  runId: z.string(),
+  sizeBytes: z.number().nullable(),
+});
+
+const searchInstrumentResultSchema = z.object({
+  type: z.literal("instrument"),
+  id: z.string(),
+  displayName: z.string(),
+  status: instrumentStatusSchema,
+  watcherStatus: z.enum(["online", "offline", "no_watcher", "deregistered"]),
+  lastWatcherHeartbeatAt: isoDateTime.nullable(),
+  runCount: z.number().int(),
+  matchReason: z.enum(["name", "pattern"]),
+  matchedPattern: z.string().nullable(),
+});
+
+const searchUserResultSchema = z.object({
+  type: z.literal("user"),
+  id: z.string(),
+  name: z.string().nullable(),
+  email: z.string().nullable(),
+  image: z.string().nullable(),
+});
+
+const searchCommentResultSchema = z.object({
+  type: z.literal("comment"),
+  id: z.string(),
+  bodyPreview: z.string(),
+  createdAt: isoDateTime,
+  instrumentId: z.string(),
+  instrumentName: z.string(),
+  runId: z.string(),
+  userId: z.string(),
+  userName: z.string(),
+});
+
+/** Grouped result from `globalSearch` (dates already ISO strings). */
+export const globalSearchOutputSchema = z.object({
+  runs: z.array(searchRunResultSchema),
+  files: z.array(searchFileResultSchema),
+  instruments: z.array(searchInstrumentResultSchema),
+  users: z.array(searchUserResultSchema),
+  comments: z.array(searchCommentResultSchema),
+  counts: z.object({
+    runs: z.number().int(),
+    files: z.number().int(),
+    instruments: z.number().int(),
+    users: z.number().int(),
+    comments: z.number().int(),
+    total: z.number().int(),
+  }),
+});
+
+/** Per-instrument row from `getInstrumentSummaries` after JSON round-trip. */
+export const instrumentSummarySchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  status: instrumentStatusSchema,
+  runCount: z.number().int(),
+  lastRunAt: isoDateTime.nullable(),
+  filesPendingUpload: z.number().int(),
+  watcherStatus: z.enum(["online", "offline", "no_watcher"]),
+});
+
+// Object root so 2025-era MCP clients don't SEP-2106-wrap a bare array as
+// `{ result: [...] }` while text content stays unwrapped.
+export const getSystemStatusOutputSchema = z.object({
+  instruments: z.array(instrumentSummarySchema),
+});

--- a/web/lib/mcp/tools/discovery.ts
+++ b/web/lib/mcp/tools/discovery.ts
@@ -2,7 +2,11 @@ import type { McpServer } from "@modelcontextprotocol/server";
 import { getInstrumentSummaries, getUserById } from "@/lib/api/dashboard";
 import { globalSearch } from "@/lib/api/search";
 import { toolRegistrationConfig } from "@/lib/mcp/catalog/register";
-import { errorResult, getMcpUserId, textResult } from "@/lib/mcp/tools/helpers";
+import {
+  errorResult,
+  getMcpUserId,
+  structuredResult,
+} from "@/lib/mcp/tools/helpers";
 import { MIN_QUERY_LENGTH } from "@/lib/search-constants";
 import {
   getMeTool,
@@ -24,7 +28,7 @@ export function registerDiscoveryTools(server: McpServer) {
         query,
         scope: scope ?? "all",
       });
-      return textResult(result);
+      return structuredResult(result);
     }
   );
 
@@ -41,7 +45,7 @@ export function registerDiscoveryTools(server: McpServer) {
       if (!user) {
         return errorResult(`User '${userId}' not found.`);
       }
-      return textResult(user);
+      return structuredResult(user);
     }
   );
 
@@ -51,7 +55,7 @@ export function registerDiscoveryTools(server: McpServer) {
     // No inputSchema → v2 passes ServerContext as the only argument.
     async () => {
       const summaries = await getInstrumentSummaries();
-      return textResult(summaries);
+      return structuredResult({ instruments: summaries });
     }
   );
 }

--- a/web/lib/mcp/tools/files.defs.ts
+++ b/web/lib/mcp/tools/files.defs.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
 import type { McpToolDef } from "@/lib/mcp/catalog/types";
+import {
+  dismissFileOutputSchema,
+  getFileDownloadUrlOutputSchema,
+  getFileOutputSchema,
+  getRunArchiveOutputSchema,
+  reprocessFileOutputSchema,
+} from "./files.output";
 
 export const getFileTool = {
   name: "get_file",
@@ -9,6 +16,7 @@ export const getFileTool = {
   group: "files",
   scope: "files:read",
   inputSchema: { fileId: z.number().int().describe("Numeric file ID") },
+  outputSchema: getFileOutputSchema,
   annotations: { readOnlyHint: true },
 } as const satisfies McpToolDef;
 
@@ -20,6 +28,7 @@ export const getFileDownloadUrlTool = {
   group: "files",
   scope: "files:read",
   inputSchema: { fileId: z.number().int().describe("Numeric file ID") },
+  outputSchema: getFileDownloadUrlOutputSchema,
   annotations: { readOnlyHint: true },
 } as const satisfies McpToolDef;
 
@@ -34,6 +43,7 @@ export const getRunArchiveTool = {
     instrumentId: z.string().describe("Instrument identifier"),
     runId: z.string().describe("Run identifier within the instrument"),
   },
+  outputSchema: getRunArchiveOutputSchema,
   annotations: { readOnlyHint: true },
 } as const satisfies McpToolDef;
 
@@ -45,6 +55,7 @@ export const reprocessFileTool = {
   group: "files",
   scope: "files:reprocess",
   inputSchema: { fileId: z.number().int().describe("Numeric file ID") },
+  outputSchema: reprocessFileOutputSchema,
   // destructiveHint is true because the tool resets status/errorMessage/
   // processedAt. The Lambda re-processes the file, but the mutation is
   // irreversible from the tool's perspective and clients should confirm.
@@ -59,6 +70,7 @@ export const dismissFileTool = {
   group: "files",
   scope: "files:delete",
   inputSchema: { fileId: z.number().int().describe("Numeric file ID") },
+  outputSchema: dismissFileOutputSchema,
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,

--- a/web/lib/mcp/tools/files.output.ts
+++ b/web/lib/mcp/tools/files.output.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+import {
+  fileCategorySchema,
+  fileStatusSchema,
+  isoDateTime,
+} from "@/lib/api/openapi/schemas/common";
+
+/** Full `files` row as returned by `get_file` after JSON round-trip. */
+export const getFileOutputSchema = z.object({
+  id: z.number().int(),
+  instrumentRunId: z.string(),
+  filename: z.string(),
+  relativePath: z.string().nullable(),
+  s3Bucket: z.string().nullable(),
+  s3Key: z.string().nullable(),
+  contentType: z.string().nullable(),
+  sizeBytes: z.number().nullable(),
+  category: fileCategorySchema,
+  status: fileStatusSchema,
+  metadata: z.record(z.string(), z.unknown()),
+  errorMessage: z.string().nullable(),
+  detectedAt: isoDateTime.nullable(),
+  uploadRequestedAt: isoDateTime.nullable(),
+  uploadedAt: isoDateTime.nullable(),
+  processedAt: isoDateTime.nullable(),
+  fileCreatedAt: isoDateTime.nullable(),
+  createdAt: isoDateTime,
+  deletedAt: isoDateTime.nullable(),
+});
+
+export const getFileDownloadUrlOutputSchema = z.object({
+  fileId: z.number().int(),
+  filename: z.string(),
+  downloadUrl: z.string(),
+  expiresInSeconds: z.number().int(),
+});
+
+export const getRunArchiveOutputSchema = z.discriminatedUnion("status", [
+  z.object({
+    status: z.literal("ready"),
+    instrumentId: z.string(),
+    runId: z.string(),
+    downloadUrl: z.string(),
+    filename: z.string(),
+    sizeBytes: z.number().nullable(),
+    expiresInSeconds: z.number().int(),
+    contentType: z.literal("application/zip"),
+  }),
+  z.object({
+    status: z.literal("building"),
+    instrumentId: z.string(),
+    runId: z.string(),
+    jobId: z.string(),
+    retryAfterSeconds: z.number().int(),
+    hint: z.string(),
+  }),
+]);
+
+export const reprocessFileOutputSchema = z.object({
+  status: z.literal("processing"),
+  fileId: z.number().int(),
+});
+
+export const dismissFileOutputSchema = z.object({
+  id: z.number().int(),
+  filename: z.string(),
+  deletedAt: isoDateTime,
+  alreadyApplied: z.boolean(),
+});

--- a/web/lib/mcp/tools/files.ts
+++ b/web/lib/mcp/tools/files.ts
@@ -10,7 +10,7 @@ import { toolRegistrationConfig } from "@/lib/mcp/catalog/register";
 import {
   errorResult,
   requireMcpWrite,
-  textResult,
+  structuredResult,
 } from "@/lib/mcp/tools/helpers";
 import {
   getPresignedDownloadUrl,
@@ -33,7 +33,7 @@ export function registerFileTools(server: McpServer) {
       if (!file) {
         return errorResult(`File '${fileId}' not found.`);
       }
-      return textResult(file);
+      return structuredResult(file);
     }
   );
 
@@ -57,7 +57,7 @@ export function registerFileTools(server: McpServer) {
         PRESIGNED_DOWNLOAD_URL_EXPIRY_SECONDS
       );
 
-      return textResult({
+      return structuredResult({
         fileId,
         filename: lookup.filename,
         downloadUrl,
@@ -87,7 +87,7 @@ export function registerFileTools(server: McpServer) {
       }
 
       if (result.status === "ready") {
-        return textResult({
+        return structuredResult({
           status: "ready",
           instrumentId,
           runId,
@@ -99,7 +99,7 @@ export function registerFileTools(server: McpServer) {
         });
       }
 
-      return textResult({
+      return structuredResult({
         status: "building",
         instrumentId,
         runId,
@@ -122,7 +122,7 @@ export function registerFileTools(server: McpServer) {
       if (!result.ok) {
         return errorResult(`[${result.code}] ${result.message}`);
       }
-      return textResult({ status: "processing", fileId: result.fileId });
+      return structuredResult({ status: "processing", fileId: result.fileId });
     }
   );
 
@@ -138,7 +138,7 @@ export function registerFileTools(server: McpServer) {
       if (!result.ok) {
         return errorResult(result.message);
       }
-      return textResult({
+      return structuredResult({
         id: result.id,
         filename: result.filename,
         deletedAt: result.deletedAt,

--- a/web/lib/mcp/tools/helpers.ts
+++ b/web/lib/mcp/tools/helpers.ts
@@ -1,6 +1,20 @@
 import type { AuthInfo } from "@modelcontextprotocol/server";
 import { lookupRunByNaturalKey, type RunFile } from "@/lib/api/instrument-runs";
 
+/**
+ * Success payload for MCP tools that declare `outputSchema`. Round-trips
+ * through JSON so `content` text and `structuredContent` stay identical
+ * (Dates become ISO strings) and SDK output validation can't diverge.
+ */
+export function structuredResult(data: unknown) {
+  const json = JSON.stringify(data, null, 2);
+  return {
+    content: [{ type: "text" as const, text: json }],
+    structuredContent: JSON.parse(json) as unknown,
+  };
+}
+
+/** @deprecated Prefer `structuredResult` once the tool has an `outputSchema`. */
 export function textResult(data: unknown) {
   return {
     content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],

--- a/web/lib/mcp/tools/helpers.ts
+++ b/web/lib/mcp/tools/helpers.ts
@@ -14,13 +14,6 @@ export function structuredResult(data: unknown) {
   };
 }
 
-/** @deprecated Prefer `structuredResult` once the tool has an `outputSchema`. */
-export function textResult(data: unknown) {
-  return {
-    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
-  };
-}
-
 export function errorResult(message: string) {
   return {
     content: [{ type: "text" as const, text: message }],

--- a/web/lib/mcp/tools/instruments.defs.ts
+++ b/web/lib/mcp/tools/instruments.defs.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 import type { McpToolDef } from "@/lib/mcp/catalog/types";
+import {
+  getInstrumentFilterOptionsOutputSchema,
+  getInstrumentOutputSchema,
+  listInstrumentsOutputSchema,
+} from "./instruments.output";
 
 export const listInstrumentsTool = {
   name: "list_instruments",
@@ -14,6 +19,7 @@ export const listInstrumentsTool = {
       .optional()
       .describe("Filter instruments by status"),
   },
+  outputSchema: listInstrumentsOutputSchema,
   annotations: { readOnlyHint: true },
 } as const satisfies McpToolDef;
 
@@ -31,6 +37,7 @@ export const getInstrumentTool = {
         "Kebab-case instrument identifier (e.g. 'spectramax-id3-plate-reader')"
       ),
   },
+  outputSchema: getInstrumentOutputSchema,
   annotations: { readOnlyHint: true },
 } as const satisfies McpToolDef;
 
@@ -48,6 +55,7 @@ export const getInstrumentFilterOptionsTool = {
         "Kebab-case instrument identifier (e.g. 'spectramax-id3-plate-reader')"
       ),
   },
+  outputSchema: getInstrumentFilterOptionsOutputSchema,
   annotations: { readOnlyHint: true },
 } as const satisfies McpToolDef;
 

--- a/web/lib/mcp/tools/instruments.output.ts
+++ b/web/lib/mcp/tools/instruments.output.ts
@@ -4,13 +4,7 @@ import {
   instrumentTypeSchema,
   isoDateTime,
 } from "@/lib/api/openapi/schemas/common";
-
-const actorUserSchema = z.object({
-  userId: z.string(),
-  displayName: z.string(),
-  initials: z.string(),
-  avatarUrl: z.string().nullable(),
-});
+import { mcpActorUserSchema } from "./common.output";
 
 /** List-row shape from `getInstrumentListWithCounts` after JSON round-trip. */
 export const instrumentListItemSchema = z.object({
@@ -51,7 +45,7 @@ export const getInstrumentOutputSchema = z.object({
   activeWatcherHostname: z.string().nullable(),
   activeWatcherDeregistered: z.boolean(),
   retiredAt: isoDateTime.nullable(),
-  retiredByUser: actorUserSchema.nullable(),
+  retiredByUser: mcpActorUserSchema.nullable(),
   createdAt: isoDateTime,
   updatedAt: isoDateTime,
 });

--- a/web/lib/mcp/tools/instruments.output.ts
+++ b/web/lib/mcp/tools/instruments.output.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import {
+  instrumentStatusSchema,
+  instrumentTypeSchema,
+  isoDateTime,
+} from "@/lib/api/openapi/schemas/common";
+
+const actorUserSchema = z.object({
+  userId: z.string(),
+  displayName: z.string(),
+  initials: z.string(),
+  avatarUrl: z.string().nullable(),
+});
+
+/** List-row shape from `getInstrumentListWithCounts` after JSON round-trip. */
+export const instrumentListItemSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  status: instrumentStatusSchema,
+  instrumentType: instrumentTypeSchema,
+  filePatterns: z.array(z.string()),
+  hasDeregisteredWatcher: z.boolean(),
+  runCount: z.number().int(),
+  runsThisWeek: z.number().int(),
+  lastRunAt: isoDateTime.nullable(),
+  lastWatcherHeartbeatAt: isoDateTime.nullable(),
+  watcherCount: z.number().int(),
+  watchersOnline: z.number().int(),
+  createdAt: isoDateTime,
+});
+
+// Object root so 2025-era MCP clients don't SEP-2106-wrap a bare array as
+// `{ result: [...] }` while text content stays unwrapped.
+export const listInstrumentsOutputSchema = z.object({
+  instruments: z.array(instrumentListItemSchema),
+});
+
+/** Detail shape from `getInstrumentById` after JSON round-trip. */
+export const getInstrumentOutputSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  status: instrumentStatusSchema,
+  instrumentType: instrumentTypeSchema,
+  filePatterns: z.array(z.string()),
+  runCount: z.number().int(),
+  watcherCount: z.number().int(),
+  watchersOnline: z.number().int(),
+  watchersOffline: z.number().int(),
+  lastWatcherHeartbeatAt: isoDateTime.nullable(),
+  activeWatcherId: z.string().nullable(),
+  activeWatcherHostname: z.string().nullable(),
+  activeWatcherDeregistered: z.boolean(),
+  retiredAt: isoDateTime.nullable(),
+  retiredByUser: actorUserSchema.nullable(),
+  createdAt: isoDateTime,
+  updatedAt: isoDateTime,
+});
+
+/**
+ * `options` varies by instrument type (plate reader, gel doc, qPCR, …).
+ * Keep it open so new filter keys don't break the tool contract.
+ */
+export const getInstrumentFilterOptionsOutputSchema = z.object({
+  instrumentId: z.string(),
+  options: z.record(z.string(), z.unknown()),
+});

--- a/web/lib/mcp/tools/instruments.ts
+++ b/web/lib/mcp/tools/instruments.ts
@@ -5,7 +5,7 @@ import {
 } from "@/lib/api/instruments";
 import { toolRegistrationConfig } from "@/lib/mcp/catalog/register";
 import { resolveInstrumentFilterOptions } from "@/lib/mcp/instrument-filter-options";
-import { errorResult, textResult } from "@/lib/mcp/tools/helpers";
+import { errorResult, structuredResult } from "@/lib/mcp/tools/helpers";
 import {
   getInstrumentFilterOptionsTool,
   getInstrumentTool,
@@ -21,7 +21,7 @@ export function registerInstrumentTools(server: McpServer) {
       const filtered = status
         ? instruments.filter((i) => i.status === status)
         : instruments;
-      return textResult(filtered);
+      return structuredResult({ instruments: filtered });
     }
   );
 
@@ -33,7 +33,7 @@ export function registerInstrumentTools(server: McpServer) {
       if (!instrument) {
         return errorResult(`Instrument '${instrumentId}' not found.`);
       }
-      return textResult(instrument);
+      return structuredResult(instrument);
     }
   );
 
@@ -45,7 +45,7 @@ export function registerInstrumentTools(server: McpServer) {
       if (!result.ok) {
         return errorResult(result.error);
       }
-      return textResult({ instrumentId, options: result.options });
+      return structuredResult({ instrumentId, options: result.options });
     }
   );
 }

--- a/web/lib/mcp/tools/runs.defs.ts
+++ b/web/lib/mcp/tools/runs.defs.ts
@@ -3,6 +3,25 @@ import { mcpMetadataFilterInputSchema } from "@/lib/api/run-metadata-filters";
 import { fileStatusEnum } from "@/lib/db/schema";
 import type { McpToolDef } from "@/lib/mcp/catalog/types";
 import { RUN_STATUS_VALUES } from "@/lib/runs/run-status";
+import {
+  addRunCommentOutputSchema,
+  claimRunOutputSchema,
+  claimRunsOutputSchema,
+  deleteRunCommentOutputSchema,
+  deleteRunOutputSchema,
+  editRunCommentOutputSchema,
+  getRunOutputSchema,
+  getRunReportOutputSchema,
+  listRunAttributorsOutputSchema,
+  listRunCommentsOutputSchema,
+  listRunFilesOutputSchema,
+  reprocessRunOutputSchema,
+  requestRunUploadAllOutputSchema,
+  requestRunUploadOutputSchema,
+  restoreRunOutputSchema,
+  searchRunsOutputSchema,
+  unclaimRunOutputSchema,
+} from "./runs.output";
 
 export const searchRunsTool = {
   name: "search_runs",
@@ -11,6 +30,7 @@ export const searchRunsTool = {
   title: "Search Runs",
   description:
     "Search instrument runs with filtering, pagination, and sorting. Supports run status filters and instrument-metadata filters (plate reader, gel-doc, qPCR, Hina microscope, Epson scanner). Prefer global_search when the query may match filenames, instrument names, or attributor names rather than run IDs. Discover valid metadata filter values via get_instrument_filter_options or datahub://instruments/{id}/filter-options.",
+  outputSchema: searchRunsOutputSchema,
   inputSchema: {
     instrumentId: z
       .union([z.string(), z.array(z.string())])
@@ -87,6 +107,7 @@ export const getRunTool = {
   title: "Get Run",
   description:
     "Get details for a specific instrument run by its natural key (instrument ID + run ID). Returns metadata, timestamps, instrument info, and attributions by default. Pass include to attach the first page of files, comments, and/or a failure_summary without extra tool calls. For processed measurement samples prefer get_run_report.",
+  outputSchema: getRunOutputSchema,
   inputSchema: {
     instrumentId: z.string().describe("Instrument identifier"),
     runId: z.string().describe("Run identifier within the instrument"),
@@ -107,6 +128,7 @@ export const getRunReportTool = {
   title: "Get Run Report",
   description:
     "Return an analysis-ready summary for a run: file counts, failure summary, image/report file refs, and a bounded processed-CSV sample (columns + first rows). Prefer this over downloading full CSVs when comparing or summarizing experimental results.",
+  outputSchema: getRunReportOutputSchema,
   inputSchema: {
     instrumentId: z.string().describe("Instrument identifier"),
     runId: z.string().describe("Run identifier within the instrument"),
@@ -121,6 +143,7 @@ export const listRunFilesTool = {
   title: "List Run Files",
   description:
     "List files associated with a run (raw uploads and processed artifacts) with their status, category, and size. Paginated — runs can have thousands of files. Filter by status to gather fileIds for request_run_upload (e.g. status=['detected']). Use get_file for full per-file detail including metadata and S3 location.",
+  outputSchema: listRunFilesOutputSchema,
   inputSchema: {
     instrumentId: z.string().describe("Instrument identifier"),
     runId: z.string().describe("Run identifier within the instrument"),
@@ -154,6 +177,7 @@ export const claimRunTool = {
   title: "Claim Run",
   description:
     "Mark a run as performed by the authenticated user. Idempotent — claiming a run you already claimed is a no-op. Only self-attribution is supported; you cannot claim a run on behalf of another user. Prefer claim_runs when attributing multiple runs.",
+  outputSchema: claimRunOutputSchema,
   inputSchema: {
     instrumentId: z.string().describe("Instrument identifier"),
     runId: z.string().describe("Run identifier within the instrument"),
@@ -172,6 +196,7 @@ export const claimRunsTool = {
   title: "Claim Runs",
   description:
     "Mark multiple runs on one instrument as performed by the authenticated user (max 100). Idempotent per run. Returns claimed runs and any runIds that were not found; a missing ID does not fail the whole batch. Only self-attribution is supported.",
+  outputSchema: claimRunsOutputSchema,
   inputSchema: {
     instrumentId: z.string().describe("Instrument identifier"),
     runIds: z
@@ -194,6 +219,7 @@ export const unclaimRunTool = {
   title: "Unclaim Run",
   description:
     "Remove the authenticated user's attribution from a run. Idempotent — unclaiming a run you don't currently claim is a no-op. Only self-attribution is supported; you cannot remove another user's attribution.",
+  outputSchema: unclaimRunOutputSchema,
   inputSchema: {
     instrumentId: z.string().describe("Instrument identifier"),
     runId: z.string().describe("Run identifier within the instrument"),
@@ -214,6 +240,7 @@ export const listRunAttributorsTool = {
   title: "List Run Attributors",
   description:
     "List distinct users who have claimed at least one run on a given instrument. Use the returned userId with search_runs ranBy=<userId>.",
+  outputSchema: listRunAttributorsOutputSchema,
   inputSchema: {
     instrumentId: z.string().describe("Instrument identifier"),
   },
@@ -231,6 +258,7 @@ export const listRunCommentsTool = {
     instrumentId: z.string().describe("Instrument identifier"),
     runId: z.string().describe("Run identifier within the instrument"),
   },
+  outputSchema: listRunCommentsOutputSchema,
   annotations: { readOnlyHint: true },
 } as const satisfies McpToolDef;
 
@@ -246,6 +274,7 @@ export const addRunCommentTool = {
     runId: z.string().describe("Run identifier within the instrument"),
     body: z.string().describe("Markdown comment body"),
   },
+  outputSchema: addRunCommentOutputSchema,
   annotations: { readOnlyHint: false, destructiveHint: false },
 } as const satisfies McpToolDef;
 
@@ -260,6 +289,7 @@ export const editRunCommentTool = {
     commentId: z.string().describe("Comment UUID"),
     body: z.string().describe("Updated markdown body"),
   },
+  outputSchema: editRunCommentOutputSchema,
   annotations: { readOnlyHint: false, destructiveHint: false },
 } as const satisfies McpToolDef;
 
@@ -273,6 +303,7 @@ export const deleteRunCommentTool = {
   inputSchema: {
     commentId: z.string().describe("Comment UUID"),
   },
+  outputSchema: deleteRunCommentOutputSchema,
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,
@@ -291,6 +322,7 @@ export const reprocessRunTool = {
     instrumentId: z.string().describe("Instrument identifier"),
     runId: z.string().describe("Run identifier within the instrument"),
   },
+  outputSchema: reprocessRunOutputSchema,
   // destructiveHint mirrors reprocess_file: this overwrites processed
   // artifacts and resets per-file status in bulk, so clients should
   // confirm even though no data is deleted.
@@ -308,6 +340,7 @@ export const deleteRunTool = {
     instrumentId: z.string().describe("Instrument identifier"),
     runId: z.string().describe("Run identifier within the instrument"),
   },
+  outputSchema: deleteRunOutputSchema,
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,
@@ -326,6 +359,7 @@ export const restoreRunTool = {
     instrumentId: z.string().describe("Instrument identifier"),
     runId: z.string().describe("Run identifier within the instrument"),
   },
+  outputSchema: restoreRunOutputSchema,
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,
@@ -349,6 +383,7 @@ export const requestRunUploadTool = {
       .max(100)
       .describe("Numeric file IDs to queue"),
   },
+  outputSchema: requestRunUploadOutputSchema,
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,
@@ -367,6 +402,7 @@ export const requestRunUploadAllTool = {
     instrumentId: z.string().describe("Instrument identifier"),
     runId: z.string().describe("Run identifier within the instrument"),
   },
+  outputSchema: requestRunUploadAllOutputSchema,
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/web/lib/mcp/tools/runs.output.ts
+++ b/web/lib/mcp/tools/runs.output.ts
@@ -7,17 +7,10 @@ import {
   paginationSchema,
   runSourceSchema,
 } from "@/lib/api/openapi/schemas/common";
+import { mcpActorUserSchema } from "./common.output";
 
 // Plain Zod only — do not import from openapi/schemas/runs (those use
 // `.openapi()` and require registry side effects that unit tests skip).
-
-/** Attribution row shared by claim/unclaim/list/search/get_run. */
-export const mcpAttributionSchema = z.object({
-  userId: z.string(),
-  displayName: z.string(),
-  initials: z.string(),
-  avatarUrl: z.string().nullable(),
-});
 
 /** Trimmed file row from `toMcpFile` after JSON round-trip. */
 export const mcpRunFileSchema = z.object({
@@ -47,7 +40,6 @@ export const mcpFailureSummarySchema = z.object({
   totalFiles: z.number().int(),
 });
 
-/** Comment DTO after JSON round-trip (shared with group B comment tools). */
 export const mcpRunCommentSchema = z.object({
   id: z.string(),
   body: z.string(),
@@ -59,13 +51,6 @@ export const mcpRunCommentSchema = z.object({
   }),
   created_at: isoDateTime,
   edited_at: isoDateTime.nullable(),
-});
-
-const actorUserSchema = z.object({
-  userId: z.string(),
-  displayName: z.string(),
-  initials: z.string(),
-  avatarUrl: z.string().nullable(),
 });
 
 /**
@@ -93,7 +78,7 @@ export const searchRunsListItemSchema = z.object({
   // Aggregated with a bigint cast; drivers may surface large totals as strings.
   total_size_bytes: z.union([z.number(), z.string()]),
   error_messages: z.array(z.string()),
-  attributions: z.array(mcpAttributionSchema),
+  attributions: z.array(mcpActorUserSchema),
 });
 
 export const searchRunsOutputSchema = z.object({
@@ -115,8 +100,8 @@ export const getRunOutputSchema = z.object({
   deletedBy: z.string().nullable(),
   instrumentDisplayName: z.string(),
   instrumentType: instrumentTypeSchema,
-  deletedByUser: actorUserSchema.nullable(),
-  attributions: z.array(mcpAttributionSchema),
+  deletedByUser: mcpActorUserSchema.nullable(),
+  attributions: z.array(mcpActorUserSchema),
   files: z.array(mcpRunFileSchema).optional(),
   filesPagination: paginationSchema.optional(),
   comments: z.array(mcpRunCommentSchema).optional(),
@@ -133,7 +118,6 @@ const reportFileRefSchema = z.object({
 });
 
 export const getRunReportOutputSchema = z.object({
-  ok: z.literal(true),
   instrumentId: z.string(),
   runId: z.string(),
   instrumentType: z.string(),
@@ -161,7 +145,7 @@ export const listRunFilesOutputSchema = z.object({
 export const claimRunOutputSchema = z.object({
   instrumentId: z.string(),
   runId: z.string(),
-  attributions: z.array(mcpAttributionSchema),
+  attributions: z.array(mcpActorUserSchema),
 });
 
 export const claimRunsOutputSchema = z.object({
@@ -169,7 +153,7 @@ export const claimRunsOutputSchema = z.object({
   claimed: z.array(
     z.object({
       runId: z.string(),
-      attributions: z.array(mcpAttributionSchema),
+      attributions: z.array(mcpActorUserSchema),
     })
   ),
   notFound: z.array(z.string()),
@@ -186,8 +170,6 @@ export const listRunAttributorsOutputSchema = z.object({
     })
   ),
 });
-
-// Group B: comments / reprocess / lifecycle / upload
 
 export const listRunCommentsOutputSchema = z.object({
   comments: z.array(mcpRunCommentSchema),
@@ -227,15 +209,13 @@ export const requestRunUploadOutputSchema = z.object({
   instrumentId: z.string(),
   runId: z.string(),
   filesQueued: z.number().int(),
-  files: z
-    .array(
-      z.object({
-        id: z.number().int(),
-        filename: z.string(),
-        uploadRequestedAt: isoDateTime.nullable(),
-      })
-    )
-    .optional(),
+  files: z.array(
+    z.object({
+      id: z.number().int(),
+      filename: z.string(),
+      uploadRequestedAt: isoDateTime.nullable(),
+    })
+  ),
 });
 
 export const requestRunUploadAllOutputSchema = z.object({

--- a/web/lib/mcp/tools/runs.output.ts
+++ b/web/lib/mcp/tools/runs.output.ts
@@ -1,0 +1,245 @@
+import { z } from "zod";
+import {
+  fileCategorySchema,
+  fileStatusSchema,
+  instrumentTypeSchema,
+  isoDateTime,
+  paginationSchema,
+  runSourceSchema,
+} from "@/lib/api/openapi/schemas/common";
+
+// Plain Zod only — do not import from openapi/schemas/runs (those use
+// `.openapi()` and require registry side effects that unit tests skip).
+
+/** Attribution row shared by claim/unclaim/list/search/get_run. */
+export const mcpAttributionSchema = z.object({
+  userId: z.string(),
+  displayName: z.string(),
+  initials: z.string(),
+  avatarUrl: z.string().nullable(),
+});
+
+/** Trimmed file row from `toMcpFile` after JSON round-trip. */
+export const mcpRunFileSchema = z.object({
+  id: z.number().int(),
+  filename: z.string(),
+  relativePath: z.string().nullable(),
+  category: fileCategorySchema,
+  status: fileStatusSchema,
+  sizeBytes: z.number().nullable(),
+  contentType: z.string().nullable(),
+  errorMessage: z.string().nullable(),
+  createdAt: isoDateTime,
+  uploadedAt: isoDateTime.nullable(),
+  processedAt: isoDateTime.nullable(),
+});
+
+/** Failure summary attached via `get_run` include=failure_summary / report. */
+export const mcpFailureSummarySchema = z.object({
+  byStatus: z.record(z.string(), z.number().int()),
+  failed: z.array(
+    z.object({
+      id: z.number().int(),
+      filename: z.string(),
+      errorMessage: z.string().nullable(),
+    })
+  ),
+  totalFiles: z.number().int(),
+});
+
+/** Comment DTO after JSON round-trip (shared with group B comment tools). */
+export const mcpRunCommentSchema = z.object({
+  id: z.string(),
+  body: z.string(),
+  user: z.object({
+    id: z.string(),
+    displayName: z.string(),
+    initials: z.string(),
+    avatarUrl: z.string().nullable(),
+  }),
+  created_at: isoDateTime,
+  edited_at: isoDateTime.nullable(),
+});
+
+const actorUserSchema = z.object({
+  userId: z.string(),
+  displayName: z.string(),
+  initials: z.string(),
+  avatarUrl: z.string().nullable(),
+});
+
+/**
+ * `search_runs` list rows use underscored SQL aliases (not camelCase), with
+ * camelCase `attributions` nested — match that mixed casing exactly.
+ */
+export const searchRunsListItemSchema = z.object({
+  id: z.string().uuid(),
+  instrument_id: z.string(),
+  instrument_display_name: z.string().nullable(),
+  instrument_type: instrumentTypeSchema,
+  run_id: z.string(),
+  source: runSourceSchema,
+  metadata: z.record(z.string(), z.unknown()).nullable(),
+  created_at: isoDateTime,
+  acquired_at: isoDateTime.nullable(),
+  updated_at: isoDateTime,
+  deleted_at: isoDateTime.nullable(),
+  file_count: z.number().int(),
+  files_completed: z.number().int(),
+  files_failed: z.number().int(),
+  files_pending_upload: z.number().int(),
+  files_uploaded: z.number().int(),
+  files_processing: z.number().int(),
+  // Aggregated with a bigint cast; drivers may surface large totals as strings.
+  total_size_bytes: z.union([z.number(), z.string()]),
+  error_messages: z.array(z.string()),
+  attributions: z.array(mcpAttributionSchema),
+});
+
+export const searchRunsOutputSchema = z.object({
+  data: z.array(searchRunsListItemSchema),
+  pagination: paginationSchema,
+});
+
+export const getRunOutputSchema = z.object({
+  id: z.string().uuid(),
+  instrumentId: z.string(),
+  runId: z.string(),
+  source: runSourceSchema,
+  watcherId: z.string().uuid().nullable(),
+  metadata: z.record(z.string(), z.unknown()),
+  createdAt: isoDateTime,
+  acquiredAt: isoDateTime.nullable(),
+  updatedAt: isoDateTime,
+  deletedAt: isoDateTime.nullable(),
+  deletedBy: z.string().nullable(),
+  instrumentDisplayName: z.string(),
+  instrumentType: instrumentTypeSchema,
+  deletedByUser: actorUserSchema.nullable(),
+  attributions: z.array(mcpAttributionSchema),
+  files: z.array(mcpRunFileSchema).optional(),
+  filesPagination: paginationSchema.optional(),
+  comments: z.array(mcpRunCommentSchema).optional(),
+  failureSummary: mcpFailureSummarySchema.optional(),
+});
+
+const reportFileRefSchema = z.object({
+  id: z.number().int(),
+  filename: z.string(),
+  category: fileCategorySchema,
+  contentType: z.string().nullable(),
+  status: fileStatusSchema,
+  sizeBytes: z.number().nullable(),
+});
+
+export const getRunReportOutputSchema = z.object({
+  ok: z.literal(true),
+  instrumentId: z.string(),
+  runId: z.string(),
+  instrumentType: z.string(),
+  metadata: z.unknown(),
+  fileCounts: z.record(z.string(), z.number().int()),
+  processedCsv: z
+    .object({
+      rowCount: z.number().int(),
+      columns: z.array(z.string()),
+      sampleRows: z.array(z.record(z.string(), z.string())),
+      sampleRowLimit: z.number().int(),
+      truncated: z.boolean(),
+    })
+    .nullable(),
+  images: z.array(reportFileRefSchema),
+  reportFiles: z.array(reportFileRefSchema),
+  failureSummary: mcpFailureSummarySchema,
+});
+
+export const listRunFilesOutputSchema = z.object({
+  data: z.array(mcpRunFileSchema),
+  pagination: paginationSchema,
+});
+
+export const claimRunOutputSchema = z.object({
+  instrumentId: z.string(),
+  runId: z.string(),
+  attributions: z.array(mcpAttributionSchema),
+});
+
+export const claimRunsOutputSchema = z.object({
+  instrumentId: z.string(),
+  claimed: z.array(
+    z.object({
+      runId: z.string(),
+      attributions: z.array(mcpAttributionSchema),
+    })
+  ),
+  notFound: z.array(z.string()),
+});
+
+export const unclaimRunOutputSchema = claimRunOutputSchema;
+
+/** Object wrapper for 2025-era wire compat (bare arrays get `{ result }` wrapping). */
+export const listRunAttributorsOutputSchema = z.object({
+  attributors: z.array(
+    z.object({
+      userId: z.string(),
+      displayName: z.string(),
+    })
+  ),
+});
+
+// Group B: comments / reprocess / lifecycle / upload
+
+export const listRunCommentsOutputSchema = z.object({
+  comments: z.array(mcpRunCommentSchema),
+});
+
+export const addRunCommentOutputSchema = mcpRunCommentSchema;
+export const editRunCommentOutputSchema = mcpRunCommentSchema;
+
+export const deleteRunCommentOutputSchema = z.object({
+  id: z.string(),
+  deleted: z.literal(true),
+});
+
+export const reprocessRunOutputSchema = z.object({
+  instrumentId: z.string(),
+  runId: z.string(),
+  filesQueued: z.number().int(),
+  filesFailed: z.number().int(),
+});
+
+export const deleteRunOutputSchema = z.object({
+  instrumentId: z.string(),
+  runId: z.string(),
+  deletedAt: isoDateTime.nullable(),
+  deletedBy: z.string().nullable(),
+  alreadyApplied: z.boolean(),
+});
+
+export const restoreRunOutputSchema = z.object({
+  instrumentId: z.string(),
+  runId: z.string(),
+  deletedAt: isoDateTime.nullable(),
+  alreadyApplied: z.boolean(),
+});
+
+export const requestRunUploadOutputSchema = z.object({
+  instrumentId: z.string(),
+  runId: z.string(),
+  filesQueued: z.number().int(),
+  files: z
+    .array(
+      z.object({
+        id: z.number().int(),
+        filename: z.string(),
+        uploadRequestedAt: isoDateTime.nullable(),
+      })
+    )
+    .optional(),
+});
+
+export const requestRunUploadAllOutputSchema = z.object({
+  instrumentId: z.string(),
+  runId: z.string(),
+  filesQueued: z.number().int(),
+});

--- a/web/lib/mcp/tools/runs.ts
+++ b/web/lib/mcp/tools/runs.ts
@@ -31,7 +31,7 @@ import {
   getMcpUserId,
   requireMcpWrite,
   resolveAttributionTarget,
-  textResult,
+  structuredResult,
   toMcpFile,
 } from "@/lib/mcp/tools/helpers";
 import { validateSearchRunsMetadataFilters } from "@/lib/mcp/validate-run-filters";
@@ -104,7 +104,7 @@ export function registerRunTools(server: McpServer) {
         ranBy,
         statuses: args.status,
       });
-      return textResult(result);
+      return structuredResult(result);
     }
   );
 
@@ -151,7 +151,7 @@ export function registerRunTools(server: McpServer) {
         await Promise.all(tasks);
       }
 
-      return textResult(payload);
+      return structuredResult(payload);
     }
   );
 
@@ -163,7 +163,7 @@ export function registerRunTools(server: McpServer) {
       if (!result.ok) {
         return errorResult(result.message);
       }
-      return textResult(result);
+      return structuredResult(result);
     }
   );
 
@@ -182,7 +182,7 @@ export function registerRunTools(server: McpServer) {
         perPage: perPage ?? 50,
         ...(status ? { statuses: status } : {}),
       });
-      return textResult({ data: data.map(toMcpFile), pagination });
+      return structuredResult({ data: data.map(toMcpFile), pagination });
     }
   );
 
@@ -210,7 +210,7 @@ export function registerRunTools(server: McpServer) {
         .onConflictDoNothing();
 
       const byRun = await getAttributionsByRunIds([resolved.runUuid]);
-      return textResult({
+      return structuredResult({
         instrumentId,
         runId,
         attributions: byRun.get(resolved.runUuid) ?? [],
@@ -262,7 +262,7 @@ export function registerRunTools(server: McpServer) {
         }
       }
 
-      return textResult({ instrumentId, claimed, notFound });
+      return structuredResult({ instrumentId, claimed, notFound });
     }
   );
 
@@ -294,7 +294,7 @@ export function registerRunTools(server: McpServer) {
         );
 
       const byRun = await getAttributionsByRunIds([resolved.runUuid]);
-      return textResult({
+      return structuredResult({
         instrumentId,
         runId,
         attributions: byRun.get(resolved.runUuid) ?? [],
@@ -307,7 +307,7 @@ export function registerRunTools(server: McpServer) {
     toolRegistrationConfig(listRunAttributorsTool),
     async ({ instrumentId }) => {
       const attributors = await getRanByFilterOptions(instrumentId);
-      return textResult(attributors);
+      return structuredResult({ attributors });
     }
   );
 
@@ -322,7 +322,7 @@ export function registerRunTools(server: McpServer) {
         );
       }
       const comments = await listCommentsForRun(run.id);
-      return textResult({ comments });
+      return structuredResult({ comments });
     }
   );
 
@@ -369,7 +369,7 @@ export function registerRunTools(server: McpServer) {
         origin,
       });
 
-      return textResult(comment);
+      return structuredResult(comment);
     }
   );
 
@@ -407,7 +407,7 @@ export function registerRunTools(server: McpServer) {
       if (!updated) {
         return errorResult(`Comment '${commentId}' not found.`);
       }
-      return textResult(updated);
+      return structuredResult(updated);
     }
   );
 
@@ -437,7 +437,7 @@ export function registerRunTools(server: McpServer) {
       }
 
       await softDeleteComment({ commentId, userId });
-      return textResult({ id: commentId, deleted: true });
+      return structuredResult({ id: commentId, deleted: true });
     }
   );
 
@@ -453,7 +453,7 @@ export function registerRunTools(server: McpServer) {
       if (!result.ok) {
         return errorResult(result.message);
       }
-      return textResult({
+      return structuredResult({
         instrumentId: result.instrumentId,
         runId: result.runId,
         filesQueued: result.filesQueued,
@@ -480,11 +480,11 @@ export function registerRunTools(server: McpServer) {
       if (!result.ok) {
         return errorResult(result.message);
       }
-      return textResult({
+      return structuredResult({
         instrumentId: result.instrumentId,
         runId: result.runId,
         deletedAt: result.deletedAt,
-        deletedBy: result.deletedBy,
+        deletedBy: result.deletedBy ?? null,
         alreadyApplied: result.alreadyApplied,
       });
     }
@@ -502,7 +502,7 @@ export function registerRunTools(server: McpServer) {
       if (!result.ok) {
         return errorResult(result.message);
       }
-      return textResult({
+      return structuredResult({
         instrumentId: result.instrumentId,
         runId: result.runId,
         deletedAt: result.deletedAt,
@@ -527,7 +527,7 @@ export function registerRunTools(server: McpServer) {
       if (!result.ok) {
         return errorResult(result.message);
       }
-      return textResult({
+      return structuredResult({
         instrumentId: result.instrumentId,
         runId: result.runId,
         filesQueued: result.filesQueued,
@@ -548,7 +548,7 @@ export function registerRunTools(server: McpServer) {
       if (!result.ok) {
         return errorResult(result.message);
       }
-      return textResult({
+      return structuredResult({
         instrumentId: result.instrumentId,
         runId: result.runId,
         filesQueued: result.filesQueued,

--- a/web/lib/mcp/tools/runs.ts
+++ b/web/lib/mcp/tools/runs.ts
@@ -163,7 +163,8 @@ export function registerRunTools(server: McpServer) {
       if (!result.ok) {
         return errorResult(result.message);
       }
-      return structuredResult(result);
+      const { ok: _, ...payload } = result;
+      return structuredResult(payload);
     }
   );
 
@@ -531,7 +532,7 @@ export function registerRunTools(server: McpServer) {
         instrumentId: result.instrumentId,
         runId: result.runId,
         filesQueued: result.filesQueued,
-        files: result.files,
+        files: result.files ?? [],
       });
     }
   );

--- a/web/lib/mcp/tools/watchers.defs.ts
+++ b/web/lib/mcp/tools/watchers.defs.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 import { watcherEventTypeEnum } from "@/lib/db/schema";
 import type { McpToolDef } from "@/lib/mcp/catalog/types";
+import {
+  getWatcherHeartbeatsOutputSchema,
+  getWatcherOutputSchema,
+  listWatcherEventsOutputSchema,
+  listWatchersOutputSchema,
+} from "./watchers.output";
 
 export const listWatchersTool = {
   name: "list_watchers",
@@ -27,6 +33,7 @@ export const listWatchersTool = {
         "Filter by effective status (stale is computed from heartbeat age)"
       ),
   },
+  outputSchema: listWatchersOutputSchema,
   annotations: { readOnlyHint: true },
 } as const satisfies McpToolDef;
 
@@ -38,6 +45,7 @@ export const getWatcherTool = {
   group: "watchers",
   scope: "watchers:read",
   inputSchema: { watcherId: z.string().describe("Watcher UUID") },
+  outputSchema: getWatcherOutputSchema,
   annotations: { readOnlyHint: true },
 } as const satisfies McpToolDef;
 
@@ -75,6 +83,7 @@ export const listWatcherEventsTool = {
       .optional()
       .describe("Results per page (default: 50, max: 100)"),
   },
+  outputSchema: listWatcherEventsOutputSchema,
   annotations: { readOnlyHint: true },
 } as const satisfies McpToolDef;
 
@@ -95,6 +104,7 @@ export const getWatcherHeartbeatsTool = {
       .optional()
       .describe("Lookback window in hours (default: 24, max: 168)"),
   },
+  outputSchema: getWatcherHeartbeatsOutputSchema,
   annotations: { readOnlyHint: true },
 } as const satisfies McpToolDef;
 

--- a/web/lib/mcp/tools/watchers.output.ts
+++ b/web/lib/mcp/tools/watchers.output.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import {
+  isoDateTime,
+  uploadModeSchema,
+  watcherEventTypeSchema,
+  watcherStatusSchema,
+} from "@/lib/api/openapi/schemas/common";
+
+const actorUserSchema = z.object({
+  userId: z.string(),
+  displayName: z.string(),
+  initials: z.string(),
+  avatarUrl: z.string().nullable(),
+});
+
+/** List-row shape from `getWatcherList` after JSON round-trip. */
+export const watcherListItemSchema = z.object({
+  id: z.string(),
+  instrumentId: z.string(),
+  instrumentDisplayName: z.string().nullable(),
+  hostname: z.string().nullable(),
+  watcherVersion: z.string().nullable(),
+  effectiveStatus: watcherStatusSchema,
+  lastHeartbeatAt: isoDateTime.nullable(),
+  createdAt: isoDateTime,
+  deletedAt: isoDateTime.nullable(),
+});
+
+// Object root so 2025-era MCP clients don't SEP-2106-wrap a bare array as
+// `{ result: [...] }` while text content stays unwrapped.
+export const listWatchersOutputSchema = z.object({
+  watchers: z.array(watcherListItemSchema),
+});
+
+export const getWatcherOutputSchema = watcherListItemSchema.extend({
+  osInfo: z.string().nullable(),
+  configYaml: z.string().nullable(),
+  configChecksum: z.string().nullable(),
+  updatedAt: isoDateTime,
+  deregisteredByUser: actorUserSchema.nullable(),
+});
+
+const watcherEventRowSchema = z.object({
+  id: z.number().int(),
+  eventType: watcherEventTypeSchema,
+  message: z.string(),
+  details: z.unknown(),
+  timestamp: isoDateTime,
+});
+
+export const listWatcherEventsOutputSchema = z.object({
+  watcherId: z.string(),
+  sinceIso: isoDateTime,
+  lookbackHours: z.number().int(),
+  rows: z.array(watcherEventRowSchema),
+  total: z.number().int(),
+});
+
+const watcherHeartbeatRowSchema = z.object({
+  id: z.number().int(),
+  timestamp: isoDateTime,
+  status: z.string(),
+  uploadMode: uploadModeSchema.nullable(),
+  filesUploadedSinceLast: z.number().int().nullable(),
+  runsReportedSinceLast: z.number().int().nullable(),
+  errorsSinceLast: z.number().int().nullable(),
+  uptimeSeconds: z.number().int().nullable(),
+});
+
+export const getWatcherHeartbeatsOutputSchema = z.object({
+  watcherId: z.string(),
+  sinceIso: isoDateTime,
+  lookbackHours: z.number().int(),
+  total: z.number().int(),
+  heartbeats: z.array(watcherHeartbeatRowSchema),
+});

--- a/web/lib/mcp/tools/watchers.output.ts
+++ b/web/lib/mcp/tools/watchers.output.ts
@@ -5,13 +5,7 @@ import {
   watcherEventTypeSchema,
   watcherStatusSchema,
 } from "@/lib/api/openapi/schemas/common";
-
-const actorUserSchema = z.object({
-  userId: z.string(),
-  displayName: z.string(),
-  initials: z.string(),
-  avatarUrl: z.string().nullable(),
-});
+import { mcpActorUserSchema } from "./common.output";
 
 /** List-row shape from `getWatcherList` after JSON round-trip. */
 export const watcherListItemSchema = z.object({
@@ -37,7 +31,7 @@ export const getWatcherOutputSchema = watcherListItemSchema.extend({
   configYaml: z.string().nullable(),
   configChecksum: z.string().nullable(),
   updatedAt: isoDateTime,
-  deregisteredByUser: actorUserSchema.nullable(),
+  deregisteredByUser: mcpActorUserSchema.nullable(),
 });
 
 const watcherEventRowSchema = z.object({

--- a/web/lib/mcp/tools/watchers.ts
+++ b/web/lib/mcp/tools/watchers.ts
@@ -7,7 +7,7 @@ import {
   getWatcherList,
 } from "@/lib/api/watchers";
 import { toolRegistrationConfig } from "@/lib/mcp/catalog/register";
-import { errorResult, textResult } from "@/lib/mcp/tools/helpers";
+import { errorResult, structuredResult } from "@/lib/mcp/tools/helpers";
 import {
   getWatcherHeartbeatsTool,
   getWatcherTool,
@@ -31,7 +31,7 @@ export function registerWatcherTools(server: McpServer) {
           (w) => w.effectiveStatus === (status as EffectiveStatus)
         );
       }
-      return textResult(watchers);
+      return structuredResult({ watchers });
     }
   );
 
@@ -43,7 +43,7 @@ export function registerWatcherTools(server: McpServer) {
       if (!watcher) {
         return errorResult(`Watcher '${watcherId}' not found.`);
       }
-      return textResult(watcher);
+      return structuredResult(watcher);
     }
   );
 
@@ -53,17 +53,18 @@ export function registerWatcherTools(server: McpServer) {
     async ({ watcherId, hours, eventTypes, page, pageSize }) => {
       const lookbackHours = hours ?? 24;
       const since = new Date(Date.now() - lookbackHours * 60 * 60 * 1000);
-      const result = await getWatcherEvents(watcherId, {
+      const { rows, total } = await getWatcherEvents(watcherId, {
         since,
         eventTypes,
         page: page ?? 1,
         pageSize: pageSize ?? 50,
       });
-      return textResult({
+      return structuredResult({
         watcherId,
         sinceIso: since.toISOString(),
         lookbackHours,
-        ...result,
+        rows,
+        total,
       });
     }
   );
@@ -79,7 +80,7 @@ export function registerWatcherTools(server: McpServer) {
         page: 1,
         pageSize: 100,
       });
-      return textResult({
+      return structuredResult({
         watcherId,
         sinceIso: since.toISOString(),
         lookbackHours,

--- a/web/tests/integration/mcp-oauth.test.ts
+++ b/web/tests/integration/mcp-oauth.test.ts
@@ -350,10 +350,12 @@ describe("MCP OAuth authorization-code flow", () => {
     expect(mcpRes.status).toBe(200);
     const mcpData = await parseSseResponse(mcpRes);
     expect(mcpData.result?.isError).toBeFalsy();
-    const payload = JSON.parse(mcpData.result.content[0].text) as Array<{
-      id: string;
-    }>;
-    expect(payload.some((row) => row.id === instrumentId)).toBe(true);
+    const payload = JSON.parse(mcpData.result.content[0].text) as {
+      instruments: Array<{ id: string }>;
+    };
+    expect(payload.instruments.some((row) => row.id === instrumentId)).toBe(
+      true
+    );
   });
 
   it("DCR without scope body still allows authorize with read write", async () => {

--- a/web/tests/integration/mcp.test.ts
+++ b/web/tests/integration/mcp.test.ts
@@ -202,8 +202,8 @@ describe("MCP Server (HTTP)", () => {
     const data = await parseSseResponse(res);
     expect(data.result.isError).toBeFalsy();
     const text = data.result.content[0].text;
-    const instruments = JSON.parse(text);
-    expect(instruments).toEqual(
+    const payload = JSON.parse(text) as { instruments: unknown[] };
+    expect(payload.instruments).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: instrumentId })])
     );
   });
@@ -336,11 +336,10 @@ describe("MCP Server (HTTP)", () => {
 
     const result = await callTool("list_run_attributors", { instrumentId });
     expect(result.isError).toBeFalsy();
-    const parsed = JSON.parse(result.content[0].text) as Array<{
-      userId: string;
-      displayName: string;
-    }>;
-    expect(parsed.map((p) => p.userId)).toContain(userId);
+    const parsed = JSON.parse(result.content[0].text) as {
+      attributors: Array<{ userId: string; displayName: string }>;
+    };
+    expect(parsed.attributors.map((p) => p.userId)).toContain(userId);
   });
 
   it("get_run response includes the attributions array", async () => {

--- a/web/tests/mcp/mcp-catalog.test.ts
+++ b/web/tests/mcp/mcp-catalog.test.ts
@@ -37,14 +37,29 @@ describe("MCP catalog document", () => {
     for (const def of MCP_TOOL_DEFS) {
       expect(def.outputSchema, `${def.name} missing outputSchema`).toBeTruthy();
       const tool = doc.tools.find((t) => t.name === def.name);
+      if (!tool) {
+        throw new Error(`${def.name} missing from catalog`);
+      }
       // Object roots expose `type`; discriminated unions may be `oneOf`/`anyOf`.
       expect(
-        tool?.outputSchema?.type != null ||
-          tool?.outputSchema?.oneOf != null ||
-          tool?.outputSchema?.anyOf != null,
+        tool.outputSchema.type != null ||
+          tool.outputSchema.oneOf != null ||
+          tool.outputSchema.anyOf != null,
         `${def.name} catalog outputSchema missing type/oneOf/anyOf`
       ).toBe(true);
     }
+  });
+
+  it("stamps type:object on discriminated-union output schemas", () => {
+    const doc = buildMcpCatalogDocument();
+    const archive = doc.tools.find((t) => t.name === "get_run_archive");
+    if (!archive) {
+      throw new Error("get_run_archive missing from catalog");
+    }
+    expect(archive.outputSchema.type).toBe("object");
+    expect(
+      archive.outputSchema.oneOf != null || archive.outputSchema.anyOf != null
+    ).toBe(true);
   });
 
   it("preserves per-tool scope tags on the public catalog payload", () => {

--- a/web/tests/mcp/mcp-catalog.test.ts
+++ b/web/tests/mcp/mcp-catalog.test.ts
@@ -31,6 +31,22 @@ describe("MCP catalog document", () => {
     }
   });
 
+  it("publishes outputSchema for every tool", () => {
+    const doc = buildMcpCatalogDocument();
+    expect(MCP_TOOL_DEFS).toHaveLength(32);
+    for (const def of MCP_TOOL_DEFS) {
+      expect(def.outputSchema, `${def.name} missing outputSchema`).toBeTruthy();
+      const tool = doc.tools.find((t) => t.name === def.name);
+      // Object roots expose `type`; discriminated unions may be `oneOf`/`anyOf`.
+      expect(
+        tool?.outputSchema?.type != null ||
+          tool?.outputSchema?.oneOf != null ||
+          tool?.outputSchema?.anyOf != null,
+        `${def.name} catalog outputSchema missing type/oneOf/anyOf`
+      ).toBe(true);
+    }
+  });
+
   it("preserves per-tool scope tags on the public catalog payload", () => {
     const doc = buildMcpCatalogDocument();
     const scopedDefs = MCP_TOOL_DEFS.filter((t) => t.scope);

--- a/web/tests/mcp/mcp-instruments-discovery-structured.test.ts
+++ b/web/tests/mcp/mcp-instruments-discovery-structured.test.ts
@@ -1,0 +1,241 @@
+import { Client } from "@modelcontextprotocol/client";
+import { InMemoryTransport, McpServer } from "@modelcontextprotocol/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getMeOutputSchema,
+  getSystemStatusOutputSchema,
+  globalSearchOutputSchema,
+} from "@/lib/mcp/tools/discovery.output";
+import {
+  getInstrumentFilterOptionsOutputSchema,
+  getInstrumentOutputSchema,
+  listInstrumentsOutputSchema,
+} from "@/lib/mcp/tools/instruments.output";
+
+const { MOCK_LIST_INSTRUMENT, MOCK_INSTRUMENT_DETAIL } = vi.hoisted(() => {
+  const MOCK_LIST_INSTRUMENT = {
+    id: "test-plate-reader",
+    displayName: "Test Plate Reader",
+    status: "active" as const,
+    instrumentType: "plate_reader" as const,
+    filePatterns: ["*.txt"],
+    hasDeregisteredWatcher: false,
+    runCount: 3,
+    runsThisWeek: 1,
+    lastRunAt: new Date("2025-01-01T00:00:00.000Z"),
+    lastWatcherHeartbeatAt: new Date("2025-01-01T00:00:00.000Z"),
+    watcherCount: 1,
+    watchersOnline: 1,
+    createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  };
+  return {
+    MOCK_LIST_INSTRUMENT,
+    MOCK_INSTRUMENT_DETAIL: {
+      id: MOCK_LIST_INSTRUMENT.id,
+      displayName: MOCK_LIST_INSTRUMENT.displayName,
+      status: MOCK_LIST_INSTRUMENT.status,
+      instrumentType: MOCK_LIST_INSTRUMENT.instrumentType,
+      filePatterns: MOCK_LIST_INSTRUMENT.filePatterns,
+      runCount: MOCK_LIST_INSTRUMENT.runCount,
+      watcherCount: MOCK_LIST_INSTRUMENT.watcherCount,
+      watchersOnline: MOCK_LIST_INSTRUMENT.watchersOnline,
+      watchersOffline: 0,
+      lastWatcherHeartbeatAt: MOCK_LIST_INSTRUMENT.lastWatcherHeartbeatAt,
+      activeWatcherId: "watcher-1",
+      activeWatcherHostname: "lab-pc",
+      activeWatcherDeregistered: false,
+      retiredAt: null,
+      retiredByUser: null,
+      createdAt: MOCK_LIST_INSTRUMENT.createdAt,
+      updatedAt: new Date("2024-06-01T00:00:00.000Z"),
+    },
+  };
+});
+
+vi.mock("@/lib/api/instruments", () => ({
+  getInstrumentListWithCounts: vi
+    .fn()
+    .mockResolvedValue([MOCK_LIST_INSTRUMENT]),
+  getInstrumentById: vi
+    .fn()
+    .mockImplementation((id: string) =>
+      id === "test-plate-reader" ? MOCK_INSTRUMENT_DETAIL : null
+    ),
+}));
+
+vi.mock("@/lib/api/instrument-runs", () => ({
+  getInstrumentFilterOptions: vi.fn().mockResolvedValue({
+    kind: "plate_reader",
+    options: {
+      wavelengths: ["450"],
+      measurementModes: ["Absorbance"],
+      measurementTypes: ["Endpoint"],
+    },
+  }),
+}));
+
+vi.mock("@/lib/api/dashboard", () => ({
+  getInstrumentSummaries: vi.fn().mockResolvedValue([
+    {
+      id: "test-plate-reader",
+      displayName: "Test Plate Reader",
+      status: "active",
+      runCount: 3,
+      lastRunAt: new Date("2025-01-01T00:00:00.000Z"),
+      filesPendingUpload: 0,
+      watcherStatus: "online",
+    },
+  ]),
+  getUserById: vi.fn().mockResolvedValue({
+    id: "user-1",
+    name: "Ada",
+    email: "ada@example.com",
+    image: null,
+    isAdmin: true,
+  }),
+}));
+
+vi.mock("@/lib/api/search", () => ({
+  globalSearch: vi.fn().mockResolvedValue({
+    runs: [],
+    files: [],
+    instruments: [],
+    users: [],
+    comments: [],
+    counts: {
+      runs: 0,
+      files: 0,
+      instruments: 0,
+      users: 0,
+      comments: 0,
+      total: 0,
+    },
+  }),
+}));
+
+import { registerDiscoveryTools } from "@/lib/mcp/tools/discovery";
+import { registerInstrumentTools } from "@/lib/mcp/tools/instruments";
+
+function parseText(content: unknown): unknown {
+  const text = (content as Array<{ type: string; text: string }>)[0]?.text;
+  return JSON.parse(text ?? "");
+}
+
+describe("instruments + discovery structuredContent", () => {
+  let server: McpServer;
+  let client: Client;
+
+  beforeEach(async () => {
+    server = new McpServer(
+      { name: "data-hub-test", version: "0.0.0" },
+      { capabilities: { tools: {} }, instructions: "test" }
+    );
+    registerInstrumentTools(server);
+    registerDiscoveryTools(server);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    client = new Client({ name: "test-client", version: "0.0.0" });
+    await Promise.all([
+      client.connect(clientTransport),
+      server.connect(serverTransport),
+    ]);
+  });
+
+  afterEach(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it("advertises outputSchema for all six tools", async () => {
+    const { tools } = await client.listTools();
+    for (const name of [
+      "list_instruments",
+      "get_instrument",
+      "get_instrument_filter_options",
+      "global_search",
+      "get_me",
+      "get_system_status",
+    ]) {
+      const tool = tools.find((t) => t.name === name);
+      expect(tool?.outputSchema, `${name} missing outputSchema`).toBeTruthy();
+    }
+  });
+
+  it("list_instruments structuredContent matches text and schema", async () => {
+    const result = await client.callTool({
+      name: "list_instruments",
+      arguments: {},
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = parseText(result.content) as {
+      instruments: Array<{ id: string }>;
+    };
+    expect(parsed.instruments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "test-plate-reader" }),
+      ])
+    );
+    expect(result.structuredContent).toEqual(parsed);
+    expect(listInstrumentsOutputSchema.parse(parsed)).toEqual(parsed);
+  });
+
+  it("get_instrument structuredContent matches text and schema", async () => {
+    const result = await client.callTool({
+      name: "get_instrument",
+      arguments: { instrumentId: "test-plate-reader" },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = parseText(result.content);
+    expect(result.structuredContent).toEqual(parsed);
+    expect(getInstrumentOutputSchema.parse(parsed)).toEqual(parsed);
+  });
+
+  it("get_instrument_filter_options structuredContent matches text and schema", async () => {
+    const result = await client.callTool({
+      name: "get_instrument_filter_options",
+      arguments: { instrumentId: "test-plate-reader" },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = parseText(result.content);
+    expect(result.structuredContent).toEqual(parsed);
+    expect(getInstrumentFilterOptionsOutputSchema.parse(parsed)).toEqual(
+      parsed
+    );
+  });
+
+  it("global_search structuredContent matches text and schema", async () => {
+    const result = await client.callTool({
+      name: "global_search",
+      arguments: { query: "plate" },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = parseText(result.content);
+    expect(result.structuredContent).toEqual(parsed);
+    expect(globalSearchOutputSchema.parse(parsed)).toEqual(parsed);
+  });
+
+  it("get_system_status structuredContent matches text and schema", async () => {
+    const result = await client.callTool({
+      name: "get_system_status",
+      arguments: {},
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = parseText(result.content) as {
+      instruments: unknown[];
+    };
+    expect(Array.isArray(parsed.instruments)).toBe(true);
+    expect(result.structuredContent).toEqual(parsed);
+    expect(getSystemStatusOutputSchema.parse(parsed)).toEqual(parsed);
+  });
+
+  it("get_me errors without auth (no structuredContent)", async () => {
+    const result = await client.callTool({
+      name: "get_me",
+      arguments: {},
+    });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toBeUndefined();
+    expect(getMeOutputSchema.safeParse({}).success).toBe(false);
+  });
+});

--- a/web/tests/mcp/mcp-protocol.test.ts
+++ b/web/tests/mcp/mcp-protocol.test.ts
@@ -813,6 +813,17 @@ describe("MCP Protocol (in-memory)", () => {
     }
   });
 
+  it("catalog outputSchema matches tools/list", async () => {
+    const doc = buildMcpCatalogDocument();
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      const catalog = doc.tools.find((t) => t.name === tool.name);
+      expect(catalog?.outputSchema, `${tool.name} catalog mismatch`).toEqual(
+        tool.outputSchema
+      );
+    }
+  });
+
   it("claim_run is annotated as write / non-destructive / idempotent", async () => {
     const { tools } = await client.listTools();
     const tool = tools.find((t) => t.name === "claim_run");
@@ -1268,6 +1279,7 @@ describe("MCP Protocol (in-memory)", () => {
       processedCsv: { sampleRowLimit: number };
     };
     expect(parsed.processedCsv.sampleRowLimit).toBe(20);
+    expect(parsed).not.toHaveProperty("ok");
     expectStructuredMatchesText(result);
   });
 

--- a/web/tests/mcp/mcp-protocol.test.ts
+++ b/web/tests/mcp/mcp-protocol.test.ts
@@ -11,13 +11,88 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const {
   MOCK_INSTRUMENT,
   MOCK_GEL_DOC_INSTRUMENT,
-  MOCK_GENERIC_INSTRUMENT,
+  MOCK_INSTRUMENT_DETAIL,
+  MOCK_GEL_DOC_INSTRUMENT_DETAIL,
+  MOCK_GENERIC_INSTRUMENT_DETAIL,
   MOCK_FILE,
-} = vi.hoisted(() => ({
-  MOCK_INSTRUMENT: {
+  MOCK_RUN_LIST_ROW,
+  mockRunDetail,
+  MOCK_RUN_UUID_1,
+  MOCK_RUN_UUID_2,
+} = vi.hoisted(() => {
+  // Zod's uuid() checks RFC variant bits — all-ones / sequential hex fails.
+  const MOCK_RUN_UUID_1 = "11111111-1111-4111-a111-111111111111";
+  const MOCK_RUN_UUID_2 = "22222222-2222-4222-b222-222222222222";
+  const MOCK_RUN_LIST_ROW = {
+    id: MOCK_RUN_UUID_1,
+    instrument_id: "test-plate-reader",
+    instrument_display_name: "Test Plate Reader",
+    instrument_type: "plate_reader" as const,
+    run_id: "run-1",
+    source: "watcher" as const,
+    metadata: {},
+    created_at: new Date("2025-01-01T00:00:00.000Z"),
+    acquired_at: new Date("2025-01-01T00:00:00.000Z"),
+    updated_at: new Date("2025-01-01T00:00:00.000Z"),
+    deleted_at: null,
+    file_count: 1,
+    files_completed: 1,
+    files_failed: 0,
+    files_pending_upload: 0,
+    files_uploaded: 0,
+    files_processing: 0,
+    total_size_bytes: 1234,
+    error_messages: [] as string[],
+    attributions: [] as Array<{
+      userId: string;
+      displayName: string;
+      initials: string;
+      avatarUrl: string | null;
+    }>,
+  };
+  function mockRunDetail(instrumentId: string, runId: string, id: string) {
+    return {
+      id,
+      instrumentId,
+      runId,
+      source: "watcher" as const,
+      watcherId: null,
+      metadata: {},
+      createdAt: new Date("2025-01-01T00:00:00.000Z"),
+      acquiredAt: new Date("2025-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+      deletedAt: null,
+      deletedBy: null,
+      instrumentDisplayName: "Test Plate Reader",
+      instrumentType: "plate_reader" as const,
+      deletedByUser: null,
+      attributions: [] as Array<{
+        userId: string;
+        displayName: string;
+        initials: string;
+        avatarUrl: string | null;
+      }>,
+    };
+  }
+  const listBase = {
+    hasDeregisteredWatcher: false,
+    runsThisWeek: 0,
+    lastWatcherHeartbeatAt: new Date("2025-01-01"),
+  };
+  const detailBase = {
+    watchersOffline: 0,
+    activeWatcherId: "watcher-1",
+    activeWatcherHostname: "lab-pc",
+    activeWatcherDeregistered: false,
+    retiredAt: null,
+    retiredByUser: null,
+    updatedAt: new Date("2024-06-01"),
+    lastWatcherHeartbeatAt: new Date("2025-01-01"),
+  };
+  const MOCK_INSTRUMENT = {
     id: "test-plate-reader",
     displayName: "Test Plate Reader",
-    status: "active",
+    status: "active" as const,
     instrumentType: "plate_reader",
     filePatterns: ["*.txt"],
     runCount: 3,
@@ -25,11 +100,13 @@ const {
     watcherCount: 1,
     watchersOnline: 1,
     createdAt: new Date("2024-01-01"),
-  },
-  MOCK_GEL_DOC_INSTRUMENT: {
+    ...listBase,
+    runsThisWeek: 1,
+  };
+  const MOCK_GEL_DOC_INSTRUMENT = {
     id: "test-gel-doc",
     displayName: "Test Gel Doc",
-    status: "active",
+    status: "active" as const,
     instrumentType: "gel_doc",
     filePatterns: ["*.tif"],
     runCount: 1,
@@ -37,11 +114,12 @@ const {
     watcherCount: 1,
     watchersOnline: 1,
     createdAt: new Date("2024-01-01"),
-  },
-  MOCK_GENERIC_INSTRUMENT: {
+    ...listBase,
+  };
+  const MOCK_GENERIC_INSTRUMENT = {
     id: "test-generic",
     displayName: "Test Generic",
-    status: "active",
+    status: "active" as const,
     instrumentType: "generic",
     filePatterns: ["*.dat"],
     runCount: 0,
@@ -49,22 +127,78 @@ const {
     watcherCount: 0,
     watchersOnline: 0,
     createdAt: new Date("2024-01-01"),
-  },
-  MOCK_FILE: {
-    id: 42,
-    instrumentRunId: "internal-1",
-    filename: "data.csv",
-    status: "completed",
-    s3Bucket: "test-bucket",
-    s3Key: "path/to/data.csv",
-    contentType: "text/csv",
-    sizeBytes: 1234,
-    category: "raw",
-    metadata: {},
-    errorMessage: null,
-    deletedAt: null,
-  },
-}));
+    ...listBase,
+    lastWatcherHeartbeatAt: null,
+  };
+  return {
+    MOCK_INSTRUMENT,
+    MOCK_GEL_DOC_INSTRUMENT,
+    MOCK_INSTRUMENT_DETAIL: {
+      id: MOCK_INSTRUMENT.id,
+      displayName: MOCK_INSTRUMENT.displayName,
+      status: MOCK_INSTRUMENT.status,
+      instrumentType: MOCK_INSTRUMENT.instrumentType,
+      filePatterns: MOCK_INSTRUMENT.filePatterns,
+      runCount: MOCK_INSTRUMENT.runCount,
+      watcherCount: MOCK_INSTRUMENT.watcherCount,
+      watchersOnline: MOCK_INSTRUMENT.watchersOnline,
+      createdAt: MOCK_INSTRUMENT.createdAt,
+      ...detailBase,
+    },
+    MOCK_GEL_DOC_INSTRUMENT_DETAIL: {
+      id: MOCK_GEL_DOC_INSTRUMENT.id,
+      displayName: MOCK_GEL_DOC_INSTRUMENT.displayName,
+      status: MOCK_GEL_DOC_INSTRUMENT.status,
+      instrumentType: MOCK_GEL_DOC_INSTRUMENT.instrumentType,
+      filePatterns: MOCK_GEL_DOC_INSTRUMENT.filePatterns,
+      runCount: MOCK_GEL_DOC_INSTRUMENT.runCount,
+      watcherCount: MOCK_GEL_DOC_INSTRUMENT.watcherCount,
+      watchersOnline: MOCK_GEL_DOC_INSTRUMENT.watchersOnline,
+      createdAt: MOCK_GEL_DOC_INSTRUMENT.createdAt,
+      ...detailBase,
+    },
+    MOCK_GENERIC_INSTRUMENT_DETAIL: {
+      id: MOCK_GENERIC_INSTRUMENT.id,
+      displayName: MOCK_GENERIC_INSTRUMENT.displayName,
+      status: MOCK_GENERIC_INSTRUMENT.status,
+      instrumentType: MOCK_GENERIC_INSTRUMENT.instrumentType,
+      filePatterns: MOCK_GENERIC_INSTRUMENT.filePatterns,
+      runCount: MOCK_GENERIC_INSTRUMENT.runCount,
+      watcherCount: MOCK_GENERIC_INSTRUMENT.watcherCount,
+      watchersOnline: MOCK_GENERIC_INSTRUMENT.watchersOnline,
+      createdAt: MOCK_GENERIC_INSTRUMENT.createdAt,
+      ...detailBase,
+      activeWatcherId: null,
+      activeWatcherHostname: null,
+      lastWatcherHeartbeatAt: null,
+    },
+    MOCK_FILE: {
+      id: 42,
+      instrumentRunId: MOCK_RUN_UUID_1,
+      filename: "data.csv",
+      relativePath: "data.csv",
+      status: "completed",
+      s3Bucket: "test-bucket",
+      s3Key: "path/to/data.csv",
+      contentType: "text/csv",
+      sizeBytes: 1234,
+      category: "raw",
+      metadata: {},
+      errorMessage: null,
+      detectedAt: null,
+      uploadRequestedAt: null,
+      uploadedAt: new Date("2025-01-01T00:00:00Z"),
+      processedAt: new Date("2025-01-01T00:00:00Z"),
+      fileCreatedAt: null,
+      createdAt: new Date("2025-01-01T00:00:00Z"),
+      deletedAt: null,
+    },
+    MOCK_RUN_LIST_ROW,
+    mockRunDetail,
+    MOCK_RUN_UUID_1,
+    MOCK_RUN_UUID_2,
+  };
+});
 
 vi.mock("@/lib/api/instruments", () => ({
   // The generic instrument is intentionally omitted from the list so we can
@@ -75,13 +209,13 @@ vi.mock("@/lib/api/instruments", () => ({
     .mockResolvedValue([MOCK_INSTRUMENT, MOCK_GEL_DOC_INSTRUMENT]),
   getInstrumentById: vi.fn().mockImplementation((id: string) => {
     if (id === "test-plate-reader") {
-      return MOCK_INSTRUMENT;
+      return MOCK_INSTRUMENT_DETAIL;
     }
     if (id === "test-gel-doc") {
-      return MOCK_GEL_DOC_INSTRUMENT;
+      return MOCK_GEL_DOC_INSTRUMENT_DETAIL;
     }
     if (id === "test-generic") {
-      return MOCK_GENERIC_INSTRUMENT;
+      return MOCK_GENERIC_INSTRUMENT_DETAIL;
     }
     return null;
   }),
@@ -89,17 +223,20 @@ vi.mock("@/lib/api/instruments", () => ({
 
 vi.mock("@/lib/api/instrument-runs", () => ({
   buildRunListQuery: vi.fn().mockResolvedValue({
-    data: [{ run_id: "run-1" }, { run_id: "run-2" }],
+    data: [
+      MOCK_RUN_LIST_ROW,
+      { ...MOCK_RUN_LIST_ROW, id: MOCK_RUN_UUID_2, run_id: "run-2" },
+    ],
     pagination: { page: 1, per_page: 50, total: 2, total_pages: 1 },
   }),
   lookupRunByNaturalKey: vi
     .fn()
     .mockImplementation((_instId: string, runId: string) => {
       if (runId === "run-1") {
-        return { id: "internal-1", instrumentId: _instId, runId };
+        return mockRunDetail(_instId, runId, MOCK_RUN_UUID_1);
       }
       if (runId === "run-2") {
-        return { id: "internal-2", instrumentId: _instId, runId };
+        return mockRunDetail(_instId, runId, MOCK_RUN_UUID_2);
       }
       return null;
     }),
@@ -109,10 +246,10 @@ vi.mock("@/lib/api/instrument-runs", () => ({
       const map = new Map<string, string>();
       for (const runId of runIds) {
         if (runId === "run-1") {
-          map.set(runId, "internal-1");
+          map.set(runId, MOCK_RUN_UUID_1);
         }
         if (runId === "run-2") {
-          map.set(runId, "internal-2");
+          map.set(runId, MOCK_RUN_UUID_2);
         }
       }
       return map;
@@ -222,13 +359,51 @@ vi.mock("@/lib/api/search", () => ({
 }));
 
 vi.mock("@/lib/api/watchers", () => ({
-  getWatcherList: vi.fn().mockResolvedValue([]),
-  getWatcherById: vi.fn().mockResolvedValue(null),
+  getWatcherList: vi.fn().mockResolvedValue([
+    {
+      id: "watcher-1",
+      instrumentId: "test-plate-reader",
+      instrumentDisplayName: "Test Plate Reader",
+      hostname: "bench-pc",
+      watcherVersion: "1.0.0",
+      effectiveStatus: "watching",
+      lastHeartbeatAt: new Date("2025-01-01T12:00:00Z"),
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      deletedAt: null,
+    },
+  ]),
+  getWatcherById: vi.fn().mockImplementation((id: string) => {
+    if (id !== "watcher-1") {
+      return null;
+    }
+    return {
+      id: "watcher-1",
+      instrumentId: "test-plate-reader",
+      instrumentDisplayName: "Test Plate Reader",
+      hostname: "bench-pc",
+      watcherVersion: "1.0.0",
+      effectiveStatus: "watching",
+      lastHeartbeatAt: new Date("2025-01-01T12:00:00Z"),
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      deletedAt: null,
+      osInfo: "linux",
+      configYaml: "watch: true\n",
+      configChecksum: "abc123",
+      updatedAt: new Date("2025-01-01T00:00:00Z"),
+      deregisteredByUser: null,
+    };
+  }),
   getWatcherEvents: vi.fn().mockResolvedValue({
-    rows: [],
-    total: 0,
-    page: 1,
-    pageSize: 50,
+    rows: [
+      {
+        id: 1,
+        eventType: "file_uploaded",
+        message: "uploaded data.csv",
+        details: { filename: "data.csv" },
+        timestamp: new Date("2025-01-01T12:00:00Z"),
+      },
+    ],
+    total: 1,
   }),
   getWatcherHeartbeats: vi.fn().mockResolvedValue({
     rows: [
@@ -624,6 +799,20 @@ describe("MCP Protocol (in-memory)", () => {
     expect(globalSearch?.inputSchema.properties).toHaveProperty("query");
   });
 
+  it("every registered tool advertises outputSchema", async () => {
+    const { tools } = await client.listTools();
+    expect(tools).toHaveLength(32);
+    for (const tool of tools) {
+      const schema = tool.outputSchema as
+        | { type?: string; oneOf?: unknown; anyOf?: unknown }
+        | undefined;
+      expect(
+        schema?.type != null || schema?.oneOf != null || schema?.anyOf != null,
+        `${tool.name} missing outputSchema`
+      ).toBe(true);
+    }
+  });
+
   it("claim_run is annotated as write / non-destructive / idempotent", async () => {
     const { tools } = await client.listTools();
     const tool = tools.find((t) => t.name === "claim_run");
@@ -685,17 +874,29 @@ describe("MCP Protocol (in-memory)", () => {
     return JSON.parse(text ?? "");
   }
 
+  function expectStructuredMatchesText(result: {
+    content: unknown;
+    structuredContent?: unknown;
+  }) {
+    // All tools return object roots so content text and structuredContent match.
+    expect(result.structuredContent).toEqual(parseText(result.content));
+  }
+
   it("list_instruments returns JSON text content", async () => {
     const result = await client.callTool({
       name: "list_instruments",
       arguments: {},
     });
     expect(result.isError).toBeFalsy();
-    expect(parseText(result.content)).toEqual(
+    const parsed = parseText(result.content) as {
+      instruments: unknown[];
+    };
+    expect(parsed.instruments).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: "test-plate-reader" }),
       ])
     );
+    expect(result.structuredContent).toEqual(parsed);
   });
 
   it("get_instrument returns instrument detail", async () => {
@@ -706,6 +907,7 @@ describe("MCP Protocol (in-memory)", () => {
     expect(result.isError).toBeFalsy();
     const parsed = parseText(result.content) as { id: string };
     expect(parsed.id).toBe("test-plate-reader");
+    expect(result.structuredContent).toEqual(parsed);
   });
 
   it("search_runs returns paginated results", async () => {
@@ -717,6 +919,7 @@ describe("MCP Protocol (in-memory)", () => {
     const parsed = parseText(result.content);
     expect(parsed).toHaveProperty("data");
     expect(parsed).toHaveProperty("pagination");
+    expectStructuredMatchesText(result);
   });
 
   it("search_runs rejects invalid metadata filters with allowed values", async () => {
@@ -780,6 +983,7 @@ describe("MCP Protocol (in-memory)", () => {
     expect(parsed).toHaveProperty("users");
     expect(parsed).toHaveProperty("comments");
     expect(parsed.counts).toHaveProperty("total");
+    expect(result.structuredContent).toEqual(parsed);
   });
 
   it("global_search rejects short queries", async () => {
@@ -804,6 +1008,11 @@ describe("MCP Protocol (in-memory)", () => {
       arguments: {},
     });
     expect(result.isError).toBeFalsy();
+    const parsed = parseText(result.content) as {
+      instruments: unknown[];
+    };
+    expect(Array.isArray(parsed.instruments)).toBe(true);
+    expect(result.structuredContent).toEqual(parsed);
   });
 
   it("list_watchers returns data", async () => {
@@ -812,6 +1021,47 @@ describe("MCP Protocol (in-memory)", () => {
       arguments: {},
     });
     expect(result.isError).toBeFalsy();
+    expectStructuredMatchesText(result);
+    const parsed = parseText(result.content) as {
+      watchers: Array<{ id: string }>;
+    };
+    expect(parsed.watchers).toEqual([
+      expect.objectContaining({ id: "watcher-1", effectiveStatus: "watching" }),
+    ]);
+  });
+
+  it("get_watcher returns watcher detail", async () => {
+    const result = await client.callTool({
+      name: "get_watcher",
+      arguments: { watcherId: "watcher-1" },
+    });
+    expect(result.isError).toBeFalsy();
+    expectStructuredMatchesText(result);
+    const parsed = parseText(result.content) as {
+      id: string;
+      configYaml: string | null;
+    };
+    expect(parsed.id).toBe("watcher-1");
+    expect(parsed.configYaml).toContain("watch:");
+  });
+
+  it("list_watcher_events returns paginated events", async () => {
+    const result = await client.callTool({
+      name: "list_watcher_events",
+      arguments: { watcherId: "watcher-1", hours: 6 },
+    });
+    expect(result.isError).toBeFalsy();
+    expectStructuredMatchesText(result);
+    const parsed = parseText(result.content) as {
+      watcherId: string;
+      lookbackHours: number;
+      total: number;
+      rows: unknown[];
+    };
+    expect(parsed.watcherId).toBe("watcher-1");
+    expect(parsed.lookbackHours).toBe(6);
+    expect(parsed.total).toBe(1);
+    expect(parsed.rows).toHaveLength(1);
   });
 
   it("get_file returns the file record", async () => {
@@ -820,6 +1070,7 @@ describe("MCP Protocol (in-memory)", () => {
       arguments: { fileId: 42 },
     });
     expect(result.isError).toBeFalsy();
+    expectStructuredMatchesText(result);
     const parsed = parseText(result.content) as { id: number };
     expect(parsed.id).toBe(42);
   });
@@ -830,6 +1081,7 @@ describe("MCP Protocol (in-memory)", () => {
       arguments: { fileId: 42 },
     });
     expect(result.isError).toBeFalsy();
+    expectStructuredMatchesText(result);
     const parsed = parseText(result.content) as {
       fileId: number;
       filename: string;
@@ -847,6 +1099,7 @@ describe("MCP Protocol (in-memory)", () => {
       arguments: { instrumentId: "test-plate-reader", runId: "run-1" },
     });
     expect(result.isError).toBeFalsy();
+    expectStructuredMatchesText(result);
     const parsed = parseText(result.content) as {
       status: string;
       downloadUrl?: string;
@@ -877,6 +1130,7 @@ describe("MCP Protocol (in-memory)", () => {
       arguments: { instrumentId: "test-plate-reader", runId: "run-1" },
     });
     expect(result.isError).toBeFalsy();
+    expectStructuredMatchesText(result);
     const parsed = parseText(result.content) as {
       status: string;
       jobId?: string;
@@ -905,6 +1159,7 @@ describe("MCP Protocol (in-memory)", () => {
     expect(result.content).toEqual([
       { type: "text", text: "No downloadable files for this run" },
     ]);
+    expect(result.structuredContent).toBeUndefined();
   });
 
   it("reprocess_file succeeds for a reprocessable file", async () => {
@@ -913,6 +1168,7 @@ describe("MCP Protocol (in-memory)", () => {
       arguments: { fileId: 42 },
     });
     expect(result.isError).toBeFalsy();
+    expectStructuredMatchesText(result);
     const parsed = parseText(result.content) as {
       status: string;
       fileId: number;
@@ -921,12 +1177,30 @@ describe("MCP Protocol (in-memory)", () => {
     expect(parsed.fileId).toBe(42);
   });
 
+  it("dismiss_file returns the soft-deleted file", async () => {
+    const result = await client.callTool({
+      name: "dismiss_file",
+      arguments: { fileId: 1 },
+    });
+    expect(result.isError).toBeFalsy();
+    expectStructuredMatchesText(result);
+    const parsed = parseText(result.content) as {
+      id: number;
+      filename: string;
+      alreadyApplied: boolean;
+    };
+    expect(parsed.id).toBe(1);
+    expect(parsed.filename).toBe("a.txt");
+    expect(parsed.alreadyApplied).toBe(false);
+  });
+
   it("get_watcher_heartbeats returns heartbeat history", async () => {
     const result = await client.callTool({
       name: "get_watcher_heartbeats",
-      arguments: { watcherId: "abc", hours: 12 },
+      arguments: { watcherId: "watcher-1", hours: 12 },
     });
     expect(result.isError).toBeFalsy();
+    expectStructuredMatchesText(result);
     const parsed = parseText(result.content) as {
       watcherId: string;
       sinceIso: string;
@@ -934,7 +1208,7 @@ describe("MCP Protocol (in-memory)", () => {
       total: number;
       heartbeats: unknown[];
     };
-    expect(parsed.watcherId).toBe("abc");
+    expect(parsed.watcherId).toBe("watcher-1");
     expect(parsed.lookbackHours).toBe(12);
     expect(parsed.total).toBe(1);
     expect(parsed.heartbeats).toHaveLength(1);
@@ -981,6 +1255,7 @@ describe("MCP Protocol (in-memory)", () => {
       failureSummary: { totalFiles: number };
     };
     expect(parsed.failureSummary).toHaveProperty("totalFiles");
+    expectStructuredMatchesText(result);
   });
 
   it("get_run_report returns bounded processed CSV sample", async () => {
@@ -993,6 +1268,7 @@ describe("MCP Protocol (in-memory)", () => {
       processedCsv: { sampleRowLimit: number };
     };
     expect(parsed.processedCsv.sampleRowLimit).toBe(20);
+    expectStructuredMatchesText(result);
   });
 
   it("list_run_files returns error for nonexistent run", async () => {
@@ -1040,7 +1316,7 @@ describe("MCP Protocol (in-memory)", () => {
     });
 
     expect(result.isError).toBeFalsy();
-    expect(getRunFilesPage).toHaveBeenCalledWith("internal-1", {
+    expect(getRunFilesPage).toHaveBeenCalledWith(MOCK_RUN_UUID_1, {
       page: 2,
       perPage: 10,
       statuses: ["detected", "upload_requested"],
@@ -1059,6 +1335,7 @@ describe("MCP Protocol (in-memory)", () => {
     expect(payload.data[0]).not.toHaveProperty("s3Key");
     expect(payload.data[0]).not.toHaveProperty("metadata");
     expect(payload.data[0].filename).toBe("data.csv");
+    expectStructuredMatchesText(result);
   });
 
   it("get_file returns error for nonexistent file", async () => {
@@ -1107,11 +1384,127 @@ describe("MCP Protocol (in-memory)", () => {
       arguments: { instrumentId: "test-plate-reader" },
     });
     expect(result.isError).toBeFalsy();
-    const parsed = parseText(result.content) as Array<{
-      userId: string;
-      displayName: string;
-    }>;
-    expect(parsed).toEqual([{ userId: "u-1", displayName: "Alice" }]);
+    const parsed = parseText(result.content) as {
+      attributors: Array<{ userId: string; displayName: string }>;
+    };
+    expect(parsed).toEqual({
+      attributors: [{ userId: "u-1", displayName: "Alice" }],
+    });
+    expectStructuredMatchesText(result);
+  });
+
+  it("list_run_comments returns structured comments payload", async () => {
+    const result = await client.callTool({
+      name: "list_run_comments",
+      arguments: { instrumentId: "test-plate-reader", runId: "run-1" },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = parseText(result.content) as { comments: unknown[] };
+    expect(parsed).toEqual({ comments: [] });
+    expectStructuredMatchesText(result);
+  });
+
+  it("reprocess_run returns structured queue counts", async () => {
+    const result = await client.callTool({
+      name: "reprocess_run",
+      arguments: { instrumentId: "test-plate-reader", runId: "run-1" },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = parseText(result.content) as {
+      instrumentId: string;
+      filesQueued: number;
+      filesFailed: number;
+    };
+    expect(parsed.instrumentId).toBe("test-plate-reader");
+    expect(parsed.filesQueued).toBe(1);
+    expect(parsed.filesFailed).toBe(0);
+    expectStructuredMatchesText(result);
+  });
+
+  it("delete_run and restore_run return structured lifecycle payloads", async () => {
+    const deleted = await client.callTool({
+      name: "delete_run",
+      arguments: { instrumentId: "test-plate-reader", runId: "run-1" },
+    });
+    expect(deleted.isError).toBeFalsy();
+    const deletedPayload = parseText(deleted.content) as {
+      alreadyApplied: boolean;
+      deletedAt: string;
+    };
+    expect(deletedPayload.alreadyApplied).toBe(false);
+    expect(deletedPayload.deletedAt).toBeTruthy();
+    expectStructuredMatchesText(deleted);
+
+    const restored = await client.callTool({
+      name: "restore_run",
+      arguments: { instrumentId: "test-plate-reader", runId: "run-1" },
+    });
+    expect(restored.isError).toBeFalsy();
+    const restoredPayload = parseText(restored.content) as {
+      deletedAt: null;
+      alreadyApplied: boolean;
+    };
+    expect(restoredPayload.deletedAt).toBeNull();
+    expect(restoredPayload.alreadyApplied).toBe(false);
+    expectStructuredMatchesText(restored);
+  });
+
+  it("request_run_upload tools return structured queue payloads", async () => {
+    const one = await client.callTool({
+      name: "request_run_upload",
+      arguments: {
+        instrumentId: "test-plate-reader",
+        runId: "run-1",
+        fileIds: [1],
+      },
+    });
+    expect(one.isError).toBeFalsy();
+    const onePayload = parseText(one.content) as {
+      filesQueued: number;
+      files: Array<{ id: number; filename: string }>;
+    };
+    expect(onePayload.filesQueued).toBe(1);
+    expect(onePayload.files).toEqual([
+      expect.objectContaining({ id: 1, filename: "a.txt" }),
+    ]);
+    expectStructuredMatchesText(one);
+
+    const all = await client.callTool({
+      name: "request_run_upload_all",
+      arguments: { instrumentId: "test-plate-reader", runId: "run-1" },
+    });
+    expect(all.isError).toBeFalsy();
+    const allPayload = parseText(all.content) as { filesQueued: number };
+    expect(allPayload.filesQueued).toBe(2);
+    expectStructuredMatchesText(all);
+  });
+
+  it("comment mutation tools require authInfo on the in-memory transport", async () => {
+    for (const call of [
+      {
+        name: "add_run_comment",
+        arguments: {
+          instrumentId: "test-plate-reader",
+          runId: "run-1",
+          body: "hi",
+        },
+      },
+      {
+        name: "edit_run_comment",
+        arguments: { commentId: "c-1", body: "edited" },
+      },
+      {
+        name: "delete_run_comment",
+        arguments: { commentId: "c-1" },
+      },
+    ] as const) {
+      const result = await client.callTool(call);
+      expect(result.isError).toBe(true);
+      const text = (result.content as Array<{ type: string; text: string }>)[0]
+        .text;
+      expect(text).toContain("Authenticated user not available");
+      expect(result.structuredContent).toBeUndefined();
+    }
   });
 
   // The in-memory transport does not supply `authInfo`, so the tool must
@@ -1165,6 +1558,7 @@ describe("MCP Protocol (in-memory)", () => {
     };
     expect(payload.instrumentId).toBe("test-plate-reader");
     expect(payload.options.wavelengths).toContain("450");
+    expect(result.structuredContent).toEqual(payload);
   });
 
   it("get_instrument_filter_options errors for unknown instruments", async () => {


### PR DESCRIPTION
## Summary

MCP tools used to return a JSON string in a text blob. Agents had to parse that string to get at individual fields.

This change does three things:

- Every tool now also returns the same data as named fields, so clients can read `id` or `runCount` directly.
- Each tool publishes the shape of that result up front. Clients know which fields to expect, and a mismatch is reported as an error instead of slipping through.
- Lists come back inside a named object (`{ instruments: [...] }`, `{ watchers: [...] }`, and so on) instead of a bare array. That keeps older and newer MCP clients from wrapping the same result in two different ways.

The public catalog (`GET /mcp/v1/schema.json`) describes those result shapes the same way a live MCP connection does.

## Caller-visible list wrapping

These four tools used to return a JSON array in the text payload. They now return an object:

| Tool | Before | After |
| --- | --- | --- |
| `list_instruments` | `[...]` | `{ instruments: [...] }` |
| `list_watchers` | `[...]` | `{ watchers: [...] }` |
| `get_system_status` | `[...]` | `{ instruments: [...] }` |
| `list_run_attributors` | `[...]` | `{ attributors: [...] }` |

Anything that parsed those text blobs as arrays needs to read the named field instead. Clients that use the structured fields already get the object.

Also: `get_run_report` no longer includes a leftover `ok: true` on success (failures were already returned as errors). `request_run_upload` always includes the `files` list.

## Test plan

- [x] `make check-all` passes
- [x] MCP unit tests pass (`web/tests/mcp/`)
- [x] MCP integration tests pass (`make fe-test-integration`)
- [x] Connect a real MCP client and confirm tool results still render and the declared shapes match

Made with [Cursor](https://cursor.com)
