### PR TITLE
Add generic notification dispatch endpoint

### DIFF
--- a/web/app/(app)/settings/notifications/page.tsx
+++ b/web/app/(app)/settings/notifications/page.tsx
@@ -92,10 +92,12 @@ async function NotificationsFormSection({
         runsAllMuted: prefs.runsAllMuted,
         commentsAttributedEnabled: prefs.commentsAttributedEnabled,
         commentsParticipatedEnabled: prefs.commentsParticipatedEnabled,
+        genericEnabled: prefs.genericEnabled,
         slackRunsEnabled: prefs.slackRunsEnabled,
         slackCommentsAttributedEnabled: prefs.slackCommentsAttributedEnabled,
         slackCommentsParticipatedEnabled:
           prefs.slackCommentsParticipatedEnabled,
+        slackGenericEnabled: prefs.slackGenericEnabled,
       }}
       slackChannelConfig={
         slackChannelConfig

--- a/web/app/api/v1/notifications/dispatch/route.ts
+++ b/web/app/api/v1/notifications/dispatch/route.ts
@@ -1,0 +1,110 @@
+import { inArray } from "drizzle-orm";
+import { after, type NextRequest } from "next/server";
+import { authorizeToken } from "@/lib/api/auth";
+import { apiError, CONFLICT, VALIDATION_ERROR } from "@/lib/api/errors";
+import { lookupRunByNaturalKey } from "@/lib/api/instrument-runs";
+import { notifyGeneric } from "@/lib/api/notifications";
+import { dispatchNotificationsBody, readJsonBody } from "@/lib/api/openapi";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+import { deliverSlackDms } from "@/lib/slack/dm";
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/notifications/dispatch
+//
+// Machine-facing notification creation: an integration posts a free-text
+// message addressed to specific users, optionally anchored to a run. Each
+// recipient's per-channel preferences decide delivery (in-app bell and/or
+// Slack DM); exact repeats of an unread message are skipped so retries are
+// safe.
+//
+// PAT-only: a browser session's `*` scope would let any member spam other
+// users' bells and Slack DMs — the same reasoning as run creation.
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest) {
+  const authResult = await authorizeToken(request, "notifications:create");
+  if (authResult instanceof Response) {
+    return authResult;
+  }
+
+  const body = await readJsonBody(request, dispatchNotificationsBody);
+  if (body instanceof Response) {
+    return body;
+  }
+
+  // Resolve the optional run anchor by natural key.
+  let run:
+    | {
+        internalId: string;
+        instrumentId: string;
+        instrumentDisplayName: string;
+        runDisplayId: string;
+      }
+    | undefined;
+  if (body.run) {
+    const found = await lookupRunByNaturalKey(
+      body.run.instrument_id,
+      body.run.run_id
+    );
+    if (!found) {
+      return apiError(
+        400,
+        VALIDATION_ERROR,
+        `Run '${body.run.run_id}' not found for instrument '${body.run.instrument_id}'`
+      );
+    }
+    if (found.deletedAt) {
+      return apiError(
+        409,
+        CONFLICT,
+        "Cannot attach a notification to a soft-deleted run"
+      );
+    }
+    run = {
+      internalId: found.id,
+      instrumentId: found.instrumentId,
+      instrumentDisplayName: found.instrumentDisplayName,
+      runDisplayId: found.runId,
+    };
+  }
+
+  // Validate recipients and resolve the actor's display name in one lookup.
+  const requestedIds = [...new Set(body.user_ids)];
+  const lookupIds = [...new Set([...requestedIds, authResult.userId])];
+  const userRows = await db
+    .select({ id: users.id, name: users.name, email: users.email })
+    .from(users)
+    .where(inArray(users.id, lookupIds));
+  const byId = new Map(userRows.map((row) => [row.id, row]));
+
+  const validRecipientIds = requestedIds.filter((id) => byId.has(id));
+  const unknownUserIds = requestedIds.filter((id) => !byId.has(id));
+  const actor = byId.get(authResult.userId);
+  const actorDisplayName = actor?.name ?? actor?.email ?? "Someone";
+
+  const result = await notifyGeneric({
+    actorUserId: authResult.userId,
+    actorDisplayName,
+    recipientUserIds: validRecipientIds,
+    message: body.message,
+    run,
+    origin: new URL(request.url).origin,
+  });
+
+  // Slack is a best-effort side channel: DMs fire after the response so
+  // Slack latency or an outage never delays or blocks the in-app insert.
+  if (result.slackJobs.length > 0) {
+    after(async () => {
+      await deliverSlackDms(result.slackJobs);
+    });
+  }
+
+  return Response.json(
+    {
+      notified_user_ids: result.notifiedUserIds,
+      skipped_user_ids: [...unknownUserIds, ...result.skippedUserIds],
+    },
+    { status: 201 }
+  );
+}

--- a/web/app/api/v1/notifications/route.ts
+++ b/web/app/api/v1/notifications/route.ts
@@ -8,9 +8,10 @@ import {
   markRead,
 } from "@/lib/api/notifications";
 
-// Notification reads/writes are session-only — these are personal-UX
-// surfaces, never invoked by the watcher / Lambda PATs, so they don't
-// participate in the `Scope` vocabulary.
+// Notification reads/writes here are session-only — these are personal-UX
+// surfaces, never invoked by the watcher / Lambda PATs. The machine-facing
+// surface is `POST /api/v1/notifications/dispatch`, gated by the
+// `notifications:create` scope.
 
 const PostBodySchema = z.object({
   ids: z.array(z.string().uuid()).optional(),
@@ -50,6 +51,7 @@ export async function GET(request: NextRequest) {
       instrument_type: n.instrumentType,
       comment_id: n.commentId,
       comment_body: n.commentBody,
+      body: n.body,
       actor: n.actor,
     })),
   });

--- a/web/app/api/v1/settings/notifications/route.ts
+++ b/web/app/api/v1/settings/notifications/route.ts
@@ -16,9 +16,11 @@ const PREFERENCE_FIELDS = {
   runs_all_muted: "runsAllMuted",
   comments_attributed_enabled: "commentsAttributedEnabled",
   comments_participated_enabled: "commentsParticipatedEnabled",
+  generic_enabled: "genericEnabled",
   slack_runs_enabled: "slackRunsEnabled",
   slack_comments_attributed_enabled: "slackCommentsAttributedEnabled",
   slack_comments_participated_enabled: "slackCommentsParticipatedEnabled",
+  slack_generic_enabled: "slackGenericEnabled",
 } as const satisfies Record<string, keyof NotificationPreferencesDto>;
 
 type ApiPreferenceKey = keyof typeof PREFERENCE_FIELDS;

--- a/web/components/notifications/notification-bell-content.tsx
+++ b/web/components/notifications/notification-bell-content.tsx
@@ -65,9 +65,37 @@ const BUCKET_LABEL: Record<Bucket, string> = {
   earlier: "Earlier",
 };
 
+// Every type except `generic` is run-anchored at write time; the wire
+// fields are nullable only because anchor-less `generic` rows exist. This
+// guard narrows once in `buildEntries` so the row renderers stay
+// stringly-typed.
+type AnchoredNotificationItem = NotificationItem & {
+  runId: string;
+  runDisplayId: string;
+  instrumentId: string;
+  instrumentDisplayName: string;
+  instrumentType: InstrumentType;
+};
+
+function isAnchored(n: NotificationItem): n is AnchoredNotificationItem {
+  return (
+    n.runId !== null &&
+    n.runDisplayId !== null &&
+    n.instrumentId !== null &&
+    n.instrumentDisplayName !== null &&
+    n.instrumentType !== null
+  );
+}
+
 interface CommentEntry {
   id: string;
   kind: "comment";
+  notification: AnchoredNotificationItem;
+}
+
+interface GenericEntry {
+  id: string;
+  kind: "generic";
   notification: NotificationItem;
 }
 
@@ -78,13 +106,13 @@ interface RunGroupEntry {
   instrumentType: InstrumentType;
   kind: "run_group";
   latestCreatedAt: string;
-  runs: NotificationItem[];
+  runs: AnchoredNotificationItem[];
 }
 
-type Entry = CommentEntry | RunGroupEntry;
+type Entry = CommentEntry | GenericEntry | RunGroupEntry;
 type BucketedEntries = Record<Bucket, Entry[]>;
 
