### PR TITLE
Accept null content_type on file PATCH; preserve size/type on Lambda adopt

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -418,7 +418,7 @@ requires-dist = [
 
 [[package]]
 name = "data-hub-watcher"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "watcher" }
 dependencies = [
     { name = "click" },

--- a/watcher/pyproject.toml
+++ b/watcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-hub-watcher"
-version = "1.0.1"
+version = "1.0.2"
 description = "File-watcher agent for lab instrument PCs that ingests data into Data Hub."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/watcher/src/data_hub_watcher/uploader.py
+++ b/watcher/src/data_hub_watcher/uploader.py
@@ -49,13 +49,15 @@ class _QueueAttempt:
     reason: str
 
 
-def _guess_content_type(path: Path) -> str | None:
+def _guess_content_type(path: Path) -> str:
     # `mimetypes.guess_type` is case-sensitive on some platforms. Azure
     # Cielo writes reports as `.PDF`; without the lowercase, the PUT
     # stores `binary/octet-stream` and browsers download the file.
     lowered = path.with_suffix(path.suffix.lower())
     content_type, _ = mimetypes.guess_type(str(lowered))
-    return content_type
+    # Extensions with no MIME mapping (e.g. `.AZE`) still need a concrete
+    # type so the S3 object and the file record don't end up with null.
+    return content_type or "application/octet-stream"
 
 
 def _resolve_within(watch_dir: Path, relative: str) -> Path | None:

--- a/watcher/tests/test_uploader.py
+++ b/watcher/tests/test_uploader.py
@@ -963,3 +963,7 @@ class TestUploadQueueWorker:
 
 def test_guess_content_type_handles_uppercase_pdf() -> None:
     assert _guess_content_type(Path("Experiment_Report.PDF")) == "application/pdf"
+
+
+def test_guess_content_type_falls_back_for_unknown_extension() -> None:
+    assert _guess_content_type(Path("Experiment_20000101000000.AZE")) == "application/octet-stream"

--- a/web/app/api/v1/files/[fileId]/route.ts
+++ b/web/app/api/v1/files/[fileId]/route.ts
@@ -158,7 +158,10 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
     }
   }
 
