### PR TITLE
Let users reprocess runs whose files have stalled

### DIFF
--- a/web/components/instruments/instruments-table.tsx
+++ b/web/components/instruments/instruments-table.tsx
@@ -5,7 +5,7 @@ import { InstrumentStatusBadge } from "@/components/instruments/instrument-statu
 import { RowActionsCell } from "@/components/instruments/row-actions-cell";
 import { ClickableRow } from "@/components/instruments/runs-table/clickable-row";
 import { InstrumentNotificationsCell } from "@/components/notifications/instrument-notifications-cell";
-import { Badge } from "@/components/ui/badge";
+import { TruncatedBadges } from "@/components/runs/metadata-badges";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Table,
@@ -193,21 +193,11 @@ export function InstrumentsTable({
                   )}
                 </TableCell>
                 <TableCell>
-                  {row.filePatterns.length > 0 ? (
-                    <div className="flex flex-wrap gap-1">
-                      {row.filePatterns.map((p) => (
-                        <Badge
-                          className="font-mono font-normal text-xs"
-                          key={p}
-                          variant="outline"
-                        >
-                          {p}
-                        </Badge>
-                      ))}
-                    </div>
-                  ) : (
-                    <span className="text-muted-foreground">—</span>
-                  )}
+                  <TruncatedBadges
+                    badgeClassName="font-normal text-xs"
+                    values={row.filePatterns}
+                    variant="outline"
+                  />
                 </TableCell>
                 <TableCell className="font-mono">{row.runsThisWeek}</TableCell>
                 <TableCell>

--- a/web/components/instruments/runs-table/run-bulk-action-bar.tsx
+++ b/web/components/instruments/runs-table/run-bulk-action-bar.tsx
@@ -180,9 +180,7 @@ export function RunBulkActionBar() {
   const reprocessTargets = refs.map((r) => ({
     instrumentId: r.instrumentId,
     runId: r.runId,
-    filesCompleted: r.stats.filesCompleted,
-    filesFailed: r.stats.filesFailed,
-    filesUploaded: r.stats.filesUploaded,
+    eligibleFileCount: r.stats.reprocessableFileCount,
   }));
 
   // On desktop the expanded sidebar reserves space on the left, so anchor the

--- a/web/components/instruments/runs-table/run-row-actions.tsx
+++ b/web/components/instruments/runs-table/run-row-actions.tsx
@@ -27,7 +27,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useArchiveDownload } from "@/hooks/use-archive-download";
-import { computeRunCaps } from "@/lib/runs/row-actions";
+import { computeRunCaps, reprocessableFileCount } from "@/lib/runs/row-actions";
 import { cn } from "@/lib/utils";
 import type { RunRow } from ".";
 
@@ -197,9 +197,7 @@ export function RunRowActions({ row }: { row: RunRow }) {
           {
             instrumentId: row.instrument_id,
             runId: row.run_id,
-            filesCompleted: row.files_completed,
-            filesFailed: row.files_failed,
-            filesUploaded: row.files_uploaded,
+            eligibleFileCount: reprocessableFileCount(row),
           },
         ]}
       />

