### PR TITLE
Skip extra qPCR files instead of failing them on reprocess

### DIFF
--- a/developer-docs/lambda.md
+++ b/developer-docs/lambda.md
@@ -47,7 +47,7 @@ Dispatch is by `instrument_type` (Postgres/TS enum), not instrument ID. The regi
 | `tape_station` | `agilent_4150_tapestation` | `.pdf` |
 | `fplc` | `akta_fplc` | `.pdf` |
 | `gel_doc` | `azure_600_gel_doc` | `.tif` / `.tiff` |
-| `qpcr` | `azure_cielo_qpcr` | ends with `_cq values.csv` |
+| `qpcr` | `azure_cielo_qpcr` | `.csv` / `.pdf` |
 | `epson_v700_scanner` | `epson_v700_scanner` | `.tif` / `.tiff` |
 | `hina_microscope` | `hina_microscope` | `.nd2` |
 | `plate_reader` | `spectramax_plate_reader` | `.xls` |

--- a/lambda/src/data_hub_lambda/azure_cielo_qpcr/parse_dye_channels.py
+++ b/lambda/src/data_hub_lambda/azure_cielo_qpcr/parse_dye_channels.py
@@ -5,6 +5,10 @@ from pathlib import Path
 _FLUORESCENCE_COLUMN = "Fluorescence"
 
 
+def is_cq_values_filename(filename: str) -> bool:
+    return filename.lower().endswith("_cq values.csv")
+
+
 def parse_dye_channels(file_path: Path) -> list[str]:
     """Extract the unique dye channel names from a Cq Values CSV file.
 

--- a/lambda/src/data_hub_lambda/azure_cielo_qpcr/process_file.py
+++ b/lambda/src/data_hub_lambda/azure_cielo_qpcr/process_file.py
@@ -9,7 +9,10 @@ from data_hub_lambda.azure_cielo_qpcr.melting_curve import (
     write_plate_json,
     write_tidy_csv,
 )
-from data_hub_lambda.azure_cielo_qpcr.parse_dye_channels import parse_dye_channels
+from data_hub_lambda.azure_cielo_qpcr.parse_dye_channels import (
+    is_cq_values_filename,
+    parse_dye_channels,
+)
 from data_hub_shared import s3_utils
 from data_hub_shared.config import config
 
@@ -19,19 +22,8 @@ logger = logging.getLogger(__name__)
 def process_file(instrument_id: str, run_id: str, filename: str) -> None:
     """Process a single Azure Cielo qPCR file through the Data Hub API.
 