-  if (body.content_type !== undefined) {
+  // Treat an explicit null as "no value": the watcher sends null for
+  // extensions without a MIME mapping, and storing it would clear a type
+  // the create/adopt paths may already have set.
+  if (body.content_type != null) {
     updates.contentType = body.content_type;
   }
   if (body.size_bytes !== undefined) {

--- a/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/files/route.ts
+++ b/web/app/api/v1/instruments/[instrumentId]/runs/[runId]/files/route.ts
@@ -91,8 +91,11 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
         .set({
           s3Bucket,
           s3Key,
-          contentType,
-          sizeBytes,
+          // The Lambda omits content_type/size_bytes for raw uploads; keep
+          // what the watcher's detected_files report recorded rather than
+          // wiping the columns to null.
+          contentType: contentType ?? existing.contentType,
+          sizeBytes: sizeBytes ?? existing.sizeBytes,
           // Honour the Lambda-supplied category when adopting a row. The
           // watcher always inserts with the default ("raw"), so without
           // this the insert vs. reconcile branches would diverge for

--- a/web/lib/api/openapi/schemas/files.ts
+++ b/web/lib/api/openapi/schemas/files.ts
@@ -15,7 +15,9 @@ export const createFileBody = z.object({
 // caller repoint a file at an arbitrary object.
 export const patchFileBody = z.object({
   status: fileStatusSchema.optional(),
-  content_type: z.string().optional(),
+  // Nullable, not just optional: watchers send an explicit null when the OS
+  // has no MIME mapping for the extension (e.g. `.AZE` project files).
+  content_type: z.string().nullish(),
   size_bytes: z.number().optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
   error_message: z.string().optional(),

--- a/web/tests/integration/files.test.ts
+++ b/web/tests/integration/files.test.ts
@@ -240,6 +240,79 @@ describe("Files API", () => {
     expect(data.status).toBe("uploaded");
   });
 
+  // The Lambda omits content_type/size_bytes when registering a raw upload.
+  // Adoption must keep what the watcher's detected_files report recorded —
+  // overwriting with null is how the .AZE backlog lost its sizes.
+  it("POST adoption preserves existing size_bytes and content_type when omitted", async () => {
+    const adoptRunId = "files-adopt-preserve-run";
+    const sizedFile = "preserve_size.aze";
+    const typedFile = "preserve_type.aze";
+
+    await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: {
+        run_id: adoptRunId,
+        source: "watcher",
+        detected_files: [
+          {
+            relative_path: sizedFile,
+            filename: sizedFile,
+            size_bytes: 7_340_032,
+          },
+          {
+            relative_path: typedFile,
+            filename: typedFile,
+            size_bytes: 1024,
+          },
+        ],
+      },
+    });
+
+    const detail = await api(
+      `/api/v1/instruments/${instrumentId}/runs/${adoptRunId}`,
+      { token }
+    );
+    const detailData = await detail.json();
+    const typed = detailData.files.find(
+      (f: { filename: string }) => f.filename === typedFile
+    );
+
+    // Give one detected row a content type while it is still pre-upload.
+    const patchRes = await api(`/api/v1/files/${typed.id}`, {
+      method: "PATCH",
+      token,
+      body: { content_type: "application/octet-stream" },
+    });
+    expect(patchRes.status).toBe(200);
+
+    // Lambda path adopts both rows, omitting size_bytes and content_type.
+    for (const filename of [sizedFile, typedFile]) {
+      const res = await api(
+        `/api/v1/instruments/${instrumentId}/runs/${adoptRunId}/files`,
+        {
+          method: "POST",
+          token,
+          body: {
+            s3_bucket: "test-bucket",
+            s3_key: `${instrumentId}/${adoptRunId}/${filename}`,
+            filename,
+          },
+        }
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.status).toBe("uploaded");
+      if (filename === sizedFile) {
+        expect(data.size_bytes).toBe(7_340_032);
+        expect(data.content_type).toBeNull();
+      } else {
+        expect(data.size_bytes).toBe(1024);
+        expect(data.content_type).toBe("application/octet-stream");
+      }
+    }
+  });
+
   // Idempotent on s3_key via a partial unique index. This prevents duplicate
   // file records when the Lambda retries after a timeout.
   it("POST is idempotent on s3_key — returns 200 for duplicate", async () => {
@@ -340,6 +413,47 @@ describe("Files API", () => {
     expect(data.s3_bucket).toBe("test-raw-data-bucket");
     expect(data.s3_key).toBe(`${instrumentId}/${runId}/sample.csv`);
     expect(data.uploaded_at).toBeTruthy();
+    fileDetail.parse(data);
+  });
+
+  // Watchers send an explicit null content_type for extensions the OS has no
+  // MIME mapping for (e.g. `.AZE`). The PATCH must accept it and leave the
+  // column untouched rather than reject the mark-uploaded call.
+  it("PATCH accepts an explicit null content_type", async () => {
+    const nullCtRunId = "files-null-content-type-run";
+    const filename = "Experiment_20000101000000.AZE";
+
+    await api(`/api/v1/instruments/${instrumentId}/runs`, {
+      method: "POST",
+      token,
+      body: {
+        run_id: nullCtRunId,
+        source: "watcher",
+        detected_files: [
+          { relative_path: filename, filename, size_bytes: 2048 },
+        ],
+      },
+    });
+
+    const detail = await api(
+      `/api/v1/instruments/${instrumentId}/runs/${nullCtRunId}`,
+      { token }
+    );
+    const detailData = await detail.json();
+    const detected = detailData.files.find(
+      (f: { filename: string }) => f.filename === filename
+    );
+
+    const res = await api(`/api/v1/files/${detected.id}`, {
+      method: "PATCH",
+      token,
+      body: { status: "uploaded", content_type: null },
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe("uploaded");
+    expect(data.content_type).toBeNull();
+    expect(data.size_bytes).toBe(2048);
     fileDetail.parse(data);
   });
 


### PR DESCRIPTION
## Problem

After the Azure Cielo qPCR watcher config added `*.AZE` to its file patterns, every AZE upload failed its mark-uploaded PATCH with `content_type: Invalid input: expected string, received null`, and the affected file rows ended up with `size_bytes` / `content_type` wiped to null.

Root cause chain:

1. Python's `mimetypes` has no mapping for `.AZE`, so the watcher's `_guess_content_type` returned `None`, and `mark_file_uploaded` sent it verbatim as JSON `null`.
2. `patchFileBody` declared `content_type: z.string().optional()` — absent is allowed, an explicit `null` is not — so the PATCH 400'd *after* the S3 PUT had already succeeded, leaving the row in a pre-upload state.
3. The S3 event fired the Lambda, whose `POST .../files` adopts pre-upload rows and unconditionally set `contentType` / `sizeBytes` from its request body — which omits both for raw uploads — wiping the values the watcher's `detected_files` report had already recorded.

CSV/PDF uploads never hit this because their MIME types are known, so the PATCH lands before the Lambda's adopt call and the adopt branch is skipped.

## Changes

- **`patchFileBody`**: `content_type` is now `z.string().nullish()`; the PATCH route treats an explicit `null` as "no value" rather than clearing the column.
- **`POST .../files` adoption**: keeps the existing row's `contentType` / `sizeBytes` when the request omits them, instead of overwriting with null.
- **Watcher**: `_guess_content_type` falls back to `application/octet-stream` for extensions with no MIME mapping, so future watcher releases always send a concrete type (also applied to the S3 object). Watcher bumped to 1.0.2 per `watcher/AGENTS.md`.

## Testing

- New integration tests: PATCH accepts explicit `content_type: null`; POST adoption preserves existing `size_bytes` / `content_type` when omitted.
- New watcher unit test: unknown extension falls back to `application/octet-stream`.
- `watcher/tests/test_uploader.py` (37 passed), `web` integration `files.test.ts` (37 passed), `make check` clean.

## Rollout notes

- The server-side fixes take effect on the next web deploy and are sufficient on their own — the current watcher fleet (1.0.0) unblocks without a release.
- The watcher change only reaches lab PCs after a `watcher-v1.0.2` tag from `production` and advertising it in Settings → Watchers.
- Follow-up (not in this PR): backfill `size_bytes` for the already-affected AZE raw rows in production from S3 HEAD objects.

Made with [Cursor](https://cursor.com)