### PR TITLE
Reject browser sessions on machine-only API routes

### DIFF
--- a/developer-docs/watcher.md
+++ b/developer-docs/watcher.md
@@ -134,7 +134,7 @@ The config file lives at `~/.data-hub/config.yaml` by default. Override with `--
 
 ### API key binding and rotation
 
-Each watcher is bound to the personal access token (PAT) that registered it. Heartbeats, config sync, events, upload-queue polls, and update-checks from a different PAT receive `403 Forbidden`. Prefer **one PAT per instrument PC** so a compromised key on one machine cannot control other watchers.
+Each watcher is bound to the personal access token (PAT) that registered it. Heartbeats, config sync, events, upload-queue polls, and update-checks from a different PAT receive `403 Forbidden`. Those agent endpoints also reject browser sessions — they accept a PAT only. Prefer **one PAT per instrument PC** so a compromised key on one machine cannot control other watchers.
 
 When you rotate a PC's PAT:
 

--- a/web/app/api/v1/archive-jobs/[id]/route.ts
+++ b/web/app/api/v1/archive-jobs/[id]/route.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { authorize } from "@/lib/api/auth";
+import { authorizeToken } from "@/lib/api/auth";
 import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { patchArchiveJobBody, readJsonBody } from "@/lib/api/openapi";
 import { isValidUUID } from "@/lib/api/validators";
@@ -15,25 +15,22 @@ interface RouteContext {
 // PATCH /api/v1/archive-jobs/:id
 //
 // Lambda callback used to flip an async build to its terminal state.
-// Authenticates with the standard `Authorization: Bearer <PAT>` (or
-// session) — same as every other API route. The Lambda calls this with
-// its `DATA_HUB_API_KEY` PAT, the same credential it uses for every
-// other Lambda → API call.
+// PAT-only: the Lambda calls this with its `DATA_HUB_API_KEY` PAT.
+// Browser sessions carry `*` and must not flip job status or rewrite
+// `archive_bucket` / `archive_key`.
 //
-// Note: any authenticated caller can update an archive job (including
-// writing arbitrary `archive_bucket`/`archive_key`). The UI does not
-// trust this row's `status` for download readiness — it polls
-// `/download-archive` which short-circuits on an S3 HEAD against the
-// canonical archive key — so worst case a tampered row breaks its own
-// download. We can tighten by validating `archive_bucket` /
-// `archive_key` against the canonical shape if abuse becomes a real
-// concern.
+// Note: any PAT with `archive-jobs:write` can still update a job
+// (including writing arbitrary `archive_bucket`/`archive_key`). The UI
+// does not trust this row's `status` for download readiness — it polls
+// `/download-archive`, which short-circuits on an S3 HEAD against the
+// canonical archive key. We can tighten by validating those fields
+// against the canonical shape if abuse becomes a real concern.
 // ---------------------------------------------------------------------------
 
 const TERMINAL_STATUSES = new Set(["ready", "failed"]);
 
 export async function PATCH(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "archive-jobs:write");
+  const authResult = await authorizeToken(request, "archive-jobs:write");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/files/[fileId]/route.ts
+++ b/web/app/api/v1/files/[fileId]/route.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { authorize } from "@/lib/api/auth";
+import { authorize, authorizeToken } from "@/lib/api/auth";
 import {
   apiError,
   apiErrorFromResult,
@@ -44,10 +44,14 @@ const VALID_TRANSITIONS: Record<string, string[]> = {
 //
 // Enforces the file status state machine and rejects mutations on
 // soft-deleted files or files whose parent run is soft-deleted.
+//
+// PAT-only (no browser sessions): session auth carries `*` scope, and
+// accepting it let any signed-in user mark files uploaded or overwrite
+// Lambda-owned metadata. DELETE below stays session-reachable for dismiss.
 // ---------------------------------------------------------------------------
 
 export async function PATCH(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "files:update");
+  const authResult = await authorizeToken(request, "files:update");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload-url/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/request-upload-url/route.ts
@@ -1,6 +1,6 @@
 import { and, eq, isNull } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { authorize } from "@/lib/api/auth";
+import { authorizeToken } from "@/lib/api/auth";
 import {
   apiError,
   CONFLICT,
@@ -33,10 +33,13 @@ const UPLOADED_OR_LATER_STATUSES = new Set([
 // needing AWS credentials. Creates a file record if one doesn't already exist.
 // Short-circuits with `already_uploaded: true` when the file has already
 // reached S3.
+//
+// PAT-only: session `*` would let any member mint a presigned PUT for the
+// canonical raw-data key. The dashboard queues uploads via `request-upload`.
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "runs:upload");
+  const authResult = await authorizeToken(request, "runs:upload");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/route.ts
@@ -1,6 +1,6 @@
 import { eq, sql } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { authorize } from "@/lib/api/auth";
+import { authorize, authorizeToken } from "@/lib/api/auth";
 import {
   apiError,
   apiErrorFromResult,
@@ -103,10 +103,13 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
 //   - { metadata: {...} } — full replacement of run-level metadata
 //   - { detected_files: [...] } — upsert new detected files (watcher path)
 // Rejects updates to soft-deleted runs with 409.
+//
+// PAT-only: session `*` would let any member overwrite Lambda metadata or
+// inject detected files. GET/DELETE stay session-reachable for the UI.
 // ---------------------------------------------------------------------------
 
 export async function PATCH(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "runs:update");
+  const authResult = await authorizeToken(request, "runs:update");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/instruments/[instrumentId]/runs/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/route.ts
@@ -1,6 +1,6 @@
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { after, type NextRequest } from "next/server";
-import { authorize } from "@/lib/api/auth";
+import { authorize, authorizeToken } from "@/lib/api/auth";
 import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { buildRunListQuery, parseAcquiredAt } from "@/lib/api/instrument-runs";
 import { notifyRunCreated } from "@/lib/api/notifications";
@@ -24,10 +24,13 @@ interface RouteContext {
 // If the run already exists (same instrument_id + run_id), returns 200 with
 // the existing record instead of 201. This handles the race where a Lambda
 // auto-creates a run that was already reported by the watcher.
+//
+// PAT-only: the dashboard never creates runs. Session `*` would let any
+// member insert fake runs (and fire Slack / in-app notifications).
 // ---------------------------------------------------------------------------
 
 export async function POST(request: NextRequest, { params }: RouteContext) {
-  const authResult = await authorize(request, "runs:create");
+  const authResult = await authorizeToken(request, "runs:create");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/instruments/route.ts
+++ b/web/app/api/v1/instruments/route.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { authorize } from "@/lib/api/auth";
+import { authorize, authorizeToken } from "@/lib/api/auth";
 import { apiError, CONFLICT } from "@/lib/api/errors";
 import { createInstrumentBody, readJsonBody } from "@/lib/api/openapi";
 import { db } from "@/lib/db";
@@ -24,8 +24,10 @@ export async function GET(request: NextRequest) {
   return Response.json(rows);
 }
 
+// PAT-only: the watcher CLI creates instruments. Session `*` would let
+// any member insert rows; edit/retire already requires admin in-browser.
 export async function POST(request: NextRequest) {
-  const authResult = await authorize(request, "instruments:write");
+  const authResult = await authorizeToken(request, "instruments:write");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/watchers/[watcherId]/config-checksum/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/config-checksum/route.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from "next/server";
-import { authorize } from "@/lib/api/auth";
+import { authorizeToken } from "@/lib/api/auth";
 import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { isValidUUID } from "@/lib/api/validators";
 import { enforceWatcherBinding, findActiveWatcher } from "@/lib/api/watchers";
@@ -8,7 +8,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ watcherId: string }> }
 ) {
-  const authResult = await authorize(request, "watchers:read");
+  // PAT-only: watcher config-drift poll. Sessions previously skipped
+  // PAT↔watcher binding.
+  const authResult = await authorizeToken(request, "watchers:read");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/watchers/[watcherId]/config/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/config/route.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { authorize } from "@/lib/api/auth";
+import { authorizeToken } from "@/lib/api/auth";
 import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { readJsonBody, watcherConfigBody } from "@/lib/api/openapi";
 import { isValidUUID } from "@/lib/api/validators";
@@ -17,7 +17,9 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ watcherId: string }> }
 ) {
-  const authResult = await authorize(request, "watchers:report");
+  // PAT-only: sessions carry `*` and would let any member overwrite
+  // stored watcher config (dashboard never PUTs this).
+  const authResult = await authorizeToken(request, "watchers:report");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/watchers/[watcherId]/events/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/events/route.ts
@@ -1,6 +1,6 @@
 import { and, desc, eq, gte, inArray } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { authorize } from "@/lib/api/auth";
+import { authorize, authorizeToken } from "@/lib/api/auth";
 import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { readJsonBody, watcherEventBody } from "@/lib/api/openapi";
 import {
@@ -22,7 +22,9 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ watcherId: string }> }
 ) {
-  const authResult = await authorize(request, "watchers:report");
+  // PAT-only: sessions carry `*` and would let any member inject fake
+  // watcher events. GET below stays session-reachable for the dashboard.
+  const authResult = await authorizeToken(request, "watchers:report");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/heartbeat/route.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { authorize } from "@/lib/api/auth";
+import { authorizeToken } from "@/lib/api/auth";
 import {
   apiError,
   NOT_FOUND,
@@ -26,7 +26,9 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ watcherId: string }> }
 ) {
-  const authResult = await authorize(request, "watchers:report");
+  // PAT-only: sessions carry `*` and previously could stop any watcher
+  // (heartbeat is never called from the dashboard).
+  const authResult = await authorizeToken(request, "watchers:report");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/watchers/[watcherId]/update-check/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/update-check/route.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from "next/server";
-import { authorize } from "@/lib/api/auth";
+import { authorizeToken } from "@/lib/api/auth";
 import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { isValidUUID } from "@/lib/api/validators";
 import { enforceWatcherBinding, findActiveWatcher } from "@/lib/api/watchers";
@@ -48,7 +48,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ watcherId: string }> }
 ) {
-  const authResult = await authorize(request, "watchers:read");
+  // PAT-only: watcher self-update poll. Sessions previously skipped
+  // PAT↔watcher binding.
+  const authResult = await authorizeToken(request, "watchers:read");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/watchers/[watcherId]/upload-queue/route.ts
+++ b/web/app/api/v1/watchers/[watcherId]/upload-queue/route.ts
@@ -1,6 +1,6 @@
 import { and, eq, isNotNull, isNull } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { authorize } from "@/lib/api/auth";
+import { authorizeToken } from "@/lib/api/auth";
 import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
 import { isValidUUID } from "@/lib/api/validators";
 import { enforceWatcherBinding, findActiveWatcher } from "@/lib/api/watchers";
@@ -11,7 +11,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ watcherId: string }> }
 ) {
-  const authResult = await authorize(request, "watchers:read");
+  // PAT-only: this is the watcher's poll, not a dashboard read. Sessions
+  // previously skipped PAT↔watcher binding.
+  const authResult = await authorizeToken(request, "watchers:read");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/app/api/v1/watchers/register/route.ts
+++ b/web/app/api/v1/watchers/register/route.ts
@@ -1,6 +1,6 @@
 import { and, eq, isNull } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { authorize } from "@/lib/api/auth";
+import { authorizeToken } from "@/lib/api/auth";
 import {
   apiError,
   CONFLICT,
@@ -11,8 +11,10 @@ import { readJsonBody, registerWatcherBody } from "@/lib/api/openapi";
 import { db } from "@/lib/db";
 import { instruments, watchers } from "@/lib/db/schema";
 
+// PAT-only: browser sessions carry `*` and would let any signed-in
+// member register a watcher and occupy the one-per-instrument slot.
 export async function POST(request: NextRequest) {
-  const authResult = await authorize(request, "watchers:report");
+  const authResult = await authorizeToken(request, "watchers:report");
   if (authResult instanceof Response) {
     return authResult;
   }

--- a/web/lib/api/openapi/paths/archive.ts
+++ b/web/lib/api/openapi/paths/archive.ts
@@ -13,7 +13,8 @@ registry.registerPath({
   path: "/archive-jobs/{id}",
   operationId: "updateArchiveJob",
   summary: "Update an archive job",
-  description: "Requires scope `archive-jobs:write`.",
+  description:
+    "Requires scope `archive-jobs:write`. PAT only; browser sessions are rejected.",
   tags: ["Archive"],
   security: bearerSecurity,
   request: {

--- a/web/lib/api/openapi/paths/files.ts
+++ b/web/lib/api/openapi/paths/files.ts
@@ -34,7 +34,8 @@ registry.registerPath({
   path: "/instruments/{instrumentId}/runs/{runId}/files",
   operationId: "createRunFile",
   summary: "Create a run file record",
-  description: "Requires scope `files:create`.",
+  description:
+    "Requires scope `files:create`. PAT only; browser sessions are rejected.",
   tags: ["Files"],
   security: bearerSecurity,
   request: { params: runParams, body: body(createFileBody) },
@@ -49,7 +50,8 @@ registry.registerPath({
   path: "/files/{fileId}",
   operationId: "updateFile",
   summary: "Update a file",
-  description: "Requires scope `files:update`.",
+  description:
+    "Requires scope `files:update`. PAT only; browser sessions are rejected.",
   tags: ["Files"],
   security: bearerSecurity,
   request: { params: fileParams, body: body(patchFileBody) },

--- a/web/lib/api/openapi/paths/instruments.ts
+++ b/web/lib/api/openapi/paths/instruments.ts
@@ -33,7 +33,8 @@ registry.registerPath({
   path: "/instruments",
   operationId: "createInstrument",
   summary: "Create an instrument",
-  description: "Requires scope `instruments:write`.",
+  description:
+    "Requires scope `instruments:write`. PAT only; browser sessions are rejected.",
   tags: ["Instruments"],
   security: bearerSecurity,
   request: {

--- a/web/lib/api/openapi/paths/runs.ts
+++ b/web/lib/api/openapi/paths/runs.ts
@@ -41,6 +41,8 @@ const runParams = z.object({
 const commentParams = runParams.extend({ commentId: commentIdParam });
 const tag = ["Runs"];
 const scoped = (scope: string) => `Requires scope \`${scope}\`.`;
