### PR TITLE
Render report PDFs inline when S3 stored them as binary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,10 @@ User-, operator-, and admin-facing documentation — installing a watcher, setti
 
 This repo's `developer-docs/` covers contributing to and self-hosting Data Hub itself: architecture internals, local dev setup (`getting-started.md`, `local-development.md`), conventions, the step-by-step self-hosting guide for the web app and AWS infrastructure (`first-time-deployment.md`) plus CI/ongoing-deploy reference (`ci-and-deployment.md`), and per-package references (`lambda.md`, `watcher.md`, `shared-library.md`). See `developer-docs/README.md` for the full index.
 
+### Watcher version
+
+Shipped watcher changes (`watcher/src/`) need a version bump in the same branch. Follow `watcher/AGENTS.md`: bump `[project].version` in `watcher/pyproject.toml` once if it still matches the merge-base, then run `uv lock`. Do not tag the release from the feature branch.
+
 ### Watcher CLI catalog (docs site)
 
 The public [Watcher CLI](https://datahub.arcadiascience.com/docs/cli-reference) page renders from a JSON catalog generated from Click in `watcher/src/data_hub_watcher/cli_catalog.py`.

--- a/packages/shared/src/data_hub_shared/s3_utils.py
+++ b/packages/shared/src/data_hub_shared/s3_utils.py
@@ -40,12 +40,16 @@ def parse_s3_uri(s3_uri: str) -> tuple[str, str]:
 def _extra_args(file_path: Path) -> dict[str, str]:
     """Build `ExtraArgs` for an S3 upload (content-type, disposition)."""
     args: dict[str, str] = {}
-    content_type, _ = mimetypes.guess_type(str(file_path))
+    content_type = get_content_type(file_path)
     if content_type:
         args["ContentType"] = content_type
-        # Images and video get "inline" so browsers render / play them
+        # Images, video, and PDFs get "inline" so browsers render them
         # instead of prompting a download when accessed via pre-signed URL.
-        if content_type.startswith("image/") or content_type.startswith("video/"):
+        if (
+            content_type.startswith("image/")
+            or content_type.startswith("video/")
+            or content_type == "application/pdf"
+        ):
             args["ContentDisposition"] = "inline"
     return args
 
@@ -148,6 +152,11 @@ def upload_folder(
 
 
 def get_content_type(file_path: Path) -> str | None:
-    """Return the guessed MIME type for *file_path*, or `None`."""
-    content_type, _ = mimetypes.guess_type(str(file_path))
+    """Return the guessed MIME type for *file_path*, or `None`.
+
+    `mimetypes.guess_type` is case-sensitive on some platforms, so the
+    suffix is lowercased first. Azure Cielo writes reports as `.PDF`.
+    """
+    lowered = file_path.with_suffix(file_path.suffix.lower())
+    content_type, _ = mimetypes.guess_type(str(lowered))
     return content_type

--- a/packages/shared/tests/test_s3_utils.py
+++ b/packages/shared/tests/test_s3_utils.py
@@ -1,12 +1,13 @@
 """Unit tests for shared S3 helpers."""
 
 from __future__ import annotations
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 from botocore.exceptions import ClientError
 
-from data_hub_shared.s3_utils import object_exists
+from data_hub_shared.s3_utils import _extra_args, get_content_type, object_exists
 
 
 def _client_error(code: str, status: int) -> ClientError:
@@ -58,3 +59,14 @@ def test_object_exists_other_errors_raise() -> None:
     client.head_object.side_effect = _client_error("500", 500)
     with pytest.raises(ClientError):
         object_exists("s3://bucket/key", s3_client=client)
+
+
+def test_get_content_type_is_case_insensitive() -> None:
+    assert get_content_type(Path("Experiment_Report.PDF")) == "application/pdf"
+
+
+def test_extra_args_marks_pdfs_inline() -> None:
+    assert _extra_args(Path("Experiment_Report.PDF")) == {
+        "ContentType": "application/pdf",
+        "ContentDisposition": "inline",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -418,7 +418,7 @@ requires-dist = [
 
 [[package]]
 name = "data-hub-watcher"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "watcher" }
 dependencies = [
     { name = "click" },

--- a/watcher/AGENTS.md
+++ b/watcher/AGENTS.md
@@ -1,0 +1,19 @@
+# Watcher agent notes
+
+The published package version is `[project].version` in `watcher/pyproject.toml`. Heartbeats and `data-hub-watcher --version` read that value from the installed package metadata. Lab PCs only pick up a new version after someone tags `watcher-vX.Y.Z` on `production` and advertises it in Settings → Watchers — see [Roll out watcher releases](https://datahub.arcadiascience.com/docs/watcher-releases).
+
+## Bump the version when you change shipped code
+
+If this branch changes anything under `watcher/src/` (runtime, CLI, upload, update), bump `watcher/pyproject.toml` **once on the branch** before you finish.
+
+1. Compare `[project].version` to the merge-base (`staging` unless the user named another base).
+2. If it still matches the base, bump it:
+   - **patch** (`1.0.0` → `1.0.1`) — bug fixes and behavior changes that do not add a feature or break a contract
+   - **minor** (`1.0.1` → `1.1.0`) — new commands, flags, or backward-compatible features
+   - **major** (`1.1.0` → `2.0.0`) — breaking CLI, config, or API-protocol changes
+3. Run `uv lock` from the repo root so `uv.lock` records the new workspace version.
+4. Do not bump again for later commits on the same branch. If the base already moved past your number, bump from the current base version instead.
+
+Do **not** bump for tests-only, docs-only, or `AGENTS.md` edits. Do **not** tag `watcher-v*` from a feature branch. Do **not** change the seeded `watcher_release_config` latest version — that is the advertised fleet pin for local seed data, not this package version.
+
+The CLI catalog step in the root `AGENTS.md` still applies when you change Click help or options.

--- a/watcher/pyproject.toml
+++ b/watcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-hub-watcher"
-version = "1.0.0"
+version = "1.0.1"
 description = "File-watcher agent for lab instrument PCs that ingests data into Data Hub."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/watcher/src/data_hub_watcher/uploader.py
+++ b/watcher/src/data_hub_watcher/uploader.py
@@ -50,7 +50,11 @@ class _QueueAttempt:
 
 
 def _guess_content_type(path: Path) -> str | None:
-    content_type, _ = mimetypes.guess_type(str(path))
+    # `mimetypes.guess_type` is case-sensitive on some platforms. Azure
+    # Cielo writes reports as `.PDF`; without the lowercase, the PUT
+    # stores `binary/octet-stream` and browsers download the file.
+    lowered = path.with_suffix(path.suffix.lower())
+    content_type, _ = mimetypes.guess_type(str(lowered))
     return content_type
 
 

--- a/watcher/tests/test_uploader.py
+++ b/watcher/tests/test_uploader.py
@@ -21,7 +21,7 @@ from data_hub_watcher.models import (
     UploadQueueResponse,
 )
 from data_hub_watcher.state import StateDB
-from data_hub_watcher.uploader import Uploader, UploadQueueWorker
+from data_hub_watcher.uploader import Uploader, UploadQueueWorker, _guess_content_type
 
 
 @pytest.fixture()
@@ -959,3 +959,7 @@ class TestUploadQueueWorker:
         finally:
             # Let the blocked poll finish so the daemon thread exits cleanly.
             release.set()
+
+
+def test_guess_content_type_handles_uppercase_pdf() -> None:
+    assert _guess_content_type(Path("Experiment_Report.PDF")) == "application/pdf"

--- a/web/app/api/v1/files/[fileId]/download/route.ts
+++ b/web/app/api/v1/files/[fileId]/download/route.ts
@@ -1,10 +1,8 @@
-import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 import { authorize } from "@/lib/api/auth";
 import { apiError, NOT_FOUND, VALIDATION_ERROR } from "@/lib/api/errors";
-import { db } from "@/lib/db";
-import { files, instrumentRuns } from "@/lib/db/schema";
-import { getPresignedDownloadUrl } from "@/lib/s3";
+import { lookupFileForDownload } from "@/lib/api/files";
+import { embedDownloadOptions, getPresignedDownloadUrl } from "@/lib/s3";
 
 interface RouteContext {
   params: Promise<{ fileId: string }>;
@@ -16,6 +14,10 @@ interface RouteContext {
 // Generates a short-lived pre-signed S3 URL and issues a 302 redirect.
 // This avoids exposing raw S3 URLs in the web UI's HTML while still
 // allowing direct browser downloads.
+//
+// `?disposition=inline` signs the URL so S3 returns the file as a renderable
+// document. Needed for PDF iframes: watcher uploads of `.PDF` often store
+// `binary/octet-stream`, which browsers download instead of displaying.
 // ---------------------------------------------------------------------------
 
 export async function GET(request: NextRequest, { params }: RouteContext) {
@@ -30,40 +32,21 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
     return apiError(400, VALIDATION_ERROR, "Invalid file ID");
   }
 
-  const [file] = await db
-    .select({
-      s3Bucket: files.s3Bucket,
-      s3Key: files.s3Key,
-      deletedAt: files.deletedAt,
-      instrumentRunId: files.instrumentRunId,
-    })
-    .from(files)
-    .where(eq(files.id, numericId))
-    .limit(1);
-
-  if (!file) {
+  const file = await lookupFileForDownload(numericId);
+  if (!file.ok) {
+    if (file.reason === "not_uploaded") {
+      return apiError(404, NOT_FOUND, "File has not been uploaded to S3 yet");
+    }
     return apiError(404, NOT_FOUND, `File '${fileId}' not found`);
   }
 
-  if (file.deletedAt) {
-    return apiError(404, NOT_FOUND, `File '${fileId}' not found`);
-  }
-
-  const [parentRun] = await db
-    .select({ deletedAt: instrumentRuns.deletedAt })
-    .from(instrumentRuns)
-    .where(eq(instrumentRuns.id, file.instrumentRunId))
-    .limit(1);
-
-  if (parentRun?.deletedAt) {
-    return apiError(404, NOT_FOUND, `File '${fileId}' not found`);
-  }
-
-  if (!(file.s3Bucket && file.s3Key)) {
-    return apiError(404, NOT_FOUND, "File has not been uploaded to S3 yet");
-  }
-
-  const url = await getPresignedDownloadUrl(file.s3Bucket, file.s3Key);
+  const inline =
+    new URL(request.url).searchParams.get("disposition") === "inline";
+  const url = await getPresignedDownloadUrl(
+    file.s3Bucket,
+    file.s3Key,
+    inline ? embedDownloadOptions(file.filename, file.contentType) : {}
+  );
 
   return new Response(null, {
     status: 302,

--- a/web/lib/api/files.ts
+++ b/web/lib/api/files.ts
@@ -18,6 +18,7 @@ export async function getActiveFileById(
 
 export async function getActiveFilesByIds(ids: number[]): Promise<
   Array<{
+    contentType: string | null;
     filename: string;
     id: number;
     s3Bucket: string | null;
@@ -30,6 +31,7 @@ export async function getActiveFilesByIds(ids: number[]): Promise<
   return await db
     .select({
       id: files.id,
+      contentType: files.contentType,
       filename: files.filename,
       s3Bucket: files.s3Bucket,
       s3Key: files.s3Key,
@@ -61,7 +63,13 @@ export async function findActiveFileBySuffix(
 }
 
 export type FileDownloadLookup =
-  | { ok: true; filename: string; s3Bucket: string; s3Key: string }
+  | {
+      contentType: string | null;
+      filename: string;
+      ok: true;
+      s3Bucket: string;
+      s3Key: string;
+    }
   | { ok: false; reason: "not_found" | "not_uploaded" };
 
 // Resolves a file ID into the S3 coordinates needed to produce a pre-signed
@@ -72,6 +80,7 @@ export async function lookupFileForDownload(
 ): Promise<FileDownloadLookup> {
   const [file] = await db
     .select({
+      contentType: files.contentType,
       filename: files.filename,
       s3Bucket: files.s3Bucket,
       s3Key: files.s3Key,
@@ -102,6 +111,7 @@ export async function lookupFileForDownload(
 
   return {
     ok: true,
+    contentType: file.contentType,
     filename: file.filename,
     s3Bucket: file.s3Bucket,
     s3Key: file.s3Key,

--- a/web/lib/api/openapi/paths/files.ts
+++ b/web/lib/api/openapi/paths/files.ts
@@ -73,10 +73,16 @@ registry.registerPath({
   path: "/files/{fileId}/download",
   operationId: "downloadFile",
   summary: "Redirect to file download",
-  description: "Requires scope `files:read`.",
+  description:
+    "Requires scope `files:read`. Pass `disposition=inline` to override a stored `binary/octet-stream` type so browsers can render PDFs in an iframe.",
   tags: ["Files"],
   security: bearerSecurity,
-  request: { params: fileParams },
+  request: {
+    params: fileParams,
+    query: z.object({
+      disposition: z.enum(["inline"]).optional(),
+    }),
+  },
   responses: {
     302: { description: "Redirect to a presigned download URL." },
     ...errorResponses(),

--- a/web/lib/mcp/tools/files.ts
+++ b/web/lib/mcp/tools/files.ts
@@ -17,6 +17,7 @@ import {
   getPresignedDownloadUrl,
   PRESIGNED_DOWNLOAD_URL_EXPIRY_SECONDS,
 } from "@/lib/s3";
+import { contentTypeForDownload } from "@/lib/s3-local-mirror";
 import {
   dismissFileTool,
   getFileDownloadUrlTool,
@@ -58,7 +59,13 @@ export function registerFileTools(server: McpServer) {
       const downloadUrl = await getPresignedDownloadUrl(
         lookup.s3Bucket,
         lookup.s3Key,
-        PRESIGNED_DOWNLOAD_URL_EXPIRY_SECONDS
+        {
+          contentType: contentTypeForDownload(
+            lookup.contentType,
+            lookup.filename
+          ),
+          expiresIn: PRESIGNED_DOWNLOAD_URL_EXPIRY_SECONDS,
+        }
       );
 
       return structuredResult({

--- a/web/lib/mcp/tools/report-views.ts
+++ b/web/lib/mcp/tools/report-views.ts
@@ -14,7 +14,7 @@ import {
   structuredResult,
 } from "@/lib/mcp/tools/helpers";
 import { REPORT_ITEMS_WINDOW } from "@/lib/runs/report-items";
-import { getPresignedDownloadUrl } from "@/lib/s3";
+import { embedDownloadOptions, getPresignedDownloadUrl } from "@/lib/s3";
 import {
   reportViewFileUrlTool,
   reportViewItemsTool,
@@ -67,9 +67,11 @@ export function registerReportViewTools(server: McpServer) {
           if (!(file?.s3Bucket && file.s3Key)) {
             return { ...item, downloadUrl: "" };
           }
-          // Omit filename so the URL is not forced to Content-Disposition:
-          // attachment — nested PDF iframes need inline rendering.
-          const url = await getPresignedDownloadUrl(file.s3Bucket, file.s3Key);
+          const url = await getPresignedDownloadUrl(
+            file.s3Bucket,
+            file.s3Key,
+            embedDownloadOptions(file.filename, file.contentType)
+          );
           return { ...item, downloadUrl: toAbsoluteDownloadUrl(url) };
         })
       );
@@ -118,7 +120,11 @@ export function registerReportViewTools(server: McpServer) {
         );
       }
 
-      const url = await getPresignedDownloadUrl(file.s3Bucket, file.s3Key);
+      const url = await getPresignedDownloadUrl(
+        file.s3Bucket,
+        file.s3Key,
+        embedDownloadOptions(file.filename, file.contentType)
+      );
       return structuredResult({
         id: file.id,
         filename: file.filename,

--- a/web/lib/runs/rest-report-data-source.ts
+++ b/web/lib/runs/rest-report-data-source.ts
@@ -6,7 +6,7 @@ import type {
 } from "@/lib/runs/view-data-source";
 
 function restFileUrl(fileId: number): string {
-  return `/api/v1/files/${fileId}/download`;
+  return `/api/v1/files/${fileId}/download?disposition=inline`;
 }
 
 // Browser-side source for the Next.js run page. `resolveFileBySuffix` is left

--- a/web/lib/s3-local-mirror.ts
+++ b/web/lib/s3-local-mirror.ts
@@ -68,6 +68,26 @@ export function mimeFor(filePath: string): string {
   return MIME_MAP[ext] ?? "application/octet-stream";
 }
 
+const GENERIC_BINARY_TYPES = new Set([
+  "application/octet-stream",
+  "binary/octet-stream",
+]);
+
+// Watcher PUTs of uppercase extensions (`.PDF`) often land in S3 as
+// `binary/octet-stream` even when `files.content_type` is correct. Prefer
+// the stored type unless it is a generic binary type, then fall back to
+// the extension so an iframe can render the file.
+export function contentTypeForDownload(
+  stored: string | null | undefined,
+  filename: string
+): string | undefined {
+  if (stored && !GENERIC_BINARY_TYPES.has(stored.toLowerCase())) {
+    return stored;
+  }
+  const inferred = mimeFor(filename);
+  return inferred === "application/octet-stream" ? undefined : inferred;
+}
+
 export type ByteRange =
   | { kind: "full" }
   | { kind: "partial"; start: number; end: number }
@@ -120,15 +140,29 @@ export function parseByteRange(
 }
 
 // Sanitize a filename for use inside a `Content-Disposition` header.
-// Mirrors the same logic in `web/lib/s3.ts` so the local route's
-// response headers match what the AWS path would have produced via
-// `ResponseContentDisposition` on a presigned URL.
+// Shared with the AWS presign path so local and S3 responses match.
 function sanitizeContentDispositionFilename(name: string): string {
   const cleaned = name
     .replaceAll(/[\r\n"\\]/g, "")
     .replaceAll(/[\x00-\x1f\x7f]/g, "")
     .trim();
   return cleaned.slice(0, 200) || "download";
+}
+
+// `filename` without `disposition` stays `attachment` so archive downloads
+// keep their previous signed header. Report embeds pass `inline`.
+export function contentDispositionHeader(
+  disposition?: "attachment" | "inline",
+  filename?: string
+): string | undefined {
+  if (!(disposition || filename)) {
+    return;
+  }
+  const kind = disposition ?? "attachment";
+  if (!filename) {
+    return kind;
+  }
+  return `${kind}; filename="${sanitizeContentDispositionFilename(filename)}"`;
 }
 
 // Build the same-origin URL that points at the local-mirror route.
@@ -150,14 +184,17 @@ function sanitizeContentDispositionFilename(name: string): string {
 export function localMirrorDownloadUrl(
   bucket: string,
   key: string,
-  filename?: string
+  options: {
+    disposition?: "attachment" | "inline";
+    filename?: string;
+  } = {}
 ): string {
   const segments = key.split("/").map(encodeURIComponent).join("/");
-  const search = filename
-    ? `?disposition=${encodeURIComponent(
-        `attachment; filename="${sanitizeContentDispositionFilename(filename)}"`
-      )}`
-    : "";
+  const header = contentDispositionHeader(
+    options.disposition,
+    options.filename
+  );
+  const search = header ? `?disposition=${encodeURIComponent(header)}` : "";
   return `/api/local-s3/${encodeURIComponent(bucket)}/${segments}${search}`;
 }
 

--- a/web/lib/s3.ts
+++ b/web/lib/s3.ts
@@ -11,6 +11,8 @@ import {
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { awsCredentialsProvider } from "@vercel/oidc-aws-credentials-provider";
 import {
+  contentDispositionHeader,
+  contentTypeForDownload,
   getLocalMirrorRoot,
   localMirrorDownloadUrl,
   localMirrorHead,
@@ -131,6 +133,12 @@ export async function headS3Object(
 }
 
 export interface PresignedDownloadOptions {
+  // Override the object's stored Content-Type. Watcher uploads of
+  // uppercase extensions (`.PDF`) often land as `binary/octet-stream`.
+  contentType?: string;
+  // `inline` so browsers render PDFs in an iframe instead of downloading.
+  // `filename` without this stays `attachment` (archive downloads).
+  disposition?: "attachment" | "inline";
   expiresIn?: number;
   // Override the filename the browser saves the response under. Browsers
   // ignore the `<a download="…">` attribute on cross-origin URLs unless the
@@ -141,15 +149,15 @@ export interface PresignedDownloadOptions {
   filename?: string;
 }
 
-// Sanitize a filename for use inside a `Content-Disposition` header. Strips
-// CR/LF (header injection) and quotes (which would terminate the filename
-// param early), then trims to a length S3 will accept.
-function sanitizeContentDispositionFilename(name: string): string {
-  const cleaned = name
-    .replaceAll(/[\r\n"\\]/g, "")
-    .replaceAll(/[\x00-\x1f\x7f]/g, "")
-    .trim();
-  return cleaned.slice(0, 200) || "download";
+export function embedDownloadOptions(
+  filename: string,
+  storedContentType: string | null | undefined
+): Pick<PresignedDownloadOptions, "contentType" | "disposition" | "filename"> {
+  return {
+    contentType: contentTypeForDownload(storedContentType, filename),
+    disposition: "inline",
+    filename,
+  };
 }
 
 export async function getPresignedDownloadUrl(
@@ -161,6 +169,7 @@ export async function getPresignedDownloadUrl(
   const opts: PresignedDownloadOptions =
     typeof options === "number" ? { expiresIn: options } : options;
   const expiresIn = opts.expiresIn ?? PRESIGNED_DOWNLOAD_URL_EXPIRY_SECONDS;
+  const disposition = contentDispositionHeader(opts.disposition, opts.filename);
 
   // Local-mirror branch: return a same-origin URL that points at
   // `/api/local-s3/...`. The 302 in `/api/v1/files/[fileId]/download`
@@ -168,15 +177,17 @@ export async function getPresignedDownloadUrl(
   // `download_url` field both resolve relative URLs against the
   // current origin, so no consumer needs to know we swapped backends.
   if (getLocalMirrorRoot()) {
-    return localMirrorDownloadUrl(bucket, key, opts.filename);
+    return localMirrorDownloadUrl(bucket, key, {
+      disposition: opts.disposition,
+      filename: opts.filename,
+    });
   }
 
   const command = new GetObjectCommand({
     Bucket: bucket,
     Key: key,
-    ...(opts.filename && {
-      ResponseContentDisposition: `attachment; filename="${sanitizeContentDispositionFilename(opts.filename)}"`,
-    }),
+    ...(disposition && { ResponseContentDisposition: disposition }),
+    ...(opts.contentType && { ResponseContentType: opts.contentType }),
   });
   return await getSignedUrl(s3, command, { expiresIn });
 }

--- a/web/tests/mcp/mcp-protocol.test.ts
+++ b/web/tests/mcp/mcp-protocol.test.ts
@@ -473,6 +473,7 @@ vi.mock("@/lib/api/files", () => ({
     if (id === 42) {
       return {
         ok: true,
+        contentType: MOCK_FILE.contentType,
         filename: MOCK_FILE.filename,
         s3Bucket: MOCK_FILE.s3Bucket,
         s3Key: MOCK_FILE.s3Key,

--- a/web/tests/unit/mcp-report-views.test.ts
+++ b/web/tests/unit/mcp-report-views.test.ts
@@ -36,11 +36,15 @@ vi.mock("@/lib/api/files", () => ({
   findActiveFileBySuffix: vi.fn(),
 }));
 
-vi.mock("@/lib/s3", () => ({
-  getPresignedDownloadUrl: vi
-    .fn()
-    .mockResolvedValue("https://s3.example.com/signed"),
-}));
+vi.mock("@/lib/s3", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/s3")>();
+  return {
+    ...actual,
+    getPresignedDownloadUrl: vi
+      .fn()
+      .mockResolvedValue("https://s3.example.com/signed"),
+  };
+});
 
 import {
   findActiveFileBySuffix,
@@ -107,7 +111,13 @@ describe("report_view tools (authenticated)", () => {
       pagination: { limit: 50, offset: 0, total: 1 },
     });
     vi.mocked(getActiveFilesByIds).mockResolvedValue([
-      { id: 42, s3Bucket: "raw", s3Key: "gel.png" } as never,
+      {
+        id: 42,
+        contentType: "image/png",
+        filename: "gel.png",
+        s3Bucket: "raw",
+        s3Key: "gel.png",
+      },
     ]);
 
     const result = await client.callTool({
@@ -123,6 +133,11 @@ describe("report_view tools (authenticated)", () => {
         downloadUrl: "https://s3.example.com/signed",
       },
     ]);
+    expect(getPresignedDownloadUrl).toHaveBeenCalledWith("raw", "gel.png", {
+      contentType: "image/png",
+      disposition: "inline",
+      filename: "gel.png",
+    });
   });
 
   it("report_view_file_url signs a file looked up by id", async () => {
@@ -147,7 +162,12 @@ describe("report_view tools (authenticated)", () => {
     });
     expect(getPresignedDownloadUrl).toHaveBeenCalledWith(
       "processed",
-      "wells.csv"
+      "wells.csv",
+      {
+        contentType: "text/csv",
+        disposition: "inline",
+        filename: "wells.csv",
+      }
     );
   });
 

--- a/web/tests/unit/rest-report-data-source.test.ts
+++ b/web/tests/unit/rest-report-data-source.test.ts
@@ -32,8 +32,12 @@ describe("createRestReportDataSource", () => {
       "/api/v1/instruments/inst-1/runs/run-1/report-items?kind=image&offset=0&limit=50&search=gel",
       { signal: undefined }
     );
-    expect(source.resolveFileUrl(42)).toBe("/api/v1/files/42/download");
-    expect(source.peekFileUrl?.(42)).toBe("/api/v1/files/42/download");
+    expect(source.resolveFileUrl(42)).toBe(
+      "/api/v1/files/42/download?disposition=inline"
+    );
+    expect(source.peekFileUrl?.(42)).toBe(
+      "/api/v1/files/42/download?disposition=inline"
+    );
   });
 
   // Without this the seeker's debounced search leaves one full request per
@@ -81,7 +85,9 @@ describe("createRestReportDataSource", () => {
 
     // Bytes come straight from S3 via the 302, and only once per file.
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith("/api/v1/files/9/download");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/files/9/download?disposition=inline"
+    );
     expect(first).toEqual({
       columns: ["col_a", "col_b"],
       rows: [

--- a/web/tests/unit/s3-local-mirror.test.ts
+++ b/web/tests/unit/s3-local-mirror.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { mimeFor, parseByteRange } from "@/lib/s3-local-mirror";
+import {
+  contentDispositionHeader,
+  contentTypeForDownload,
+  localMirrorDownloadUrl,
+  mimeFor,
+  parseByteRange,
+} from "@/lib/s3-local-mirror";
 
 describe("parseByteRange", () => {
   it("serves the full file when Range is missing or malformed", () => {
@@ -39,5 +45,67 @@ describe("parseByteRange", () => {
 describe("mimeFor", () => {
   it("maps mp4 to video/mp4 so the local player can seek", () => {
     expect(mimeFor("/tmp/stack.mp4")).toBe("video/mp4");
+  });
+
+  it("treats uppercase PDF extensions as application/pdf", () => {
+    expect(mimeFor("Experiment_Report.PDF")).toBe("application/pdf");
+  });
+});
+
+describe("contentTypeForDownload", () => {
+  it("keeps a specific stored type", () => {
+    expect(contentTypeForDownload("application/pdf", "report.PDF")).toBe(
+      "application/pdf"
+    );
+  });
+
+  it("replaces a generic binary type using the filename", () => {
+    expect(contentTypeForDownload("binary/octet-stream", "report.PDF")).toBe(
+      "application/pdf"
+    );
+    expect(contentTypeForDownload("application/octet-stream", "data.csv")).toBe(
+      "text/csv"
+    );
+  });
+
+  it("infers from the filename when nothing is stored", () => {
+    expect(contentTypeForDownload(null, "report.PDF")).toBe("application/pdf");
+  });
+
+  it("returns undefined for unknown extensions", () => {
+    expect(contentTypeForDownload(null, "notes.xyz")).toBeUndefined();
+  });
+});
+
+describe("contentDispositionHeader", () => {
+  it("keeps a bare filename as attachment", () => {
+    expect(contentDispositionHeader(undefined, "run.zip")).toBe(
+      'attachment; filename="run.zip"'
+    );
+  });
+
+  it("signs report embeds as inline", () => {
+    expect(contentDispositionHeader("inline", "report.PDF")).toBe(
+      'inline; filename="report.PDF"'
+    );
+  });
+});
+
+describe("localMirrorDownloadUrl", () => {
+  it("omits disposition when neither option is set", () => {
+    expect(localMirrorDownloadUrl("raw", "run/file.pdf")).toBe(
+      "/api/local-s3/raw/run/file.pdf"
+    );
+  });
+
+  it("passes an inline header for report embeds", () => {
+    expect(
+      localMirrorDownloadUrl("raw", "run/file.pdf", {
+        disposition: "inline",
+        filename: "file.pdf",
+      })
+    ).toBe(
+      "/api/local-s3/raw/run/file.pdf?disposition=inline%3B%20filename%3D%22file.pdf%22"
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Report embeds now request file downloads with `disposition=inline`, which overrides a stored `binary/octet-stream` type so the browser renders the PDF instead of downloading it.
- Watcher and shared S3 uploads guess MIME types from a lowercased extension (Azure Cielo writes `.PDF`) and mark PDFs as inline on direct uploads.

## Test plan
- [ ] Open a qPCR run whose report is `*_Report.PDF` (e.g. Azure Cielo) and confirm the Report Data iframe shows the PDF instead of triggering a download.
- [ ] Confirm "Open in new tab" on that report also displays the PDF.
- [ ] Confirm the Files table download icon still saves the PDF.
- [ ] Open a TapeStation or FPLC run with a PDF and confirm those report embeds still render.


Made with [Cursor](https://cursor.com)