-    For Cq Values CSV files, the unique dye channel names are extracted from
-    the `Fluorescence` column and stored as run-level metadata.
-
-    For MeltingCurve CSV files, per-well melt traces become a tidy derivatives
-    CSV and a thinned plate-view JSON, both uploaded as processed artifacts.
-    Run metadata is left untouched so a later melt file cannot wipe dye
-    channels from the Cq Values pass (`update_run` replaces the whole object).
-
-    Args:
-        instrument_id: The instrument ID from the S3 key / event.
-        run_id: The run ID (`Experiment_YYYYMMDD` prefix).
-        filename: The original filename (e.g. `Experiment_20260101_Cq Values.csv`
-            or `Experiment_20260101_MeltingCurve.csv`).
+    Melting curves and Cq Values are parsed; other CSVs and PDFs complete as a no-op.
+    Melt-curve passes skip `update_run` so they cannot wipe dye channels.
     """
     logger.info("Processing Azure Cielo qPCR file: %s (run: %s)", filename, run_id)
 
@@ -53,12 +45,8 @@ def process_file(instrument_id: str, run_id: str, filename: str) -> None:
     try:
         client.update_file(file_id, status="processing")
 
-        raw_data_dir = config.LOCAL_RAW_DATA_DIRPATH / instrument_id / run_id
-        local_file_path = raw_data_dir / filename
-        s3_utils.download_file(f"s3://{s3_bucket}/{s3_key}", local_file_path)
-        logger.info("Downloaded %s to %s", filename, local_file_path)
-
         if is_melting_curve_filename(filename):
+            local_file_path = _download_raw(s3_bucket, s3_key, instrument_id, run_id, filename)
             parsed = parse_melting_curve_file(local_file_path)
             logger.info(
                 "Parsed melting curve: %d channels, %d tidy rows.",
@@ -90,10 +78,21 @@ def process_file(instrument_id: str, run_id: str, filename: str) -> None:
                 filename=json_filename,
                 content_type="application/json",
             )
-        elif filename.endswith(".csv"):
-            dye_channels = parse_dye_channels(local_file_path)
-            client.update_run(instrument_id, run_id, metadata={"dye_channels": dye_channels})
-            logger.info("Parsed dye channels: %s", dye_channels)
+        elif filename.lower().endswith(".pdf"):
+            logger.info("qPCR report %s has no preprocessing.", filename)
+        elif filename.lower().endswith(".csv"):
+            local_file_path = _download_raw(s3_bucket, s3_key, instrument_id, run_id, filename)
+            try:
+                dye_channels = parse_dye_channels(local_file_path)
+            except Exception as exc:
+                if is_cq_values_filename(filename):
+                    raise
+                logger.info("Skipping qPCR CSV %s: %s", filename, exc)
+            else:
+                client.update_run(instrument_id, run_id, metadata={"dye_channels": dye_channels})
+                logger.info("Parsed dye channels: %s", dye_channels)
+        else:
+            logger.info("Skipping qPCR file %s; not a PDF or melting curve.", filename)
 
         client.update_file(file_id, status="completed")
         logger.info("File %s marked as completed.", filename)
@@ -102,6 +101,20 @@ def process_file(instrument_id: str, run_id: str, filename: str) -> None:
         logger.error("Error processing file: %s", e)
         client.update_file(file_id, status="failed", error_message=str(e))
         raise
+
+
+def _download_raw(
+    s3_bucket: str | None,
+    s3_key: str,
+    instrument_id: str,
+    run_id: str,
+    filename: str,
+) -> Path:
+    raw_data_dir = config.LOCAL_RAW_DATA_DIRPATH / instrument_id / run_id
+    local_file_path = raw_data_dir / filename
+    s3_utils.download_file(f"s3://{s3_bucket}/{s3_key}", local_file_path)
+    logger.info("Downloaded %s to %s", filename, local_file_path)
+    return local_file_path
 
 
 def _upload_processed(

--- a/lambda/src/data_hub_lambda/processors.py
+++ b/lambda/src/data_hub_lambda/processors.py
@@ -47,7 +47,8 @@ def _ends_with_any(*suffixes: str) -> Callable[[str], bool]:
 PROCESSORS: dict[str, ProcessorEntry] = {
     "qpcr": ProcessorEntry(
         process_file=azure_cielo_qpcr.process_file,
-        matches_filename=_ends_with_any("_cq values.csv", "_meltingcurve.csv"),
+        # Sidecars must reach `process_file` so reprocess can no-op them.
+        matches_filename=_ends_with_any(".csv", ".pdf"),
     ),
     "plate_reader": ProcessorEntry(
         process_file=spectramax_plate_reader.process_file,

--- a/lambda/tests/azure_cielo_qpcr/test_parse_dye_channels.py
+++ b/lambda/tests/azure_cielo_qpcr/test_parse_dye_channels.py
@@ -3,7 +3,10 @@ from pathlib import Path
 
 import pytest
 
-from data_hub_lambda.azure_cielo_qpcr.parse_dye_channels import parse_dye_channels
+from data_hub_lambda.azure_cielo_qpcr.parse_dye_channels import (
+    is_cq_values_filename,
+    parse_dye_channels,
+)
 
 _FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures"
 
@@ -71,6 +74,13 @@ class TestParseDyeChannels:
 # ---------------------------------------------------------------------------
 # Validation / error tests
 # ---------------------------------------------------------------------------
+
+
+def test_cq_values_filename_gate() -> None:
+    assert is_cq_values_filename("Experiment_20260101_Cq Values.csv")
+    assert is_cq_values_filename("run_cq values.CSV")
+    assert not is_cq_values_filename("Experiment_20260101_Amplification Values.csv")
+    assert not is_cq_values_filename("azure_cielo_qpcr_example.csv")
 
 
 class TestParseDyeChannelsValidation:

--- a/lambda/tests/azure_cielo_qpcr/test_process_file.py
+++ b/lambda/tests/azure_cielo_qpcr/test_process_file.py
@@ -1,0 +1,211 @@
+"""Unit tests for Azure Cielo qPCR `process_file` skip vs parse behavior."""
+
+from __future__ import annotations
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from data_hub_lambda.azure_cielo_qpcr.process_file import process_file
+from data_hub_lambda.models import FileResponse
+
+_FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+@pytest.fixture(autouse=True)
+def _reset_api_client() -> Any:
+    import data_hub_lambda.api_client as api_module
+
+    original = api_module._client
+    api_module._client = None
+    try:
+        yield
+    finally:
+        api_module._client = original
+
+
+def _file_response(file_id: int = 10, filename: str = "file.csv") -> FileResponse:
+    return FileResponse(
+        id=file_id,
+        instrument_run_id="run-uuid",
+        filename=filename,
+        s3_bucket="raw",
+        s3_key=f"azure-cielo-qpcr/Experiment_20260101/{filename}",
+        category="raw",
+        status="uploaded",
+    )
+
+
+def _client() -> MagicMock:
+    client = MagicMock()
+    client.create_file.return_value = _file_response()
+    return client
+
+
+def _write_download(contents: str):
+    def _download(s3_uri: str, local_path: Path, **_: Any) -> None:
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        local_path.write_text(contents)
+
+    return _download
+
+
+def _copy_fixture(src: Path):
+    def _download(s3_uri: str, local_path: Path, **_: Any) -> None:
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        local_path.write_bytes(src.read_bytes())
+
+    return _download
+
+
+def _completed_statuses(client: MagicMock) -> list[str]:
+    return [
+        call.kwargs["status"]
+        for call in client.update_file.call_args_list
+        if "status" in call.kwargs
+    ]
+
+
+class TestProcessFileSidecars:
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "Experiment_20260101_Amplification Values.csv",
+            "Experiment_20260101_Dye calibration.csv",
+            "Experiment_20260101_Post Processed Amp Values.csv",
+            "Experiment_20260101_JBEM_rep1_Amplification Values.csv",
+        ],
+    )
+    def test_sidecar_csv_completes_without_failing(self, filename: str) -> None:
+        client = _client()
+        with (
+            patch(
+                "data_hub_lambda.azure_cielo_qpcr.process_file.get_client",
+                return_value=client,
+            ),
+            patch(
+                "data_hub_lambda.azure_cielo_qpcr.process_file.s3_utils.download_file",
+                side_effect=_write_download("Well,Sample,Target\nA1,S1,Ch1\n"),
+            ),
+        ):
+            process_file("azure-cielo-qpcr", "Experiment_20260101", filename)
+
+        assert "failed" not in _completed_statuses(client)
+        assert _completed_statuses(client)[-1] == "completed"
+        client.update_run.assert_not_called()
+
+    def test_unreadable_sidecar_csv_completes(self) -> None:
+        client = _client()
+
+        def _write_binary(s3_uri: str, local_path: Path, **_: Any) -> None:
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            local_path.write_bytes(b"\xff\xfe not utf-8")
+
+        with (
+            patch(
+                "data_hub_lambda.azure_cielo_qpcr.process_file.get_client",
+                return_value=client,
+            ),
+            patch(
+                "data_hub_lambda.azure_cielo_qpcr.process_file.s3_utils.download_file",
+                side_effect=_write_binary,
+            ),
+        ):
+            process_file(
+                "azure-cielo-qpcr",
+                "Experiment_20260101",
+                "Experiment_20260101_Dye calibration.csv",
+            )
+
+        assert _completed_statuses(client)[-1] == "completed"
+        client.update_run.assert_not_called()
+
+    def test_report_pdf_completes_without_download(self) -> None:
+        client = _client()
+        with (
+            patch(
+                "data_hub_lambda.azure_cielo_qpcr.process_file.get_client",
+                return_value=client,
+            ),
+            patch(
+                "data_hub_lambda.azure_cielo_qpcr.process_file.s3_utils.download_file"
+            ) as download,
+        ):
+            process_file(
+                "azure-cielo-qpcr",
+                "Experiment_20260101",
+                "Experiment_20260101_Report.PDF",
+            )
+
+        download.assert_not_called()
+        assert _completed_statuses(client)[-1] == "completed"
+        client.update_run.assert_not_called()
+
+    def test_cq_values_updates_dye_channels(self) -> None:
+        client = _client()
+        with (
+            patch(
+                "data_hub_lambda.azure_cielo_qpcr.process_file.get_client",
+                return_value=client,
+            ),
+            patch(
+                "data_hub_lambda.azure_cielo_qpcr.process_file.s3_utils.download_file",
+                side_effect=_copy_fixture(_FIXTURES_DIR / "azure_cielo_qpcr_example.csv"),
+            ),
+        ):
+            process_file(
+                "azure-cielo-qpcr",
+                "Experiment_20260101",
+                "Experiment_20260101_Cq Values.csv",
+            )
+
+        client.update_run.assert_called_once()
+        assert client.update_run.call_args.kwargs["metadata"]["dye_channels"] == [
+            "ORANGE 560",
+            "TAMRA",
+            "ROX",
+        ]
+        assert _completed_statuses(client)[-1] == "completed"
+
+    def test_seed_example_csv_still_yields_dye_channels(self) -> None:
+        client = _client()
+        with (
+            patch(
+                "data_hub_lambda.azure_cielo_qpcr.process_file.get_client",
+                return_value=client,
+            ),
+            patch(
+                "data_hub_lambda.azure_cielo_qpcr.process_file.s3_utils.download_file",
+                side_effect=_copy_fixture(_FIXTURES_DIR / "azure_cielo_qpcr_example.csv"),
+            ),
+        ):
+            process_file(
+                "azure-cielo-qpcr",
+                "Experiment_20260129",
+                "azure_cielo_qpcr_example.csv",
+            )
+
+        client.update_run.assert_called_once()
+        assert _completed_statuses(client)[-1] == "completed"
+
+    def test_broken_cq_values_still_fails(self) -> None:
+        client = _client()
+        with (
+            patch(
+                "data_hub_lambda.azure_cielo_qpcr.process_file.get_client",
+                return_value=client,
+            ),
+            patch(
+                "data_hub_lambda.azure_cielo_qpcr.process_file.s3_utils.download_file",
+                side_effect=_write_download("Well,Sample,Target\nA1,S1,Ch1\n"),
+            ),
+            pytest.raises(ValueError, match="Fluorescence"),
+        ):
+            process_file(
+                "azure-cielo-qpcr",
+                "Experiment_20260101",
+                "Experiment_20260101_Cq Values.csv",
+            )
+
+        assert client.update_file.call_args_list[-1].kwargs["status"] == "failed"

--- a/lambda/tests/test_processors.py
+++ b/lambda/tests/test_processors.py
@@ -12,6 +12,7 @@ from data_hub_lambda.handler import lambda_handler
 from data_hub_lambda.models import FileResponse, InstrumentResponse
 from data_hub_lambda.processors import (
     PROCESSORS,
+    ProcessorEntry,
     get_processor,
     matches_any_processor_gate,
 )
@@ -28,9 +29,12 @@ class TestFilenameGates:
             ("qpcr", "Experiment_20260101_cq values.CSV", True),
             ("qpcr", "Experiment_20260101_MeltingCurve.csv", True),
             ("qpcr", "Experiment_20260101_meltingcurve.CSV", True),
-            ("qpcr", "Experiment_20260101_CqValues.csv", False),
-            ("qpcr", "Experiment_20260101_Melting Curve.csv", False),
-            ("qpcr", "Experiment_20260101_Amplification Results.csv", False),
+            ("qpcr", "Experiment_20260101_Amplification Values.csv", True),
+            ("qpcr", "Experiment_20260101_Dye calibration.csv", True),
+            ("qpcr", "Experiment_20260101_Post Processed Amp Values.csv", True),
+            ("qpcr", "Experiment_20260101_JBEM_rep1_Report.PDF", True),
+            ("qpcr", "Experiment_20260101_Report.pdf", True),
+            ("qpcr", "Experiment_20260101_notes.txt", False),
             ("plate_reader", "plate.xls", True),
             ("plate_reader", "PLATE.XLS", True),
             ("plate_reader", "plate.xlsx", False),
@@ -66,6 +70,8 @@ class TestFilenameGates:
     def test_union_gate_matches_any_processor(self) -> None:
         assert matches_any_processor_gate("Experiment_Cq Values.csv")
         assert matches_any_processor_gate("Experiment_MeltingCurve.csv")
+        assert matches_any_processor_gate("Experiment_Amplification Values.csv")
+        assert matches_any_processor_gate("Experiment_Report.PDF")
         assert matches_any_processor_gate("scan.TIFF")
         assert matches_any_processor_gate("well.nd2")
         assert matches_any_processor_gate("run.json")
@@ -434,6 +440,45 @@ class TestHandlerDispatch:
             "run-1",
             "Experiment_Cq Values.csv",
         )
+        client.update_file.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "Experiment_Amplification Values.csv",
+            "Experiment_Dye calibration.csv",
+            "Experiment_Post Processed Amp Values.csv",
+            "Experiment_Report.PDF",
+            "Experiment_JBEM_rep1_Report.pdf",
+        ],
+    )
+    def test_reprocess_invokes_qpcr_processor_for_sidecars(self, filename: str) -> None:
+        client = MagicMock()
+        client.get_instrument.return_value = InstrumentResponse(
+            id="azure-cielo-qpcr",
+            display_name="Azure Cielo qPCR",
+            status="active",
+            instrument_type="qpcr",
+        )
+        process_file = MagicMock()
+        real = PROCESSORS["qpcr"]
+        entry = ProcessorEntry(
+            process_file=process_file,
+            matches_filename=real.matches_filename,
+        )
+
+        with (
+            patch("data_hub_lambda.handler.get_client", return_value=client),
+            patch("data_hub_lambda.handler._cleanup_tmp"),
+            patch("data_hub_lambda.handler.get_processor", return_value=entry),
+        ):
+            result = lambda_handler(
+                self._function_url_event("azure-cielo-qpcr", "run-1", filename),
+                MagicMock(),
+            )
+
+        assert result is None
+        process_file.assert_called_once_with("azure-cielo-qpcr", "run-1", filename)
         client.update_file.assert_not_called()
 
     def test_s3_event_applies_per_type_gate(self) -> None:

--- a/web/lib/db/seed.ts
+++ b/web/lib/db/seed.ts
@@ -830,9 +830,7 @@ export const INSTRUMENT_FIXTURES: Record<string, InstrumentFixture> = {
         filename: "azure_cielo_qpcr_MeltingCurve.csv",
         contentType: "text/csv",
       },
-      // Every production run exports one of these alongside the CSVs. No
-      // processor claims it; the run page serves the bytes straight to the
-      // PDF viewer.
+      // Vendor report PDF; the run page serves the raw bytes.
       {
         filename: "azure_cielo_qpcr_Report.pdf",
         contentType: "application/pdf",


### PR DESCRIPTION
## Summary
- Azure Cielo writes extra CSVs and a report PDF next to the melting-curve and Cq Values files we actually parse.
- Reprocessing a run sent every raw file to Lambda. Files the processor did not claim were marked failed, so the run looked failed even when melting-curve processing worked.
- Lambda now accepts every `.csv` and `.pdf` on qPCR. It still parses melting curves and Cq Values. Extra CSVs and the report PDF are marked completed without parsing, so they cannot fail the run.

## Test plan
- [ ] `uv run pytest lambda/tests/azure_cielo_qpcr/test_process_file.py lambda/tests/test_processors.py`
- [ ] After deploy, reprocess a qPCR run that has extra CSVs and a report PDF
- [ ] Amplification Values, Dye calibration, Post Processed Amp Values, and the report PDF show completed
- [ ] Melting-curve processing still writes the derivatives CSV and plate JSON
- [ ] Cq Values still writes dye-channel metadata
- [ ] A broken Cq Values file still fails


Made with [Cursor](https://cursor.com)