-function notificationHref(n: NotificationItem): string {
+function notificationHref(n: AnchoredNotificationItem): string {
   // Anchor to the comment id when present so the destination page can
   // scroll the comment into view.
   const base = `/instruments/${encodeURIComponent(
@@ -107,6 +135,9 @@ function commentActionLabel(n: NotificationItem): string {
       // Unreachable — `run_created` never flows into the comment row
       // renderer — but exhaustive switches keep TS honest.
       return `${actor} created`;
+    case "generic":
+      // Also unreachable — `generic` rows render in their own variant.
+      return `${actor} sent a notification`;
     default:
       return `${actor} commented on`;
   }
@@ -143,6 +174,17 @@ function buildEntries(items: NotificationItem[], now: Date): BucketedEntries {
 
   for (const n of items) {
     const bucket = bucketOf(n.createdAt, now);
+    // `generic` rows render individually and may be anchor-less — they
+    // never join the comment rows or the run_created grouping.
+    if (n.type === "generic") {
+      buckets[bucket].push({ kind: "generic", id: n.id, notification: n });
+      continue;
+    }
+    // Every remaining type is run-anchored at write time; skip a row that
+    // somehow isn't rather than crashing the popover.
+    if (!isAnchored(n)) {
+      continue;
+    }
     if (n.type === "run_created") {
       const key = `${bucket}:${n.instrumentId}`;
       const existing = groupIndex.get(key);
@@ -221,29 +263,42 @@ export function NotificationBellContent({
             }
             return (
               <NotificationSection key={bucket} label={BUCKET_LABEL[bucket]}>
-                {entries.map((entry) =>
-                  entry.kind === "comment" ? (
+                {entries.map((entry) => {
+                  // Single-row entries share one activation behavior: mark
+                  // read (when unread) and close the popover. Run groups
+                  // manage their own per-run activation.
+                  if (entry.kind === "run_group") {
+                    return (
+                      <RunGroupNotificationRow
+                        group={entry}
+                        key={entry.id}
+                        onActivate={(notificationId) => {
+                          void markOneRead(notificationId);
+                        }}
+                        onNavigate={onNavigate}
+                      />
+                    );
+                  }
+                  const activate = () => {
+                    if (entry.notification.readAt === null) {
+                      void markOneRead(entry.notification.id);
+                    }
+                    onNavigate?.();
+                  };
+                  return entry.kind === "comment" ? (
                     <CommentNotificationRow
                       key={entry.id}
                       notification={entry.notification}
-                      onActivate={() => {
-                        if (entry.notification.readAt === null) {
-                          void markOneRead(entry.notification.id);
-                        }
-                        onNavigate?.();
-                      }}
+                      onActivate={activate}
                     />
                   ) : (
-                    <RunGroupNotificationRow
-                      group={entry}
+                    <GenericNotificationRow
                       key={entry.id}
-                      onActivate={(notificationId) => {
-                        void markOneRead(notificationId);
-                      }}
-                      onNavigate={onNavigate}
+                      notification={entry.notification}
+                      onActivate={activate}
                     />
-                  )
-                )}
+                  );
+                })}
               </NotificationSection>
             );
           })}
@@ -368,7 +423,7 @@ function CommentNotificationRow({
   notification: n,
   onActivate,
 }: {
-  notification: NotificationItem;
+  notification: AnchoredNotificationItem;
   onActivate: () => void;
 }) {
   const isUnread = n.readAt === null;
@@ -412,6 +467,84 @@ function CommentNotificationRow({
           </p>
         </div>
       </Link>
+    </NotificationRowShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Generic notification — free-text message from an integration. The message
+// is the main line (the sender controls the wording); when the row is
+// run-anchored the whole row is a Link to the run, otherwise it's a button
+// whose only action is marking the row read.
+// ---------------------------------------------------------------------------
+
+function GenericNotificationRow({
+  notification: n,
+  onActivate,
+}: {
+  notification: NotificationItem;
+  onActivate: () => void;
+}) {
+  const isUnread = n.readAt === null;
+  const anchored = isAnchored(n);
+
+  // Shared inner layout — identical between the Link and button wrappers so
+  // the visual position doesn't shift with the row's navigability.
+  const content = (
+    <>
+      {n.actor ? (
+        <UserAvatar
+          size="sm"
+          user={{
+            userId: n.actor.id,
+            displayName: n.actor.displayName,
+            initials: n.actor.initials,
+            avatarUrl: n.actor.avatarUrl,
+          }}
+        />
+      ) : (
+        <UnknownUserAvatar size="sm" />
+      )}
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p className="text-sm leading-snug">{n.body}</p>
+        {anchored ? (
+          <p className="line-clamp-2 font-mono text-muted-foreground text-xs">
+            {n.instrumentDisplayName} · {n.runDisplayId}
+          </p>
+        ) : null}
+        <p
+          className="text-muted-foreground/80 text-xs"
+          suppressHydrationWarning
+        >
+          {formatRelativeTime(n.createdAt)}
+        </p>
+      </div>
+    </>
+  );
+
+  if (anchored) {
+    return (
+      <NotificationRowShell isUnread={isUnread}>
+        <Link
+          className="flex items-start gap-3 px-4 py-3 outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          href={notificationHref(n)}
+          onClick={onActivate}
+        >
+          {content}
+        </Link>
+      </NotificationRowShell>
+    );
+  }
+
+  return (
+    <NotificationRowShell isUnread={isUnread}>
+      <button
+        className="flex w-full cursor-pointer items-start gap-3 px-4 py-3 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        onClick={onActivate}
+        type="button"
+      >
+        {content}
+      </button>
     </NotificationRowShell>
   );
 }

--- a/web/components/notifications/notification-bell.tsx
+++ b/web/components/notifications/notification-bell.tsx
@@ -49,7 +49,7 @@ export function NotificationBell() {
           {unreadCount > 0 ? (
             <span
               aria-hidden
-              className="absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 font-semibold text-[10px] text-primary-foreground tabular-nums leading-none"
+              className="absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 font-semibold text-[10px] text-white tabular-nums leading-none"
             >
               {unreadCount > 99 ? "99+" : unreadCount}
             </span>

--- a/web/components/notifications/notifications-provider.tsx
+++ b/web/components/notifications/notifications-provider.tsx
@@ -29,17 +29,24 @@ export interface NotificationActor {
 
 export interface NotificationItem {
   actor: NotificationActor | null;
+  // Caller-supplied message for `generic` rows; null for every other type.
+  body: string | null;
   commentBody: string | null;
   commentId: string | null;
   createdAt: string;
   id: string;
-  instrumentDisplayName: string;
-  instrumentId: string;
-  instrumentType: InstrumentType;
+  // Run + instrument fields are null on anchor-less `generic` rows.
+  instrumentDisplayName: string | null;
+  instrumentId: string | null;
+  instrumentType: InstrumentType | null;
   readAt: string | null;
-  runDisplayId: string;
-  runId: string;
-  type: "run_created" | "comment_attributed" | "comment_participated";
+  runDisplayId: string | null;
+  runId: string | null;
+  type:
+    | "run_created"
+    | "comment_attributed"
+    | "comment_participated"
+    | "generic";
 }
 
 interface NotificationsValue {
@@ -67,16 +74,17 @@ const POLL_INTERVAL_MS = 60_000;
 
 interface ApiNotification {
   actor: NotificationActor | null;
+  body: string | null;
   comment_body: string | null;
   comment_id: string | null;
   created_at: string;
   id: string;
-  instrument_display_name: string;
-  instrument_id: string;
-  instrument_type: InstrumentType;
+  instrument_display_name: string | null;
+  instrument_id: string | null;
+  instrument_type: InstrumentType | null;
   read_at: string | null;
-  run_display_id: string;
-  run_id: string;
+  run_display_id: string | null;
+  run_id: string | null;
   type: NotificationItem["type"];
 }
 
@@ -93,6 +101,7 @@ function fromApi(n: ApiNotification): NotificationItem {
     instrumentType: n.instrument_type,
     commentId: n.comment_id,
     commentBody: n.comment_body,
+    body: n.body,
     actor: n.actor,
   };
 }

--- a/web/components/notifications/notifications-settings-form.tsx
+++ b/web/components/notifications/notifications-settings-form.tsx
@@ -35,6 +35,7 @@ const inAppPreferencesSchema = z.object({
   runsAllMuted: z.boolean(),
   commentsAttributedEnabled: z.boolean(),
   commentsParticipatedEnabled: z.boolean(),
+  genericEnabled: z.boolean(),
 });
 
 type InAppPreferences = z.infer<typeof inAppPreferencesSchema>;
@@ -122,6 +123,7 @@ export function NotificationsSettingsForm({
       commentsAttributedEnabled: initialPreferences.commentsAttributedEnabled,
       commentsParticipatedEnabled:
         initialPreferences.commentsParticipatedEnabled,
+      genericEnabled: initialPreferences.genericEnabled,
       perInstrument: initialPerInstrument,
     } satisfies FormValues,
     validators: {
@@ -142,6 +144,7 @@ export function NotificationsSettingsForm({
         runs_all_muted: value.runsAllMuted,
         comments_attributed_enabled: value.commentsAttributedEnabled,
         comments_participated_enabled: value.commentsParticipatedEnabled,
+        generic_enabled: value.genericEnabled,
       };
 
       const changedInstruments = initialInstruments.filter(
@@ -273,6 +276,32 @@ export function NotificationsSettingsForm({
                   </Field>
                 )}
               </prefsForm.Field>
+
+              <FieldSeparator />
+
+              <prefsForm.Field name="genericEnabled">
+                {(field) => (
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <FieldLabel htmlFor={field.name}>
+                        Service notifications
+                      </FieldLabel>
+                      <FieldDescription>
+                        Messages from integrations and scripts sent via the API
+                        — for example, a suggestion that a run might be yours to
+                        claim.
+                      </FieldDescription>
+                    </FieldContent>
+                    <Switch
+                      aria-label="Notify me when an integration sends me a notification"
+                      checked={field.state.value}
+                      id={field.name}
+                      name={field.name}
+                      onCheckedChange={field.handleChange}
+                    />
+                  </Field>
+                )}
+              </prefsForm.Field>
             </FieldGroup>
           </CardContent>
 
@@ -387,6 +416,7 @@ export function NotificationsSettingsForm({
               initialPreferences.slackCommentsAttributedEnabled,
             slackCommentsParticipatedEnabled:
               initialPreferences.slackCommentsParticipatedEnabled,
+            slackGenericEnabled: initialPreferences.slackGenericEnabled,
           }}
           revoked={slackConnection.revoked}
         />

--- a/web/components/notifications/slack-connection-card.tsx
+++ b/web/components/notifications/slack-connection-card.tsx
@@ -110,6 +110,7 @@ const slackPreferencesSchema = z.object({
   slackRunsEnabled: z.boolean(),
   slackCommentsAttributedEnabled: z.boolean(),
   slackCommentsParticipatedEnabled: z.boolean(),
+  slackGenericEnabled: z.boolean(),
 });
 
 export type SlackPreferences = z.infer<typeof slackPreferencesSchema>;
@@ -144,6 +145,7 @@ function Connected({
             value.slackCommentsAttributedEnabled,
           slack_comments_participated_enabled:
             value.slackCommentsParticipatedEnabled,
+          slack_generic_enabled: value.slackGenericEnabled,
         }),
       });
 
@@ -257,6 +259,29 @@ function Connected({
                     </FieldContent>
                     <Switch
                       aria-label="Send participated comment notifications via Slack DM"
+                      checked={field.state.value}
+                      id={field.name}
+                      name={field.name}
+                      onCheckedChange={field.handleChange}
+                    />
+                  </Field>
+                )}
+              </form.Field>
+
+              <form.Field name="slackGenericEnabled">
+                {(field) => (
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <FieldLabel htmlFor={field.name}>
+                        Service notifications
+                      </FieldLabel>
+                      <FieldDescription>
+                        DM me when an integration sends me a notification via
+                        the API.
+                      </FieldDescription>
+                    </FieldContent>
+                    <Switch
+                      aria-label="Send service notifications via Slack DM"
                       checked={field.state.value}
                       id={field.name}
                       name={field.name}

--- a/web/drizzle/0046_many_bucky.sql
+++ b/web/drizzle/0046_many_bucky.sql
@@ -1,0 +1,5 @@
+ALTER TYPE "public"."notification_type" ADD VALUE 'generic';--> statement-breakpoint
+ALTER TABLE "notifications" ALTER COLUMN "run_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "notification_preferences" ADD COLUMN "generic_enabled" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "notification_preferences" ADD COLUMN "slack_generic_enabled" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "notifications" ADD COLUMN "body" text;

--- a/web/drizzle/meta/0046_snapshot.json
+++ b/web/drizzle/meta/0046_snapshot.json
@@ -1,0 +1,3555 @@
+{
+  "id": "e4348b4e-6523-408b-a397-7ab237118f5f",
+  "prevId": "981e42b3-d5ef-4ae1-8ee5-cc3ec4f50b35",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archive_jobs": {
+      "name": "archive_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archive_bucket": {
+          "name": "archive_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_key": {
+          "name": "archive_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "archive_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_archive_jobs_inflight": {
+          "name": "uq_archive_jobs_inflight",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"archive_jobs\".\"status\" in ('pending', 'building')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_archive_jobs_run_fingerprint_status": {
+          "name": "idx_archive_jobs_run_fingerprint_status",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "archive_jobs_instrument_run_id_instrument_runs_id_fk": {
+          "name": "archive_jobs_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["instrument_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "archive_jobs_created_by_user_id_fk": {
+          "name": "archive_jobs_created_by_user_id_fk",
+          "tableFrom": "archive_jobs",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instrument_run_id": {
+          "name": "instrument_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "file_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raw'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_requested_at": {
+          "name": "upload_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_created_at": {
+          "name": "file_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_files_instrument_run_id_relative_path": {
+          "name": "uq_files_instrument_run_id_relative_path",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"relative_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_active_instrument_run_id_filename": {
+          "name": "uq_files_active_instrument_run_id_filename",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_files_s3_key": {
+          "name": "uq_files_s3_key",
+          "columns": [
+            {
+              "expression": "s3_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"s3_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_instrument_run_id": {
+          "name": "idx_files_instrument_run_id",
+          "columns": [
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_status_instrument_run_id": {
+          "name": "idx_files_status_instrument_run_id",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instrument_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_upload_queue": {
+          "name": "idx_files_upload_queue",
+          "columns": [
+            {
+              "expression": "upload_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"upload_requested_at\" is not null and \"files\".\"uploaded_at\" is null and \"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_metadata_gin": {
+          "name": "idx_files_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_files_filename_trgm": {
+          "name": "idx_files_filename_trgm",
+          "columns": [
+            {
+              "expression": "\"filename\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"files\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_instrument_run_id_instrument_runs_id_fk": {
+          "name": "files_instrument_run_id_instrument_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["instrument_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_notification_subscriptions": {
+      "name": "instrument_notification_subscriptions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_instrument_notification_subscriptions_user_id": {
+          "name": "idx_instrument_notification_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_notification_subscriptions_user_id_user_id_fk": {
+          "name": "instrument_notification_subscriptions_user_id_user_id_fk",
+          "tableFrom": "instrument_notification_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "instrument_notification_subscriptions_instrument_id_instruments_id_fk": {
+          "name": "instrument_notification_subscriptions_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_notification_subscriptions",
+          "tableTo": "instruments",
+          "columnsFrom": ["instrument_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "instrument_notification_subscriptions_user_id_instrument_id_pk": {
+          "name": "instrument_notification_subscriptions_user_id_instrument_id_pk",
+          "columns": ["user_id", "instrument_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instrument_runs": {
+      "name": "instrument_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "instrument_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lambda'"
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instrument_runs_instrument_id_created_at": {
+          "name": "idx_instrument_runs_instrument_id_created_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active": {
+          "name": "idx_instrument_runs_active",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_active_acquired_at": {
+          "name": "idx_instrument_runs_active_acquired_at",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"acquired_at\", \"created_at\") desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"instrument_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_instrument_runs_metadata_gin": {
+          "name": "idx_instrument_runs_metadata_gin",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_instrument_runs_run_id_trgm": {
+          "name": "idx_instrument_runs_run_id_trgm",
+          "columns": [
+            {
+              "expression": "\"run_id\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instrument_runs_instrument_id_instruments_id_fk": {
+          "name": "instrument_runs_instrument_id_instruments_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "instruments",
+          "columnsFrom": ["instrument_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_watcher_id_watchers_id_fk": {
+          "name": "instrument_runs_watcher_id_watchers_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "watchers",
+          "columnsFrom": ["watcher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instrument_runs_deleted_by_user_id_fk": {
+          "name": "instrument_runs_deleted_by_user_id_fk",
+          "tableFrom": "instrument_runs",
+          "tableTo": "user",
+          "columnsFrom": ["deleted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_instrument_runs_instrument_id_run_id": {
+          "name": "uq_instrument_runs_instrument_id_run_id",
+          "nullsNotDistinct": false,
+          "columns": ["instrument_id", "run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instruments": {
+      "name": "instruments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instrument_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instrument_type": {
+          "name": "instrument_type",
+          "type": "instrument_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_by": {
+          "name": "retired_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_instruments_display_name_trgm": {
+          "name": "idx_instruments_display_name_trgm",
+          "columns": [
+            {
+              "expression": "\"display_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instruments_retired_by_user_id_fk": {
+          "name": "instruments_retired_by_user_id_fk",
+          "tableFrom": "instruments",
+          "tableTo": "user",
+          "columnsFrom": ["retired_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alg": {
+          "name": "alg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crv": {
+          "name": "crv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runs_all_muted": {
+          "name": "runs_all_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "comments_attributed_enabled": {
+          "name": "comments_attributed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "comments_participated_enabled": {
+          "name": "comments_participated_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "generic_enabled": {
+          "name": "generic_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "slack_runs_enabled": {
+          "name": "slack_runs_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slack_comments_attributed_enabled": {
+          "name": "slack_comments_attributed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slack_comments_participated_enabled": {
+          "name": "slack_comments_participated_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slack_generic_enabled": {
+          "name": "slack_generic_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_user_id_fk": {
+          "name": "notification_preferences_user_id_user_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id_created_at": {
+          "name": "idx_notifications_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_id_unread": {
+          "name": "idx_notifications_user_id_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_run_id_instrument_runs_id_fk": {
+          "name": "notifications_run_id_instrument_runs_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_comment_id_run_comments_id_fk": {
+          "name": "notifications_comment_id_run_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "run_comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_user_id_user_id_fk": {
+          "name": "notifications_actor_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorizationCodeId": {
+          "name": "authorizationCodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestedUserInfoClaims": {
+          "name": "requestedUserInfoClaims",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshId": {
+          "name": "refreshId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation": {
+          "name": "confirmation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_authorizationCodeId_idx": {
+          "name": "oauthAccessToken_authorizationCodeId_idx",
+          "columns": [
+            {
+              "expression": "authorizationCodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refreshId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_clientId_oauth_client_clientId_fk": {
+          "name": "oauth_access_token_clientId_oauth_client_clientId_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["clientId"],
+          "columnsTo": ["clientId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_sessionId_session_id_fk": {
+          "name": "oauth_access_token_sessionId_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": ["sessionId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_userId_user_id_fk": {
+          "name": "oauth_access_token_userId_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refreshId_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refreshId_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": ["refreshId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client_assertion": {
+      "name": "oauth_client_assertion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client_resource": {
+      "name": "oauth_client_resource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClientResource_clientId_resourceId_uidx": {
+          "name": "oauthClientResource_clientId_resourceId_uidx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthClientResource_clientId_idx": {
+          "name": "oauthClientResource_clientId_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthClientResource_resourceId_idx": {
+          "name": "oauthClientResource_resourceId_idx",
+          "columns": [
+            {
+              "expression": "resourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_resource_clientId_oauth_client_clientId_fk": {
+          "name": "oauth_client_resource_clientId_oauth_client_clientId_fk",
+          "tableFrom": "oauth_client_resource",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["clientId"],
+          "columnsTo": ["clientId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_client_resource_resourceId_oauth_resource_identifier_fk": {
+          "name": "oauth_client_resource_resourceId_oauth_resource_identifier_fk",
+          "tableFrom": "oauth_client_resource",
+          "tableTo": "oauth_resource",
+          "columnsFrom": ["resourceId"],
+          "columnsTo": ["identifier"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientSecret": {
+          "name": "clientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clientDiscoveryId": {
+          "name": "clientDiscoveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skipConsent": {
+          "name": "skipConsent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enableEndSession": {
+          "name": "enableEndSession",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjectType": {
+          "name": "subjectType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clientCredentialsScopes": {
+          "name": "clientCredentialsScopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "softwareId": {
+          "name": "softwareId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "softwareVersion": {
+          "name": "softwareVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "softwareStatement": {
+          "name": "softwareStatement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectUris": {
+          "name": "redirectUris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postLogoutRedirectUris": {
+          "name": "postLogoutRedirectUris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backchannelLogoutUri": {
+          "name": "backchannelLogoutUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backchannelLogoutSessionRequired": {
+          "name": "backchannelLogoutSessionRequired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenEndpointAuthMethod": {
+          "name": "tokenEndpointAuthMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicationType": {
+          "name": "applicationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwks": {
+          "name": "jwks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwksUri": {
+          "name": "jwksUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantTypes": {
+          "name": "grantTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTypes": {
+          "name": "responseTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirePKCE": {
+          "name": "requirePKCE",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dpopBoundAccessTokens": {
+          "name": "dpopBoundAccessTokens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_userId_user_id_fk": {
+          "name": "oauth_client_userId_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_clientId_unique": {
+          "name": "oauth_client_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["clientId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestedUserInfoClaims": {
+          "name": "requestedUserInfoClaims",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_clientId_oauth_client_clientId_fk": {
+          "name": "oauth_consent_clientId_oauth_client_clientId_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["clientId"],
+          "columnsTo": ["clientId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_userId_user_id_fk": {
+          "name": "oauth_consent_userId_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorizationCodeId": {
+          "name": "authorizationCodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestedUserInfoClaims": {
+          "name": "requestedUserInfoClaims",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotatedAt": {
+          "name": "rotatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotationReplayResponse": {
+          "name": "rotationReplayResponse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotationReplayExpiresAt": {
+          "name": "rotationReplayExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authTime": {
+          "name": "authTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation": {
+          "name": "confirmation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_authorizationCodeId_idx": {
+          "name": "oauthRefreshToken_authorizationCodeId_idx",
+          "columns": [
+            {
+              "expression": "authorizationCodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_clientId_oauth_client_clientId_fk": {
+          "name": "oauth_refresh_token_clientId_oauth_client_clientId_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["clientId"],
+          "columnsTo": ["clientId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_sessionId_session_id_fk": {
+          "name": "oauth_refresh_token_sessionId_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": ["sessionId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_userId_user_id_fk": {
+          "name": "oauth_refresh_token_userId_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_resource": {
+      "name": "oauth_resource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessTokenTtl": {
+          "name": "accessTokenTtl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenTtl": {
+          "name": "refreshTokenTtl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signingAlgorithm": {
+          "name": "signingAlgorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signingKeyId": {
+          "name": "signingKeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowedScopes": {
+          "name": "allowedScopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customClaims": {
+          "name": "customClaims",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dpopBoundAccessTokensRequired": {
+          "name": "dpopBoundAccessTokensRequired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policyVersion": {
+          "name": "policyVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_resource_identifier_unique": {
+          "name": "oauth_resource_identifier_unique",
+          "nullsNotDistinct": false,
+          "columns": ["identifier"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['*']::text[]"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_personal_access_tokens_user_id": {
+          "name": "idx_personal_access_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_user_id_fk": {
+          "name": "personal_access_tokens_user_id_user_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_attributions": {
+      "name": "run_attributions",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_attributions_run_id": {
+          "name": "idx_run_attributions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_attributions_user_id": {
+          "name": "idx_run_attributions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_attributions_run_id_instrument_runs_id_fk": {
+          "name": "run_attributions_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_attributions_user_id_user_id_fk": {
+          "name": "run_attributions_user_id_user_id_fk",
+          "tableFrom": "run_attributions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_attributions_run_id_user_id_pk": {
+          "name": "run_attributions_run_id_user_id_pk",
+          "columns": ["run_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_comments": {
+      "name": "run_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_run_comments_run_id_created_at": {
+          "name": "idx_run_comments_run_id_created_at",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_comments_user_id": {
+          "name": "idx_run_comments_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_comments_body_trgm": {
+          "name": "idx_run_comments_body_trgm",
+          "columns": [
+            {
+              "expression": "\"body\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"run_comments\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_comments_run_id_instrument_runs_id_fk": {
+          "name": "run_comments_run_id_instrument_runs_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "instrument_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_comments_user_id_user_id_fk": {
+          "name": "run_comments_user_id_user_id_fk",
+          "tableFrom": "run_comments",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_channel_config": {
+      "name": "slack_channel_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_channel_config_updated_by_user_id_fk": {
+          "name": "slack_channel_config_updated_by_user_id_fk",
+          "tableFrom": "slack_channel_config",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "slack_channel_config_singleton": {
+          "name": "slack_channel_config_singleton",
+          "value": "\"slack_channel_config\".\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_connections": {
+      "name": "slack_connections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_name": {
+          "name": "slack_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_connections_user_id_user_id_fk": {
+          "name": "slack_connections_user_id_user_id_fk",
+          "tableFrom": "slack_connections",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_events": {
+      "name": "watcher_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "watcher_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_events_watcher_id_timestamp": {
+          "name": "idx_watcher_events_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_watcher_events_watcher_id_event_type": {
+          "name": "idx_watcher_events_watcher_id_event_type",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_events_watcher_id_watchers_id_fk": {
+          "name": "watcher_events_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_events",
+          "tableTo": "watchers",
+          "columnsFrom": ["watcher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_heartbeats": {
+      "name": "watcher_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watcher_id": {
+          "name": "watcher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_mode": {
+          "name": "upload_mode",
+          "type": "upload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_uploaded_since_last": {
+          "name": "files_uploaded_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "runs_reported_since_last": {
+          "name": "runs_reported_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_since_last": {
+          "name": "errors_since_last",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_watcher_heartbeats_watcher_id_timestamp": {
+          "name": "idx_watcher_heartbeats_watcher_id_timestamp",
+          "columns": [
+            {
+              "expression": "watcher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watcher_heartbeats_watcher_id_watchers_id_fk": {
+          "name": "watcher_heartbeats_watcher_id_watchers_id_fk",
+          "tableFrom": "watcher_heartbeats",
+          "tableTo": "watchers",
+          "columnsFrom": ["watcher_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watcher_release_config": {
+      "name": "watcher_release_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_supported_version": {
+          "name": "min_supported_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mandatory": {
+          "name": "mandatory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watcher_release_config_updated_by_user_id_fk": {
+          "name": "watcher_release_config_updated_by_user_id_fk",
+          "tableFrom": "watcher_release_config",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "watcher_release_config_singleton": {
+          "name": "watcher_release_config_singleton",
+          "value": "\"watcher_release_config\".\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.watchers": {
+      "name": "watchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_info": {
+          "name": "os_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watcher_version": {
+          "name": "watcher_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_checksum": {
+          "name": "config_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_yaml": {
+          "name": "config_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "watcher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deregistered_by": {
+          "name": "deregistered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_by_token": {
+          "name": "registered_by_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_watchers_active_instrument_id": {
+          "name": "uq_watchers_active_instrument_id",
+          "columns": [
+            {
+              "expression": "instrument_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"watchers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchers_instrument_id_instruments_id_fk": {
+          "name": "watchers_instrument_id_instruments_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "instruments",
+          "columnsFrom": ["instrument_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "watchers_deregistered_by_user_id_fk": {
+          "name": "watchers_deregistered_by_user_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "user",
+          "columnsFrom": ["deregistered_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "watchers_registered_by_token_personal_access_tokens_id_fk": {
+          "name": "watchers_registered_by_token_personal_access_tokens_id_fk",
+          "tableFrom": "watchers",
+          "tableTo": "personal_access_tokens",
+          "columnsFrom": ["registered_by_token"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.archive_job_status": {
+      "name": "archive_job_status",
+      "schema": "public",
+      "values": ["pending", "building", "ready", "failed"]
+    },
+    "public.file_category": {
+      "name": "file_category",
+      "schema": "public",
+      "values": ["raw", "processed"]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "detected",
+        "upload_requested",
+        "uploaded",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.instrument_run_source": {
+      "name": "instrument_run_source",
+      "schema": "public",
+      "values": ["lambda", "watcher"]
+    },
+    "public.instrument_status": {
+      "name": "instrument_status",
+      "schema": "public",
+      "values": ["pending", "active", "inactive"]
+    },
+    "public.instrument_type": {
+      "name": "instrument_type",
+      "schema": "public",
+      "values": [
+        "generic",
+        "plate_reader",
+        "gel_doc",
+        "qpcr",
+        "tape_station",
+        "hina_microscope",
+        "epson_v700_scanner",
+        "instant_raman",
+        "fplc",
+        "dishcam",
+        "aunty"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "run_created",
+        "comment_attributed",
+        "comment_participated",
+        "generic"
+      ]
+    },
+    "public.upload_mode": {
+      "name": "upload_mode",
+      "schema": "public",
+      "values": ["auto", "manual"]
+    },
+    "public.watcher_event_type": {
+      "name": "watcher_event_type",
+      "schema": "public",
+      "values": [
+        "watcher_started",
+        "watcher_stopped",
+        "file_uploaded",
+        "upload_failed",
+        "run_reported",
+        "config_synced",
+        "error",
+        "update_started",
+        "update_succeeded",
+        "update_failed"
+      ]
+    },
+    "public.watcher_status": {
+      "name": "watcher_status",
+      "schema": "public",
+      "values": ["registered", "watching", "stopped"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1788299470872,
       "tag": "0045_relax_account_issuer",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1788891244869,
+      "tag": "0046_many_bucky",
+      "breakpoints": true
     }
   ]
 }

--- a/web/lib/api/notifications.ts
+++ b/web/lib/api/notifications.ts
@@ -23,15 +23,17 @@ import {
 } from "@/lib/db/schema";
 import {
   buildCommentBlocks,
+  buildGenericBlocks,
   buildRunCreatedBlocks,
   deliverSlackDms,
+  type SlackDmJob,
 } from "@/lib/slack/dm";
 import { toInitials } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
 // Notifications — in-app event delivery for instrument runs and run comments.
 //
-// Three trigger types live in `notification_type`:
+// Four trigger types live in `notification_type`:
 //   - `run_created`           : a new run was created on a subscribed
 //                                instrument; emitted to every user with a
 //                                `instrument_notification_subscriptions`
@@ -40,18 +42,25 @@ import { toInitials } from "@/lib/utils";
 //                                is false.
 //   - `comment_attributed`    : a run-attributee received a new comment.
 //   - `comment_participated`  : a prior commenter received a new comment.
+//   - `generic`               : an integration posted a free-text message
+//                                via `POST /api/v1/notifications/dispatch`
+//                                (gated by the `notifications:create` scope).
 //
-// All preference-mutating routes are session-only — these endpoints are
-// personal-UX, never invoked by PATs, so we don't add a scope.
+// Preference-mutating routes remain session-only — they're personal-UX
+// surfaces, never invoked by PATs.
 // ---------------------------------------------------------------------------
 
 export interface NotificationPreferencesDto {
   commentsAttributedEnabled: boolean;
   commentsParticipatedEnabled: boolean;
+  // In-app `generic` delivery defaults on — dispatch messages are always
+  // addressed to the recipient, so they're expected to be low-volume.
+  genericEnabled: boolean;
   // In-app delivery
   runsAllMuted: boolean;
   slackCommentsAttributedEnabled: boolean;
   slackCommentsParticipatedEnabled: boolean;
+  slackGenericEnabled: boolean;
   // Slack delivery — independent of in-app; all default false until the user
   // connects Slack (at which point the OAuth callback flips these to true).
   slackRunsEnabled: boolean;
@@ -61,9 +70,11 @@ const DEFAULT_PREFERENCES: NotificationPreferencesDto = {
   runsAllMuted: false,
   commentsAttributedEnabled: true,
   commentsParticipatedEnabled: true,
+  genericEnabled: true,
   slackRunsEnabled: false,
   slackCommentsAttributedEnabled: false,
   slackCommentsParticipatedEnabled: false,
+  slackGenericEnabled: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -83,11 +94,13 @@ export async function getPreferences(
         notificationPreferences.commentsAttributedEnabled,
       commentsParticipatedEnabled:
         notificationPreferences.commentsParticipatedEnabled,
+      genericEnabled: notificationPreferences.genericEnabled,
       slackRunsEnabled: notificationPreferences.slackRunsEnabled,
       slackCommentsAttributedEnabled:
         notificationPreferences.slackCommentsAttributedEnabled,
       slackCommentsParticipatedEnabled:
         notificationPreferences.slackCommentsParticipatedEnabled,
+      slackGenericEnabled: notificationPreferences.slackGenericEnabled,
     })
     .from(notificationPreferences)
     .where(eq(notificationPreferences.userId, userId))
@@ -188,8 +201,15 @@ export async function setInstrumentSubscription(
 
 // Hard cap on the comment-body snippet returned in the popover payload —
 // the full body is never needed for the bell list and we don't want
-// kilobyte-sized markdown blobs piggy-backing on every poll.
+// kilobyte-sized markdown blobs piggy-backing on every poll. Also applied
+// to `generic` messages (route-capped at 500, so the cap rarely bites).
 const COMMENT_BODY_PREVIEW_LENGTH = 240;
+
+function toPreview(text: string | null): string | null {
+  return text && text.length > COMMENT_BODY_PREVIEW_LENGTH
+    ? `${text.slice(0, COMMENT_BODY_PREVIEW_LENGTH).trimEnd()}…`
+    : text;
+}
 
 export interface NotificationDto {
   actor: {
@@ -198,6 +218,9 @@ export interface NotificationDto {
     initials: string;
     avatarUrl: string | null;
   } | null;
+  // Caller-supplied message for `generic` rows, preview-truncated like
+  // `commentBody`. NULL for every other type.
+  body: string | null;
   // Truncated markdown body of the originating comment — only populated
   // when `commentId` is set. NULL for `run_created` rows and for comment
   // rows whose comment has been soft-deleted.
@@ -205,17 +228,22 @@ export interface NotificationDto {
   commentId: string | null;
   createdAt: Date;
   id: string;
-  instrumentDisplayName: string;
+  // Run + instrument fields are NULL on anchor-less `generic` rows.
+  instrumentDisplayName: string | null;
   // Natural keys for linking — `/instruments/:instrumentId/runs/:runId` is
   // what the row navigates to.
-  instrumentId: string;
+  instrumentId: string | null;
   // Surfaced so the bell can render a type-specific icon for grouped
   // `run_created` rows (microscope / gel doc / plate reader).
-  instrumentType: InstrumentType;
+  instrumentType: InstrumentType | null;
   readAt: Date | null;
-  runDisplayId: string;
-  runId: string;
-  type: "run_created" | "comment_attributed" | "comment_participated";
+  runDisplayId: string | null;
+  runId: string | null;
+  type:
+    | "run_created"
+    | "comment_attributed"
+    | "comment_participated"
+    | "generic";
 }
 
 export async function listNotifications(
@@ -241,14 +269,16 @@ export async function listNotifications(
       // filter below; the row still exists so the user can navigate to
       // the run, the popover just renders without a preview.
       commentBody: runComments.body,
+      body: notifications.body,
       actorId: actor.id,
       actorName: actor.name,
       actorEmail: actor.email,
       actorImage: actor.image,
     })
     .from(notifications)
-    .innerJoin(instrumentRuns, eq(instrumentRuns.id, notifications.runId))
-    .innerJoin(instruments, eq(instruments.id, instrumentRuns.instrumentId))
+    // Left joins: anchor-less `generic` rows have no run to join through.
+    .leftJoin(instrumentRuns, eq(instrumentRuns.id, notifications.runId))
+    .leftJoin(instruments, eq(instruments.id, instrumentRuns.instrumentId))
     .leftJoin(actor, eq(actor.id, notifications.actorUserId))
     .leftJoin(
       runComments,
@@ -269,10 +299,6 @@ export async function listNotifications(
     const actorDisplayName = row.actorId
       ? (row.actorName ?? row.actorEmail ?? "Unknown")
       : null;
-    const previewBody =
-      row.commentBody && row.commentBody.length > COMMENT_BODY_PREVIEW_LENGTH
-        ? `${row.commentBody.slice(0, COMMENT_BODY_PREVIEW_LENGTH).trimEnd()}…`
-        : row.commentBody;
     return {
       id: row.id,
       type: row.type,
@@ -284,7 +310,8 @@ export async function listNotifications(
       instrumentDisplayName: row.instrumentDisplayName,
       instrumentType: row.instrumentType,
       commentId: row.commentId,
-      commentBody: previewBody,
+      commentBody: toPreview(row.commentBody),
+      body: toPreview(row.body),
       actor:
         row.actorId && actorDisplayName
           ? {
@@ -629,4 +656,155 @@ export async function notifyComment(input: {
   } catch (err) {
     console.error("notifyComment failed", err);
   }
+}
+
+// ---------------------------------------------------------------------------
+// `generic` fan-out — free-text messages posted by integrations via
+// `POST /api/v1/notifications/dispatch`. Unlike the after()-deferred
+// fan-outs above, dispatch reports delivery in its response, so failures
+// here must surface (the route returns 500) rather than being swallowed —
+// a lying 201 would tell the caller everyone was skipped.
+// ---------------------------------------------------------------------------
+
+export interface NotifyGenericResult {
+  // Received the message on at least one channel (in-app row or Slack DM).
+  notifiedUserIds: string[];
+  // Received nothing: the actor, exact-repeat deliveries, or both channels
+  // muted / disconnected. (The route additionally folds in unknown user IDs.)
+  skippedUserIds: string[];
+  // Ready-to-send DM jobs — the route fires these in `after()` so Slack
+  // latency never delays the response.
+  slackJobs: SlackDmJob[];
+}
+
+export async function notifyGeneric(input: {
+  actorUserId: string;
+  actorDisplayName: string;
+  recipientUserIds: string[];
+  message: string;
+  // Run anchor for the notification. Omit for an anchor-less message.
+  run?: {
+    internalId: string;
+    instrumentId: string;
+    instrumentDisplayName: string;
+    runDisplayId: string;
+  };
+  // Needed to build the run link in Slack DMs; without it (library-level
+  // tests) the DM goes out without a link.
+  origin?: string;
+}): Promise<NotifyGenericResult> {
+  // Dedupe and drop the actor — no self-notification.
+  const actorSkipped = input.recipientUserIds.includes(input.actorUserId)
+    ? [input.actorUserId]
+    : [];
+  const recipients = [...new Set(input.recipientUserIds)].filter(
+    (id) => id !== input.actorUserId
+  );
+
+  if (recipients.length === 0) {
+    return { notifiedUserIds: [], skippedUserIds: actorSkipped, slackJobs: [] };
+  }
+
+  // Exact-repeat guard: skip recipients already holding an *unread* generic
+  // row with the same message and the same anchor. Retrying a dispatch is
+  // safe; a different message (or a read row) delivers again.
+  const repeats = await db
+    .select({ userId: notifications.userId })
+    .from(notifications)
+    .where(
+      and(
+        eq(notifications.type, "generic"),
+        inArray(notifications.userId, recipients),
+        isNull(notifications.readAt),
+        eq(notifications.body, input.message),
+        input.run
+          ? eq(notifications.runId, input.run.internalId)
+          : isNull(notifications.runId)
+      )
+    );
+  const repeatSet = new Set(repeats.map((r) => r.userId));
+  const fresh = recipients.filter((id) => !repeatSet.has(id));
+
+  if (fresh.length === 0) {
+    return {
+      notifiedUserIds: [],
+      skippedUserIds: [
+        ...actorSkipped,
+        ...recipients.filter((id) => repeatSet.has(id)),
+      ],
+      slackJobs: [],
+    };
+  }
+
+  // One query pulls both channel-routing columns per candidate, same shape
+  // as the run/comment fan-outs. Unknown user IDs simply don't join and
+  // land in `skippedUserIds` below.
+  const candidates = await db
+    .select({
+      userId: users.id,
+      // In-app: `!== false` so a missing pref row means on (the default).
+      genericEnabled: notificationPreferences.genericEnabled,
+      // Slack: live connection (non-revoked) AND the toggle on.
+      slackUserId: slackConnections.slackUserId,
+      slackGenericEnabled: notificationPreferences.slackGenericEnabled,
+      slackRevokedAt: slackConnections.revokedAt,
+    })
+    .from(users)
+    .leftJoin(
+      notificationPreferences,
+      eq(notificationPreferences.userId, users.id)
+    )
+    .leftJoin(slackConnections, eq(slackConnections.userId, users.id))
+    .where(inArray(users.id, fresh));
+
+  const inAppIds = new Set(
+    candidates.filter((c) => c.genericEnabled !== false).map((c) => c.userId)
+  );
+
+  const runUrl =
+    input.run && input.origin
+      ? `${input.origin}/instruments/${input.run.instrumentId}/runs/${encodeURIComponent(input.run.runDisplayId)}`
+      : undefined;
+
+  const slackJobs: SlackDmJob[] = candidates
+    .filter(
+      (c) =>
+        c.slackUserId && !c.slackRevokedAt && (c.slackGenericEnabled ?? false)
+    )
+    .map((c) => ({
+      userId: c.userId,
+      slackUserId: c.slackUserId ?? "",
+      payload: {
+        text: `${input.actorDisplayName} sent you a notification: ${input.message}`,
+        blocks: buildGenericBlocks({
+          actorDisplayName: input.actorDisplayName,
+          message: input.message,
+          runUrl,
+        }),
+      },
+    }));
+  const slackIds = new Set(slackJobs.map((j) => j.userId));
+
+  const inAppRows = candidates
+    .filter((c) => inAppIds.has(c.userId))
+    .map((c) => ({
+      userId: c.userId,
+      type: "generic" as const,
+      runId: input.run?.internalId ?? null,
+      actorUserId: input.actorUserId,
+      body: input.message,
+    }));
+  if (inAppRows.length > 0) {
+    await db.insert(notifications).values(inAppRows);
+  }
+
+  return {
+    notifiedUserIds: fresh.filter((id) => inAppIds.has(id) || slackIds.has(id)),
+    skippedUserIds: [
+      ...actorSkipped,
+      ...recipients.filter((id) => repeatSet.has(id)),
+      ...fresh.filter((id) => !(inAppIds.has(id) || slackIds.has(id))),
+    ],
+    slackJobs,
+  };
 }

--- a/web/lib/api/openapi/document.ts
+++ b/web/lib/api/openapi/document.ts
@@ -6,6 +6,7 @@ import "./paths/runs";
 import "./paths/files";
 import "./paths/watchers";
 import "./paths/archive";
+import "./paths/notifications";
 
 const DOCUMENT_TAGS = [
   { name: "Meta", description: "Schema discovery" },
@@ -17,6 +18,7 @@ const DOCUMENT_TAGS = [
   { name: "Files", description: "Run files, downloads, and reprocessing" },
   { name: "Watchers", description: "Watcher registration and telemetry" },
   { name: "Archive", description: "Run archive builds" },
+  { name: "Notifications", description: "User notifications" },
 ] as const;
 
 export function buildOpenApiDocument() {

--- a/web/lib/api/openapi/index.ts
+++ b/web/lib/api/openapi/index.ts
@@ -20,6 +20,10 @@ export {
   patchInstrumentBody,
 } from "./schemas/instruments";
 export {
+  dispatchNotificationsBody,
+  dispatchNotificationsResult,
+} from "./schemas/notifications";
+export {
   attributionsResponse,
   commentBody,
   commentDeleted,

--- a/web/lib/api/openapi/paths/notifications.ts
+++ b/web/lib/api/openapi/paths/notifications.ts
@@ -1,0 +1,30 @@
+import {
+  bearerSecurity,
+  errorResponses,
+  jsonResponse,
+  registry,
+} from "../registry";
+import {
+  dispatchNotificationsBody,
+  dispatchNotificationsResult,
+} from "../schemas/notifications";
+
+registry.registerPath({
+  method: "post",
+  path: "/notifications/dispatch",
+  operationId: "dispatchNotifications",
+  summary: "Send a notification to users",
+  description:
+    "Requires scope `notifications:create`. PAT only; browser sessions are rejected. Posts a free-text `generic` notification to each recipient, optionally anchored to a run. Delivery is per-recipient preference: in-app bell and/or Slack DM. Exact repeats of an unread message are skipped, so retries are safe.",
+  tags: ["Notifications"],
+  security: bearerSecurity,
+  request: {
+    body: {
+      content: { "application/json": { schema: dispatchNotificationsBody } },
+    },
+  },
+  responses: {
+    201: jsonResponse("Dispatch result.", dispatchNotificationsResult),
+    ...errorResponses(),
+  },
+});

--- a/web/lib/api/openapi/schemas/notifications.ts
+++ b/web/lib/api/openapi/schemas/notifications.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+// Caps keep a single dispatch bounded: 50 recipients per call, 500 chars of
+// message (the bell preview-truncates to 240 either way).
+export const dispatchNotificationsBody = z.object({
+  user_ids: z.array(z.string().min(1)).min(1).max(50),
+  message: z.string().trim().min(1).max(500),
+  // Optional run anchor, by natural key — external callers know instrument
+  // IDs and run display IDs from the API, not internal UUIDs.
+  run: z
+    .object({
+      instrument_id: z.string().min(1),
+      run_id: z.string().min(1),
+    })
+    .optional(),
+});
+
+export const dispatchNotificationsResult = z
+  .object({
+    notified_user_ids: z.array(z.string()),
+    skipped_user_ids: z.array(z.string()),
+  })
+  .openapi("DispatchNotificationsResult");

--- a/web/lib/api/scope-catalog.ts
+++ b/web/lib/api/scope-catalog.ts
@@ -111,6 +111,11 @@ export const SCOPE_METADATA: Record<Scope, ScopeMeta> = {
     description: "Update run-archive job status (Lambda callback).",
     destructive: false,
   },
+  "notifications:create": {
+    label: "Send notifications",
+    description: "Send notifications to users, optionally about a run.",
+    destructive: false,
+  },
 };
 
 export interface ScopePreset {

--- a/web/lib/api/scopes.ts
+++ b/web/lib/api/scopes.ts
@@ -24,6 +24,7 @@ export const ALL_SCOPES = [
   "watchers:admin",
   "archive-jobs:read",
   "archive-jobs:write",
+  "notifications:create",
 ] as const;
 
 export type Scope = (typeof ALL_SCOPES)[number];

--- a/web/lib/db/schema.ts
+++ b/web/lib/db/schema.ts
@@ -831,11 +831,14 @@ export const archiveJobs = pgTable(
 // `comment_attributed` and `comment_participated` fire on a new comment for
 // run attributees and prior commenters respectively. The `attributed`
 // variant takes precedence when a single recipient qualifies under both
-// rules so the popover doesn't show the same comment twice.
+// rules so the popover doesn't show the same comment twice. `generic` rows
+// are free-text messages posted by integrations via the dispatch endpoint;
+// they alone may be anchor-less (`runId` NULL).
 export const notificationTypeEnum = pgEnum("notification_type", [
   "run_created",
   "comment_attributed",
   "comment_participated",
+  "generic",
 ]);
 
 // One row per user holding the global notification toggles. Created on
@@ -862,6 +865,11 @@ export const notificationPreferences = pgTable("notification_preferences", {
   commentsParticipatedEnabled: boolean("comments_participated_enabled")
     .notNull()
     .default(true),
+  // Receive in-app `generic` notifications posted by integrations via the
+  // dispatch endpoint. Defaults on: unlike the run/comment triggers these
+  // are always addressed to the recipient, so they're expected to be
+  // low-volume.
+  genericEnabled: boolean("generic_enabled").notNull().default(true),
   // Slack delivery toggles — independent of the in-app toggles above so a
   // user can receive a notification type via Slack only, in-app only, both,
   // or neither. All default false; connecting Slack (via OAuth) flips them to
@@ -873,6 +881,9 @@ export const notificationPreferences = pgTable("notification_preferences", {
   slackCommentsParticipatedEnabled: boolean(
     "slack_comments_participated_enabled"
   )
+    .notNull()
+    .default(false),
+  slackGenericEnabled: boolean("slack_generic_enabled")
     .notNull()
     .default(false),
   updatedAt: timestamp("updated_at", {
@@ -938,14 +949,19 @@ export const notifications = pgTable(
     // The run the notification refers to; cascade on delete so soft- or
     // hard-deleted runs don't leave orphan rows in the popover. (Runs are
     // soft-deleted in practice, but the FK protects against accidental
-    // hard delete in tests / future cleanups.)
-    runId: uuid("run_id")
-      .notNull()
-      .references(() => instrumentRuns.id, { onDelete: "cascade" }),
-    // NULL for `run_created`. Set for both comment trigger types.
+    // hard delete in tests / future cleanups.) NULL only for anchor-less
+    // `generic` rows — every other type is always run-anchored.
+    runId: uuid("run_id").references(() => instrumentRuns.id, {
+      onDelete: "cascade",
+    }),
+    // NULL for `run_created` and `generic`. Set for both comment trigger
+    // types.
     commentId: uuid("comment_id").references(() => runComments.id, {
       onDelete: "cascade",
     }),
+    // Caller-supplied message text for `generic` rows; NULL for every
+    // other type, whose copy is derived from type + actor at render time.
+    body: text("body"),
     // The user whose action produced the notification. `set null` so a
     // deleted user doesn't take the recipient's history with them.
     actorUserId: text("actor_user_id").references(() => users.id, {

--- a/web/lib/slack/connections.ts
+++ b/web/lib/slack/connections.ts
@@ -83,6 +83,7 @@ async function setAllSlackPrefs(
       slackRunsEnabled: enabled,
       slackCommentsAttributedEnabled: enabled,
       slackCommentsParticipatedEnabled: enabled,
+      slackGenericEnabled: enabled,
     })
     .onConflictDoUpdate({
       target: notificationPreferences.userId,
@@ -90,6 +91,7 @@ async function setAllSlackPrefs(
         slackRunsEnabled: enabled,
         slackCommentsAttributedEnabled: enabled,
         slackCommentsParticipatedEnabled: enabled,
+        slackGenericEnabled: enabled,
         updatedAt: new Date(),
       },
     });

--- a/web/lib/slack/dm.ts
+++ b/web/lib/slack/dm.ts
@@ -196,3 +196,22 @@ export function buildCommentBlocks(opts: {
     },
   ];
 }
+
+export function buildGenericBlocks(opts: {
+  actorDisplayName: string;
+  message: string;
+  // Present only when the notification is run-anchored and the caller
+  // supplied an origin to build the link from.
+  runUrl?: string;
+}): (Block | KnownBlock)[] {
+  const link = opts.runUrl ? `\n<${opts.runUrl}|View in Data Hub>` : "";
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*${opts.actorDisplayName}* sent you a notification:\n${opts.message}${link}`,
+      },
+    },
+  ];
+}

