### PR TITLE
Fix run report colors and tighten MCP instructions

### DIFF
--- a/web/lib/mcp/instructions.ts
+++ b/web/lib/mcp/instructions.ts
@@ -1,24 +1,41 @@
-/** Delivered to every MCP client at initialize — reachable without resources. */
-export const MCP_SERVER_INSTRUCTIONS = [
-  "Data Hub MCP stores lab instrument runs, files, watchers, and attributions.",
-  "",
-  "Dates: dateFrom/dateTo and prompt date defaults are UTC calendar days",
-  "(inclusive), matched against coalesce(acquired_at, created_at). The web",
-  "dashboard uses the viewer's timezone for “today”, so counts can differ.",
-  "",
-  "Run status is derived from raw file states, priority-exclusive:",
-  "failed > stalled > pending (detected/upload_requested) > uploaded >",
-  "processing > completed > empty. A file counts as stalled once it has been",
-  "in processing past the stall window (20 minutes by default); such runs are",
-  "recoverable with reprocess_run.",
-  "",
-  "Tool routing:",
-  "- Prefer global_search for filenames, instrument names, users, or comments.",
-  "- Prefer search_runs for date/status/metadata filters.",
-  '- My runs: search_runs with ranBy="me" (or get_me then ranBy=<id>).',
-  "- Prefer get_run_report for bounded CSV samples over downloading full files.",
-  "- Metadata filter enums: get_instrument_filter_options or",
-  "  datahub://instruments/{id}/filter-options.",
-  "- Watcher diagnosis: list_watchers → get_watcher_heartbeats →",
-  "  list_watcher_events (unhealthy agents only).",
-].join("\n");
+/**
+ * Delivered to every MCP client at initialize — reachable without resources.
+ *
+ * Scoped to what tool descriptions cannot carry on their own: cross-tool
+ * constraints, routing, and volume limits. Full status and date definitions
+ * live in `datahub://glossary` so they are not restated here.
+ */
+export const MCP_SERVER_INSTRUCTIONS = `
+Data Hub exposes lab instrument runs, their files, watcher agents, and run
+attributions (who ran what).
+
+Writes: mutating tools need the write scope and otherwise fail with "Token is
+missing required scope: write" — ask the user to re-authorize rather than
+retrying. Confirm with the user before deleting, dismissing, unclaiming, or
+reprocessing anything. Attribution and comments always act as the token's
+owner; you cannot claim a run or comment as someone else.
+
+Dates: dateFrom/dateTo are inclusive UTC calendar days matched against
+coalesce(acquired_at, created_at). The web dashboard uses the viewer's
+timezone, so its daily counts can differ.
+
+Run status is derived from a run's file states, in this order of precedence:
+failed > stalled > pending > uploaded > processing > completed > empty.
+Stalled runs recover with reprocess_run; pending runs need
+request_run_upload_all and an online watcher. Definitions: datahub://glossary.
+
+Tool routing:
+- global_search for filenames, instrument names, users, or comments.
+- search_runs for date, status, or instrument-metadata filters.
+- My runs: search_runs with ranBy="me" (or get_me then ranBy=<id>).
+- get_run_report for run results; it also renders an interactive report in
+  hosts that support MCP Apps. get_run returns metadata only.
+- Metadata filter values: get_instrument_filter_options or
+  datahub://instruments/{id}/filter-options.
+- Watcher diagnosis: list_watchers → get_watcher_heartbeats →
+  list_watcher_events (unhealthy agents only).
+
+A run can have thousands of files: filter list_run_files by status rather than
+paging all of it, and prefer get_run_report's bounded sample over downloading
+full CSVs.
+`.trim();