+const scopedPat = (scope: string) =>
+  `Requires scope \`${scope}\`. PAT only; browser sessions are rejected.`;
 const body = (schema: z.ZodType) => ({
   content: { "application/json": { schema } },
 });
@@ -79,7 +81,7 @@ registry.registerPath({
   path: "/instruments/{instrumentId}/runs",
   operationId: "createInstrumentRun",
   summary: "Create an instrument run",
-  description: scoped("runs:create"),
+  description: scopedPat("runs:create"),
   tags: tag,
   security: bearerSecurity,
   request: {
@@ -108,7 +110,7 @@ registry.registerPath({
   path: "/instruments/{instrumentId}/runs/{runId}",
   operationId: "updateInstrumentRun",
   summary: "Update a run",
-  description: scoped("runs:update"),
+  description: scopedPat("runs:update"),
   tags: tag,
   security: bearerSecurity,
   request: { params: runParams, body: body(patchRunBody) },
@@ -196,7 +198,7 @@ registry.registerPath({
   path: "/instruments/{instrumentId}/runs/{runId}/request-upload-url",
   operationId: "requestRunUploadUrl",
   summary: "Request a presigned upload URL",
-  description: scoped("runs:upload"),
+  description: scopedPat("runs:upload"),
   tags: tag,
   security: bearerSecurity,
   request: { params: runParams, body: body(requestUploadUrlBody) },

--- a/web/lib/api/openapi/paths/watchers.ts
+++ b/web/lib/api/openapi/paths/watchers.ts
@@ -32,6 +32,8 @@ const responses = (description: string, schema: z.ZodType = z.unknown()) => ({
   200: jsonResponse(description, schema),
   ...errorResponses(),
 });
+const PAT_ONLY = " PAT only; browser sessions are rejected.";
+
 const operation = (
   method: "get" | "post" | "put" | "delete",
   path: string,
@@ -39,14 +41,15 @@ const operation = (
   summary: string,
   scope: string,
   responseSchema: z.ZodType,
-  request?: object
+  request?: object,
+  patOnly = false
 ) =>
   registry.registerPath({
     method,
     path,
     operationId,
     summary,
-    description: `Requires scope \`${scope}\`.`,
+    description: `Requires scope \`${scope}\`.${patOnly ? PAT_ONLY : ""}`,
     tags: ["Watchers"],
     security: bearerSecurity,
     ...(request ? { request } : {}),
@@ -73,7 +76,8 @@ registry.registerPath({
   path: "/watchers/register",
   operationId: "registerWatcher",
   summary: "Register a watcher",
-  description: "Requires scope `watchers:report`.",
+  description:
+    "Requires scope `watchers:report`. PAT only; browser sessions are rejected.",
   tags: ["Watchers"],
   security: bearerSecurity,
   request: { body: body(registerWatcherBody) },
@@ -107,7 +111,8 @@ operation(
   "Update watcher configuration",
   "watchers:report",
   watcherChecksumResponse,
-  { params: watcherParams, body: body(watcherConfigBody) }
+  { params: watcherParams, body: body(watcherConfigBody) },
+  true
 );
 operation(
   "get",
@@ -116,14 +121,16 @@ operation(
   "Get watcher configuration checksum",
   "watchers:read",
   watcherChecksumResponse,
-  { params: watcherParams }
+  { params: watcherParams },
+  true
 );
 registry.registerPath({
   method: "post",
   path: "/watchers/{watcherId}/events",
   operationId: "createWatcherEvent",
   summary: "Report a watcher event",
-  description: "Requires scope `watchers:report`.",
+  description:
+    "Requires scope `watchers:report`. PAT only; browser sessions are rejected.",
   tags: ["Watchers"],
   security: bearerSecurity,
   request: { params: watcherParams, body: body(watcherEventBody) },
@@ -148,7 +155,8 @@ operation(
   "Record a watcher heartbeat",
   "watchers:report",
   watcherHeartbeatAck,
-  { params: watcherParams, body: body(heartbeatBody) }
+  { params: watcherParams, body: body(heartbeatBody) },
+  true
 );
 operation(
   "get",
@@ -166,7 +174,8 @@ operation(
   "Get watcher upload queue",
   "watchers:read",
   watcherUploadQueueResponse,
-  { params: watcherParams }
+  { params: watcherParams },
+  true
 );
 operation(
   "get",
@@ -175,5 +184,6 @@ operation(
   "Check watcher update availability",
   "watchers:read",
   watcherUpdateCheckResponse,
-  { params: watcherParams }
+  { params: watcherParams },
+  true
 );

--- a/web/lib/api/watcher-binding.ts
+++ b/web/lib/api/watcher-binding.ts
@@ -9,13 +9,16 @@ export type WatcherBindingVerdict = "allow" | "deny" | "tofu";
  * Pure binding decision used by `enforceWatcherBinding` in `watchers.ts`.
  * Session/match/mismatch branches are unit-tested here; the TOFU claim path
  * and HTTP 403/200 behaviour live in the integration suite.
+ *
+ * Sessions deny so a future slip back to `authorize` cannot impersonate a
+ * watcher. Agent routes themselves already use `authorizeToken`.
  */
 export function decideWatcherBinding(
   authResult: AuthResult,
   registeredByToken: string | null
 ): WatcherBindingVerdict {
   if (authResult.authMethod === "session") {
-    return "allow";
+    return "deny";
   }
   if (!authResult.tokenId) {
     return "deny";

--- a/web/lib/api/watchers.ts
+++ b/web/lib/api/watchers.ts
@@ -32,9 +32,10 @@ export async function findActiveWatcher(watcherId: string) {
 
 /**
  * Returns null when the caller may act on this watcher, or a Response the
- * handler should return. Sessions are fully privileged (browser admins).
- * Token callers must match the watcher's registered PAT. A null binding is
- * claimed trust-on-first-use (atomic), then enforced thereafter.
+ * handler should return. Sessions are denied — watcher agent routes are
+ * PAT-only via `authorizeToken`. Token callers must match the watcher's
+ * registered PAT. A null binding is claimed trust-on-first-use (atomic),
+ * then enforced thereafter.
  */
 export async function enforceWatcherBinding(
   authResult: AuthResult,

--- a/web/tests/integration/helpers.ts
+++ b/web/tests/integration/helpers.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from "node:crypto";
+import { makeSignature } from "better-auth/crypto";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 // biome-ignore lint/performance/noNamespaceImport: tests need the full schema module for Db typing
@@ -90,6 +92,37 @@ export async function seedTestUser(
     ...options,
   });
   return { userId, token, tokenId };
+}
+
+function getAuthSecret(): string {
+  const secret = process.env.__TEST_AUTH_SECRET;
+  if (!secret) {
+    throw new Error("__TEST_AUTH_SECRET not set — global setup failed?");
+  }
+  return secret;
+}
+
+/**
+ * Seed a live session row and return a Cookie header Better Auth accepts.
+ * Cookie name is `better-auth.session_token` (not `__Secure-…`) because the
+ * test server's `BETTER_AUTH_URL` is `http://…` — Better Auth only prefixes
+ * `__Secure-` when the base URL is HTTPS.
+ */
+export async function seedSessionCookie(userId: string): Promise<string> {
+  const token = randomBytes(32).toString("base64url");
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+  await getTestDb().insert(schema.sessions).values({
+    id: crypto.randomUUID(),
+    token,
+    userId,
+    expiresAt,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const signature = await makeSignature(token, getAuthSecret());
+  const signed = encodeURIComponent(`${token}.${signature}`);
+  return `better-auth.session_token=${signed}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/tests/integration/machine-routes-reject-session.test.ts
+++ b/web/tests/integration/machine-routes-reject-session.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  api,
+  closeTestDb,
+  resetDb,
+  seedSessionCookie,
+  seedTestUser,
+} from "@/tests/integration/helpers";
+
+// Regression pin for the session-`*` bypass on machine-only routes.
+// Browser logins carry every scope, so these watcher/Lambda callbacks
+// must reject a session cookie and accept only a PAT.
+//
+// Auth is the first check on each handler, so dummy ids are enough —
+// we never reach lookup.
+
+const WATCHER_ID = "00000000-0000-0000-0000-000000000000";
+const JOB_ID = "11111111-1111-1111-1111-111111111111";
+const INSTRUMENT_ID = "session-reject-instrument";
+const RUN_ID = "session-reject-run";
+
+const MACHINE_ROUTES: {
+  method: "GET" | "POST" | "PUT" | "PATCH";
+  path: string;
+  body?: unknown;
+}[] = [
+  {
+    method: "POST",
+    path: "/api/v1/watchers/register",
+    body: { instrument_id: INSTRUMENT_ID },
+  },
+  {
+    method: "POST",
+    path: `/api/v1/watchers/${WATCHER_ID}/heartbeat`,
+    body: { status: "stopped" },
+  },
+  {
+    method: "PUT",
+    path: `/api/v1/watchers/${WATCHER_ID}/config`,
+    body: { config_yaml: "instrument: {}\n", config_checksum: "x" },
+  },
+  {
+    method: "POST",
+    path: `/api/v1/watchers/${WATCHER_ID}/events`,
+    body: {
+      events: [
+        {
+          event_type: "watcher_started",
+          timestamp: new Date().toISOString(),
+          message: "session reject",
+        },
+      ],
+    },
+  },
+  {
+    method: "GET",
+    path: `/api/v1/watchers/${WATCHER_ID}/upload-queue`,
+  },
+  {
+    method: "GET",
+    path: `/api/v1/watchers/${WATCHER_ID}/config-checksum`,
+  },
+  {
+    method: "GET",
+    path: `/api/v1/watchers/${WATCHER_ID}/update-check`,
+  },
+  {
+    method: "PATCH",
+    path: "/api/v1/files/1",
+    body: { status: "uploaded" },
+  },
+  {
+    method: "POST",
+    path: `/api/v1/instruments/${INSTRUMENT_ID}/runs/${RUN_ID}/request-upload-url`,
+    body: { filename: "attack.csv" },
+  },
+  {
+    method: "POST",
+    path: `/api/v1/instruments/${INSTRUMENT_ID}/runs`,
+    body: { run_id: RUN_ID, source: "watcher" },
+  },
+  {
+    method: "PATCH",
+    path: `/api/v1/instruments/${INSTRUMENT_ID}/runs/${RUN_ID}`,
+    body: { metadata: { forged: true } },
+  },
+  {
+    method: "PATCH",
+    path: `/api/v1/archive-jobs/${JOB_ID}`,
+    body: { status: "failed", error_message: "session reject" },
+  },
+  {
+    method: "POST",
+    path: "/api/v1/instruments",
+    body: { id: "forged-instrument" },
+  },
+];
+
+describe("Machine-only routes reject browser sessions", () => {
+  let sessionCookie: string;
+
+  beforeAll(async () => {
+    await resetDb();
+    const { userId } = await seedTestUser({ isAdmin: false });
+    sessionCookie = await seedSessionCookie(userId);
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  // Confirms the cookie is a live session — otherwise a 401 on the
+  // machine routes could just mean cookie synthesis is broken.
+  it("GET /api/v1/instruments accepts the same session cookie", async () => {
+    const res = await api("/api/v1/instruments", {
+      headers: { Cookie: sessionCookie },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  for (const c of MACHINE_ROUTES) {
+    it(`${c.method} ${c.path} returns 401`, async () => {
+      const res = await api(c.path, {
+        method: c.method,
+        headers: { Cookie: sessionCookie },
+        body: c.body,
+      });
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error.code).toBe("UNAUTHORIZED");
+    });
+  }
+});

--- a/web/tests/integration/mcp-oauth.test.ts
+++ b/web/tests/integration/mcp-oauth.test.ts
@@ -1,5 +1,4 @@
 import { createHash, randomBytes } from "node:crypto";
-import { makeSignature } from "better-auth/crypto";
 import { eq } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 // biome-ignore lint/performance/noNamespaceImport: integration tests need the full schema module for Db typing
@@ -10,6 +9,7 @@ import {
   getBaseUrl,
   getTestDb,
   resetDb,
+  seedSessionCookie,
   seedTestUser,
 } from "@/tests/integration/helpers";
 
@@ -36,42 +36,6 @@ function expectedIssuer(): string {
 
 function expectedMcpResource(): string {
   return `${getBaseUrl()}/mcp/v1`;
-}
-
-function getAuthSecret(): string {
-  const secret = process.env.__TEST_AUTH_SECRET;
-  if (!secret) {
-    throw new Error("__TEST_AUTH_SECRET not set — global setup failed?");
-  }
-  return secret;
-}
-
-/** Sign a Better Auth session cookie value (`token.signature`, URI-encoded). */
-async function signSessionCookieValue(token: string): Promise<string> {
-  const signature = await makeSignature(token, getAuthSecret());
-  return encodeURIComponent(`${token}.${signature}`);
-}
-
-/**
- * Seed a live session row and return a Cookie header Better Auth accepts.
- * Cookie name is `better-auth.session_token` (not `__Secure-…`) because the
- * test server's `BETTER_AUTH_URL` is `http://…` — Better Auth only prefixes
- * `__Secure-` when the base URL is HTTPS.
- */
-async function seedSessionCookie(userId: string): Promise<string> {
-  const token = randomBytes(32).toString("base64url");
-  const now = new Date();
-  const expiresAt = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
-  await getTestDb().insert(schema.sessions).values({
-    id: crypto.randomUUID(),
-    token,
-    userId,
-    expiresAt,
-    createdAt: now,
-    updatedAt: now,
-  });
-  const signed = await signSessionCookieValue(token);
-  return `better-auth.session_token=${signed}`;
 }
 
 function pkcePair(): { verifier: string; challenge: string } {

--- a/web/tests/integration/watcher-binding.test.ts
+++ b/web/tests/integration/watcher-binding.test.ts
@@ -11,8 +11,8 @@ import {
 
 // Cross-control IDOR guard: a watchers:report (or :read) PAT may only
 // operate on the watcher it registered. Bound endpoints are exercised
-// parametrically so none regress. Session exemption is covered by the
-// unit suite (`decideWatcherBinding`) — this harness has no cookies.
+// parametrically so none regress. Session denial is covered by the
+// unit suite (`decideWatcherBinding`) and machine-routes-reject-session.
 
 const WATCHER_SCOPES = [
   "watchers:report",

--- a/web/tests/unit/watcher-binding.test.ts
+++ b/web/tests/unit/watcher-binding.test.ts
@@ -26,9 +26,9 @@ function tokenAuth(tokenId: string): AuthResult {
 }
 
 describe("decideWatcherBinding", () => {
-  it("allows browser sessions regardless of binding", () => {
-    expect(decideWatcherBinding(sessionAuth(), null)).toBe("allow");
-    expect(decideWatcherBinding(sessionAuth(), "some-pat-id")).toBe("allow");
+  it("denies browser sessions regardless of binding", () => {
+    expect(decideWatcherBinding(sessionAuth(), null)).toBe("deny");
+    expect(decideWatcherBinding(sessionAuth(), "some-pat-id")).toBe("deny");
   });
 
   it("allows a token that matches the registered PAT", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Browser logins carry every API permission (`*`). Several watcher and Lambda callbacks still accepted a session cookie, so any signed-in (non-admin) member could impersonate an agent.

This switches those machine-only handlers to `authorizeToken` (same helper as the file-create fix) and denies sessions in watcher↔PAT binding so a future slip back to `authorize` cannot impersonate a watcher.

**Locked (PAT only):**

- Watcher register, heartbeat, config PUT, events POST, upload-queue, config-checksum, update-check
- File PATCH and `request-upload-url`
- Run create / PATCH, archive-job PATCH, instrument create

Dashboard routes stay on `authorize` (list/detail, dismiss, reprocess, request-upload, comments, delete/restore run).

## Test plan

- [x] `make check-all`
- [x] Unit: watcher-binding now denies sessions; OpenAPI document still builds
- [x] Integration: `machine-routes-reject-session` plus files, watchers, watcher-binding, instrument-runs, request-upload-url, archive-jobs (152 passed)
- [ ] Review: a non-admin Google login must 401 on heartbeat / file PATCH / request-upload-url; a watcher PAT still succeeds

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f871c00b-a4a1-46c2-abcd-6d9b0290725f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f871c00b-a4a1-46c2-abcd-6d9b0290725f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

