### PR TITLE
Trust Vercel preview OIDC subjects on staging only

### DIFF
--- a/developer-docs/ci-and-deployment.md
+++ b/developer-docs/ci-and-deployment.md
@@ -61,6 +61,8 @@ Data Hub is self-hosted, running across three backend pieces per environment: a 
 
 The Next.js app is deployed on [Vercel](https://vercel.com). Every branch and commit generates a preview deployment. Merges to `staging` and `production` deploy to their respective environments automatically.
 
+Preview deployments assume the staging web-app IAM role only. The production role must never trust `environment:preview` OIDC subjects — a preview is just a branch push, so that trust would bypass production branch protection. `infra/template.yaml` enforces this with the `AllowPreviewSubject` condition.
+
 Environment variables are managed in the Vercel dashboard and can be pulled locally with:
 
 ```sh

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -47,6 +47,12 @@ Globals:
     Timeout: 900
     MemorySize: 10240
 
+Conditions:
+  # Preview deployments may only ever touch staging. A preview is just a
+  # branch push, so trusting preview subjects on the production role would
+  # bypass production branch protection.
+  AllowPreviewSubject: !Equals [!Ref Environment, staging]
+
 Resources:
   # ---- S3 buckets ----
 
@@ -415,6 +421,7 @@ Resources:
 
   # ---- IAM: Vercel web app role (OIDC federation) ----
   # Lets the Next.js app presign S3 URLs without long-lived AWS credentials.
+  # Preview deployments are trusted on staging only — see AllowPreviewSubject.
 
   WebAppS3Role:
     Type: AWS::IAM::Role
@@ -433,7 +440,10 @@ Resources:
               StringLike:
                 "oidc.vercel.com/arcadia-science:sub":
                   - !Sub "owner:arcadia-science:project:data-hub:environment:${Environment}"
-                  - "owner:arcadia-science:project:data-hub:environment:preview"
+                  - !If
+                    - AllowPreviewSubject
+                    - "owner:arcadia-science:project:data-hub:environment:preview"
+                    - !Ref "AWS::NoValue"
       Policies:
         - PolicyName: S3PresignedUrlAccess
           PolicyDocument:


### PR DESCRIPTION
## Summary

Fixes a high-severity IAM misconfiguration: the per-environment `WebAppS3Role` trust policy unconditionally allowed Vercel OIDC subjects with `environment:preview`, so any preview deployment (a feature-branch push or PR build) could call `sts:AssumeRoleWithWebIdentity` on **`data-hub-webapp-production`** and inherit its permissions:

- `s3:GetObject`/`s3:PutObject` on the production raw bucket (the bucket-policy write-deny exempts this role via `aws:PrincipalArn`, which AWS resolves to the role ARN for any session of the role)
- `s3:GetObject` on the production processed bucket, list/get on the archives bucket
- `lambda:InvokeFunctionUrl` on the production function

Verified against the live role trust policy, the Vercel project config (OIDC enabled, team issuer mode, project `data-hub`), and Vercel's documented `sub` claim format (`owner:<team>:project:<project>:environment:<env>`).

## Fix

Gate the `preview` subject behind a new `AllowPreviewSubject` condition (`Environment == staging`). Staging's trust policy is unchanged; production drops to `environment:production` only. Preview deployments are unaffected — their `AWS_ROLE_ARN` env var already points at the staging role.

## Rollout (done)

The CI deploy role lacks `iam:UpdateAssumeRolePolicy` by design, so this was rolled out via admin change sets (`UsePreviousValue` for all parameters) against both stacks on 2026-09-08. Merging this PR brings git in line with the deployed state; the `deploy-lambda.yml` workflow will no-op on the trust policy afterward.

## Test plan

- [x] `make sam-validate` (cfn-lint) passes
- [x] `make check` passes
- [x] Staging change set showed no `AssumeRolePolicyDocument` change; deployed `UPDATE_COMPLETE`; live staging role still trusts `staging` + `preview`
- [x] Production change set's only material change was `WebAppS3Role.AssumeRolePolicyDocument`; deployed `UPDATE_COMPLETE`; live production role now trusts `environment:production` only
- [x] Production download flow: presigned URL generated via the production API post-deploy (exercises OIDC → assume production role → sign); IAM simulation confirms `s3:GetObject`/`s3:PutObject`/`lambda:InvokeFunctionUrl` intact
- [x] Preview end-to-end probe (throwaway branch + preview deployment, since deleted): `{"staging":"assumed","production":"AccessDenied"}` — a real preview OIDC token can still assume staging and is now denied by production; both outcomes confirmed in CloudTrail
- [x] CloudTrail audit of `AssumeRoleWithWebIdentity` against the production role (90-day event history): no successful preview-subject assumptions