--- a/web/lib/mcp/tools/runs.defs.ts
+++ b/web/lib/mcp/tools/runs.defs.ts
@@ -107,7 +107,7 @@ export const getRunTool = {
   scope: "runs:read",
   title: "Get Run",
   description:
-    "Get details for a specific instrument run by its natural key (instrument ID + run ID). Returns metadata, timestamps, instrument info, and attributions by default. Pass include to attach the first page of files, comments, and/or a failure_summary without extra tool calls. For processed measurement samples prefer get_run_report.",
+    "Get details for a specific instrument run by its natural key (instrument ID + run ID). Returns metadata, timestamps, instrument info, and attributions by default. Pass include to attach the first page of files, comments, and/or a failure_summary without extra tool calls. To show the interactive report (plate maps, spectra, images) or a bounded processed-CSV sample, call get_run_report for the same run.",
   outputSchema: getRunOutputSchema,
   inputSchema: {
     instrumentId: z.string().describe("Instrument identifier"),
@@ -128,7 +128,7 @@ export const getRunReportTool = {
   scope: "files:read",
   title: "Get Run Report",
   description:
-    "Return an analysis-ready summary for a run: file counts, failure summary, image/report file refs, and a bounded processed-CSV sample (columns + first rows). Prefer this over downloading full CSVs when comparing or summarizing experimental results.",
+    "Return an analysis-ready summary for a run: file counts, failure summary, image/report file refs, and a bounded processed-CSV sample (columns + first rows). Prefer this over downloading full CSVs when comparing or summarizing experimental results. Hosts that support MCP Apps render the interactive report View when this tool is called.",
   outputSchema: getRunReportOutputSchema,
   inputSchema: {
     instrumentId: z.string().describe("Instrument identifier"),

--- a/web/mcp-apps/run-report.css
+++ b/web/mcp-apps/run-report.css
@@ -5,33 +5,10 @@
 @source "../lib";
 @source ".";
 
-/* Host style variables win when present; Data Hub tokens stay as fallbacks. */
-:root {
-  --background: var(--color-background-primary, oklch(1 0 0));
-  --foreground: var(--color-text-primary, oklch(0.145 0 0));
-  --card: var(--color-background-secondary, oklch(1 0 0));
-  --card-foreground: var(--color-text-primary, oklch(0.145 0 0));
-  --primary: var(--color-text-primary, oklch(0.205 0 0));
-  --primary-foreground: var(--color-text-inverse, oklch(0.985 0 0));
-  --muted: var(--color-background-secondary, #f7f7f7);
-  --muted-foreground: var(--color-text-secondary, oklch(0.556 0 0));
-  --border: var(--color-border-primary, oklch(0.922 0 0));
-  --ring: var(--color-ring-primary, oklch(0.708 0 0));
-  --radius: var(--border-radius-md, 0.625rem);
-}
-
-[data-theme="dark"] {
-  --background: var(--color-background-primary, oklch(0.145 0 0));
-  --foreground: var(--color-text-primary, oklch(0.985 0 0));
-  --card: var(--color-background-secondary, oklch(0.21 0 0));
-  --card-foreground: var(--color-text-primary, oklch(0.985 0 0));
-  --primary: var(--color-text-primary, oklch(0.922 0 0));
-  --primary-foreground: var(--color-text-inverse, oklch(0.205 0 0));
-  --muted: var(--color-background-secondary, oklch(0.269 0 0));
-  --muted-foreground: var(--color-text-secondary, oklch(0.708 0 0));
-  --border: var(--color-border-primary, oklch(1 0 0 / 10%));
-  --ring: var(--color-ring-primary, oklch(0.556 0 0));
-}
+/* Colors stay on Data Hub tokens so the View matches the website. Host
+   `--color-background-*` values are a warm cream that also painted
+   selected rows and tabs (`bg-muted`). Light/dark still follow the host
+   via the `dark` class; fonts still come from `useHostStyles`. */
 
 /* Do not set min-height: 100% here. The SDK measures html with
    height: max-content; stretching to the host-set iframe height made


### PR DESCRIPTION
## Summary

- The run report view inherited Cursor's cream background, which also painted selected rows and active tabs. It now uses Data Hub's own colors. Light/dark still follows the host.
- `get_run` and `get_run_report` now say which one shows the interactive report.
- Server instructions swap duplicated status/date detail (already in `datahub://glossary`) for the write-scope failure, confirming before destructive calls, and file-volume guidance.

## Test plan

- [x] `make check-all` and `npm run test:unit` pass
- [ ] In Cursor: card is white, selected row is gray, dark mode still follows the host