--- a/web/components/instruments/runs-table/run-selection-provider.tsx
+++ b/web/components/instruments/runs-table/run-selection-provider.tsx
@@ -16,7 +16,7 @@ export interface RunStats {
   fileCount: number;
   filesCompleted: number;
   filesFailed: number;
-  filesUploaded: number;
+  reprocessableFileCount: number;
 }
 
 export interface RunRef {

--- a/web/components/runs/metadata-badges.tsx
+++ b/web/components/runs/metadata-badges.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from "react";
 import { Badge } from "@/components/ui/badge";
 import {
   Tooltip,
@@ -5,6 +6,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+
+type BadgeVariant = ComponentProps<typeof Badge>["variant"];
 
 export function getMetadataField(
   metadata: unknown,
@@ -116,15 +119,23 @@ function BadgeRow({
   values,
   colorMap,
   className,
+  badgeClassName,
+  variant,
 }: {
   values: string[];
   colorMap?: Record<string, string>;
   className?: string;
+  badgeClassName?: string;
+  variant?: BadgeVariant;
 }) {
   return (
     <div className={cn("flex flex-wrap gap-1", className)}>
       {values.map((v) => (
-        <Badge className={cn("font-mono", colorMap?.[v])} key={v}>
+        <Badge
+          className={cn("font-mono", badgeClassName, colorMap?.[v])}
+          key={v}
+          variant={variant}
+        >
           {v}
         </Badge>
       ))}
@@ -155,17 +166,28 @@ export function TruncatedBadges({
   values,
   colorMap,
   maxVisible = 2,
+  badgeClassName,
+  variant,
 }: {
   values: string[];
   colorMap?: Record<string, string>;
   maxVisible?: number;
+  badgeClassName?: string;
+  variant?: BadgeVariant;
 }) {
   if (values.length === 0) {
     return <span className="text-muted-foreground">&mdash;</span>;
   }
 
   if (values.length <= maxVisible) {
-    return <BadgeRow colorMap={colorMap} values={values} />;
+    return (
+      <BadgeRow
+        badgeClassName={badgeClassName}
+        colorMap={colorMap}
+        values={values}
+        variant={variant}
+      />
+    );
   }
 
   const visible = values.slice(0, maxVisible);
@@ -176,7 +198,11 @@ export function TruncatedBadges({
       <TooltipTrigger asChild>
         <div className="flex flex-wrap gap-1">
           {visible.map((v) => (
-            <Badge className={cn("font-mono", colorMap?.[v])} key={v}>
+            <Badge
+              className={cn("font-mono", badgeClassName, colorMap?.[v])}
+              key={v}
+              variant={variant}
+            >
               {v}
             </Badge>
           ))}
@@ -190,7 +216,13 @@ export function TruncatedBadges({
         </div>
       </TooltipTrigger>
       <TooltipContent className="max-w-none">
-        <BadgeRow className="flex-nowrap" colorMap={colorMap} values={values} />
+        <BadgeRow
+          badgeClassName={badgeClassName}
+          className="flex-nowrap"
+          colorMap={colorMap}
+          values={values}
+          variant={variant}
+        />
       </TooltipContent>
     </Tooltip>
   );

--- a/web/components/runs/reprocess-runs-dialog.tsx
+++ b/web/components/runs/reprocess-runs-dialog.tsx
@@ -16,9 +16,9 @@ import {
 } from "@/components/ui/alert-dialog";
 
 export interface ReprocessRunTarget {
-  filesCompleted: number;
-  filesFailed: number;
-  filesUploaded: number;
+  // Pre-summed by the caller via `reprocessableFileCount` so the dialog never
+  // has to know which file states the endpoint will pick up.
+  eligibleFileCount: number;
   instrumentId: string;
   runId: string;
 }
@@ -76,10 +76,7 @@ export function ReprocessRunsDialog({
   const [isPending, startTransition] = useTransition();
 
   const runCount = runs.length;
-  const eligibleFiles = runs.reduce(
-    (sum, r) => sum + r.filesCompleted + r.filesFailed + r.filesUploaded,
-    0
-  );
+  const eligibleFiles = runs.reduce((sum, r) => sum + r.eligibleFileCount, 0);
 
   function handleConfirm(e: React.MouseEvent) {
     e.preventDefault();
@@ -116,8 +113,9 @@ export function ReprocessRunsDialog({
             This will re-run the processing pipeline on{" "}
             <strong>{eligibleFiles}</strong>{" "}
             {eligibleFiles === 1 ? "file" : "files"} currently in the{" "}
-            <em>uploaded</em>, <em>completed</em>, or <em>failed</em> state.
-            Results will overwrite any existing processed artifacts.
+            <em>uploaded</em>, <em>completed</em>, or <em>failed</em> state, or
+            stuck in <em>processing</em>. Results will overwrite any existing
+            processed artifacts.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/web/components/runs/run-comments-list.tsx
+++ b/web/components/runs/run-comments-list.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useOptimistic, useState } from "react";
 import { RunCommentForm } from "@/components/runs/run-comment-form";
 import { RunCommentItem } from "@/components/runs/run-comment-item";
+import { RunSectionHeading } from "@/components/runs/run-section-heading";
 import { Card } from "@/components/ui/card";
 import type { RunCommentDto } from "@/lib/api/run-comments";
 import { useSession } from "@/lib/auth-client";
@@ -164,40 +165,45 @@ export function RunCommentsList({
     setCommitted((prev) => prev.filter((c) => c.id !== commentId));
   }
 
-  // Empty + form-only: when there are no comments and no logged-in user,
-  // the empty-state message stands alone outside the card stack.
-  if (optimistic.length === 0 && !currentUserId) {
-    return <p className="text-muted-foreground text-sm">No comments yet.</p>;
-  }
-
+  // Count comes from `optimistic`, not the server-rendered initial
+  // length, so the "Comments (N)" heading tracks post/delete without a
+  // separate count state (per `rerender-derived-state-no-effect`).
+  const commentCount = optimistic.length;
   const rowClass = "px-4 py-4 first:pt-1 last:pb-1";
 
   return (
-    <Card className="gap-0 py-0" size="sm">
-      <div className="flex flex-col divide-y divide-border">
-        {optimistic.length === 0 ? (
-          <p className={`${rowClass} text-muted-foreground text-sm`}>
-            No comments yet.
-          </p>
-        ) : (
-          optimistic.map((comment) => (
-            <div className={rowClass} key={comment.id}>
-              <RunCommentItem
-                comment={comment}
-                currentUserId={currentUserId}
-                onDelete={deleteCommentAction}
-                onUpdate={updateCommentAction}
-              />
-            </div>
-          ))
-        )}
+    <div className="flex flex-col gap-2">
+      <RunSectionHeading countLabel={commentCount} title="Comments" />
+      {commentCount === 0 && !currentUserId ? (
+        <p className="text-muted-foreground text-sm">No comments yet.</p>
+      ) : (
+        <Card className="gap-0 py-0" size="sm">
+          <div className="flex flex-col divide-y divide-border">
+            {commentCount === 0 ? (
+              <p className={`${rowClass} text-muted-foreground text-sm`}>
+                No comments yet.
+              </p>
+            ) : (
+              optimistic.map((comment) => (
+                <div className={rowClass} key={comment.id}>
+                  <RunCommentItem
+                    comment={comment}
+                    currentUserId={currentUserId}
+                    onDelete={deleteCommentAction}
+                    onUpdate={updateCommentAction}
+                  />
+                </div>
+              ))
+            )}
 
-        {currentUserId && (
-          <div className={rowClass}>
-            <RunCommentForm onSubmit={createCommentAction} />
+            {currentUserId ? (
+              <div className={rowClass}>
+                <RunCommentForm onSubmit={createCommentAction} />
+              </div>
+            ) : null}
           </div>
-        )}
-      </div>
-    </Card>
+        </Card>
+      )}
+    </div>
   );
 }

--- a/web/components/runs/run-comments-section.tsx
+++ b/web/components/runs/run-comments-section.tsx
@@ -1,18 +1,10 @@
 import { RunCommentsList } from "@/components/runs/run-comments-list";
-import { RunSectionHeading } from "@/components/runs/run-section-heading";
 import type { RunCommentDto } from "@/lib/api/run-comments";
 
-// Server component. The page fetches `initialComments` in parallel with
-// the rest of the run-detail data (per `server-parallel-fetching`) and
-// hands them in here, so this component itself is pure presentation.
-//
-// Layout matches the other run-detail sections (Report Data, Files): the
-// heading sits outside the card stack with an inline count in the form
-// "Comments (N)".
-// Each comment and the new-comment form get their own card inside
-// `RunCommentsList` to match the conversational stacked-cards design.
-// The whole stack is capped to half the container width so prose
-// doesn't sprawl across wide screens.
+// Server component. The page fetches comments in parallel with the rest
+// of the run-detail data (per `server-parallel-fetching`) and hands them
+// in here. The heading lives inside `RunCommentsList` so the count can
+// track optimistic create/delete.
 export function RunCommentsSection({
   instrumentId,
   runId,
@@ -23,15 +15,10 @@ export function RunCommentsSection({
   comments: RunCommentDto[];
 }) {
   return (
-    <div className="flex flex-col gap-2">
-      <RunSectionHeading countLabel={comments.length} title="Comments" />
-      <div>
-        <RunCommentsList
-          initialComments={comments}
-          instrumentId={instrumentId}
-          runId={runId}
-        />
-      </div>
-    </div>
+    <RunCommentsList
+      initialComments={comments}
+      instrumentId={instrumentId}
+      runId={runId}
+    />
   );
 }

--- a/web/lib/runs/row-actions.ts
+++ b/web/lib/runs/row-actions.ts
@@ -15,7 +15,7 @@ import { isProcessableInstrumentType } from "@/lib/instruments/processable-types
 // - Download:  at least one file has made it to S3 (i.e. is not `detected`
 //              or `upload_requested`).
 // - Reprocess: instrument_type has a Lambda processor and at least one raw
-//              file is in `uploaded`, `completed`, or `failed`.
+//              file is in `uploaded`, `completed`, `failed`, or stalled.
 // - Delete:    the run isn't already soft-deleted.
 // ---------------------------------------------------------------------------
 
@@ -31,11 +31,24 @@ export function canDownloadRun(row: RunRow): boolean {
   );
 }
 
+// Mirrors the server-side file filter in `reprocessRun`, which queues raw
+// files in REPROCESSABLE_STATUSES plus any whose `processing` has passed the
+// stall window. Keeping the buckets in one place stops the row menu from
+// disagreeing with what the endpoint would actually do.
+export function reprocessableFileCount(row: RunRow): number {
+  return (
+    row.files_uploaded +
+    row.files_failed +
+    row.files_completed +
+    row.files_stalled
+  );
+}
+
 export function canReprocessRun(row: RunRow): boolean {
   return (
     row.deleted_at === null &&
     isProcessableInstrumentType(row.instrument_type) &&
-    row.files_completed + row.files_failed + row.files_uploaded > 0
+    reprocessableFileCount(row) > 0
   );
 }
 
@@ -57,7 +70,7 @@ export function computeRunStats(row: RunRow): RunStats {
     fileCount: row.file_count,
     filesCompleted: row.files_completed,
     filesFailed: row.files_failed,
-    filesUploaded: row.files_uploaded,
+    reprocessableFileCount: reprocessableFileCount(row),
   };
 }
 

--- a/web/tests/unit/run-row-actions.test.ts
+++ b/web/tests/unit/run-row-actions.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import type { RunRow } from "@/components/instruments/runs-table";
+import {
+  canDeleteRun,
+  canDownloadRun,
+  canReprocessRun,
+  canUploadRun,
+  computeRunStats,
+  reprocessableFileCount,
+} from "@/lib/runs/row-actions";
+
+// The row menu and bulk bar decide what to offer from these predicates alone,
+// so a bucket missing here silently hides an action the API would have
+// accepted — which is exactly how stalled runs lost their Reprocess entry.
+
+const BASE: RunRow = {
+  id: "11111111-1111-4111-a111-111111111111",
+  instrument_id: "test-plate-reader",
+  instrument_display_name: "Test Plate Reader",
+  instrument_type: "plate_reader",
+  run_id: "run-1",
+  source: "watcher",
+  metadata: {},
+  created_at: new Date("2025-01-01T00:00:00.000Z"),
+  acquired_at: new Date("2025-01-01T00:00:00.000Z"),
+  updated_at: new Date("2025-01-01T00:00:00.000Z"),
+  deleted_at: null,
+  file_count: 0,
+  files_completed: 0,
+  files_failed: 0,
+  files_pending_upload: 0,
+  files_uploaded: 0,
+  files_processing: 0,
+  files_stalled: 0,
+  total_size_bytes: 0,
+  error_messages: [],
+  comment_count: 0,
+  attributions: [],
+};
+
+function row(overrides: Partial<RunRow>): RunRow {
+  return { ...BASE, ...overrides };
+}
+
+describe("canReprocessRun", () => {
+  it("allows a run whose only unfinished file has stalled", () => {
+    expect(canReprocessRun(row({ file_count: 1, files_stalled: 1 }))).toBe(
+      true
+    );
+  });
+
+  it("allows uploaded, failed, and completed files on their own", () => {
+    expect(canReprocessRun(row({ file_count: 1, files_uploaded: 1 }))).toBe(
+      true
+    );
+    expect(canReprocessRun(row({ file_count: 1, files_failed: 1 }))).toBe(true);
+    expect(canReprocessRun(row({ file_count: 1, files_completed: 1 }))).toBe(
+      true
+    );
+  });
+
+  it("rejects a run whose files are all still inside the stall window", () => {
+    expect(canReprocessRun(row({ file_count: 1, files_processing: 1 }))).toBe(
+      false
+    );
+  });
+
+  it("rejects runs with nothing to reprocess, soft-deleted runs, and instrument types with no processor", () => {
+    expect(
+      canReprocessRun(row({ file_count: 1, files_pending_upload: 1 }))
+    ).toBe(false);
+    expect(
+      canReprocessRun(
+        row({
+          file_count: 1,
+          files_stalled: 1,
+          deleted_at: new Date("2025-02-01T00:00:00.000Z"),
+        })
+      )
+    ).toBe(false);
+    expect(
+      canReprocessRun(
+        row({
+          file_count: 1,
+          files_stalled: 1,
+          instrument_type: "generic",
+        })
+      )
+    ).toBe(false);
+  });
+});
+
+describe("reprocessableFileCount", () => {
+  it("sums every bucket the run reprocess endpoint would queue", () => {
+    expect(
+      reprocessableFileCount(
+        row({
+          file_count: 6,
+          files_uploaded: 1,
+          files_failed: 2,
+          files_completed: 3,
+          files_stalled: 4,
+          files_pending_upload: 5,
+          files_processing: 6,
+        })
+      )
+    ).toBe(10);
+  });
+
+  it("is what the confirmation dialog counts", () => {
+    const stalled = row({ file_count: 2, files_stalled: 2 });
+    expect(computeRunStats(stalled).reprocessableFileCount).toBe(2);
+  });
+});
+
+describe("the other row capabilities", () => {
+  it("offers upload only while files are still on the instrument PC", () => {
+    expect(canUploadRun(row({ file_count: 1, files_pending_upload: 1 }))).toBe(
+      true
+    );
+    expect(canUploadRun(row({ file_count: 1, files_completed: 1 }))).toBe(
+      false
+    );
+  });
+
+  it("offers download once at least one file has reached S3", () => {
+    expect(
+      canDownloadRun(row({ file_count: 2, files_pending_upload: 1 }))
+    ).toBe(true);
+    expect(
+      canDownloadRun(row({ file_count: 2, files_pending_upload: 2 }))
+    ).toBe(false);
+    expect(canDownloadRun(BASE)).toBe(false);
+  });
+
+  it("hides every action on a soft-deleted run", () => {
+    const deleted = row({
+      file_count: 1,
+      files_completed: 1,
+      deleted_at: new Date("2025-02-01T00:00:00.000Z"),
+    });
+    expect(canUploadRun(deleted)).toBe(false);
+    expect(canDownloadRun(deleted)).toBe(false);
+    expect(canReprocessRun(deleted)).toBe(false);
+    expect(canDeleteRun(deleted)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Runs whose files have stalled now offer **Reprocess run** in the row menu and the bulk action bar on the instrument runs table.

## Changes

A file counts as stalled once it has sat in processing past the stall window (20 minutes by default), meaning the processor went away and it needs another attempt. Reprocessing a single stalled file already worked from the run detail page; the runs table had no equivalent for the whole run.

The server was already correct — `POST /api/v1/instruments/:id/runs/:runId/reprocess` queues every raw file that is uploaded, failed, completed, or stalled. Only the browser-side check disagreed: `canReprocessRun` counted the first three and left stalled out, so a run whose only unfinished file had stalled offered no retry, even though its status icon said the file "can be reprocessed".

`reprocessableFileCount` now sums the four states the endpoint queues, and `canReprocessRun` reads it. The confirmation dialog had been re-deriving that sum from three separate count props, which is how the two sides drifted apart; it takes one pre-summed `eligibleFileCount` instead, with wording updated to match. The dashboard runs table shares the same row-actions component and picks up the fix too.

## Driveby changes

Separate commits, droppable.

- The "Comments (N)" heading came from the server's initial fetch, so posting or deleting a comment left the number stale until the next refresh. It moved into `RunCommentsList` and now counts the list the page renders.
- The instruments table printed every file pattern inline, widening rows. It now uses `TruncatedBadges`: first two visible, rest in a tooltip.

## Testing

`web/tests/unit/run-row-actions.test.ts` covers the stalled case, each eligible state on its own, and the refusals: still inside the stall window, soft-deleted, and an instrument type with no processor. `npm run test:unit` (369 tests) and `make check` both pass.

By hand: on an instrument page, open the "…" menu of a run with a file stuck past the stall window — **Reprocess run** is there.