--- a/web/tests/integration/notification-dispatch.test.ts
+++ b/web/tests/integration/notification-dispatch.test.ts
@@ -1,0 +1,464 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { listNotifications, updatePreferences } from "@/lib/api/notifications";
+import {
+  instrumentRuns,
+  instruments,
+  notifications,
+  slackConnections,
+} from "@/lib/db/schema";
+import {
+  api,
+  clearCapturedSlackDms,
+  closeTestDb,
+  getCapturedSlackDms,
+  getTestDb,
+  resetDb,
+  seedTestUser,
+} from "@/tests/integration/helpers";
+
+// End-to-end coverage for `POST /api/v1/notifications/dispatch`, the
+// machine-facing surface for integration-posted `generic` notifications.
+// The route is PAT-only, so every call goes through the seeded-token
+// harness. In-app inserts are synchronous and asserted via the response +
+// DB; Slack DMs fire in `after()`, so DM assertions poll the capture
+// buffer like the notifications suite polls for rows.
+
+interface DispatchResponse {
+  notified_user_ids: string[];
+  skipped_user_ids: string[];
+}
+
+describe("Notification dispatch", () => {
+  const instrumentId = "dispatch-instrument";
+  const runId = "dispatch-run";
+  const message = "This run might be yours to claim.";
+
+  beforeAll(async () => {
+    await resetDb();
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  beforeEach(async () => {
+    await resetDb();
+    await clearCapturedSlackDms();
+    const db = getTestDb();
+    await db.insert(instruments).values({
+      id: instrumentId,
+      displayName: "Dispatch Instrument",
+      status: "active",
+    });
+  });
+
+  async function seedRun(displayId = runId): Promise<string> {
+    const db = getTestDb();
+    const [row] = await db
+      .insert(instrumentRuns)
+      .values({ instrumentId, runId: displayId, source: "lambda" })
+      .returning({ id: instrumentRuns.id });
+    return row.id;
+  }
+
+  async function connectSlack(userId: string, slackUserId: string) {
+    const db = getTestDb();
+    await db.insert(slackConnections).values({
+      userId,
+      slackUserId,
+      slackTeamId: "T_TEST",
+      slackTeamName: "Test Workspace",
+      connectedAt: new Date(),
+      revokedAt: null,
+    });
+  }
+
+  /** Polls until the after()-deferred Slack DMs land in the capture buffer. */
+  async function waitForDms(count: number): Promise<void> {
+    const deadline = Date.now() + 3000;
+    while (Date.now() < deadline) {
+      if ((await getCapturedSlackDms()).length >= count) {
+        return;
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    throw new Error(`Timed out waiting for ${count} Slack DM(s)`);
+  }
+
+  async function dispatch(token: string, body: Record<string, unknown>) {
+    const res = await api("/api/v1/notifications/dispatch", {
+      method: "POST",
+      token,
+      body,
+    });
+    return { res, body: (await res.json()) as DispatchResponse };
+  }
+
+  function rowsFor(userId: string) {
+    const db = getTestDb();
+    return db
+      .select()
+      .from(notifications)
+      .where(eq(notifications.userId, userId));
+  }
+
+  // =========================================================================
+  // Auth + validation gates
+  // =========================================================================
+
+  describe("auth and validation", () => {
+    it("rejects requests without a token", async () => {
+      const res = await api("/api/v1/notifications/dispatch", {
+        method: "POST",
+        body: { user_ids: ["u1"], message },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects a token without the notifications:create scope", async () => {
+      const { token } = await seedTestUser({ scopes: ["runs:read"] });
+      const res = await api("/api/v1/notifications/dispatch", {
+        method: "POST",
+        token,
+        body: { user_ids: ["u1"], message },
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("rejects malformed bodies", async () => {
+      const { token } = await seedTestUser({
+        scopes: ["notifications:create"],
+      });
+
+      const cases: Record<string, unknown>[] = [
+        // Empty recipient list.
+        { user_ids: [], message },
+        // Over the 50-recipient cap.
+        { user_ids: Array.from({ length: 51 }, (_, i) => `u${i}`), message },
+        // Missing message.
+        { user_ids: ["u1"] },
+        // Whitespace-only message (trimmed before min(1)).
+        { user_ids: ["u1"], message: "   " },
+        // Over the 500-char cap.
+        { user_ids: ["u1"], message: "x".repeat(501) },
+      ];
+      for (const body of cases) {
+        const res = await api("/api/v1/notifications/dispatch", {
+          method: "POST",
+          token,
+          body,
+        });
+        expect(res.status).toBe(400);
+      }
+    });
+  });
+
+  // =========================================================================
+  // Dispatch behavior
+  // =========================================================================
+
+  describe("dispatch", () => {
+    it("delivers a run-anchored notification in-app by default", async () => {
+      const { userId: actorId, token } = await seedTestUser({
+        name: "Claim Bot",
+        scopes: ["notifications:create"],
+      });
+      const { userId: recipient } = await seedTestUser();
+      const internalId = await seedRun();
+
+      const { res, body } = await dispatch(token, {
+        user_ids: [recipient],
+        message,
+        run: { instrument_id: instrumentId, run_id: runId },
+      });
+
+      expect(res.status).toBe(201);
+      expect(body.notified_user_ids).toEqual([recipient]);
+      expect(body.skipped_user_ids).toEqual([]);
+
+      const rows = await rowsFor(recipient);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].type).toBe("generic");
+      expect(rows[0].body).toBe(message);
+      expect(rows[0].runId).toBe(internalId);
+      expect(rows[0].actorUserId).toBe(actorId);
+      expect(rows[0].readAt).toBeNull();
+    });
+
+    it("delivers an anchor-less notification and lists it", async () => {
+      const { token } = await seedTestUser({
+        scopes: ["notifications:create"],
+      });
+      const { userId: recipient } = await seedTestUser();
+
+      const { res, body } = await dispatch(token, {
+        user_ids: [recipient],
+        message: "Scheduled maintenance tonight.",
+      });
+
+      expect(res.status).toBe(201);
+      expect(body.notified_user_ids).toEqual([recipient]);
+
+      const rows = await rowsFor(recipient);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].runId).toBeNull();
+
+      // The bell's read path must surface run-less rows (left joins).
+      const list = await listNotifications(recipient);
+      expect(list).toHaveLength(1);
+      expect(list[0].type).toBe("generic");
+      expect(list[0].body).toBe("Scheduled maintenance tonight.");
+      expect(list[0].runId).toBeNull();
+      expect(list[0].instrumentId).toBeNull();
+    });
+
+    it("reports unknown user IDs as skipped and still notifies the rest", async () => {
+      const { token } = await seedTestUser({
+        scopes: ["notifications:create"],
+      });
+      const { userId: recipient } = await seedTestUser();
+
+      const { body } = await dispatch(token, {
+        user_ids: [recipient, "no-such-user"],
+        message,
+      });
+
+      expect(body.notified_user_ids).toEqual([recipient]);
+      expect(body.skipped_user_ids).toEqual(["no-such-user"]);
+    });
+
+    it("never notifies the actor, even when listed", async () => {
+      const { userId: actorId, token } = await seedTestUser({
+        scopes: ["notifications:create"],
+      });
+      const { userId: recipient } = await seedTestUser();
+
+      const { body } = await dispatch(token, {
+        user_ids: [actorId, recipient],
+        message,
+      });
+
+      expect(body.notified_user_ids).toEqual([recipient]);
+      expect(body.skipped_user_ids).toEqual([actorId]);
+      expect(await rowsFor(actorId)).toHaveLength(0);
+    });
+
+    it("rejects an unknown run reference with 400", async () => {
+      const { token } = await seedTestUser({
+        scopes: ["notifications:create"],
+      });
+      const { userId: recipient } = await seedTestUser();
+
+      const { res } = await dispatch(token, {
+        user_ids: [recipient],
+        message,
+        run: { instrument_id: instrumentId, run_id: "no-such-run" },
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects a soft-deleted run with 409", async () => {
+      const { token } = await seedTestUser({
+        scopes: ["notifications:create"],
+      });
+      const { userId: recipient } = await seedTestUser();
+      const internalId = await seedRun();
+
+      const db = getTestDb();
+      await db
+        .update(instrumentRuns)
+        .set({ deletedAt: new Date() })
+        .where(eq(instrumentRuns.id, internalId));
+
+      const { res } = await dispatch(token, {
+        user_ids: [recipient],
+        message,
+        run: { instrument_id: instrumentId, run_id: runId },
+      });
+      expect(res.status).toBe(409);
+    });
+
+    it("skips exact repeats while unread, redelivers when read or changed", async () => {
+      const { token } = await seedTestUser({
+        scopes: ["notifications:create"],
+      });
+      const { userId: recipient } = await seedTestUser();
+      await seedRun();
+      const run = { instrument_id: instrumentId, run_id: runId };
+
+      const first = await dispatch(token, {
+        user_ids: [recipient],
+        message,
+        run,
+      });
+      expect(first.body.notified_user_ids).toEqual([recipient]);
+
+      // Same message + same anchor, still unread → skipped.
+      const repeat = await dispatch(token, {
+        user_ids: [recipient],
+        message,
+        run,
+      });
+      expect(repeat.body.notified_user_ids).toEqual([]);
+      expect(repeat.body.skipped_user_ids).toEqual([recipient]);
+      expect(await rowsFor(recipient)).toHaveLength(1);
+
+      // A different message to the same user delivers again.
+      const changed = await dispatch(token, {
+        user_ids: [recipient],
+        message: "Different message.",
+        run,
+      });
+      expect(changed.body.notified_user_ids).toEqual([recipient]);
+      expect(await rowsFor(recipient)).toHaveLength(2);
+
+      // Once every copy is read, the original message delivers again.
+      const db = getTestDb();
+      await db
+        .update(notifications)
+        .set({ readAt: new Date() })
+        .where(eq(notifications.userId, recipient));
+      const afterRead = await dispatch(token, {
+        user_ids: [recipient],
+        message,
+        run,
+      });
+      expect(afterRead.body.notified_user_ids).toEqual([recipient]);
+      expect(await rowsFor(recipient)).toHaveLength(3);
+    });
+
+    it("dedupes anchor-less repeats independently of anchored ones", async () => {
+      const { token } = await seedTestUser({
+        scopes: ["notifications:create"],
+      });
+      const { userId: recipient } = await seedTestUser();
+
+      // Anchor-less and run-anchored rows with the same message are
+      // distinct deliveries — the anchor is part of the repeat key.
+      await seedRun();
+      await dispatch(token, { user_ids: [recipient], message });
+      const anchored = await dispatch(token, {
+        user_ids: [recipient],
+        message,
+        run: { instrument_id: instrumentId, run_id: runId },
+      });
+      expect(anchored.body.notified_user_ids).toEqual([recipient]);
+
+      const anchorlessRepeat = await dispatch(token, {
+        user_ids: [recipient],
+        message,
+      });
+      expect(anchorlessRepeat.body.skipped_user_ids).toEqual([recipient]);
+      expect(await rowsFor(recipient)).toHaveLength(2);
+    });
+  });
+
+  // =========================================================================
+  // Per-channel preference gating
+  // =========================================================================
+
+  describe("channel gating", () => {
+    it("skips in-app delivery when genericEnabled is false", async () => {
+      const { token } = await seedTestUser({
+        scopes: ["notifications:create"],
+      });
+      const { userId: recipient } = await seedTestUser();
+      await updatePreferences(recipient, { genericEnabled: false });
+
+      const { body } = await dispatch(token, {
+        user_ids: [recipient],
+        message,
+      });
+
+      expect(body.notified_user_ids).toEqual([]);
+      expect(body.skipped_user_ids).toEqual([recipient]);
+      expect(await rowsFor(recipient)).toHaveLength(0);
+    });
+
+    it("sends a Slack DM when connected and slackGenericEnabled", async () => {
+      const { token } = await seedTestUser({
+        name: "Claim Bot",
+        scopes: ["notifications:create"],
+      });
+      const { userId: recipient } = await seedTestUser();
+      await connectSlack(recipient, "U_GENERIC");
+      await updatePreferences(recipient, { slackGenericEnabled: true });
+      await seedRun();
+
+      const { body } = await dispatch(token, {
+        user_ids: [recipient],
+        message,
+        run: { instrument_id: instrumentId, run_id: runId },
+      });
+
+      // Both channels on → in-app row plus the DM.
+      expect(body.notified_user_ids).toEqual([recipient]);
+      expect(await rowsFor(recipient)).toHaveLength(1);
+
+      await waitForDms(1);
+      const dms = await getCapturedSlackDms();
+      expect(dms[0].channel).toBe("U_GENERIC");
+      expect(dms[0].text).toContain("Claim Bot");
+      expect(dms[0].text).toContain(message);
+    });
+
+    it("counts a Slack-only recipient as notified", async () => {
+      const { token } = await seedTestUser({
+        scopes: ["notifications:create"],
+      });
+      const { userId: recipient } = await seedTestUser();
+      await connectSlack(recipient, "U_SLACK_ONLY_GENERIC");
+      // In-app off, Slack on.
+      await updatePreferences(recipient, {
+        genericEnabled: false,
+        slackGenericEnabled: true,
+      });
+
+      const { body } = await dispatch(token, {
+        user_ids: [recipient],
+        message,
+      });
+
+      expect(body.notified_user_ids).toEqual([recipient]);
+      expect(await rowsFor(recipient)).toHaveLength(0);
+
+      await waitForDms(1);
+      const dms = await getCapturedSlackDms();
+      expect(dms[0].channel).toBe("U_SLACK_ONLY_GENERIC");
+    });
+
+    it("sends no DM when the Slack toggle is off or the connection revoked", async () => {
+      const { token } = await seedTestUser({
+        scopes: ["notifications:create"],
+      });
+      const { userId: toggleOff } = await seedTestUser();
+      const { userId: revoked } = await seedTestUser();
+      // Connected but the toggle stays at its default (off).
+      await connectSlack(toggleOff, "U_TOGGLE_OFF");
+      // Connected, enabled, then revoked.
+      await connectSlack(revoked, "U_REVOKED_GENERIC");
+      await updatePreferences(revoked, { slackGenericEnabled: true });
+      const db = getTestDb();
+      await db
+        .update(slackConnections)
+        .set({ revokedAt: new Date() })
+        .where(eq(slackConnections.userId, revoked));
+
+      const { body } = await dispatch(token, {
+        user_ids: [toggleOff, revoked],
+        message,
+      });
+
+      // In-app is on by default, so both are still notified — just no DMs.
+      expect(body.notified_user_ids.sort()).toEqual(
+        [toggleOff, revoked].sort()
+      );
+
+      // Give the after() hook a beat to (not) fire, then assert the buffer
+      // stayed empty.
+      await new Promise((r) => setTimeout(r, 500));
+      expect(await getCapturedSlackDms()).toHaveLength(0);
+    });
+  });
+});

--- a/web/tests/integration/notifications.test.ts
+++ b/web/tests/integration/notifications.test.ts
@@ -109,9 +109,11 @@ describe("Notifications", () => {
         runsAllMuted: false,
         commentsAttributedEnabled: true,
         commentsParticipatedEnabled: true,
+        genericEnabled: true,
         slackRunsEnabled: false,
         slackCommentsAttributedEnabled: false,
         slackCommentsParticipatedEnabled: false,
+        slackGenericEnabled: false,
       });
 
       // Defaults are lazy-upserted so subsequent reads hit the row, not
@@ -129,9 +131,11 @@ describe("Notifications", () => {
         runsAllMuted: true,
         commentsAttributedEnabled: true,
         commentsParticipatedEnabled: true,
+        genericEnabled: true,
         slackRunsEnabled: false,
         slackCommentsAttributedEnabled: false,
         slackCommentsParticipatedEnabled: false,
+        slackGenericEnabled: false,
       });
 
       // A partial patch on the other axis leaves the first one intact.
@@ -141,9 +145,11 @@ describe("Notifications", () => {
         runsAllMuted: true,
         commentsAttributedEnabled: true,
         commentsParticipatedEnabled: false,
+        genericEnabled: true,
         slackRunsEnabled: false,
         slackCommentsAttributedEnabled: false,
         slackCommentsParticipatedEnabled: false,
+        slackGenericEnabled: false,
       });
     });
 


### PR DESCRIPTION
## What this adds

A new endpoint, `POST /api/v1/notifications/dispatch`, that lets an external service post a free-text notification to specific users. The motivating use case is a service that tells a user a run might be theirs to claim, but the wording is entirely caller-supplied, so the same endpoint covers any run-related nudge or run-free announcement.

How a dispatch flows:

- The caller posts `{ user_ids, message, run? }` with a personal access token carrying the new `notifications:create` scope.
- The route validates the recipient IDs and resolves the optional run by its natural key (`instrument_id` + `run_id`).
- Each recipient's own preferences decide delivery: the in-app bell (on by default) and Slack DM (on when the user has connected Slack and left the toggle on).
- A recipient who already holds the same unread message for the same run is skipped, so retrying a dispatch never double-notifies.
- The response is `201 { notified_user_ids, skipped_user_ids }`, where "notified" means reached on at least one channel.

## Schema changes

Migration `0046_many_bucky.sql`:

- Adds `generic` to the `notification_type` enum.
- Adds a nullable `body` column to `notifications` for the message text; only `generic` rows set it.
- Makes `notifications.run_id` nullable so a notification can exist without a run.
- Adds `generic_enabled` (default true) and `slack_generic_enabled` (default false) to `notification_preferences`.

## UI

- The bell popover renders `generic` rows with the sender's avatar and the message text. Run-anchored rows link to the run page; run-free rows just mark themselves read on click.
- Notification settings gain a "Service notifications" toggle on both the in-app form and the Slack card. Connecting or disconnecting Slack opts the Slack toggle in or out, same as the existing Slack toggles.
- The bell icon's unread count badge is now red (`bg-destructive`).

## Design decisions worth knowing

- The endpoint is PAT-only; browser sessions are rejected so a logged-in member can't use it to spam other users' bells. Run creation works the same way for the same reason.
- `notifyGeneric` lets database failures surface as 500s instead of swallowing them like the other fan-out helpers do. The dispatch response reports delivery, so a swallowed failure would return a 201 claiming everyone was skipped. The repeat-skip rule makes retrying after a 500 safe.
- The full message (up to 500 chars) is stored; the 240-character preview truncation happens at read time, same as comment bodies.

## Testing

- New integration suite `web/tests/integration/notification-dispatch.test.ts` with 15 tests: auth gates, run-anchored and run-free dispatch, repeat-skip rules, per-channel preference gating, and Slack DM capture.
- `make check` is clean. Unit tests: 369 passed. Integration tests: 405 passed across 30 files.

Made with [Cursor](https://cursor.com)